### PR TITLE
Create a capsule derived type for each class

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -389,6 +389,12 @@ F_abstract_interface_subprogram_template
    Defaults to ``arg{index}`` where *index* is the 0-based argument index.
    see :ref:`TypesAnchor_Function_Pointers`.
 
+F_capsule_data_type_class_template
+    Name of the derived type which is the ``BIND(C)`` equivalent of the
+    struct used to implement a shadow class.
+    Each class must have a unique name.
+    Defaults to ``SHROUD_{class_lower}_capsule``.
+
 F_enum_member_template
     Name of enumeration member in Fortran wrapper.
     ``{class_prefix}{enum_lower}_{enum_member_lower}``

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1061,13 +1061,13 @@ pointers for every instance::
 
 For Fortran a derived type is created::
 
-    type, bind(C) :: SHROUD_capsule_data
+    type, bind(C) :: SHROUD_class1_capsule
         type(C_PTR) :: addr = C_NULL_PTR  ! address of C++ memory
         integer(C_INT) :: idtor = 0       ! index of destructor
     end type SHROUD_capsule_data
 
     type class1
-        type(SHROUD_capsule_data), private :: cxxmem
+        type(SHROUD_class1_capsule), private :: cxxmem
     contains
         procedure :: method1 => class1_method1
     end type class1
@@ -1140,7 +1140,7 @@ This produces the C code::
 The derived type has a function with the ``NOPASS`` keyword::
 
     type singleton
-        type(SHROUD_capsule_data), private :: cxxmem
+        type(SHROUD_singleton_capsule), private :: cxxmem
     contains
         procedure, nopass :: get_reference => singleton_get_reference
     end type singleton

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -1206,11 +1206,14 @@ used to release POD pointers; otherwise, ``delete`` will be used.
 C and Fortran
 -------------
 
+.. XXX They can be set from the template *F_capsule_data_type_class_template*.
+   Need C template too.
+
 Fortran keeps track of C++ objects with the struct
 **C_capsule_data_type** and the ``bind(C)`` equivalent
 **F_capsule_data_type**. Their names default to
-``{C_prefix}SHROUD_capsule_data`` and ``SHROUD_capsule_data``. In the
-Tutorial these types are defined in C as::
+``{C_prefix}SHROUD_capsule_data`` and ``SHROUD_{class_lower}_capsule``.
+In the Tutorial these types are defined in C as::
 
     struct s_TUT_class1 {
         void *addr;     /* address of C++ memory */
@@ -1220,10 +1223,10 @@ Tutorial these types are defined in C as::
 
 And Fortran::
 
-    type, bind(C) :: SHROUD_capsule_data
+    type, bind(C) :: SHROUD_class1_capsule
         type(C_PTR) :: addr = C_NULL_PTR  ! address of C++ memory
         integer(C_INT) :: idtor = 0       ! index of destructor
-    end type SHROUD_capsule_data
+    end type SHROUD_class1_capsule
 
 *addr* is the address of the C or C++ variable, such as a ``char *``
 or ``std::string *``.  *idtor* is a Shroud generated index of the

--- a/regression/example.yaml
+++ b/regression/example.yaml
@@ -77,10 +77,10 @@ typemap:
     cxx_header: sidre/Group.hpp
     c_header: sidre/wrapGroup.h
     c_type: SIDRE_group
+    f_module_name: sidre_mod
     f_derived_type: datagroup
+    f_capsule_data_type: SHROUD_group_capsule
     f_to_c: '{f_var}%get_instance()'
-    f_module:
-      sidre_mod: [ group ]
     PY_PyTypeObject: FillInTypeForGroup
 
 declarations:

--- a/regression/forward.yaml
+++ b/regression/forward.yaml
@@ -61,11 +61,10 @@ typemap:
     base: shadow
 # cxx_type : defaults to type
     c_type: TUT_class1
+    f_module_name: tutorial_mod
     f_derived_type: class1
+    f_capsule_data_type: custom_capsule
     f_to_c: "{f_var}%get_instance()"
-    f_module:
-      tutorial_mod:
-      - class1
 
 declarations:
 - decl: class Class3

--- a/regression/reference/clibrary/clibrary.json
+++ b/regression/reference/clibrary/clibrary.json
@@ -1956,6 +1956,7 @@
             "F_abstract_interface_argument_template": "arg{index}", 
             "F_abstract_interface_subprogram_template": "{underscore_name}_{argname}", 
             "F_auto_reference_count": false, 
+            "F_capsule_data_type_class_template": "SHROUD_{class_lower}_capsule", 
             "F_enum_member_template": "{class_prefix}{enum_lower}_{enum_member_lower}", 
             "F_force_wrapper": false, 
             "F_impl_filename_class_template": "wrapf{cxx_class}.{F_filename_suffix}", 

--- a/regression/reference/example/example.json
+++ b/regression/reference/example/example.json
@@ -9,6 +9,7 @@
                     "C_header_filename": "wrapExClass1.h", 
                     "C_impl_filename": "wrapExClass1.cpp", 
                     "C_type_name": "AA_exclass1", 
+                    "F_capsule_data_type": "SHROUD_exclass1_capsule", 
                     "F_derived_name": "exclass1", 
                     "F_impl_filename": "wrapfExClass1.f", 
                     "F_module_name": "exclass1_mod", 
@@ -1899,6 +1900,7 @@
                     "C_header_filename": "wrapExClass2.h", 
                     "C_impl_filename": "wrapExClass2.cpp", 
                     "C_type_name": "AA_exclass2", 
+                    "F_capsule_data_type": "SHROUD_exclass2_capsule", 
                     "F_derived_name": "exclass2", 
                     "F_impl_filename": "wrapfExClass2.f", 
                     "F_module_name": "exclass2_mod", 
@@ -4942,6 +4944,7 @@
                     "C_header_filename": "wrapExClass3.h", 
                     "C_impl_filename": "wrapExClass3.cpp", 
                     "C_type_name": "AA_exclass3", 
+                    "F_capsule_data_type": "SHROUD_exclass3_capsule", 
                     "F_derived_name": "exclass3", 
                     "F_impl_filename": "wrapfExClass3.f", 
                     "F_module_name": "exclass3_mod", 
@@ -9311,6 +9314,7 @@
             "F_abstract_interface_argument_template": "arg{index}", 
             "F_abstract_interface_subprogram_template": "{underscore_name}_{argname}", 
             "F_auto_reference_count": false, 
+            "F_capsule_data_type_class_template": "SHROUD_{class_lower}_capsule", 
             "F_enum_member_template": "{class_prefix}{enum_lower}_{enum_member_lower}", 
             "F_force_wrapper": false, 
             "F_impl_filename_class_template": "wrapf{cxx_class}.{F_filename_suffix}", 
@@ -9459,18 +9463,19 @@
             "cxx_to_c": "static_cast<{c_const}void *>(\t{cxx_addr}{cxx_var})", 
             "cxx_type": "axom::sidre::Group", 
             "f_c_module": {
-                "--import--": [
-                    "SHROUD_capsule_data"
+                "sidre_mod": [
+                    "SHROUD_group_capsule"
                 ]
             }, 
-            "f_c_type": "type(SHROUD_capsule_data)", 
+            "f_c_type": "type(SHROUD_group_capsule)", 
+            "f_capsule_data_type": "SHROUD_group_capsule", 
             "f_derived_type": "datagroup", 
             "f_module": {
-                "__line__": 82, 
                 "sidre_mod": [
-                    "group"
+                    "datagroup"
                 ]
             }, 
+            "f_module_name": "sidre_mod", 
             "f_statements": {
                 "result": {
                     "call": [
@@ -9791,16 +9796,18 @@
             "cxx_type": "example::nested::ExClass1", 
             "f_c_module": {
                 "--import--": [
-                    "SHROUD_capsule_data"
+                    "SHROUD_exclass1_capsule"
                 ]
             }, 
-            "f_c_type": "type(SHROUD_capsule_data)", 
+            "f_c_type": "type(SHROUD_exclass1_capsule)", 
+            "f_capsule_data_type": "SHROUD_exclass1_capsule", 
             "f_derived_type": "exclass1", 
             "f_module": {
                 "exclass1_mod": [
                     "exclass1"
                 ]
             }, 
+            "f_module_name": "exclass1_mod", 
             "f_statements": {
                 "result": {
                     "call": [
@@ -9864,16 +9871,18 @@
             "cxx_type": "example::nested::ExClass2", 
             "f_c_module": {
                 "--import--": [
-                    "SHROUD_capsule_data"
+                    "SHROUD_exclass2_capsule"
                 ]
             }, 
-            "f_c_type": "type(SHROUD_capsule_data)", 
+            "f_c_type": "type(SHROUD_exclass2_capsule)", 
+            "f_capsule_data_type": "SHROUD_exclass2_capsule", 
             "f_derived_type": "exclass2", 
             "f_module": {
                 "exclass2_mod": [
                     "exclass2"
                 ]
             }, 
+            "f_module_name": "exclass2_mod", 
             "f_statements": {
                 "result": {
                     "call": [
@@ -9932,16 +9941,18 @@
             "cxx_type": "example::nested::ExClass3", 
             "f_c_module": {
                 "--import--": [
-                    "SHROUD_capsule_data"
+                    "SHROUD_exclass3_capsule"
                 ]
             }, 
-            "f_c_type": "type(SHROUD_capsule_data)", 
+            "f_c_type": "type(SHROUD_exclass3_capsule)", 
+            "f_capsule_data_type": "SHROUD_exclass3_capsule", 
             "f_derived_type": "exclass3", 
             "f_module": {
                 "exclass3_mod": [
                     "exclass3"
                 ]
             }, 
+            "f_module_name": "exclass3_mod", 
             "f_statements": {
                 "result": {
                     "call": [

--- a/regression/reference/example/userlibrary_types.yaml
+++ b/regression/reference/example/userlibrary_types.yaml
@@ -51,29 +51,26 @@ declarations:
           cxx_header: ExClass1.hpp
           cxx_type: example::nested::ExClass1
           c_type: AA_exclass1
+          f_module_name: exclass1_mod
           f_derived_type: exclass1
+          f_capsule_data_type: SHROUD_exclass1_capsule
           f_to_c: "{f_var}%cxxmem"
-          f_module:
-            exclass1_mod:
-            - exclass1
       - type: ExClass2
         fields:
           base: shadow
           cxx_header: ExClass2.hpp
           cxx_type: example::nested::ExClass2
           c_type: AA_exclass2
+          f_module_name: exclass2_mod
           f_derived_type: exclass2
+          f_capsule_data_type: SHROUD_exclass2_capsule
           f_to_c: "{f_var}%cxxmem"
-          f_module:
-            exclass2_mod:
-            - exclass2
       - type: ExClass3
         fields:
           base: shadow
           cxx_type: example::nested::ExClass3
           c_type: AA_exclass3
+          f_module_name: exclass3_mod
           f_derived_type: exclass3
+          f_capsule_data_type: SHROUD_exclass3_capsule
           f_to_c: "{f_var}%cxxmem"
-          f_module:
-            exclass3_mod:
-            - exclass3

--- a/regression/reference/example/wrapfExClass1.f
+++ b/regression/reference/example/wrapfExClass1.f
@@ -68,8 +68,13 @@ module exclass1_mod
     top of module splicer  1
     ! splicer end class.ExClass1.module_top
 
+    type, bind(C) :: SHROUD_exclass1_capsule
+        type(C_PTR) :: addr = C_NULL_PTR  ! address of C++ memory
+        integer(C_INT) :: idtor = 0       ! index of destructor
+    end type SHROUD_exclass1_capsule
+
     type exclass1
-        type(SHROUD_capsule_data) :: cxxmem
+        type(SHROUD_exclass1_capsule) :: cxxmem
         ! splicer begin class.ExClass1.component_part
           component part 1a
           component part 1b
@@ -109,9 +114,9 @@ module exclass1_mod
                 result(SHT_rv) &
                 bind(C, name="AA_exclass1_ctor_0")
             use iso_c_binding, only : C_PTR
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(OUT) :: SHT_crv
+            type(SHROUD_exclass1_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_exclass1_ctor_0
 
@@ -119,10 +124,10 @@ module exclass1_mod
                 result(SHT_rv) &
                 bind(C, name="AA_exclass1_ctor_1")
             use iso_c_binding, only : C_CHAR, C_PTR
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass1_capsule
             implicit none
             character(kind=C_CHAR), intent(IN) :: name(*)
-            type(SHROUD_capsule_data), intent(OUT) :: SHT_crv
+            type(SHROUD_exclass1_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_exclass1_ctor_1
 
@@ -130,28 +135,28 @@ module exclass1_mod
                 result(SHT_rv) &
                 bind(C, name="AA_exclass1_ctor_1_bufferify")
             use iso_c_binding, only : C_CHAR, C_INT, C_PTR
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass1_capsule
             implicit none
             character(kind=C_CHAR), intent(IN) :: name(*)
             integer(C_INT), value, intent(IN) :: Lname
-            type(SHROUD_capsule_data), intent(OUT) :: SHT_crv
+            type(SHROUD_exclass1_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_exclass1_ctor_1_bufferify
 
         subroutine c_exclass1_dtor(self) &
                 bind(C, name="AA_exclass1_dtor")
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass1_capsule), intent(IN) :: self
         end subroutine c_exclass1_dtor
 
         function c_exclass1_increment_count(self, incr) &
                 result(SHT_rv) &
                 bind(C, name="AA_exclass1_increment_count")
             use iso_c_binding, only : C_INT
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass1_capsule), intent(IN) :: self
             integer(C_INT), value, intent(IN) :: incr
             integer(C_INT) :: SHT_rv
         end function c_exclass1_increment_count
@@ -160,9 +165,9 @@ module exclass1_mod
                 result(SHT_rv) &
                 bind(C, name="AA_exclass1_get_name_error_pattern")
             use iso_c_binding, only : C_PTR
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass1_capsule), intent(IN) :: self
             type(C_PTR) SHT_rv
         end function c_exclass1_get_name_error_pattern
 
@@ -170,9 +175,9 @@ module exclass1_mod
                 SHF_rv, NSHF_rv) &
                 bind(C, name="AA_exclass1_get_name_error_pattern_bufferify")
             use iso_c_binding, only : C_CHAR, C_INT
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass1_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(OUT) :: SHF_rv(*)
             integer(C_INT), value, intent(IN) :: NSHF_rv
         end subroutine c_exclass1_get_name_error_pattern_bufferify
@@ -181,9 +186,9 @@ module exclass1_mod
                 result(SHT_rv) &
                 bind(C, name="AA_exclass1_get_name_length")
             use iso_c_binding, only : C_INT
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass1_capsule), intent(IN) :: self
             integer(C_INT) :: SHT_rv
         end function c_exclass1_get_name_length
 
@@ -191,18 +196,18 @@ module exclass1_mod
                 result(SHT_rv) &
                 bind(C, name="AA_exclass1_get_name_error_check")
             use iso_c_binding, only : C_PTR
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass1_capsule), intent(IN) :: self
             type(C_PTR) SHT_rv
         end function c_exclass1_get_name_error_check
 
         subroutine c_exclass1_get_name_error_check_bufferify(self, &
                 DSHF_rv) &
                 bind(C, name="AA_exclass1_get_name_error_check_bufferify")
-            import :: SHROUD_array, SHROUD_capsule_data
+            import :: SHROUD_array, SHROUD_exclass1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass1_capsule), intent(IN) :: self
             type(SHROUD_array), intent(INOUT) :: DSHF_rv
         end subroutine c_exclass1_get_name_error_check_bufferify
 
@@ -210,18 +215,18 @@ module exclass1_mod
                 result(SHT_rv) &
                 bind(C, name="AA_exclass1_get_name_arg")
             use iso_c_binding, only : C_PTR
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass1_capsule), intent(IN) :: self
             type(C_PTR) SHT_rv
         end function c_exclass1_get_name_arg
 
         subroutine c_exclass1_get_name_arg_bufferify(self, name, Nname) &
                 bind(C, name="AA_exclass1_get_name_arg_bufferify")
             use iso_c_binding, only : C_CHAR, C_INT
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass1_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(OUT) :: name(*)
             integer(C_INT), value, intent(IN) :: Nname
         end subroutine c_exclass1_get_name_arg_bufferify
@@ -230,9 +235,9 @@ module exclass1_mod
                 result(SHT_rv) &
                 bind(C, name="AA_exclass1_get_root")
             use iso_c_binding, only : C_PTR
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass1_capsule), intent(IN) :: self
             type(C_PTR) :: SHT_rv
         end function c_exclass1_get_root
 
@@ -240,9 +245,9 @@ module exclass1_mod
                 result(SHT_rv) &
                 bind(C, name="AA_exclass1_get_value_from_int")
             use iso_c_binding, only : C_INT
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass1_capsule), intent(IN) :: self
             integer(C_INT), value, intent(IN) :: value
             integer(C_INT) :: SHT_rv
         end function c_exclass1_get_value_from_int
@@ -251,9 +256,9 @@ module exclass1_mod
                 result(SHT_rv) &
                 bind(C, name="AA_exclass1_get_value_1")
             use iso_c_binding, only : C_LONG
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass1_capsule), intent(IN) :: self
             integer(C_LONG), value, intent(IN) :: value
             integer(C_LONG) :: SHT_rv
         end function c_exclass1_get_value_1
@@ -262,9 +267,9 @@ module exclass1_mod
                 result(SHT_rv) &
                 bind(C, name="AA_exclass1_get_addr")
             use iso_c_binding, only : C_PTR
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass1_capsule), intent(IN) :: self
             type(C_PTR) :: SHT_rv
         end function c_exclass1_get_addr
 
@@ -272,18 +277,18 @@ module exclass1_mod
                 result(SHT_rv) &
                 bind(C, name="AA_exclass1_has_addr")
             use iso_c_binding, only : C_BOOL
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass1_capsule), intent(IN) :: self
             logical(C_BOOL), value, intent(IN) :: in
             logical(C_BOOL) :: SHT_rv
         end function c_exclass1_has_addr
 
         subroutine c_exclass1_splicer_special(self) &
                 bind(C, name="AA_exclass1_splicer_special")
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass1_capsule), intent(IN) :: self
         end subroutine c_exclass1_splicer_special
 
         ! splicer begin class.ExClass1.additional_interfaces

--- a/regression/reference/example/wrapfExClass2.f
+++ b/regression/reference/example/wrapfExClass2.f
@@ -68,8 +68,13 @@ module exclass2_mod
     top of module splicer  2
     ! splicer end class.ExClass2.module_top
 
+    type, bind(C) :: SHROUD_exclass2_capsule
+        type(C_PTR) :: addr = C_NULL_PTR  ! address of C++ memory
+        integer(C_INT) :: idtor = 0       ! index of destructor
+    end type SHROUD_exclass2_capsule
+
     type exclass2
-        type(SHROUD_capsule_data) :: cxxmem
+        type(SHROUD_exclass2_capsule) :: cxxmem
         ! splicer begin class.ExClass2.component_part
         ! splicer end class.ExClass2.component_part
     contains
@@ -116,10 +121,10 @@ module exclass2_mod
                 result(SHT_rv) &
                 bind(C, name="AA_exclass2_ctor")
             use iso_c_binding, only : C_CHAR, C_PTR
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass2_capsule
             implicit none
             character(kind=C_CHAR), intent(IN) :: name(*)
-            type(SHROUD_capsule_data), intent(OUT) :: SHT_crv
+            type(SHROUD_exclass2_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_exclass2_ctor
 
@@ -127,37 +132,37 @@ module exclass2_mod
                 result(SHT_rv) &
                 bind(C, name="AA_exclass2_ctor_bufferify")
             use iso_c_binding, only : C_CHAR, C_INT, C_PTR
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass2_capsule
             implicit none
             character(kind=C_CHAR), intent(IN) :: name(*)
             integer(C_INT), value, intent(IN) :: trim_name
-            type(SHROUD_capsule_data), intent(OUT) :: SHT_crv
+            type(SHROUD_exclass2_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_exclass2_ctor_bufferify
 
         subroutine c_exclass2_dtor(self) &
                 bind(C, name="AA_exclass2_dtor")
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass2_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass2_capsule), intent(IN) :: self
         end subroutine c_exclass2_dtor
 
         pure function c_exclass2_get_name(self) &
                 result(SHT_rv) &
                 bind(C, name="AA_exclass2_get_name")
             use iso_c_binding, only : C_PTR
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass2_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass2_capsule), intent(IN) :: self
             type(C_PTR) SHT_rv
         end function c_exclass2_get_name
 
         subroutine c_exclass2_get_name_bufferify(self, SHF_rv, NSHF_rv) &
                 bind(C, name="AA_exclass2_get_name_bufferify")
             use iso_c_binding, only : C_CHAR, C_INT
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass2_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass2_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(OUT) :: SHF_rv(*)
             integer(C_INT), value, intent(IN) :: NSHF_rv
         end subroutine c_exclass2_get_name_bufferify
@@ -166,17 +171,17 @@ module exclass2_mod
                 result(SHT_rv) &
                 bind(C, name="AA_exclass2_get_name2")
             use iso_c_binding, only : C_PTR
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass2_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass2_capsule), intent(IN) :: self
             type(C_PTR) SHT_rv
         end function c_exclass2_get_name2
 
         subroutine c_exclass2_get_name2_bufferify(self, DSHF_rv) &
                 bind(C, name="AA_exclass2_get_name2_bufferify")
-            import :: SHROUD_array, SHROUD_capsule_data
+            import :: SHROUD_array, SHROUD_exclass2_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass2_capsule), intent(IN) :: self
             type(SHROUD_array), intent(INOUT) :: DSHF_rv
         end subroutine c_exclass2_get_name2_bufferify
 
@@ -184,17 +189,17 @@ module exclass2_mod
                 result(SHT_rv) &
                 bind(C, name="AA_exclass2_get_name3")
             use iso_c_binding, only : C_PTR
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass2_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass2_capsule), intent(IN) :: self
             type(C_PTR) SHT_rv
         end function c_exclass2_get_name3
 
         subroutine c_exclass2_get_name3_bufferify(self, DSHF_rv) &
                 bind(C, name="AA_exclass2_get_name3_bufferify")
-            import :: SHROUD_array, SHROUD_capsule_data
+            import :: SHROUD_array, SHROUD_exclass2_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass2_capsule), intent(IN) :: self
             type(SHROUD_array), intent(INOUT) :: DSHF_rv
         end subroutine c_exclass2_get_name3_bufferify
 
@@ -202,17 +207,17 @@ module exclass2_mod
                 result(SHT_rv) &
                 bind(C, name="AA_exclass2_get_name4")
             use iso_c_binding, only : C_PTR
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass2_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass2_capsule), intent(IN) :: self
             type(C_PTR) SHT_rv
         end function c_exclass2_get_name4
 
         subroutine c_exclass2_get_name4_bufferify(self, DSHF_rv) &
                 bind(C, name="AA_exclass2_get_name4_bufferify")
-            import :: SHROUD_array, SHROUD_capsule_data
+            import :: SHROUD_array, SHROUD_exclass2_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass2_capsule), intent(IN) :: self
             type(SHROUD_array), intent(INOUT) :: DSHF_rv
         end subroutine c_exclass2_get_name4_bufferify
 
@@ -220,9 +225,9 @@ module exclass2_mod
                 result(SHT_rv) &
                 bind(C, name="AA_exclass2_get_name_length")
             use iso_c_binding, only : C_INT
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass2_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass2_capsule), intent(IN) :: self
             integer(C_INT) :: SHT_rv
         end function c_exclass2_get_name_length
 
@@ -230,83 +235,83 @@ module exclass2_mod
                 result(SHT_rv) &
                 bind(C, name="AA_exclass2_get_class1")
             use iso_c_binding, only : C_PTR
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass1_capsule, SHROUD_exclass2_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
-            type(SHROUD_capsule_data), intent(IN) :: in
-            type(SHROUD_capsule_data), intent(OUT) :: SHT_crv
+            type(SHROUD_exclass2_capsule), intent(IN) :: self
+            type(SHROUD_exclass1_capsule), intent(IN) :: in
+            type(SHROUD_exclass1_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_exclass2_get_class1
 
         subroutine c_exclass2_declare_0(self, type) &
                 bind(C, name="AA_exclass2_declare_0")
             use iso_c_binding, only : C_INT
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass2_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass2_capsule), intent(IN) :: self
             integer(C_INT), value, intent(IN) :: type
         end subroutine c_exclass2_declare_0
 
         subroutine c_exclass2_declare_1(self, type, len) &
                 bind(C, name="AA_exclass2_declare_1")
             use iso_c_binding, only : C_INT, C_LONG
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass2_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass2_capsule), intent(IN) :: self
             integer(C_INT), value, intent(IN) :: type
             integer(C_LONG), value, intent(IN) :: len
         end subroutine c_exclass2_declare_1
 
         subroutine c_exclass2_destroyall(self) &
                 bind(C, name="AA_exclass2_destroyall")
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass2_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass2_capsule), intent(IN) :: self
         end subroutine c_exclass2_destroyall
 
         pure function c_exclass2_get_type_id(self) &
                 result(SHT_rv) &
                 bind(C, name="AA_exclass2_get_type_id")
             use iso_c_binding, only : C_INT
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass2_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass2_capsule), intent(IN) :: self
             integer(C_INT) :: SHT_rv
         end function c_exclass2_get_type_id
 
         subroutine c_exclass2_set_value_int(self, value) &
                 bind(C, name="AA_exclass2_set_value_int")
             use iso_c_binding, only : C_INT
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass2_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass2_capsule), intent(IN) :: self
             integer(C_INT), value, intent(IN) :: value
         end subroutine c_exclass2_set_value_int
 
         subroutine c_exclass2_set_value_long(self, value) &
                 bind(C, name="AA_exclass2_set_value_long")
             use iso_c_binding, only : C_LONG
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass2_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass2_capsule), intent(IN) :: self
             integer(C_LONG), value, intent(IN) :: value
         end subroutine c_exclass2_set_value_long
 
         subroutine c_exclass2_set_value_float(self, value) &
                 bind(C, name="AA_exclass2_set_value_float")
             use iso_c_binding, only : C_FLOAT
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass2_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass2_capsule), intent(IN) :: self
             real(C_FLOAT), value, intent(IN) :: value
         end subroutine c_exclass2_set_value_float
 
         subroutine c_exclass2_set_value_double(self, value) &
                 bind(C, name="AA_exclass2_set_value_double")
             use iso_c_binding, only : C_DOUBLE
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass2_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass2_capsule), intent(IN) :: self
             real(C_DOUBLE), value, intent(IN) :: value
         end subroutine c_exclass2_set_value_double
 
@@ -314,9 +319,9 @@ module exclass2_mod
                 result(SHT_rv) &
                 bind(C, name="AA_exclass2_get_value_int")
             use iso_c_binding, only : C_INT
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass2_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass2_capsule), intent(IN) :: self
             integer(C_INT) :: SHT_rv
         end function c_exclass2_get_value_int
 
@@ -324,9 +329,9 @@ module exclass2_mod
                 result(SHT_rv) &
                 bind(C, name="AA_exclass2_get_value_double")
             use iso_c_binding, only : C_DOUBLE
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass2_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass2_capsule), intent(IN) :: self
             real(C_DOUBLE) :: SHT_rv
         end function c_exclass2_get_value_double
 

--- a/regression/reference/example/wrapfExClass3.f
+++ b/regression/reference/example/wrapfExClass3.f
@@ -52,16 +52,16 @@ module exclass3_mod
     implicit none
 
 
-    type, bind(C) :: SHROUD_capsule_data
-        type(C_PTR) :: addr = C_NULL_PTR  ! address of C++ memory
-        integer(C_INT) :: idtor = 0       ! index of destructor
-    end type SHROUD_capsule_data
-
     ! splicer begin class.ExClass3.module_top
     ! splicer end class.ExClass3.module_top
 
+    type, bind(C) :: SHROUD_exclass3_capsule
+        type(C_PTR) :: addr = C_NULL_PTR  ! address of C++ memory
+        integer(C_INT) :: idtor = 0       ! index of destructor
+    end type SHROUD_exclass3_capsule
+
     type exclass3
-        type(SHROUD_capsule_data) :: cxxmem
+        type(SHROUD_exclass3_capsule) :: cxxmem
         ! splicer begin class.ExClass3.component_part
         ! splicer end class.ExClass3.component_part
     contains
@@ -92,9 +92,9 @@ module exclass3_mod
 #ifdef USE_CLASS3_A
         subroutine c_exclass3_exfunc_0(self) &
                 bind(C, name="AA_exclass3_exfunc_0")
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass3_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass3_capsule), intent(IN) :: self
         end subroutine c_exclass3_exfunc_0
 #endif
 
@@ -102,9 +102,9 @@ module exclass3_mod
         subroutine c_exclass3_exfunc_1(self, flag) &
                 bind(C, name="AA_exclass3_exfunc_1")
             use iso_c_binding, only : C_INT
-            import :: SHROUD_capsule_data
+            import :: SHROUD_exclass3_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_exclass3_capsule), intent(IN) :: self
             integer(C_INT), value, intent(IN) :: flag
         end subroutine c_exclass3_exfunc_1
 #endif

--- a/regression/reference/example/wrapfuserlibrary.f
+++ b/regression/reference/example/wrapfuserlibrary.f
@@ -221,16 +221,16 @@ module userlibrary_mod
 
         subroutine c_testgroup1(grp) &
                 bind(C, name="AA_testgroup1")
-            import :: SHROUD_capsule_data
+            use sidre_mod, only : SHROUD_group_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: grp
+            type(SHROUD_group_capsule), intent(IN) :: grp
         end subroutine c_testgroup1
 
         subroutine c_testgroup2(grp) &
                 bind(C, name="AA_testgroup2")
-            import :: SHROUD_capsule_data
+            use sidre_mod, only : SHROUD_group_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: grp
+            type(SHROUD_group_capsule), intent(IN) :: grp
         end subroutine c_testgroup2
 
         subroutine func_ptr1(get) &
@@ -459,7 +459,7 @@ contains
 
     ! void testgroup1(axom::sidre::Group * grp +intent(in))
     subroutine testgroup1(grp)
-        use sidre_mod, only : group
+        use sidre_mod, only : datagroup
         type(datagroup), intent(IN) :: grp
         ! splicer begin function.testgroup1
         call c_testgroup1(grp%cxxmem)
@@ -468,7 +468,7 @@ contains
 
     ! void testgroup2(const axom::sidre::Group * grp +intent(in))
     subroutine testgroup2(grp)
-        use sidre_mod, only : group
+        use sidre_mod, only : datagroup
         type(datagroup), intent(IN) :: grp
         ! splicer begin function.testgroup2
         call c_testgroup2(grp%cxxmem)

--- a/regression/reference/forward/forward.json
+++ b/regression/reference/forward/forward.json
@@ -9,6 +9,7 @@
                     "C_header_filename": "wrapClass3.h", 
                     "C_impl_filename": "wrapClass3.cpp", 
                     "C_type_name": "FOR_class3", 
+                    "F_capsule_data_type": "SHROUD_class3_capsule", 
                     "F_derived_name": "class3", 
                     "LUA_class_reg": "l_Class3_Reg", 
                     "LUA_ctor_name": "Class3", 
@@ -31,7 +32,7 @@
                     "cxx_class": "Class3", 
                     "cxx_type": "Class3"
                 }, 
-                "linenumber": 71, 
+                "linenumber": 70, 
                 "name": "Class3", 
                 "options": {}, 
                 "scope": "tutorial::Class3::", 
@@ -44,6 +45,7 @@
                     "C_header_filename": "wrapClass2.h", 
                     "C_impl_filename": "wrapClass2.cpp", 
                     "C_type_name": "FOR_class2", 
+                    "F_capsule_data_type": "SHROUD_class2_capsule", 
                     "F_derived_name": "class2", 
                     "LUA_class_reg": "l_Class2_Reg", 
                     "LUA_ctor_name": "Class2", 
@@ -143,7 +145,7 @@
                             "function_name": "ctor", 
                             "underscore_name": "ctor"
                         }, 
-                        "linenumber": 77, 
+                        "linenumber": 76, 
                         "options": {}
                     }, 
                     {
@@ -186,7 +188,7 @@
                             "function_name": "dtor", 
                             "underscore_name": "dtor"
                         }, 
-                        "linenumber": 78, 
+                        "linenumber": 77, 
                         "options": {}
                     }, 
                     {
@@ -296,7 +298,7 @@
                             "function_name": "func1", 
                             "underscore_name": "func1"
                         }, 
-                        "linenumber": 79, 
+                        "linenumber": 78, 
                         "options": {}
                     }, 
                     {
@@ -407,11 +409,11 @@
                             "function_name": "acceptClass3", 
                             "underscore_name": "accept_class3"
                         }, 
-                        "linenumber": 80, 
+                        "linenumber": 79, 
                         "options": {}
                     }
                 ], 
-                "linenumber": 75, 
+                "linenumber": 74, 
                 "name": "Class2", 
                 "options": {}, 
                 "scope": "tutorial::Class2::", 
@@ -576,6 +578,7 @@
             "F_abstract_interface_argument_template": "arg{index}", 
             "F_abstract_interface_subprogram_template": "{underscore_name}_{argname}", 
             "F_auto_reference_count": false, 
+            "F_capsule_data_type_class_template": "SHROUD_{class_lower}_capsule", 
             "F_enum_member_template": "{class_prefix}{enum_lower}_{enum_member_lower}", 
             "F_force_wrapper": false, 
             "F_impl_filename_class_template": "wrapf{cxx_class}.{F_filename_suffix}", 
@@ -1501,18 +1504,19 @@
             "cxx_to_c": "static_cast<{c_const}void *>(\t{cxx_addr}{cxx_var})", 
             "cxx_type": "tutorial::Class1", 
             "f_c_module": {
-                "--import--": [
-                    "SHROUD_capsule_data"
+                "tutorial_mod": [
+                    "custom_capsule"
                 ]
             }, 
-            "f_c_type": "type(SHROUD_capsule_data)", 
+            "f_c_type": "type(custom_capsule)", 
+            "f_capsule_data_type": "custom_capsule", 
             "f_derived_type": "class1", 
             "f_module": {
-                "__line__": 66, 
                 "tutorial_mod": [
                     "class1"
                 ]
             }, 
+            "f_module_name": "tutorial_mod", 
             "f_statements": {
                 "result": {
                     "call": [
@@ -1574,16 +1578,18 @@
             "cxx_type": "tutorial::Class2", 
             "f_c_module": {
                 "--import--": [
-                    "SHROUD_capsule_data"
+                    "SHROUD_class2_capsule"
                 ]
             }, 
-            "f_c_type": "type(SHROUD_capsule_data)", 
+            "f_c_type": "type(SHROUD_class2_capsule)", 
+            "f_capsule_data_type": "SHROUD_class2_capsule", 
             "f_derived_type": "class2", 
             "f_module": {
                 "forward_mod": [
                     "class2"
                 ]
             }, 
+            "f_module_name": "forward_mod", 
             "f_statements": {
                 "result": {
                     "call": [
@@ -1646,16 +1652,18 @@
             "cxx_type": "tutorial::Class3", 
             "f_c_module": {
                 "--import--": [
-                    "SHROUD_capsule_data"
+                    "SHROUD_class3_capsule"
                 ]
             }, 
-            "f_c_type": "type(SHROUD_capsule_data)", 
+            "f_c_type": "type(SHROUD_class3_capsule)", 
+            "f_capsule_data_type": "SHROUD_class3_capsule", 
             "f_derived_type": "class3", 
             "f_module": {
                 "forward_mod": [
                     "class3"
                 ]
             }, 
+            "f_module_name": "forward_mod", 
             "f_statements": {
                 "result": {
                     "call": [

--- a/regression/reference/forward/forward_types.yaml
+++ b/regression/reference/forward/forward_types.yaml
@@ -49,18 +49,16 @@ declarations:
         base: shadow
         cxx_type: tutorial::Class2
         c_type: FOR_class2
+        f_module_name: forward_mod
         f_derived_type: class2
+        f_capsule_data_type: SHROUD_class2_capsule
         f_to_c: "{f_var}%cxxmem"
-        f_module:
-          forward_mod:
-          - class2
     - type: Class3
       fields:
         base: shadow
         cxx_type: tutorial::Class3
         c_type: FOR_class3
+        f_module_name: forward_mod
         f_derived_type: class3
+        f_capsule_data_type: SHROUD_class3_capsule
         f_to_c: "{f_var}%cxxmem"
-        f_module:
-          forward_mod:
-          - class3

--- a/regression/reference/forward/wrapfforward.f
+++ b/regression/reference/forward/wrapfforward.f
@@ -55,16 +55,16 @@ module forward_mod
     ! splicer begin module_top
     ! splicer end module_top
 
-    type, bind(C) :: SHROUD_capsule_data
-        type(C_PTR) :: addr = C_NULL_PTR  ! address of C++ memory
-        integer(C_INT) :: idtor = 0       ! index of destructor
-    end type SHROUD_capsule_data
-
     ! splicer begin class.Class3.module_top
     ! splicer end class.Class3.module_top
 
+    type, bind(C) :: SHROUD_class3_capsule
+        type(C_PTR) :: addr = C_NULL_PTR  ! address of C++ memory
+        integer(C_INT) :: idtor = 0       ! index of destructor
+    end type SHROUD_class3_capsule
+
     type class3
-        type(SHROUD_capsule_data) :: cxxmem
+        type(SHROUD_class3_capsule) :: cxxmem
         ! splicer begin class.Class3.component_part
         ! splicer end class.Class3.component_part
     contains
@@ -78,8 +78,13 @@ module forward_mod
     ! splicer begin class.Class2.module_top
     ! splicer end class.Class2.module_top
 
+    type, bind(C) :: SHROUD_class2_capsule
+        type(C_PTR) :: addr = C_NULL_PTR  ! address of C++ memory
+        integer(C_INT) :: idtor = 0       ! index of destructor
+    end type SHROUD_class2_capsule
+
     type class2
-        type(SHROUD_capsule_data) :: cxxmem
+        type(SHROUD_class2_capsule) :: cxxmem
         ! splicer begin class.Class2.component_part
         ! splicer end class.Class2.component_part
     contains
@@ -112,33 +117,34 @@ module forward_mod
                 result(SHT_rv) &
                 bind(C, name="FOR_class2_ctor")
             use iso_c_binding, only : C_PTR
-            import :: SHROUD_capsule_data
+            import :: SHROUD_class2_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(OUT) :: SHT_crv
+            type(SHROUD_class2_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_class2_ctor
 
         subroutine c_class2_dtor(self) &
                 bind(C, name="FOR_class2_dtor")
-            import :: SHROUD_capsule_data
+            import :: SHROUD_class2_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_class2_capsule), intent(IN) :: self
         end subroutine c_class2_dtor
 
         subroutine c_class2_func1(self, arg) &
                 bind(C, name="FOR_class2_func1")
-            import :: SHROUD_capsule_data
+            use tutorial_mod, only : custom_capsule
+            import :: SHROUD_class2_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
-            type(SHROUD_capsule_data), intent(IN) :: arg
+            type(SHROUD_class2_capsule), intent(IN) :: self
+            type(custom_capsule), intent(IN) :: arg
         end subroutine c_class2_func1
 
         subroutine c_class2_accept_class3(self, arg) &
                 bind(C, name="FOR_class2_accept_class3")
-            import :: SHROUD_capsule_data
+            import :: SHROUD_class2_capsule, SHROUD_class3_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
-            type(SHROUD_capsule_data), intent(IN) :: arg
+            type(SHROUD_class2_capsule), intent(IN) :: self
+            type(SHROUD_class3_capsule), intent(IN) :: arg
         end subroutine c_class2_accept_class3
 
         ! splicer begin class.Class2.additional_interfaces

--- a/regression/reference/include/default_library_types.yaml
+++ b/regression/reference/include/default_library_types.yaml
@@ -47,11 +47,10 @@ declarations:
       base: shadow
       cxx_type: Class2
       c_type: DEF_class2
+      f_module_name: class2_mod
       f_derived_type: class2
+      f_capsule_data_type: SHROUD_class2_capsule
       f_to_c: "{f_var}%cxxmem"
-      f_module:
-        class2_mod:
-        - class2
   - namespace: three
     declarations: three
     - type: Class1
@@ -60,8 +59,7 @@ declarations:
         cxx_header: class_header.hpp
         cxx_type: three::Class1
         c_type: DEF_class1
+        f_module_name: class1_mod
         f_derived_type: class1
+        f_capsule_data_type: SHROUD_class1_capsule
         f_to_c: "{f_var}%cxxmem"
-        f_module:
-          class1_mod:
-          - class1

--- a/regression/reference/include/include.json
+++ b/regression/reference/include/include.json
@@ -9,6 +9,7 @@
                     "C_header_filename": "wrapClass1.h", 
                     "C_impl_filename": "wrapClass1.cpp", 
                     "C_type_name": "DEF_class1", 
+                    "F_capsule_data_type": "SHROUD_class1_capsule", 
                     "F_derived_name": "class1", 
                     "F_impl_filename": "wrapfClass1.f", 
                     "F_module_name": "class1_mod", 
@@ -110,6 +111,7 @@
                     "C_header_filename": "wrapClass2.h", 
                     "C_impl_filename": "wrapClass2.cpp", 
                     "C_type_name": "DEF_class2", 
+                    "F_capsule_data_type": "SHROUD_class2_capsule", 
                     "F_derived_name": "class2", 
                     "F_impl_filename": "wrapfClass2.f", 
                     "F_module_name": "class2_mod", 
@@ -464,6 +466,7 @@
             "F_abstract_interface_argument_template": "arg{index}", 
             "F_abstract_interface_subprogram_template": "{underscore_name}_{argname}", 
             "F_auto_reference_count": false, 
+            "F_capsule_data_type_class_template": "SHROUD_{class_lower}_capsule", 
             "F_enum_member_template": "{class_prefix}{enum_lower}_{enum_member_lower}", 
             "F_force_wrapper": false, 
             "F_impl_filename_class_template": "wrapf{cxx_class}.{F_filename_suffix}", 
@@ -545,16 +548,18 @@
             "cxx_type": "Class2", 
             "f_c_module": {
                 "--import--": [
-                    "SHROUD_capsule_data"
+                    "SHROUD_class2_capsule"
                 ]
             }, 
-            "f_c_type": "type(SHROUD_capsule_data)", 
+            "f_c_type": "type(SHROUD_class2_capsule)", 
+            "f_capsule_data_type": "SHROUD_class2_capsule", 
             "f_derived_type": "class2", 
             "f_module": {
                 "class2_mod": [
                     "class2"
                 ]
             }, 
+            "f_module_name": "class2_mod", 
             "f_statements": {
                 "result": {
                     "call": [
@@ -1480,16 +1485,18 @@
             "cxx_type": "three::Class1", 
             "f_c_module": {
                 "--import--": [
-                    "SHROUD_capsule_data"
+                    "SHROUD_class1_capsule"
                 ]
             }, 
-            "f_c_type": "type(SHROUD_capsule_data)", 
+            "f_c_type": "type(SHROUD_class1_capsule)", 
+            "f_capsule_data_type": "SHROUD_class1_capsule", 
             "f_derived_type": "class1", 
             "f_module": {
                 "class1_mod": [
                     "class1"
                 ]
             }, 
+            "f_module_name": "class1_mod", 
             "f_statements": {
                 "result": {
                     "call": [

--- a/regression/reference/include/wrapfClass1.f
+++ b/regression/reference/include/wrapfClass1.f
@@ -49,14 +49,14 @@ module class1_mod
     implicit none
 
 
-    type, bind(C) :: SHROUD_capsule_data
+
+    type, bind(C) :: SHROUD_class1_capsule
         type(C_PTR) :: addr = C_NULL_PTR  ! address of C++ memory
         integer(C_INT) :: idtor = 0       ! index of destructor
-    end type SHROUD_capsule_data
-
+    end type SHROUD_class1_capsule
 
     type class1
-        type(SHROUD_capsule_data) :: cxxmem
+        type(SHROUD_class1_capsule) :: cxxmem
     contains
         procedure :: method1 => class1_method1
         procedure :: get_instance => class1_get_instance
@@ -77,9 +77,9 @@ module class1_mod
         subroutine c_class1_method1(self, arg1) &
                 bind(C, name="DEF_class1_method1")
             use iso_c_binding, only : C_INT
-            import :: SHROUD_capsule_data
+            import :: SHROUD_class1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_class1_capsule), intent(IN) :: self
             integer(C_INT), value, intent(IN) :: arg1
         end subroutine c_class1_method1
 

--- a/regression/reference/include/wrapfClass2.f
+++ b/regression/reference/include/wrapfClass2.f
@@ -49,14 +49,14 @@ module class2_mod
     implicit none
 
 
-    type, bind(C) :: SHROUD_capsule_data
+
+    type, bind(C) :: SHROUD_class2_capsule
         type(C_PTR) :: addr = C_NULL_PTR  ! address of C++ memory
         integer(C_INT) :: idtor = 0       ! index of destructor
-    end type SHROUD_capsule_data
-
+    end type SHROUD_class2_capsule
 
     type class2
-        type(SHROUD_capsule_data) :: cxxmem
+        type(SHROUD_class2_capsule) :: cxxmem
     contains
         procedure :: method1 => class2_method1
         procedure :: method2 => class2_method2
@@ -78,18 +78,18 @@ module class2_mod
         subroutine c_class2_method1(self, comm) &
                 bind(C, name="DEF_class2_method1")
             use iso_c_binding, only : C_INT
-            import :: SHROUD_capsule_data
+            import :: SHROUD_class2_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_class2_capsule), intent(IN) :: self
             integer(C_INT), value, intent(IN) :: comm
         end subroutine c_class2_method1
 
         subroutine c_class2_method2(self, c2) &
                 bind(C, name="DEF_class2_method2")
-            import :: SHROUD_capsule_data
+            import :: SHROUD_class1_capsule, SHROUD_class2_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
-            type(SHROUD_capsule_data), intent(IN) :: c2
+            type(SHROUD_class2_capsule), intent(IN) :: self
+            type(SHROUD_class1_capsule), intent(IN) :: c2
         end subroutine c_class2_method2
 
     end interface

--- a/regression/reference/interface/interface.json
+++ b/regression/reference/interface/interface.json
@@ -296,6 +296,7 @@
             "F_abstract_interface_argument_template": "arg{index}", 
             "F_abstract_interface_subprogram_template": "{underscore_name}_{argname}", 
             "F_auto_reference_count": false, 
+            "F_capsule_data_type_class_template": "SHROUD_{class_lower}_capsule", 
             "F_enum_member_template": "{class_prefix}{enum_lower}_{enum_member_lower}", 
             "F_force_wrapper": false, 
             "F_impl_filename_class_template": "wrapf{cxx_class}.{F_filename_suffix}", 

--- a/regression/reference/names/foo.f
+++ b/regression/reference/names/foo.f
@@ -53,16 +53,16 @@ module name_module
     implicit none
 
 
-    type, bind(C) :: SHROUD_capsule_data
-        type(C_PTR) :: addr = C_NULL_PTR  ! address of C++ memory
-        integer(C_INT) :: idtor = 0       ! index of destructor
-    end type SHROUD_capsule_data
-
     ! splicer begin class.Names.module_top
     ! splicer end class.Names.module_top
 
+    type, bind(C) :: SHROUD_names_capsule
+        type(C_PTR) :: addr = C_NULL_PTR  ! address of C++ memory
+        integer(C_INT) :: idtor = 0       ! index of destructor
+    end type SHROUD_names_capsule
+
     type FNames
-        type(SHROUD_capsule_data) :: cxxmem
+        type(SHROUD_names_capsule) :: cxxmem
         ! splicer begin class.Names.component_part
         ! splicer end class.Names.component_part
     contains
@@ -87,16 +87,16 @@ module name_module
 
         subroutine xxx_tes_names_method1(self) &
                 bind(C, name="XXX_TES_names_method1")
-            import :: SHROUD_capsule_data
+            import :: SHROUD_names_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_names_capsule), intent(IN) :: self
         end subroutine xxx_tes_names_method1
 
         subroutine xxx_tes_names_method2(self2) &
                 bind(C, name="XXX_TES_names_method2")
-            import :: SHROUD_capsule_data
+            import :: SHROUD_names_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self2
+            type(SHROUD_names_capsule), intent(IN) :: self2
         end subroutine xxx_tes_names_method2
 
         ! splicer begin class.Names.additional_interfaces

--- a/regression/reference/names/names.json
+++ b/regression/reference/names/names.json
@@ -9,6 +9,7 @@
                     "C_header_filename": "foo.h", 
                     "C_impl_filename": "foo.cpp", 
                     "C_type_name": "TES_names", 
+                    "F_capsule_data_type": "SHROUD_names_capsule", 
                     "F_derived_name": "FNames", 
                     "F_impl_filename": "foo.f", 
                     "F_module_name": "name_module", 
@@ -136,6 +137,7 @@
                     "C_header_filename": "wrapNames2.hh", 
                     "C_impl_filename": "wrapNames2.cc", 
                     "C_type_name": "TES_names2", 
+                    "F_capsule_data_type": "SHROUD_names2_capsule", 
                     "F_derived_name": "names2", 
                     "F_impl_filename": "wrapfNames2.F", 
                     "F_module_name": "names2_mod", 
@@ -915,6 +917,7 @@
             "F_abstract_interface_argument_template": "arg{index}", 
             "F_abstract_interface_subprogram_template": "{underscore_name}_{argname}", 
             "F_auto_reference_count": false, 
+            "F_capsule_data_type_class_template": "SHROUD_{class_lower}_capsule", 
             "F_enum_member_template": "{class_prefix}{enum_lower}_{enum_member_lower}", 
             "F_force_wrapper": true, 
             "F_impl_filename_class_template": "wrapf{cxx_class}.{F_filename_suffix}", 
@@ -1036,16 +1039,18 @@
             "cxx_type": "Names", 
             "f_c_module": {
                 "--import--": [
-                    "SHROUD_capsule_data"
+                    "SHROUD_names_capsule"
                 ]
             }, 
-            "f_c_type": "type(SHROUD_capsule_data)", 
+            "f_c_type": "type(SHROUD_names_capsule)", 
+            "f_capsule_data_type": "SHROUD_names_capsule", 
             "f_derived_type": "FNames", 
             "f_module": {
                 "name_module": [
                     "FNames"
                 ]
             }, 
+            "f_module_name": "name_module", 
             "f_statements": {
                 "result": {
                     "call": [
@@ -1107,16 +1112,18 @@
             "cxx_type": "Names2", 
             "f_c_module": {
                 "--import--": [
-                    "SHROUD_capsule_data"
+                    "SHROUD_names2_capsule"
                 ]
             }, 
-            "f_c_type": "type(SHROUD_capsule_data)", 
+            "f_c_type": "type(SHROUD_names2_capsule)", 
+            "f_capsule_data_type": "SHROUD_names2_capsule", 
             "f_derived_type": "names2", 
             "f_module": {
                 "names2_mod": [
                     "names2"
                 ]
             }, 
+            "f_module_name": "names2_mod", 
             "f_statements": {
                 "result": {
                     "call": [

--- a/regression/reference/names/testnames_types.yaml
+++ b/regression/reference/names/testnames_types.yaml
@@ -47,18 +47,16 @@ declarations:
       base: shadow
       cxx_type: Names
       c_type: TES_names
+      f_module_name: name_module
       f_derived_type: FNames
+      f_capsule_data_type: SHROUD_names_capsule
       f_to_c: "{f_var}%cxxmem"
-      f_module:
-        name_module:
-        - FNames
   - type: Names2
     fields:
       base: shadow
       cxx_type: Names2
       c_type: TES_names2
+      f_module_name: names2_mod
       f_derived_type: names2
+      f_capsule_data_type: SHROUD_names2_capsule
       f_to_c: "{f_var}%cxxmem"
-      f_module:
-        names2_mod:
-        - names2

--- a/regression/reference/names/wrapfNames2.F
+++ b/regression/reference/names/wrapfNames2.F
@@ -53,16 +53,16 @@ module names2_mod
     implicit none
 
 
-    type, bind(C) :: SHROUD_capsule_data
-        type(C_PTR) :: addr = C_NULL_PTR  ! address of C++ memory
-        integer(C_INT) :: idtor = 0       ! index of destructor
-    end type SHROUD_capsule_data
-
     ! splicer begin class.Names2.module_top
     ! splicer end class.Names2.module_top
 
+    type, bind(C) :: SHROUD_names2_capsule
+        type(C_PTR) :: addr = C_NULL_PTR  ! address of C++ memory
+        integer(C_INT) :: idtor = 0       ! index of destructor
+    end type SHROUD_names2_capsule
+
     type names2
-        type(SHROUD_capsule_data) :: cxxmem
+        type(SHROUD_names2_capsule) :: cxxmem
         ! splicer begin class.Names2.component_part
         ! splicer end class.Names2.component_part
     contains

--- a/regression/reference/none/def_types.yaml
+++ b/regression/reference/none/def_types.yaml
@@ -32,10 +32,12 @@ MPI_Comm: !!python/object:shroud.typemap.Typemap
     iso_c_binding:
     - C_INT
   f_c_type: integer(C_INT)
+  f_capsule_data_type: null
   f_cast: '{f_var}'
   f_derived_type: null
   f_kind: C_INT
   f_module: null
+  f_module_name: null
   f_statements: &id006 {}
   f_to_c: null
   f_type: integer
@@ -78,12 +80,14 @@ bool: !!python/object:shroud.typemap.Typemap
   f_args: null
   f_c_module: null
   f_c_type: logical(C_BOOL)
+  f_capsule_data_type: null
   f_cast: '{f_var}'
   f_derived_type: null
   f_kind: C_BOOL
   f_module:
     iso_c_binding:
     - C_BOOL
+  f_module_name: null
   f_statements:
     intent_in:
       c_local_var: true
@@ -210,10 +214,12 @@ char: !!python/object:shroud.typemap.Typemap
     iso_c_binding:
     - C_CHAR
   f_c_type: character(kind=C_CHAR)
+  f_capsule_data_type: null
   f_cast: '{f_var}'
   f_derived_type: null
   f_kind: C_CHAR
   f_module: null
+  f_module_name: null
   f_statements:
     result_pure:
       call:
@@ -272,10 +278,12 @@ char_scalar: !!python/object:shroud.typemap.Typemap
     iso_c_binding:
     - C_CHAR
   f_c_type: character(kind=C_CHAR)
+  f_capsule_data_type: null
   f_cast: '{f_var}'
   f_derived_type: null
   f_kind: C_CHAR
   f_module: null
+  f_module_name: null
   f_statements: *id006
   f_to_c: null
   f_type: character
@@ -338,10 +346,12 @@ charout: !!python/object:shroud.typemap.Typemap
   f_args: null
   f_c_module: null
   f_c_type: null
+  f_capsule_data_type: null
   f_cast: '{f_var}'
   f_derived_type: null
   f_kind: null
   f_module: null
+  f_module_name: null
   f_statements:
     result:
       f_helper: copy_string
@@ -390,12 +400,14 @@ double: !!python/object:shroud.typemap.Typemap
   f_args: null
   f_c_module: null
   f_c_type: null
+  f_capsule_data_type: null
   f_cast: real({f_var}, C_DOUBLE)
   f_derived_type: null
   f_kind: C_DOUBLE
   f_module:
     iso_c_binding:
     - C_DOUBLE
+  f_module_name: null
   f_statements: *id006
   f_to_c: null
   f_type: real(C_DOUBLE)
@@ -438,12 +450,14 @@ float: !!python/object:shroud.typemap.Typemap
   f_args: null
   f_c_module: null
   f_c_type: null
+  f_capsule_data_type: null
   f_cast: real({f_var}, C_FLOAT)
   f_derived_type: null
   f_kind: C_FLOAT
   f_module:
     iso_c_binding:
     - C_FLOAT
+  f_module_name: null
   f_statements: *id006
   f_to_c: null
   f_type: real(C_FLOAT)
@@ -486,12 +500,14 @@ int: !!python/object:shroud.typemap.Typemap
   f_args: null
   f_c_module: null
   f_c_type: null
+  f_capsule_data_type: null
   f_cast: int({f_var}, C_INT)
   f_derived_type: null
   f_kind: C_INT
   f_module:
     iso_c_binding:
     - C_INT
+  f_module_name: null
   f_statements: *id006
   f_to_c: null
   f_type: integer(C_INT)
@@ -534,12 +550,14 @@ int16_t: !!python/object:shroud.typemap.Typemap
   f_args: null
   f_c_module: null
   f_c_type: null
+  f_capsule_data_type: null
   f_cast: int({f_var}, C_INT16_t)
   f_derived_type: null
   f_kind: C_INT16_T
   f_module:
     iso_c_binding:
     - C_INT16_T
+  f_module_name: null
   f_statements: *id006
   f_to_c: null
   f_type: integer(C_INT16_T)
@@ -582,12 +600,14 @@ int32_t: !!python/object:shroud.typemap.Typemap
   f_args: null
   f_c_module: null
   f_c_type: null
+  f_capsule_data_type: null
   f_cast: int({f_var}, C_INT32_t)
   f_derived_type: null
   f_kind: C_INT32_T
   f_module:
     iso_c_binding:
     - C_INT32_T
+  f_module_name: null
   f_statements: *id006
   f_to_c: null
   f_type: integer(C_INT32_T)
@@ -630,12 +650,14 @@ int64_t: !!python/object:shroud.typemap.Typemap
   f_args: null
   f_c_module: null
   f_c_type: null
+  f_capsule_data_type: null
   f_cast: int({f_var}, C_INT64_t)
   f_derived_type: null
   f_kind: C_INT64_T
   f_module:
     iso_c_binding:
     - C_INT64_T
+  f_module_name: null
   f_statements: *id006
   f_to_c: null
   f_type: integer(C_INT64_T)
@@ -678,12 +700,14 @@ int8_t: !!python/object:shroud.typemap.Typemap
   f_args: null
   f_c_module: null
   f_c_type: null
+  f_capsule_data_type: null
   f_cast: int({f_var}, C_INT8_t)
   f_derived_type: null
   f_kind: C_INT8_T
   f_module:
     iso_c_binding:
     - C_INT8_T
+  f_module_name: null
   f_statements: *id006
   f_to_c: null
   f_type: integer(C_INT8_T)
@@ -726,12 +750,14 @@ long: !!python/object:shroud.typemap.Typemap
   f_args: null
   f_c_module: null
   f_c_type: null
+  f_capsule_data_type: null
   f_cast: int({f_var}, C_LONG)
   f_derived_type: null
   f_kind: C_LONG
   f_module:
     iso_c_binding:
     - C_LONG
+  f_module_name: null
   f_statements: *id006
   f_to_c: null
   f_type: integer(C_LONG)
@@ -774,12 +800,14 @@ long_long: !!python/object:shroud.typemap.Typemap
   f_args: null
   f_c_module: null
   f_c_type: null
+  f_capsule_data_type: null
   f_cast: int({f_var}, C_LONG_LONG)
   f_derived_type: null
   f_kind: C_LONG_LONG
   f_module:
     iso_c_binding:
     - C_LONG_LONG
+  f_module_name: null
   f_statements: *id006
   f_to_c: null
   f_type: integer(C_LONG_LONG)
@@ -822,12 +850,14 @@ short: !!python/object:shroud.typemap.Typemap
   f_args: null
   f_c_module: null
   f_c_type: null
+  f_capsule_data_type: null
   f_cast: int({f_var}, C_SHORT)
   f_derived_type: null
   f_kind: C_SHORT
   f_module:
     iso_c_binding:
     - C_SHORT
+  f_module_name: null
   f_statements: *id006
   f_to_c: null
   f_type: integer(C_SHORT)
@@ -870,12 +900,14 @@ size_t: !!python/object:shroud.typemap.Typemap
   f_args: null
   f_c_module: null
   f_c_type: null
+  f_capsule_data_type: null
   f_cast: int({f_var}, C_SIZE_T)
   f_derived_type: null
   f_kind: C_SIZE_T
   f_module:
     iso_c_binding:
     - C_SIZE_T
+  f_module_name: null
   f_statements: *id006
   f_to_c: null
   f_type: integer(C_SIZE_T)
@@ -978,10 +1010,12 @@ std::string: !!python/object:shroud.typemap.Typemap
     iso_c_binding:
     - C_CHAR
   f_c_type: character(kind=C_CHAR)
+  f_capsule_data_type: null
   f_cast: '{f_var}'
   f_derived_type: null
   f_kind: C_CHAR
   f_module: null
+  f_module_name: null
   f_statements:
     result_pure:
       call:
@@ -1155,10 +1189,12 @@ std::vector: !!python/object:shroud.typemap.Typemap
   f_args: null
   f_c_module: null
   f_c_type: null
+  f_capsule_data_type: null
   f_cast: '{f_var}'
   f_derived_type: null
   f_kind: null
   f_module: null
+  f_module_name: null
   f_statements:
     intent_inout:
       f_helper: copy_array_{cxx_T}
@@ -1257,10 +1293,12 @@ stringout: !!python/object:shroud.typemap.Typemap
   f_args: null
   f_c_module: null
   f_c_type: null
+  f_capsule_data_type: null
   f_cast: '{f_var}'
   f_derived_type: null
   f_kind: null
   f_module: null
+  f_module_name: null
   f_statements:
     result:
       f_helper: copy_string
@@ -1309,12 +1347,14 @@ uint16_t: !!python/object:shroud.typemap.Typemap
   f_args: null
   f_c_module: null
   f_c_type: null
+  f_capsule_data_type: null
   f_cast: int({f_var}, C_INT16_t)
   f_derived_type: null
   f_kind: C_INT16_T
   f_module:
     iso_c_binding:
     - C_INT16_T
+  f_module_name: null
   f_statements: *id006
   f_to_c: null
   f_type: integer(C_INT16_T)
@@ -1357,12 +1397,14 @@ uint32_t: !!python/object:shroud.typemap.Typemap
   f_args: null
   f_c_module: null
   f_c_type: null
+  f_capsule_data_type: null
   f_cast: int({f_var}, C_INT32_t)
   f_derived_type: null
   f_kind: C_INT32_T
   f_module:
     iso_c_binding:
     - C_INT32_T
+  f_module_name: null
   f_statements: *id006
   f_to_c: null
   f_type: integer(C_INT32_T)
@@ -1405,12 +1447,14 @@ uint64_t: !!python/object:shroud.typemap.Typemap
   f_args: null
   f_c_module: null
   f_c_type: null
+  f_capsule_data_type: null
   f_cast: int({f_var}, C_INT64_t)
   f_derived_type: null
   f_kind: C_INT64_T
   f_module:
     iso_c_binding:
     - C_INT64_T
+  f_module_name: null
   f_statements: *id006
   f_to_c: null
   f_type: integer(C_INT64_T)
@@ -1453,12 +1497,14 @@ uint8_t: !!python/object:shroud.typemap.Typemap
   f_args: null
   f_c_module: null
   f_c_type: null
+  f_capsule_data_type: null
   f_cast: int({f_var}, C_INT8_t)
   f_derived_type: null
   f_kind: C_INT8_T
   f_module:
     iso_c_binding:
     - C_INT8_T
+  f_module_name: null
   f_statements: *id006
   f_to_c: null
   f_type: integer(C_INT8_T)
@@ -1501,12 +1547,14 @@ unsigned_int: !!python/object:shroud.typemap.Typemap
   f_args: null
   f_c_module: null
   f_c_type: null
+  f_capsule_data_type: null
   f_cast: int({f_var}, C_INT)
   f_derived_type: null
   f_kind: C_INT
   f_module:
     iso_c_binding:
     - C_INT
+  f_module_name: null
   f_statements: *id006
   f_to_c: null
   f_type: integer(C_INT)
@@ -1549,12 +1597,14 @@ unsigned_long: !!python/object:shroud.typemap.Typemap
   f_args: null
   f_c_module: null
   f_c_type: null
+  f_capsule_data_type: null
   f_cast: int({f_var}, C_LONG)
   f_derived_type: null
   f_kind: C_LONG
   f_module:
     iso_c_binding:
     - C_LONG
+  f_module_name: null
   f_statements: *id006
   f_to_c: null
   f_type: integer(C_LONG)
@@ -1597,12 +1647,14 @@ unsigned_long_long: !!python/object:shroud.typemap.Typemap
   f_args: null
   f_c_module: null
   f_c_type: null
+  f_capsule_data_type: null
   f_cast: int({f_var}, C_LONG_LONG)
   f_derived_type: null
   f_kind: C_LONG_LONG
   f_module:
     iso_c_binding:
     - C_LONG_LONG
+  f_module_name: null
   f_statements: *id006
   f_to_c: null
   f_type: integer(C_LONG_LONG)
@@ -1645,12 +1697,14 @@ unsigned_short: !!python/object:shroud.typemap.Typemap
   f_args: null
   f_c_module: null
   f_c_type: null
+  f_capsule_data_type: null
   f_cast: int({f_var}, C_SHORT)
   f_derived_type: null
   f_kind: C_SHORT
   f_module:
     iso_c_binding:
     - C_SHORT
+  f_module_name: null
   f_statements: *id006
   f_to_c: null
   f_type: integer(C_SHORT)
@@ -1693,12 +1747,14 @@ void: !!python/object:shroud.typemap.Typemap
   f_args: null
   f_c_module: null
   f_c_type: null
+  f_capsule_data_type: null
   f_cast: '{f_var}'
   f_derived_type: null
   f_kind: null
   f_module:
     iso_c_binding:
     - C_PTR
+  f_module_name: null
   f_statements: *id006
   f_to_c: null
   f_type: type(C_PTR)

--- a/regression/reference/none/none.json
+++ b/regression/reference/none/none.json
@@ -136,6 +136,7 @@
             "F_abstract_interface_argument_template": "arg{index}", 
             "F_abstract_interface_subprogram_template": "{underscore_name}_{argname}", 
             "F_auto_reference_count": false, 
+            "F_capsule_data_type_class_template": "SHROUD_{class_lower}_capsule", 
             "F_enum_member_template": "{class_prefix}{enum_lower}_{enum_member_lower}", 
             "F_force_wrapper": false, 
             "F_impl_filename_class_template": "wrapf{cxx_class}.{F_filename_suffix}", 

--- a/regression/reference/ownership/ownership.json
+++ b/regression/reference/ownership/ownership.json
@@ -9,6 +9,7 @@
                     "C_header_filename": "wrapClass1.h", 
                     "C_impl_filename": "wrapClass1.cpp", 
                     "C_type_name": "OWN_class1", 
+                    "F_capsule_data_type": "SHROUD_class1_capsule", 
                     "F_derived_name": "class1", 
                     "LUA_class_reg": "l_Class1_Reg", 
                     "LUA_ctor_name": "Class1", 
@@ -2504,6 +2505,7 @@
             "F_abstract_interface_argument_template": "arg{index}", 
             "F_abstract_interface_subprogram_template": "{underscore_name}_{argname}", 
             "F_auto_reference_count": false, 
+            "F_capsule_data_type_class_template": "SHROUD_{class_lower}_capsule", 
             "F_enum_member_template": "{class_prefix}{enum_lower}_{enum_member_lower}", 
             "F_force_wrapper": false, 
             "F_impl_filename_class_template": "wrapf{cxx_class}.{F_filename_suffix}", 
@@ -2589,16 +2591,18 @@
             "cxx_type": "Class1", 
             "f_c_module": {
                 "--import--": [
-                    "SHROUD_capsule_data"
+                    "SHROUD_class1_capsule"
                 ]
             }, 
-            "f_c_type": "type(SHROUD_capsule_data)", 
+            "f_c_type": "type(SHROUD_class1_capsule)", 
+            "f_capsule_data_type": "SHROUD_class1_capsule", 
             "f_derived_type": "class1", 
             "f_module": {
                 "ownership_mod": [
                     "class1"
                 ]
             }, 
+            "f_module_name": "ownership_mod", 
             "f_statements": {
                 "result": {
                     "call": [

--- a/regression/reference/ownership/ownership_types.yaml
+++ b/regression/reference/ownership/ownership_types.yaml
@@ -47,8 +47,7 @@ declarations:
       base: shadow
       cxx_type: Class1
       c_type: OWN_class1
+      f_module_name: ownership_mod
       f_derived_type: class1
+      f_capsule_data_type: SHROUD_class1_capsule
       f_to_c: "{f_var}%cxxmem"
-      f_module:
-        ownership_mod:
-        - class1

--- a/regression/reference/ownership/wrapfownership.f
+++ b/regression/reference/ownership/wrapfownership.f
@@ -70,8 +70,13 @@ module ownership_mod
     ! splicer begin class.Class1.module_top
     ! splicer end class.Class1.module_top
 
+    type, bind(C) :: SHROUD_class1_capsule
+        type(C_PTR) :: addr = C_NULL_PTR  ! address of C++ memory
+        integer(C_INT) :: idtor = 0       ! index of destructor
+    end type SHROUD_class1_capsule
+
     type class1
-        type(SHROUD_capsule_data) :: cxxmem
+        type(SHROUD_class1_capsule) :: cxxmem
         ! splicer begin class.Class1.component_part
         ! splicer end class.Class1.component_part
     contains
@@ -96,18 +101,18 @@ module ownership_mod
 
         subroutine c_class1_dtor(self) &
                 bind(C, name="OWN_class1_dtor")
-            import :: SHROUD_capsule_data
+            import :: SHROUD_class1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_class1_capsule), intent(IN) :: self
         end subroutine c_class1_dtor
 
         function c_class1_get_flag(self) &
                 result(SHT_rv) &
                 bind(C, name="OWN_class1_get_flag")
             use iso_c_binding, only : C_INT
-            import :: SHROUD_capsule_data
+            import :: SHROUD_class1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_class1_capsule), intent(IN) :: self
             integer(C_INT) :: SHT_rv
         end function c_class1_get_flag
 
@@ -232,9 +237,9 @@ module ownership_mod
                 result(SHT_rv) &
                 bind(C, name="OWN_get_class_static")
             use iso_c_binding, only : C_PTR
-            import :: SHROUD_capsule_data
+            import :: SHROUD_class1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(OUT) :: SHT_crv
+            type(SHROUD_class1_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_get_class_static
 
@@ -242,10 +247,10 @@ module ownership_mod
                 result(SHT_rv) &
                 bind(C, name="OWN_get_class_new")
             use iso_c_binding, only : C_INT, C_PTR
-            import :: SHROUD_capsule_data
+            import :: SHROUD_class1_capsule
             implicit none
             integer(C_INT), value, intent(IN) :: flag
-            type(SHROUD_capsule_data), intent(OUT) :: SHT_crv
+            type(SHROUD_class1_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_get_class_new
 

--- a/regression/reference/strings/strings.json
+++ b/regression/reference/strings/strings.json
@@ -5469,6 +5469,7 @@
             "F_abstract_interface_argument_template": "arg{index}", 
             "F_abstract_interface_subprogram_template": "{underscore_name}_{argname}", 
             "F_auto_reference_count": false, 
+            "F_capsule_data_type_class_template": "SHROUD_{class_lower}_capsule", 
             "F_enum_member_template": "{class_prefix}{enum_lower}_{enum_member_lower}", 
             "F_force_wrapper": false, 
             "F_impl_filename_class_template": "wrapf{cxx_class}.{F_filename_suffix}", 

--- a/regression/reference/templates/templates.json
+++ b/regression/reference/templates/templates.json
@@ -9,6 +9,7 @@
                     "C_header_filename": "wrapvector_int.h", 
                     "C_impl_filename": "wrapvectorforint.cpp", 
                     "C_type_name": "TEM_vector_int", 
+                    "F_capsule_data_type": "SHROUD_vector_capsule", 
                     "F_derived_name": "vector_int", 
                     "F_impl_filename": "wrapfvector_int.f", 
                     "F_module_name": "vector_int_mod", 
@@ -460,6 +461,7 @@
                     "C_header_filename": "wrapvector_double.h", 
                     "C_impl_filename": "wrapvector_double.cpp", 
                     "C_type_name": "TEM_vector_double", 
+                    "F_capsule_data_type": "SHROUD_vector_capsule", 
                     "F_derived_name": "vector_double", 
                     "F_impl_filename": "wrapfvector_double.f", 
                     "F_module_name": "vector_double_mod", 
@@ -906,6 +908,7 @@
                     "C_header_filename": "wrapuser_int.h", 
                     "C_impl_filename": "wrapuser_int.cpp", 
                     "C_type_name": "TEM_user_int", 
+                    "F_capsule_data_type": "SHROUD_user_capsule", 
                     "F_derived_name": "user_int", 
                     "F_impl_filename": "wrapfuser_int.f", 
                     "F_module_name": "user_int_mod", 
@@ -1672,6 +1675,7 @@
             "F_abstract_interface_argument_template": "arg{index}", 
             "F_abstract_interface_subprogram_template": "{underscore_name}_{argname}", 
             "F_auto_reference_count": false, 
+            "F_capsule_data_type_class_template": "SHROUD_{class_lower}_capsule", 
             "F_enum_member_template": "{class_prefix}{enum_lower}_{enum_member_lower}", 
             "F_force_wrapper": false, 
             "F_impl_filename_class_template": "wrapf{cxx_class}.{F_filename_suffix}", 
@@ -2349,16 +2353,18 @@
             "cxx_type": "std::vector", 
             "f_c_module": {
                 "--import--": [
-                    "SHROUD_capsule_data"
+                    "SHROUD_vector_capsule"
                 ]
             }, 
-            "f_c_type": "type(SHROUD_capsule_data)", 
+            "f_c_type": "type(SHROUD_vector_capsule)", 
+            "f_capsule_data_type": "SHROUD_vector_capsule", 
             "f_derived_type": "vector", 
             "f_module": {
                 "vector_mod": [
                     "vector"
                 ]
             }, 
+            "f_module_name": "vector_mod", 
             "f_statements": {
                 "result": {
                     "call": [
@@ -2441,16 +2447,18 @@
             "cxx_type": "std::vector<double>", 
             "f_c_module": {
                 "--import--": [
-                    "SHROUD_capsule_data"
+                    "SHROUD_vector_capsule"
                 ]
             }, 
-            "f_c_type": "type(SHROUD_capsule_data)", 
+            "f_c_type": "type(SHROUD_vector_capsule)", 
+            "f_capsule_data_type": "SHROUD_vector_capsule", 
             "f_derived_type": "vector_double", 
             "f_module": {
                 "vector_double_mod": [
                     "vector_double"
                 ]
             }, 
+            "f_module_name": "vector_double_mod", 
             "f_statements": {
                 "result": {
                     "call": [
@@ -2510,16 +2518,18 @@
             "cxx_type": "std::vector<int>", 
             "f_c_module": {
                 "--import--": [
-                    "SHROUD_capsule_data"
+                    "SHROUD_vector_capsule"
                 ]
             }, 
-            "f_c_type": "type(SHROUD_capsule_data)", 
+            "f_c_type": "type(SHROUD_vector_capsule)", 
+            "f_capsule_data_type": "SHROUD_vector_capsule", 
             "f_derived_type": "vector_int", 
             "f_module": {
                 "vector_int_mod": [
                     "vector_int"
                 ]
             }, 
+            "f_module_name": "vector_int_mod", 
             "f_statements": {
                 "result": {
                     "call": [
@@ -2784,16 +2794,18 @@
             "cxx_type": "user", 
             "f_c_module": {
                 "--import--": [
-                    "SHROUD_capsule_data"
+                    "SHROUD_user_capsule"
                 ]
             }, 
-            "f_c_type": "type(SHROUD_capsule_data)", 
+            "f_c_type": "type(SHROUD_user_capsule)", 
+            "f_capsule_data_type": "SHROUD_user_capsule", 
             "f_derived_type": "user", 
             "f_module": {
                 "user_mod": [
                     "user"
                 ]
             }, 
+            "f_module_name": "user_mod", 
             "f_statements": {
                 "result": {
                     "call": [
@@ -2857,16 +2869,18 @@
             "cxx_type": "user<int>", 
             "f_c_module": {
                 "--import--": [
-                    "SHROUD_capsule_data"
+                    "SHROUD_user_capsule"
                 ]
             }, 
-            "f_c_type": "type(SHROUD_capsule_data)", 
+            "f_c_type": "type(SHROUD_user_capsule)", 
+            "f_capsule_data_type": "SHROUD_user_capsule", 
             "f_derived_type": "user_int", 
             "f_module": {
                 "user_int_mod": [
                     "user_int"
                 ]
             }, 
+            "f_module_name": "user_int_mod", 
             "f_statements": {
                 "result": {
                     "call": [

--- a/regression/reference/templates/templates_types.yaml
+++ b/regression/reference/templates/templates_types.yaml
@@ -10,29 +10,26 @@ declarations:
         cxx_header: <vector>
         cxx_type: std::vector<double>
         c_type: TEM_vector_double
+        f_module_name: vector_double_mod
         f_derived_type: vector_double
+        f_capsule_data_type: SHROUD_vector_capsule
         f_to_c: "{f_var}%cxxmem"
-        f_module:
-          vector_double_mod:
-          - vector_double
     - type: vector_int
       fields:
         base: shadow
         cxx_header: <vector>
         cxx_type: std::vector<int>
         c_type: TEM_vector_int
+        f_module_name: vector_int_mod
         f_derived_type: vector_int
+        f_capsule_data_type: SHROUD_vector_capsule
         f_to_c: "{f_var}%cxxmem"
-        f_module:
-          vector_int_mod:
-          - vector_int
   - type: user_int
     fields:
       base: shadow
       cxx_type: user<int>
       c_type: TEM_user_int
+      f_module_name: user_int_mod
       f_derived_type: user_int
+      f_capsule_data_type: SHROUD_user_capsule
       f_to_c: "{f_var}%cxxmem"
-      f_module:
-        user_int_mod:
-        - user_int

--- a/regression/reference/templates/wrapfuser_int.f
+++ b/regression/reference/templates/wrapfuser_int.f
@@ -13,16 +13,16 @@ module user_int_mod
     implicit none
 
 
-    type, bind(C) :: SHROUD_capsule_data
-        type(C_PTR) :: addr = C_NULL_PTR  ! address of C++ memory
-        integer(C_INT) :: idtor = 0       ! index of destructor
-    end type SHROUD_capsule_data
-
     ! splicer begin class.user_int.module_top
     ! splicer end class.user_int.module_top
 
+    type, bind(C) :: SHROUD_user_capsule
+        type(C_PTR) :: addr = C_NULL_PTR  ! address of C++ memory
+        integer(C_INT) :: idtor = 0       ! index of destructor
+    end type SHROUD_user_capsule
+
     type user_int
-        type(SHROUD_capsule_data) :: cxxmem
+        type(SHROUD_user_capsule) :: cxxmem
         ! splicer begin class.user_int.component_part
         ! splicer end class.user_int.component_part
     contains
@@ -47,9 +47,9 @@ module user_int_mod
         subroutine c_user_int_nested_double(self, arg1, arg2) &
                 bind(C, name="TEM_user_int_nested_double")
             use iso_c_binding, only : C_DOUBLE, C_INT
-            import :: SHROUD_capsule_data
+            import :: SHROUD_user_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_user_capsule), intent(IN) :: self
             integer(C_INT), value, intent(IN) :: arg1
             real(C_DOUBLE), value, intent(IN) :: arg2
         end subroutine c_user_int_nested_double

--- a/regression/reference/templates/wrapfvector_double.f
+++ b/regression/reference/templates/wrapfvector_double.f
@@ -13,16 +13,16 @@ module vector_double_mod
     implicit none
 
 
-    type, bind(C) :: SHROUD_capsule_data
-        type(C_PTR) :: addr = C_NULL_PTR  ! address of C++ memory
-        integer(C_INT) :: idtor = 0       ! index of destructor
-    end type SHROUD_capsule_data
-
     ! splicer begin class.vector_double.module_top
     ! splicer end class.vector_double.module_top
 
+    type, bind(C) :: SHROUD_vector_capsule
+        type(C_PTR) :: addr = C_NULL_PTR  ! address of C++ memory
+        integer(C_INT) :: idtor = 0       ! index of destructor
+    end type SHROUD_vector_capsule
+
     type vector_double
-        type(SHROUD_capsule_data) :: cxxmem
+        type(SHROUD_vector_capsule) :: cxxmem
         ! splicer begin class.vector_double.component_part
         ! splicer end class.vector_double.component_part
     contains
@@ -50,25 +50,25 @@ module vector_double_mod
                 result(SHT_rv) &
                 bind(C, name="TEM_vector_double_ctor")
             use iso_c_binding, only : C_PTR
-            import :: SHROUD_capsule_data
+            import :: SHROUD_vector_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(OUT) :: SHT_crv
+            type(SHROUD_vector_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_vector_double_ctor
 
         subroutine c_vector_double_dtor(self) &
                 bind(C, name="TEM_vector_double_dtor")
-            import :: SHROUD_capsule_data
+            import :: SHROUD_vector_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_vector_capsule), intent(IN) :: self
         end subroutine c_vector_double_dtor
 
         subroutine c_vector_double_push_back(self, value) &
                 bind(C, name="TEM_vector_double_push_back")
             use iso_c_binding, only : C_DOUBLE
-            import :: SHROUD_capsule_data
+            import :: SHROUD_vector_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_vector_capsule), intent(IN) :: self
             real(C_DOUBLE), intent(IN) :: value
         end subroutine c_vector_double_push_back
 
@@ -76,9 +76,9 @@ module vector_double_mod
                 result(SHT_rv) &
                 bind(C, name="TEM_vector_double_at")
             use iso_c_binding, only : C_DOUBLE, C_PTR, C_SIZE_T
-            import :: SHROUD_capsule_data
+            import :: SHROUD_vector_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_vector_capsule), intent(IN) :: self
             integer(C_SIZE_T), value, intent(IN) :: n
             type(C_PTR) SHT_rv
         end function c_vector_double_at

--- a/regression/reference/templates/wrapfvector_int.f
+++ b/regression/reference/templates/wrapfvector_int.f
@@ -13,16 +13,16 @@ module vector_int_mod
     implicit none
 
 
-    type, bind(C) :: SHROUD_capsule_data
-        type(C_PTR) :: addr = C_NULL_PTR  ! address of C++ memory
-        integer(C_INT) :: idtor = 0       ! index of destructor
-    end type SHROUD_capsule_data
-
     ! splicer begin class.vector_int.module_top
     ! splicer end class.vector_int.module_top
 
+    type, bind(C) :: SHROUD_vector_capsule
+        type(C_PTR) :: addr = C_NULL_PTR  ! address of C++ memory
+        integer(C_INT) :: idtor = 0       ! index of destructor
+    end type SHROUD_vector_capsule
+
     type vector_int
-        type(SHROUD_capsule_data) :: cxxmem
+        type(SHROUD_vector_capsule) :: cxxmem
         ! splicer begin class.vector_int.component_part
         ! splicer end class.vector_int.component_part
     contains
@@ -50,25 +50,25 @@ module vector_int_mod
                 result(SHT_rv) &
                 bind(C, name="TEM_vector_int_ctor")
             use iso_c_binding, only : C_PTR
-            import :: SHROUD_capsule_data
+            import :: SHROUD_vector_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(OUT) :: SHT_crv
+            type(SHROUD_vector_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_vector_int_ctor
 
         subroutine c_vector_int_dtor(self) &
                 bind(C, name="TEM_vector_int_dtor")
-            import :: SHROUD_capsule_data
+            import :: SHROUD_vector_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_vector_capsule), intent(IN) :: self
         end subroutine c_vector_int_dtor
 
         subroutine c_vector_int_push_back(self, value) &
                 bind(C, name="TEM_vector_int_push_back")
             use iso_c_binding, only : C_INT
-            import :: SHROUD_capsule_data
+            import :: SHROUD_vector_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_vector_capsule), intent(IN) :: self
             integer(C_INT), intent(IN) :: value
         end subroutine c_vector_int_push_back
 
@@ -76,9 +76,9 @@ module vector_int_mod
                 result(SHT_rv) &
                 bind(C, name="TEM_vector_int_at")
             use iso_c_binding, only : C_INT, C_PTR, C_SIZE_T
-            import :: SHROUD_capsule_data
+            import :: SHROUD_vector_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_vector_capsule), intent(IN) :: self
             integer(C_SIZE_T), value, intent(IN) :: n
             type(C_PTR) SHT_rv
         end function c_vector_int_at

--- a/regression/reference/tutorial/tutorial.json
+++ b/regression/reference/tutorial/tutorial.json
@@ -9,6 +9,7 @@
                     "C_header_filename": "wrapstruct1.h", 
                     "C_impl_filename": "wrapstruct1.cpp", 
                     "C_type_name": "TUT_struct1", 
+                    "F_capsule_data_type": "SHROUD_struct1_capsule", 
                     "F_derived_name": "struct1", 
                     "LUA_class_reg": "l_struct1_Reg", 
                     "LUA_ctor_name": "struct1", 
@@ -163,6 +164,7 @@
                     "C_header_filename": "wrapClass1.h", 
                     "C_impl_filename": "wrapClass1.cpp", 
                     "C_type_name": "TUT_class1", 
+                    "F_capsule_data_type": "SHROUD_class1_capsule", 
                     "F_derived_name": "class1", 
                     "LUA_class_reg": "l_Class1_Reg", 
                     "LUA_ctor_name": "Class1", 
@@ -1489,6 +1491,7 @@
                     "C_header_filename": "wrapSingleton.h", 
                     "C_impl_filename": "wrapSingleton.cpp", 
                     "C_type_name": "TUT_singleton", 
+                    "F_capsule_data_type": "SHROUD_singleton_capsule", 
                     "F_derived_name": "singleton", 
                     "PY_PyObject": "PY_Singleton", 
                     "PY_PyTypeObject": "PY_Singleton_Type", 
@@ -9176,6 +9179,7 @@
             "F_abstract_interface_argument_template": "arg{index}", 
             "F_abstract_interface_subprogram_template": "{underscore_name}_{argname}", 
             "F_auto_reference_count": false, 
+            "F_capsule_data_type_class_template": "SHROUD_{class_lower}_capsule", 
             "F_enum_member_template": "{class_prefix}{enum_lower}_{enum_member_lower}", 
             "F_force_wrapper": false, 
             "F_impl_filename_class_template": "wrapf{cxx_class}.{F_filename_suffix}", 
@@ -9326,16 +9330,18 @@
             "cxx_type": "Singleton", 
             "f_c_module": {
                 "--import--": [
-                    "SHROUD_capsule_data"
+                    "SHROUD_singleton_capsule"
                 ]
             }, 
-            "f_c_type": "type(SHROUD_capsule_data)", 
+            "f_c_type": "type(SHROUD_singleton_capsule)", 
+            "f_capsule_data_type": "SHROUD_singleton_capsule", 
             "f_derived_type": "singleton", 
             "f_module": {
                 "tutorial_mod": [
                     "singleton"
                 ]
             }, 
+            "f_module_name": "tutorial_mod", 
             "f_statements": {
                 "result": {
                     "call": [
@@ -10228,16 +10234,18 @@
             "cxx_type": "tutorial::Class1", 
             "f_c_module": {
                 "--import--": [
-                    "SHROUD_capsule_data"
+                    "SHROUD_class1_capsule"
                 ]
             }, 
-            "f_c_type": "type(SHROUD_capsule_data)", 
+            "f_c_type": "type(SHROUD_class1_capsule)", 
+            "f_capsule_data_type": "SHROUD_class1_capsule", 
             "f_derived_type": "class1", 
             "f_module": {
                 "tutorial_mod": [
                     "class1"
                 ]
             }, 
+            "f_module_name": "tutorial_mod", 
             "f_statements": {
                 "result": {
                     "call": [

--- a/regression/reference/tutorial/tutorial_types.yaml
+++ b/regression/reference/tutorial/tutorial_types.yaml
@@ -47,11 +47,10 @@ declarations:
       base: shadow
       cxx_type: Singleton
       c_type: TUT_singleton
+      f_module_name: tutorial_mod
       f_derived_type: singleton
+      f_capsule_data_type: SHROUD_singleton_capsule
       f_to_c: "{f_var}%cxxmem"
-      f_module:
-        tutorial_mod:
-        - singleton
   - namespace: tutorial
     declarations: tutorial
     - type: Class1
@@ -59,17 +58,13 @@ declarations:
         base: shadow
         cxx_type: tutorial::Class1
         c_type: TUT_class1
+        f_module_name: tutorial_mod
         f_derived_type: class1
+        f_capsule_data_type: SHROUD_class1_capsule
         f_to_c: "{f_var}%cxxmem"
-        f_module:
-          tutorial_mod:
-          - class1
     - type: struct1
       fields:
         base: struct
         cxx_type: tutorial::struct1
         c_type: TUT_struct1
         f_derived_type: struct1
-        f_module:
-          tutorial_mod:
-          - struct1

--- a/regression/reference/tutorial/wrapftutorial.f
+++ b/regression/reference/tutorial/wrapftutorial.f
@@ -87,8 +87,13 @@ module tutorial_mod
     ! splicer begin class.Class1.module_top
     ! splicer end class.Class1.module_top
 
+    type, bind(C) :: SHROUD_class1_capsule
+        type(C_PTR) :: addr = C_NULL_PTR  ! address of C++ memory
+        integer(C_INT) :: idtor = 0       ! index of destructor
+    end type SHROUD_class1_capsule
+
     type class1
-        type(SHROUD_capsule_data) :: cxxmem
+        type(SHROUD_class1_capsule) :: cxxmem
         ! splicer begin class.Class1.component_part
         ! splicer end class.Class1.component_part
     contains
@@ -112,8 +117,13 @@ module tutorial_mod
     ! splicer begin class.Singleton.module_top
     ! splicer end class.Singleton.module_top
 
+    type, bind(C) :: SHROUD_singleton_capsule
+        type(C_PTR) :: addr = C_NULL_PTR  ! address of C++ memory
+        integer(C_INT) :: idtor = 0       ! index of destructor
+    end type SHROUD_singleton_capsule
+
     type singleton
-        type(SHROUD_capsule_data) :: cxxmem
+        type(SHROUD_singleton_capsule) :: cxxmem
         ! splicer begin class.Singleton.component_part
         ! splicer end class.Singleton.component_part
     contains
@@ -152,9 +162,9 @@ module tutorial_mod
                 result(SHT_rv) &
                 bind(C, name="TUT_class1_new_default")
             use iso_c_binding, only : C_PTR
-            import :: SHROUD_capsule_data
+            import :: SHROUD_class1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(OUT) :: SHT_crv
+            type(SHROUD_class1_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_class1_new_default
 
@@ -162,27 +172,27 @@ module tutorial_mod
                 result(SHT_rv) &
                 bind(C, name="TUT_class1_new_flag")
             use iso_c_binding, only : C_INT, C_PTR
-            import :: SHROUD_capsule_data
+            import :: SHROUD_class1_capsule
             implicit none
             integer(C_INT), value, intent(IN) :: flag
-            type(SHROUD_capsule_data), intent(OUT) :: SHT_crv
+            type(SHROUD_class1_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_class1_new_flag
 
         subroutine c_class1_delete(self) &
                 bind(C, name="TUT_class1_delete")
-            import :: SHROUD_capsule_data
+            import :: SHROUD_class1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_class1_capsule), intent(IN) :: self
         end subroutine c_class1_delete
 
         function c_class1_method1(self) &
                 result(SHT_rv) &
                 bind(C, name="TUT_class1_method1")
             use iso_c_binding, only : C_INT
-            import :: SHROUD_capsule_data
+            import :: SHROUD_class1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_class1_capsule), intent(IN) :: self
             integer(C_INT) :: SHT_rv
         end function c_class1_method1
 
@@ -190,30 +200,30 @@ module tutorial_mod
                 result(SHT_rv) &
                 bind(C, name="TUT_class1_equivalent")
             use iso_c_binding, only : C_BOOL
-            import :: SHROUD_capsule_data
+            import :: SHROUD_class1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
-            type(SHROUD_capsule_data), intent(IN) :: obj2
+            type(SHROUD_class1_capsule), intent(IN) :: self
+            type(SHROUD_class1_capsule), intent(IN) :: obj2
             logical(C_BOOL) :: SHT_rv
         end function c_class1_equivalent
 
         subroutine c_class1_return_this(self) &
                 bind(C, name="TUT_class1_return_this")
-            import :: SHROUD_capsule_data
+            import :: SHROUD_class1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_class1_capsule), intent(IN) :: self
         end subroutine c_class1_return_this
 
         function c_class1_return_this_buffer(self, name, flag, SHT_crv) &
                 result(SHT_rv) &
                 bind(C, name="TUT_class1_return_this_buffer")
             use iso_c_binding, only : C_BOOL, C_CHAR, C_PTR
-            import :: SHROUD_capsule_data
+            import :: SHROUD_class1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_class1_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: name(*)
             logical(C_BOOL), value, intent(IN) :: flag
-            type(SHROUD_capsule_data), intent(OUT) :: SHT_crv
+            type(SHROUD_class1_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_class1_return_this_buffer
 
@@ -222,13 +232,13 @@ module tutorial_mod
                 result(SHT_rv) &
                 bind(C, name="TUT_class1_return_this_buffer_bufferify")
             use iso_c_binding, only : C_BOOL, C_CHAR, C_INT, C_PTR
-            import :: SHROUD_capsule_data
+            import :: SHROUD_class1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_class1_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: name(*)
             integer(C_INT), value, intent(IN) :: Lname
             logical(C_BOOL), value, intent(IN) :: flag
-            type(SHROUD_capsule_data), intent(OUT) :: SHT_crv
+            type(SHROUD_class1_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_class1_return_this_buffer_bufferify
 
@@ -236,10 +246,10 @@ module tutorial_mod
                 result(SHT_rv) &
                 bind(C, name="TUT_class1_getclass3")
             use iso_c_binding, only : C_PTR
-            import :: SHROUD_capsule_data
+            import :: SHROUD_class1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
-            type(SHROUD_capsule_data), intent(OUT) :: SHT_crv
+            type(SHROUD_class1_capsule), intent(IN) :: self
+            type(SHROUD_class1_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_class1_getclass3
 
@@ -247,9 +257,9 @@ module tutorial_mod
                 result(SHT_rv) &
                 bind(C, name="TUT_class1_direction_func")
             use iso_c_binding, only : C_INT
-            import :: SHROUD_capsule_data
+            import :: SHROUD_class1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_class1_capsule), intent(IN) :: self
             integer(C_INT), value, intent(IN) :: arg
             integer(C_INT) :: SHT_rv
         end function c_class1_direction_func
@@ -258,9 +268,9 @@ module tutorial_mod
                 result(SHT_rv) &
                 bind(C, name="TUT_class1_get_m_flag")
             use iso_c_binding, only : C_INT
-            import :: SHROUD_capsule_data
+            import :: SHROUD_class1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_class1_capsule), intent(IN) :: self
             integer(C_INT) :: SHT_rv
         end function c_class1_get_m_flag
 
@@ -268,18 +278,18 @@ module tutorial_mod
                 result(SHT_rv) &
                 bind(C, name="TUT_class1_get_test")
             use iso_c_binding, only : C_INT
-            import :: SHROUD_capsule_data
+            import :: SHROUD_class1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_class1_capsule), intent(IN) :: self
             integer(C_INT) :: SHT_rv
         end function c_class1_get_test
 
         subroutine c_class1_set_test(self, val) &
                 bind(C, name="TUT_class1_set_test")
             use iso_c_binding, only : C_INT
-            import :: SHROUD_capsule_data
+            import :: SHROUD_class1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: self
+            type(SHROUD_class1_capsule), intent(IN) :: self
             integer(C_INT), value, intent(IN) :: val
         end subroutine c_class1_set_test
 
@@ -290,9 +300,9 @@ module tutorial_mod
                 result(SHT_rv) &
                 bind(C, name="TUT_singleton_get_reference")
             use iso_c_binding, only : C_PTR
-            import :: SHROUD_capsule_data
+            import :: SHROUD_singleton_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(OUT) :: SHT_crv
+            type(SHROUD_singleton_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_singleton_get_reference
 
@@ -633,9 +643,9 @@ module tutorial_mod
                 result(SHT_rv) &
                 bind(C, name="TUT_useclass")
             use iso_c_binding, only : C_INT
-            import :: SHROUD_capsule_data
+            import :: SHROUD_class1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(IN) :: arg1
+            type(SHROUD_class1_capsule), intent(IN) :: arg1
             integer(C_INT) :: SHT_rv
         end function c_useclass
 
@@ -643,9 +653,9 @@ module tutorial_mod
                 result(SHT_rv) &
                 bind(C, name="TUT_getclass2")
             use iso_c_binding, only : C_PTR
-            import :: SHROUD_capsule_data
+            import :: SHROUD_class1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(OUT) :: SHT_crv
+            type(SHROUD_class1_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_getclass2
 
@@ -653,9 +663,9 @@ module tutorial_mod
                 result(SHT_rv) &
                 bind(C, name="TUT_getclass3")
             use iso_c_binding, only : C_PTR
-            import :: SHROUD_capsule_data
+            import :: SHROUD_class1_capsule
             implicit none
-            type(SHROUD_capsule_data), intent(OUT) :: SHT_crv
+            type(SHROUD_class1_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_getclass3
 
@@ -663,10 +673,10 @@ module tutorial_mod
                 result(SHT_rv) &
                 bind(C, name="TUT_get_class_copy")
             use iso_c_binding, only : C_INT, C_PTR
-            import :: SHROUD_capsule_data
+            import :: SHROUD_class1_capsule
             implicit none
             integer(C_INT), value, intent(IN) :: flag
-            type(SHROUD_capsule_data), intent(OUT) :: SHT_crv
+            type(SHROUD_class1_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_get_class_copy
 

--- a/regression/reference/types/types.json
+++ b/regression/reference/types/types.json
@@ -2692,6 +2692,7 @@
             "F_abstract_interface_argument_template": "arg{index}", 
             "F_abstract_interface_subprogram_template": "{underscore_name}_{argname}", 
             "F_auto_reference_count": false, 
+            "F_capsule_data_type_class_template": "SHROUD_{class_lower}_capsule", 
             "F_enum_member_template": "{class_prefix}{enum_lower}_{enum_member_lower}", 
             "F_force_wrapper": false, 
             "F_impl_filename_class_template": "wrapf{cxx_class}.{F_filename_suffix}", 

--- a/regression/reference/vectors/vectors.json
+++ b/regression/reference/vectors/vectors.json
@@ -1274,6 +1274,7 @@
             "F_abstract_interface_argument_template": "arg{index}", 
             "F_abstract_interface_subprogram_template": "{underscore_name}_{argname}", 
             "F_auto_reference_count": false, 
+            "F_capsule_data_type_class_template": "SHROUD_{class_lower}_capsule", 
             "F_enum_member_template": "{class_prefix}{enum_lower}_{enum_member_lower}", 
             "F_force_wrapper": false, 
             "F_impl_filename_class_template": "wrapf{cxx_class}.{F_filename_suffix}", 

--- a/shroud/ast.py
+++ b/shroud/ast.py
@@ -409,6 +409,7 @@ class LibraryNode(AstNode, NamespaceMixin):
             F_module_name_library_template='{library_lower}_mod',
             F_impl_filename_library_template='wrapf{library_lower}.{F_filename_suffix}',
 
+            F_capsule_data_type_class_template='SHROUD_{class_lower}_capsule',
             F_module_name_class_template='{class_lower}_mod',
             F_impl_filename_class_template='wrapf{cxx_class}.{F_filename_suffix}',
             F_abstract_interface_subprogram_template='{underscore_name}_{argname}',
@@ -871,6 +872,7 @@ class ClassNode(AstNode, NamespaceMixin):
         self.eval_template('C_header_filename', '_class')
         self.eval_template('C_impl_filename', '_class')
 
+        self.eval_template('F_capsule_data_type', '_class')
         if self.options.F_module_per_class:
             self.eval_template('F_module_name', '_class')
             self.eval_template('F_impl_filename', '_class')


### PR DESCRIPTION
XLF reported an error when F_capsule_data_type was being used in
multiple modules:
  Actual argument attributes do not match those specified by an
  accessible explicit interface.
Even if the derived types have the same members and same name, they are not
the same type if they are defined in different modules.

Now create a capsule derived type for each class.
The other alternative was to create a shared type in its own module.
However, this presents compile problems for the user since only one
instance of the capsule type can be compiled.