### PR TITLE
Fix a problem with forward declarations

### DIFF
--- a/docs/pypreviouswork.rst
+++ b/docs/pypreviouswork.rst
@@ -75,6 +75,7 @@ Shiboken
 Shiboken was developed to create PySide.
 
 * https://wiki.qt.io/Qt_for_Python
+* http://doc.qt.io/qtforpython/shiboken2/contents.html
 
 
 Boost Python

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -1063,6 +1063,19 @@ is used by the ``generic`` interface.
 The constructor and destructor will only be wrapped if explicitly added
 to the YAML file to avoid wrapping ``private`` constructors and destructors.
 
+.. note:: A class without a ``declarations`` is considered a forward declaration.
+          To fully define a class, the ``declarations`` is required::
+
+              - decl: class Forward
+
+              - decl: class Full
+                declarations:
+                - decl: void work(Forward *arg)
+
+              - decl: class Forward
+                declarations:
+                - decl: void work(Full *arg)
+
 ..  chained function calls
 
 Member Variables

--- a/regression/forward.yaml
+++ b/regression/forward.yaml
@@ -55,6 +55,9 @@ options:
 namespace: tutorial
 
 declarations:
+# forward declaration
+- decl: class Class3
+
 - decl: class Class1
   fields:
     c_type: TUT_class1
@@ -69,3 +72,8 @@ declarations:
   - decl: Class2()
   - decl: ~Class2()
   - decl: void func1(Class1 *arg)
+  - decl: void acceptClass3(Class3 *arg)
+
+- decl: class Class3
+# need declarations to fully declare the class
+  declarations:

--- a/regression/reference/forward/forward.json
+++ b/regression/reference/forward/forward.json
@@ -109,7 +109,7 @@
                             "function_name": "ctor", 
                             "underscore_name": "ctor"
                         }, 
-                        "linenumber": 69, 
+                        "linenumber": 72, 
                         "options": {}
                     }, 
                     {
@@ -154,7 +154,7 @@
                             "function_name": "dtor", 
                             "underscore_name": "dtor"
                         }, 
-                        "linenumber": 70, 
+                        "linenumber": 73, 
                         "options": {}
                     }, 
                     {
@@ -270,14 +270,164 @@
                             "function_name": "func1", 
                             "underscore_name": "func1"
                         }, 
-                        "linenumber": 71, 
+                        "linenumber": 74, 
+                        "options": {}
+                    }, 
+                    {
+                        "_fmtargs": {
+                            "arg": {
+                                "fmtc": {
+                                    "c_const": "", 
+                                    "c_deref": "*", 
+                                    "c_member": "->", 
+                                    "c_var": "arg", 
+                                    "cxx_addr": "", 
+                                    "cxx_cast_to_void_ptr": "static_cast<void *>(SHCXX_arg)", 
+                                    "cxx_decl": "tutorial::Class3 * SHCXX_arg", 
+                                    "cxx_member": "->", 
+                                    "cxx_type": "tutorial::Class3", 
+                                    "cxx_val": "static_cast<tutorial::Class3 *>(arg->addr)", 
+                                    "cxx_var": "SHCXX_arg", 
+                                    "idtor": "0"
+                                }, 
+                                "fmtf": {
+                                    "c_var": "arg", 
+                                    "f_var": "arg"
+                                }, 
+                                "fmtl": {
+                                    "LUA_index": 1, 
+                                    "c_deref": " *", 
+                                    "c_member": "->", 
+                                    "c_var": "\t(l_Class2_Type *)\t luaL_checkudata(\tL, 1, \"Class2.metatable\")", 
+                                    "c_var_len": "Larg", 
+                                    "cxx_member": "->", 
+                                    "cxx_type": "tutorial::Class3", 
+                                    "cxx_var": "arg", 
+                                    "lua_var": "SH_Lua_arg"
+                                }, 
+                                "fmtpy": {
+                                    "c_const": "", 
+                                    "c_decl": "FOR_class3 arg", 
+                                    "c_deref": "", 
+                                    "c_type": "FOR_class3", 
+                                    "c_var": "arg", 
+                                    "cxx_addr": "", 
+                                    "cxx_decl": "tutorial::Class3 arg", 
+                                    "cxx_member": "->", 
+                                    "cxx_type": "tutorial::Class3", 
+                                    "cxx_var": "arg", 
+                                    "numpy_type": null, 
+                                    "py_type": "PY_Class3", 
+                                    "py_var": "SHPy_arg"
+                                }
+                            }
+                        }, 
+                        "ast": {
+                            "attrs": {
+                                "_typename": "void"
+                            }, 
+                            "const": false, 
+                            "declarator": {
+                                "name": "acceptClass3", 
+                                "pointer": []
+                            }, 
+                            "func_const": false, 
+                            "params": [
+                                {
+                                    "attrs": {
+                                        "_typename": "tutorial::Class3", 
+                                        "intent": "in", 
+                                        "value": false
+                                    }, 
+                                    "const": false, 
+                                    "declarator": {
+                                        "name": "arg", 
+                                        "pointer": [
+                                            {
+                                                "const": false, 
+                                                "ptr": "*"
+                                            }
+                                        ]
+                                    }, 
+                                    "specifier": [
+                                        "Class3"
+                                    ]
+                                }
+                            ], 
+                            "specifier": [
+                                "void"
+                            ]
+                        }, 
+                        "decl": "void acceptClass3(Class3 *arg)", 
+                        "declgen": "void acceptClass3(Class3 * arg +intent(in))", 
+                        "format": {
+                            "C_call_code": "SH_this->acceptClass3(\tSHCXX_arg);", 
+                            "C_call_list": "SHCXX_arg", 
+                            "C_name": "FOR_class2_accept_class3", 
+                            "C_pre_call": "tutorial::Class2 *SH_this =\t static_cast<tutorial::Class2 *>(self->addr);\ntutorial::Class3 * SHCXX_arg =\t static_cast<tutorial::Class3 *>(arg->addr);", 
+                            "C_prototype": "FOR_class2 * self,\t FOR_class3 * arg", 
+                            "C_return_code": "return;", 
+                            "C_return_type": "void", 
+                            "F_C_call": "c_class2_accept_class3", 
+                            "F_C_name": "c_class2_accept_class3", 
+                            "F_arg_c_call": "obj%cxxmem,\t arg%cxxmem", 
+                            "F_arguments": "obj,\t arg", 
+                            "F_call_code": "call c_class2_accept_class3(obj%cxxmem,\t arg%cxxmem)", 
+                            "F_name_function": "accept_class3", 
+                            "F_name_generic": "accept_class3", 
+                            "F_name_impl": "class2_accept_class3", 
+                            "F_subprogram": "subroutine", 
+                            "LUA_name": "acceptClass3", 
+                            "LUA_name_impl": "l_class2_accept_class3", 
+                            "PY_name_impl": "PY_class2_acceptClass3", 
+                            "c_const": "", 
+                            "c_deref": "*", 
+                            "c_member": "->", 
+                            "c_var": "self", 
+                            "function_name": "acceptClass3", 
+                            "underscore_name": "accept_class3"
+                        }, 
+                        "linenumber": 75, 
                         "options": {}
                     }
                 ], 
-                "linenumber": 67, 
+                "linenumber": 70, 
                 "name": "Class2", 
                 "options": {}, 
                 "typemap_name": "tutorial::Class2"
+            }, 
+            {
+                "cxx_header": "", 
+                "format": {
+                    "CXX_this_call": "SH_this->", 
+                    "C_header_filename": "wrapClass3.h", 
+                    "C_impl_filename": "wrapClass3.cpp", 
+                    "C_type_name": "FOR_class3", 
+                    "F_derived_name": "class3", 
+                    "LUA_class_reg": "l_Class3_Reg", 
+                    "LUA_ctor_name": "Class3", 
+                    "LUA_metadata": "Class3.metatable", 
+                    "LUA_this_call": "SH_this->self->", 
+                    "LUA_userdata_member": "self", 
+                    "LUA_userdata_type": "l_Class3_Type", 
+                    "LUA_userdata_var": "SH_this", 
+                    "PY_PyObject": "PY_Class3", 
+                    "PY_PyTypeObject": "PY_Class3_Type", 
+                    "PY_capsule_name": "PY_Class3_capsule_name", 
+                    "PY_from_object_func": "PP_Class3_from_Object", 
+                    "PY_this_call": "self->obj->", 
+                    "PY_to_object_func": "PP_Class3_to_Object", 
+                    "PY_type_filename": "pyClass3type.cpp", 
+                    "class_lower": "class3", 
+                    "class_prefix": "class3_", 
+                    "class_scope": "Class3::", 
+                    "class_upper": "CLASS3", 
+                    "cxx_class": "Class3"
+                }, 
+                "linenumber": 77, 
+                "name": "Class3", 
+                "options": {}, 
+                "typemap_name": "tutorial::Class3"
             }
         ], 
         "copyright": [
@@ -1240,7 +1390,7 @@
         "tutorial::Class1": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")", 
             "LUA_type": "LUA_TUSERDATA", 
-            "__line__": 59, 
+            "__line__": 62, 
             "base": "shadow", 
             "c_statements": {
                 "intent_in": {
@@ -1270,7 +1420,7 @@
             "f_c_type": "type(SHROUD_capsule_data)", 
             "f_derived_type": "class1", 
             "f_module": {
-                "__line__": 63, 
+                "__line__": 66, 
                 "tutorial_mod": [
                     "class1"
                 ]
@@ -1370,6 +1520,78 @@
                     "cxx_local_var": "pointer", 
                     "post_parse": [
                         "{c_const}tutorial::Class2 * {cxx_var} =\t {py_var} ? {py_var}->{PY_obj} : NULL;"
+                    ]
+                }, 
+                "intent_out": {
+                    "post_call": [
+                        "{PyObject} * {py_var} =\t PyObject_New({PyObject}, &{PyTypeObject});", 
+                        "{py_var}->{PY_obj} = {cxx_addr}{cxx_var};"
+                    ]
+                }
+            }
+        }, 
+        "tutorial::Class3": {
+            "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")", 
+            "LUA_type": "LUA_TUSERDATA", 
+            "PY_PyObject": "PY_Class3", 
+            "PY_PyTypeObject": "PY_Class3_Type", 
+            "PY_from_object": "PP_Class3_from_Object", 
+            "PY_to_object": "PP_Class3_to_Object", 
+            "base": "shadow", 
+            "c_statements": {
+                "intent_in": {
+                    "buf_args": [
+                        "shadow"
+                    ]
+                }, 
+                "result": {
+                    "c_header": "<stdlib.h>", 
+                    "cxx_header": "<stdlib.h>", 
+                    "post_call": [
+                        "FOR_class3 {c_var};", 
+                        "{c_var}.addr = {cxx_cast_to_void_ptr};", 
+                        "{c_var}.idtor = {idtor};"
+                    ]
+                }
+            }, 
+            "c_to_cxx": "static_cast<{c_const}tutorial::Class3 *>({c_var}{c_member}addr)", 
+            "c_type": "FOR_class3", 
+            "cxx_to_c": "static_cast<{c_const}void *>(\t{cxx_addr}{cxx_var})", 
+            "cxx_type": "tutorial::Class3", 
+            "f_c_module": {
+                "--import--": [
+                    "SHROUD_capsule_data"
+                ]
+            }, 
+            "f_c_type": "type(SHROUD_capsule_data)", 
+            "f_derived_type": "class3", 
+            "f_module": {
+                "forward_mod": [
+                    "class3"
+                ]
+            }, 
+            "f_statements": {
+                "result": {
+                    "call": [
+                        "{F_result}%{F_derived_member} = {F_C_call}({F_arg_c_call})"
+                    ], 
+                    "need_wrapper": true
+                }
+            }, 
+            "f_to_c": "{f_var}%cxxmem", 
+            "f_type": "type(class3)", 
+            "forward": "tutorial::Class3", 
+            "py_statements": {
+                "intent_in": {
+                    "cxx_local_var": "pointer", 
+                    "post_parse": [
+                        "{c_const}tutorial::Class3 * {cxx_var} =\t {py_var} ? {py_var}->{PY_obj} : NULL;"
+                    ]
+                }, 
+                "intent_inout": {
+                    "cxx_local_var": "pointer", 
+                    "post_parse": [
+                        "{c_const}tutorial::Class3 * {cxx_var} =\t {py_var} ? {py_var}->{PY_obj} : NULL;"
                     ]
                 }, 
                 "intent_out": {

--- a/regression/reference/forward/forward.log
+++ b/regression/reference/forward/forward.log
@@ -4,25 +4,33 @@ class Class2
 C method Class2()
 C method ~Class2()
 C method void func1(Class1 * arg +intent(in))
+C method void acceptClass3(Class3 * arg +intent(in))
 Close wrapClass2.h
 Close wrapClass2.cpp
+class Class3
 Close wrapforward.cpp
 Close typesforward.h
 class Class2
 C-interface, Fortran method Class2()
 C-interface, Fortran method ~Class2()
 C-interface, Fortran method void func1(Class1 * arg +intent(in))
+C-interface, Fortran method void acceptClass3(Class3 * arg +intent(in))
+class Class3
 Close wrapfforward.f
 class Class2
 Python method Class2()
 Python method ~Class2()
 Python method void func1(Class1 * arg +intent(in))
+Python method void acceptClass3(Class3 * arg +intent(in))
 Close pyClass2type.cpp
+class Class3
+Close pyClass3type.cpp
 Close pyforwardhelper.cpp
 Close pyforwardmodule.hpp
 Close pyforwardmodule.cpp
 Lua method Class2()
 Lua method ~Class2()
 Lua method void func1(Class1 * arg +intent(in))
+Lua method void acceptClass3(Class3 * arg +intent(in))
 Close luaforwardmodule.hpp
 Close luaforwardmodule.cpp

--- a/regression/reference/forward/forward_types.yaml
+++ b/regression/reference/forward/forward_types.yaml
@@ -54,3 +54,13 @@ declarations:
         f_module:
           forward_mod:
           - class2
+    - type: Class3
+      fields:
+        base: shadow
+        cxx_type: tutorial::Class3
+        c_type: FOR_class3
+        f_derived_type: class3
+        f_to_c: "{f_var}%cxxmem"
+        f_module:
+          forward_mod:
+          - class3

--- a/regression/reference/forward/luaforwardmodule.cpp
+++ b/regression/reference/forward/luaforwardmodule.cpp
@@ -95,14 +95,38 @@ static int l_class2_func1(lua_State *L)
     // splicer end class.Class2.method.func1
 }
 
+// void acceptClass3(Class3 * arg +intent(in))
+static int l_class2_accept_class3(lua_State *L)
+{
+    // splicer begin class.Class2.method.acceptClass3
+    tutorial::Class3 * arg = static_cast<tutorial::Class3 *>(
+        (l_Class2_Type *) luaL_checkudata(
+        L, 1, "Class2.metatable")->addr);
+    l_Class2_Type * SH_this = (l_Class2_Type *) luaL_checkudata(
+        L, 1, "Class2.metatable");
+    SH_this->self->acceptClass3(arg);
+    return 0;
+    // splicer end class.Class2.method.acceptClass3
+}
+
 // splicer begin class.Class2.additional_functions
 // splicer end class.Class2.additional_functions
 
 static const struct luaL_Reg l_Class2_Reg [] = {
     {"__gc", l_class2_dtor},
     {"func1", l_class2_func1},
+    {"acceptClass3", l_class2_accept_class3},
     // splicer begin class.Class2.register
     // splicer end class.Class2.register
+    {NULL, NULL}   /*sentinel */
+};
+
+// splicer begin class.Class3.additional_functions
+// splicer end class.Class3.additional_functions
+
+static const struct luaL_Reg l_Class3_Reg [] = {
+    // splicer begin class.Class3.register
+    // splicer end class.Class3.register
     {NULL, NULL}   /*sentinel */
 };
 
@@ -138,6 +162,26 @@ int luaopen_forward(lua_State *L) {
     luaL_register(L, NULL, l_Class2_Reg);
 #else
     luaL_setfuncs(L, l_Class2_Reg, 0);
+#endif
+
+
+    /* Create the metatable and put it on the stack. */
+    luaL_newmetatable(L, "Class3.metatable");
+    /* Duplicate the metatable on the stack (We now have 2). */
+    lua_pushvalue(L, -1);
+    /* Pop the first metatable off the stack and assign it to __index
+     * of the second one. We set the metatable for the table to itself.
+     * This is equivalent to the following in lua:
+     * metatable = {}
+     * metatable.__index = metatable
+     */
+    lua_setfield(L, -2, "__index");
+
+    /* Set the methods to the metatable that should be accessed via object:func */
+#if LUA_VERSION_NUM < 502
+    luaL_register(L, NULL, l_Class3_Reg);
+#else
+    luaL_setfuncs(L, l_Class3_Reg, 0);
 #endif
 
 

--- a/regression/reference/forward/luaforwardmodule.hpp
+++ b/regression/reference/forward/luaforwardmodule.hpp
@@ -55,6 +55,14 @@ typedef struct {
     // splicer begin class.Class2.C_object
     // splicer end class.Class2.C_object
 } l_Class2_Type;
+// splicer begin class.Class3.C_declaration
+// splicer end class.Class3.C_declaration
+
+typedef struct {
+    tutorial::Class3 * self;
+    // splicer begin class.Class3.C_object
+    // splicer end class.Class3.C_object
+} l_Class3_Type;
 
 int luaopen_forward(lua_State *L);
 

--- a/regression/reference/forward/output
+++ b/regression/reference/forward/output
@@ -5,6 +5,7 @@ Wrote wrapforward.cpp
 Wrote typesforward.h
 Wrote wrapfforward.f
 Wrote pyClass2type.cpp
+Wrote pyClass3type.cpp
 Wrote pyforwardhelper.cpp
 Wrote pyforwardmodule.hpp
 Wrote pyforwardmodule.cpp

--- a/regression/reference/forward/pyClass3type.cpp
+++ b/regression/reference/forward/pyClass3type.cpp
@@ -1,4 +1,4 @@
-// pyClass2type.cpp
+// pyClass3type.cpp
 // This is generated code, do not edit
 // #######################################################################
 // Copyright (c) 2018, Lawrence Livermore National Security, LLC.
@@ -42,8 +42,8 @@
 // #######################################################################
 #include "pyforwardmodule.hpp"
 #include "tutorial.hpp"
-// splicer begin class.Class2.impl.include
-// splicer end class.Class2.impl.include
+// splicer begin class.Class3.impl.include
+// splicer end class.Class3.impl.include
 
 #ifdef __cplusplus
 #define SHROUD_UNUSED(param)
@@ -56,110 +56,35 @@
 #define PyString_FromString PyUnicode_FromString
 #define PyString_FromStringAndSize PyUnicode_FromStringAndSize
 #endif
-// splicer begin class.Class2.impl.C_definition
-// splicer end class.Class2.impl.C_definition
-// splicer begin class.Class2.impl.additional_methods
-// splicer end class.Class2.impl.additional_methods
+// splicer begin class.Class3.impl.C_definition
+// splicer end class.Class3.impl.C_definition
+// splicer begin class.Class3.impl.additional_methods
+// splicer end class.Class3.impl.additional_methods
 static void
-PY_Class2_tp_del (PY_Class2 *self)
+PY_Class3_tp_del (PY_Class3 *self)
 {
-// splicer begin class.Class2.type.del
+// splicer begin class.Class3.type.del
     delete self->obj;
     self->obj = NULL;
-// splicer end class.Class2.type.del
+// splicer end class.Class3.type.del
 }
-
-static int
-PY_Class2_tp_init(
-  PY_Class2 *self,
-  PyObject *SHROUD_UNUSED(args),
-  PyObject *SHROUD_UNUSED(kwds))
-{
-// Class2()
-// splicer begin class.Class2.method.ctor
-    self->obj = new tutorial::Class2();
-    return 0;
-// splicer end class.Class2.method.ctor
-}
-
-static char PY_class2_func1__doc__[] =
-"documentation"
-;
-
-static PyObject *
-PY_class2_func1(
-  PY_Class2 *self,
-  PyObject *args,
-  PyObject *kwds)
-{
-// void func1(Class1 * arg +intent(in))
-// splicer begin class.Class2.method.func1
-    TUT_class1 arg;
-    const char *SHT_kwlist[] = {
-        "arg",
-        NULL };
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O:func1",
-        const_cast<char **>(SHT_kwlist), &arg))
-        return NULL;
-
-    // post_parse
-    tutorial::Class1 * SH_arg = SHPy_arg ? SHPy_arg->obj : NULL;
-
-    self->obj->func1(SH_arg);
-    Py_RETURN_NONE;
-// splicer end class.Class2.method.func1
-}
-
-static char PY_class2_acceptClass3__doc__[] =
-"documentation"
-;
-
-static PyObject *
-PY_class2_acceptClass3(
-  PY_Class2 *self,
-  PyObject *args,
-  PyObject *kwds)
-{
-// void acceptClass3(Class3 * arg +intent(in))
-// splicer begin class.Class2.method.accept_class3
-    PY_Class3 * SHPy_arg;
-    const char *SHT_kwlist[] = {
-        "arg",
-        NULL };
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!:acceptClass3",
-        const_cast<char **>(SHT_kwlist), &PY_Class3_Type, &SHPy_arg))
-        return NULL;
-
-    // post_parse
-    tutorial::Class3 * arg = SHPy_arg ? SHPy_arg->obj : NULL;
-
-    self->obj->acceptClass3(arg);
-    Py_RETURN_NONE;
-// splicer end class.Class2.method.accept_class3
-}
-// splicer begin class.Class2.impl.after_methods
-// splicer end class.Class2.impl.after_methods
-static PyMethodDef PY_Class2_methods[] = {
-    {"func1", (PyCFunction)PY_class2_func1, METH_VARARGS|METH_KEYWORDS,
-        PY_class2_func1__doc__},
-    {"acceptClass3", (PyCFunction)PY_class2_acceptClass3,
-        METH_VARARGS|METH_KEYWORDS, PY_class2_acceptClass3__doc__},
-    // splicer begin class.Class2.PyMethodDef
-    // splicer end class.Class2.PyMethodDef
+// splicer begin class.Class3.impl.after_methods
+// splicer end class.Class3.impl.after_methods
+static PyMethodDef PY_Class3_methods[] = {
+    // splicer begin class.Class3.PyMethodDef
+    // splicer end class.Class3.PyMethodDef
     {NULL,   (PyCFunction)NULL, 0, NULL}            /* sentinel */
 };
 
-static char Class2__doc__[] =
+static char Class3__doc__[] =
 "virtual class"
 ;
 
 /* static */
-PyTypeObject PY_Class2_Type = {
+PyTypeObject PY_Class3_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "forward.Class2",                       /* tp_name */
-    sizeof(PY_Class2),         /* tp_basicsize */
+    "forward.Class3",                       /* tp_name */
+    sizeof(PY_Class3),         /* tp_basicsize */
     0,                              /* tp_itemsize */
     /* Methods to implement standard operations */
     (destructor)0,                 /* tp_dealloc */
@@ -186,7 +111,7 @@ PyTypeObject PY_Class2_Type = {
     0,                              /* tp_as_buffer */
     /* Flags to define presence of optional/expanded features */
     Py_TPFLAGS_DEFAULT,             /* tp_flags */
-    Class2__doc__,         /* tp_doc */
+    Class3__doc__,         /* tp_doc */
     /* Assigned meaning in release 2.0 */
     /* call function for all accessible objects */
     (traverseproc)0,                /* tp_traverse */
@@ -202,7 +127,7 @@ PyTypeObject PY_Class2_Type = {
     (getiterfunc)0,                 /* tp_iter */
     (iternextfunc)0,                /* tp_iternext */
     /* Attribute descriptor and subclassing stuff */
-    PY_Class2_methods,                             /* tp_methods */
+    PY_Class3_methods,                             /* tp_methods */
     0,                              /* tp_members */
     0,                             /* tp_getset */
     0,                              /* tp_base */
@@ -210,7 +135,7 @@ PyTypeObject PY_Class2_Type = {
     (descrgetfunc)0,                /* tp_descr_get */
     (descrsetfunc)0,                /* tp_descr_set */
     0,                              /* tp_dictoffset */
-    (initproc)PY_Class2_tp_init,                   /* tp_init */
+    (initproc)0,                   /* tp_init */
     (allocfunc)0,                  /* tp_alloc */
     (newfunc)0,                    /* tp_new */
     (freefunc)0,                   /* tp_free */
@@ -220,7 +145,7 @@ PyTypeObject PY_Class2_Type = {
     0,                              /* tp_cache */
     0,                              /* tp_subclasses */
     0,                              /* tp_weaklist */
-    (destructor)PY_Class2_tp_del,                 /* tp_del */
+    (destructor)PY_Class3_tp_del,                 /* tp_del */
     0,                              /* tp_version_tag */
 #if PY_MAJOR_VERSION >= 3
     (destructor)0,                  /* tp_finalize */

--- a/regression/reference/forward/pyforwardhelper.cpp
+++ b/regression/reference/forward/pyforwardhelper.cpp
@@ -42,6 +42,7 @@
 // #######################################################################
 #include "pyforwardmodule.hpp"
 const char *PY_Class2_capsule_name = "Class2";
+const char *PY_Class3_capsule_name = "Class3";
 
 
 PyObject *PP_Class2_to_Object(tutorial::Class2 *addr)
@@ -71,4 +72,33 @@ int PP_Class2_from_Object(PyObject *obj, void **addr)
     *addr = self->obj;
     return 1;
     // splicer end class.Class2.helper.from_object
+}
+
+PyObject *PP_Class3_to_Object(tutorial::Class3 *addr)
+{
+    // splicer begin class.Class3.helper.to_object
+    PyObject *voidobj;
+    PyObject *args;
+    PyObject *rv;
+
+    voidobj = PyCapsule_New(addr, PY_Class3_capsule_name, NULL);
+    args = PyTuple_New(1);
+    PyTuple_SET_ITEM(args, 0, voidobj);
+    rv = PyObject_Call((PyObject *) &PY_Class3_Type, args, NULL);
+    Py_DECREF(args);
+    return rv;
+    // splicer end class.Class3.helper.to_object
+}
+
+int PP_Class3_from_Object(PyObject *obj, void **addr)
+{
+    // splicer begin class.Class3.helper.from_object
+    if (obj->ob_type != &PY_Class3_Type) {
+        // raise exception
+        return 0;
+    }
+    PY_Class3 * self = (PY_Class3 *) obj;
+    *addr = self->obj;
+    return 1;
+    // splicer end class.Class3.helper.from_object
 }

--- a/regression/reference/forward/pyforwardmodule.cpp
+++ b/regression/reference/forward/pyforwardmodule.cpp
@@ -152,6 +152,15 @@ initforward(void)
     PyModule_AddObject(m, "Class2", (PyObject *)&PY_Class2_Type);
 
 
+    // Class3
+    PY_Class3_Type.tp_new   = PyType_GenericNew;
+    PY_Class3_Type.tp_alloc = PyType_GenericAlloc;
+    if (PyType_Ready(&PY_Class3_Type) < 0)
+        return RETVAL;
+    Py_INCREF(&PY_Class3_Type);
+    PyModule_AddObject(m, "Class3", (PyObject *)&PY_Class3_Type);
+
+
     PY_error_obj = PyErr_NewException((char *) error_name, NULL, NULL);
     if (PY_error_obj == NULL)
         return RETVAL;

--- a/regression/reference/forward/pyforwardmodule.hpp
+++ b/regression/reference/forward/pyforwardmodule.hpp
@@ -50,16 +50,23 @@
 namespace tutorial {
     class Class2;
 }
+namespace tutorial {
+    class Class3;
+}
 
 extern PyTypeObject PY_Class2_Type;
+extern PyTypeObject PY_Class3_Type;
 
 // splicer begin header.C_declaration
 // splicer end header.C_declaration
 
 // helper functions
 extern const char *PY_Class2_capsule_name;
+extern const char *PY_Class3_capsule_name;
 PyObject *PP_Class2_to_Object(tutorial::Class2 *addr);
 int PP_Class2_from_Object(PyObject *obj, void **addr);
+PyObject *PP_Class3_to_Object(tutorial::Class3 *addr);
+int PP_Class3_from_Object(PyObject *obj, void **addr);
 
 // splicer begin class.Class2.C_declaration
 // splicer end class.Class2.C_declaration
@@ -70,6 +77,15 @@ PyObject_HEAD
     // splicer begin class.Class2.C_object
     // splicer end class.Class2.C_object
 } PY_Class2;
+// splicer begin class.Class3.C_declaration
+// splicer end class.Class3.C_declaration
+
+typedef struct {
+PyObject_HEAD
+    tutorial::Class3 * obj;
+    // splicer begin class.Class3.C_object
+    // splicer end class.Class3.C_object
+} PY_Class3;
 
 extern PyObject *PY_error_obj;
 

--- a/regression/reference/forward/typesforward.h
+++ b/regression/reference/forward/typesforward.h
@@ -56,6 +56,12 @@ struct s_FOR_class2 {
 };
 typedef struct s_FOR_class2 FOR_class2;
 
+struct s_FOR_class3 {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_FOR_class3 FOR_class3;
+
 struct s_FOR_SHROUD_capsule_data {
     void *addr;     /* address of C++ memory */
     int idtor;      /* index of destructor */

--- a/regression/reference/forward/wrapClass2.cpp
+++ b/regression/reference/forward/wrapClass2.cpp
@@ -89,4 +89,17 @@ void FOR_class2_func1(FOR_class2 * self, TUT_class1 * arg)
 // splicer end class.Class2.method.func1
 }
 
+// void acceptClass3(Class3 * arg +intent(in))
+void FOR_class2_accept_class3(FOR_class2 * self, FOR_class3 * arg)
+{
+// splicer begin class.Class2.method.accept_class3
+    tutorial::Class2 *SH_this =
+        static_cast<tutorial::Class2 *>(self->addr);
+    tutorial::Class3 * SHCXX_arg =
+        static_cast<tutorial::Class3 *>(arg->addr);
+    SH_this->acceptClass3(SHCXX_arg);
+    return;
+// splicer end class.Class2.method.accept_class3
+}
+
 }  // extern "C"

--- a/regression/reference/forward/wrapClass2.h
+++ b/regression/reference/forward/wrapClass2.h
@@ -67,6 +67,8 @@ void FOR_class2_dtor(FOR_class2 * self);
 
 void FOR_class2_func1(FOR_class2 * self, TUT_class1 * arg);
 
+void FOR_class2_accept_class3(FOR_class2 * self, FOR_class3 * arg);
+
 #ifdef __cplusplus
 }
 #endif

--- a/shroud/ast.py
+++ b/shroud/ast.py
@@ -126,6 +126,7 @@ class NamespaceMixin(object):
 
     def create_class_typemap(self, key, **kwargs):
         """Add a typemap for a class.
+        The class is being forward declared i.e. no declarations.
         """
         self.add_typedef(key)
         fullname = self.scope + key

--- a/shroud/typemap.py
+++ b/shroud/typemap.py
@@ -1067,33 +1067,32 @@ def create_enum_typemap(node):
         register_type(type_name, ntypemap)
     return ntypemap
 
-def create_class_typemap(cls):
-    """Create a typemap for a class.
+def create_class_typemap(node):
+    """Create a typemap from a ClassNode.
 
     The C type is a capsule_data which will contains a pointer to the
     C++ memory and information on how to delete the memory.
     """
-    fmt_class = cls.fmtdict
+    fmt_class = node.fmtdict
     cxx_name = util.wformat('{namespace_scope}{cxx_class}', fmt_class)
 
     ntypemap = lookup_type(cxx_name)
-    if ntypemap is None:
-        # unname = util.un_camel(name)
-        f_name = cls.name.lower()
-        c_name = fmt_class.C_prefix + f_name
-        ntypemap = Typemap(
-            cxx_name,
-            base='shadow',
-            cxx_type=cxx_name,
-            cxx_header=cls.cxx_header or None,
-            c_type=c_name,
-            f_derived_type=fmt_class.F_derived_name,
-            f_module={fmt_class.F_module_name:[fmt_class.F_derived_name]},
-            ##- f_to_c='{f_var}%%%s()' % fmt_class.F_name_instance_get, # XXX - develop test
-            f_to_c='{f_var}%%%s' % fmt_class.F_derived_member,
-            )
-        fill_shadow_typemap_defaults(ntypemap, fmt_class)
-        register_type(cxx_name, ntypemap)
+    # unname = util.un_camel(name)
+    f_name = node.name.lower()
+    c_name = fmt_class.C_prefix + f_name
+    ntypemap = Typemap(
+        cxx_name,
+        base='shadow',
+        cxx_type=cxx_name,
+        cxx_header=node.cxx_header or None,
+        c_type=c_name,
+        f_derived_type=fmt_class.F_derived_name,
+        f_module={fmt_class.F_module_name:[fmt_class.F_derived_name]},
+        ##- f_to_c='{f_var}%%%s()' % fmt_class.F_name_instance_get, # XXX - develop test
+        f_to_c='{f_var}%%%s' % fmt_class.F_derived_member,
+    )
+    fill_shadow_typemap_defaults(ntypemap, fmt_class)
+    register_type(cxx_name, ntypemap)
 
     fmt_class.C_type_name = ntypemap.c_type
     return ntypemap
@@ -1189,28 +1188,26 @@ def fill_shadow_typemap_defaults(ntypemap, fmt):
     ntypemap.forward = ntypemap.cxx_type
 
 
-def create_struct_typemap(cls):
-    """Create a typemap for a struct.
+def create_struct_typemap(node):
+    """Create a typemap for a struct from a ClassNode.
     """
-    fmt_class = cls.fmtdict
+    fmt_class = node.fmtdict
     cxx_name = util.wformat('{namespace_scope}{cxx_class}', fmt_class)
 
-    ntypemap = lookup_type(cxx_name)
-    if ntypemap is None:
-        # unname = util.un_camel(name)
-        f_name = cls.name.lower()
-        c_name = fmt_class.C_prefix + f_name
-        ntypemap = Typemap(
-            cxx_name,
-            base='struct',
-            cxx_type=cxx_name,
-            c_type=c_name,
-            f_derived_type=fmt_class.F_derived_name,
-            f_module={fmt_class.F_module_name:[fmt_class.F_derived_name]},
-            PYN_descr=fmt_class.PY_struct_array_descr_variable,
-        )
-        fill_struct_typemap_defaults(ntypemap)
-        register_type(cxx_name, ntypemap)
+    # unname = util.un_camel(name)
+    f_name = node.name.lower()
+    c_name = fmt_class.C_prefix + f_name
+    ntypemap = Typemap(
+        cxx_name,
+        base='struct',
+        cxx_type=cxx_name,
+        c_type=c_name,
+        f_derived_type=fmt_class.F_derived_name,
+        f_module={fmt_class.F_module_name:[fmt_class.F_derived_name]},
+        PYN_descr=fmt_class.PY_struct_array_descr_variable,
+    )
+    fill_struct_typemap_defaults(ntypemap)
+    register_type(cxx_name, ntypemap)
 
     fmt_class.C_type_name = ntypemap.c_type
     return ntypemap


### PR DESCRIPTION
Looks like it was introduced when tabs were removed from the scope.
The tabs were accidentially causing create_class_typemap to always
create a typemap, like it should. Now explicitly, always create
typemap.  scope::\tname != scope::name