### PR TITLE
Rename language attribute from c++ to cxx

### DIFF
--- a/regression/reference/example/example.json
+++ b/regression/reference/example/example.json
@@ -9098,7 +9098,7 @@
                 }
             }
         ],
-        "language": "c++",
+        "language": "cxx",
         "options": {
             "C_enum_member_template": "{C_prefix}{C_scope_name}{enum_member_name}",
             "C_enum_template": "{C_prefix}{flat_name}",

--- a/regression/reference/forward/forward.json
+++ b/regression/reference/forward/forward.json
@@ -532,7 +532,7 @@
             "stdlib": "std::",
             "template_suffix": ""
         },
-        "language": "c++",
+        "language": "cxx",
         "options": {
             "C_enum_member_template": "{C_prefix}{C_scope_name}{enum_member_name}",
             "C_enum_template": "{C_prefix}{flat_name}",

--- a/regression/reference/include/include.json
+++ b/regression/reference/include/include.json
@@ -420,7 +420,7 @@
                 "options": {}
             }
         ],
-        "language": "c++",
+        "language": "cxx",
         "options": {
             "C_enum_member_template": "{C_prefix}{C_scope_name}{enum_member_name}",
             "C_enum_template": "{C_prefix}{flat_name}",

--- a/regression/reference/names/names.json
+++ b/regression/reference/names/names.json
@@ -2089,7 +2089,7 @@
                 ]
             }
         ],
-        "language": "c++",
+        "language": "cxx",
         "options": {
             "C_enum_member_template": "{C_prefix}{C_scope_name}{enum_member_name}",
             "C_enum_template": "{C_prefix}{flat_name}",

--- a/regression/reference/none/none.json
+++ b/regression/reference/none/none.json
@@ -90,7 +90,7 @@
             "stdlib": "std::",
             "template_suffix": ""
         },
-        "language": "c++",
+        "language": "cxx",
         "options": {
             "C_enum_member_template": "{C_prefix}{C_scope_name}{enum_member_name}",
             "C_enum_template": "{C_prefix}{flat_name}",

--- a/regression/reference/ownership/ownership.json
+++ b/regression/reference/ownership/ownership.json
@@ -2459,7 +2459,7 @@
                 }
             }
         ],
-        "language": "c++",
+        "language": "cxx",
         "options": {
             "C_enum_member_template": "{C_prefix}{C_scope_name}{enum_member_name}",
             "C_enum_template": "{C_prefix}{flat_name}",

--- a/regression/reference/pointers/pointers.json
+++ b/regression/reference/pointers/pointers.json
@@ -1171,7 +1171,7 @@
                 "options": {}
             }
         ],
-        "language": "c++",
+        "language": "cxx",
         "options": {
             "C_enum_member_template": "{C_prefix}{C_scope_name}{enum_member_name}",
             "C_enum_template": "{C_prefix}{flat_name}",

--- a/regression/reference/preprocess/preprocess.json
+++ b/regression/reference/preprocess/preprocess.json
@@ -546,7 +546,7 @@
             "stdlib": "std::",
             "template_suffix": ""
         },
-        "language": "c++",
+        "language": "cxx",
         "options": {
             "C_enum_member_template": "{C_prefix}{C_scope_name}{enum_member_name}",
             "C_enum_template": "{C_prefix}{flat_name}",

--- a/regression/reference/scope/scope.json
+++ b/regression/reference/scope/scope.json
@@ -509,7 +509,7 @@
             "stdlib": "std::",
             "template_suffix": ""
         },
-        "language": "c++",
+        "language": "cxx",
         "options": {
             "C_enum_member_template": "{C_prefix}{C_scope_name}{enum_member_name}",
             "C_enum_template": "{C_prefix}{flat_name}",

--- a/regression/reference/strings/strings.json
+++ b/regression/reference/strings/strings.json
@@ -5374,7 +5374,7 @@
                 }
             }
         ],
-        "language": "c++",
+        "language": "cxx",
         "options": {
             "C_enum_member_template": "{C_prefix}{C_scope_name}{enum_member_name}",
             "C_enum_template": "{C_prefix}{flat_name}",

--- a/regression/reference/templates/templates.json
+++ b/regression/reference/templates/templates.json
@@ -2103,7 +2103,7 @@
                 ]
             }
         ],
-        "language": "c++",
+        "language": "cxx",
         "options": {
             "C_enum_member_template": "{C_prefix}{C_scope_name}{enum_member_name}",
             "C_enum_template": "{C_prefix}{flat_name}",

--- a/regression/reference/tutorial/tutorial.json
+++ b/regression/reference/tutorial/tutorial.json
@@ -9414,7 +9414,7 @@
                 }
             }
         ],
-        "language": "c++",
+        "language": "cxx",
         "options": {
             "C_enum_member_template": "{C_prefix}{C_scope_name}{enum_member_name}",
             "C_enum_template": "{C_prefix}{flat_name}",

--- a/regression/reference/types/types.json
+++ b/regression/reference/types/types.json
@@ -2771,7 +2771,7 @@
                 "options": {}
             }
         ],
-        "language": "c++",
+        "language": "cxx",
         "options": {
             "C_enum_member_template": "{C_prefix}{C_scope_name}{enum_member_name}",
             "C_enum_template": "{C_prefix}{flat_name}",

--- a/regression/reference/vectors/vectors.json
+++ b/regression/reference/vectors/vectors.json
@@ -1228,7 +1228,7 @@
                 }
             }
         ],
-        "language": "c++",
+        "language": "cxx",
         "options": {
             "C_enum_member_template": "{C_prefix}{C_scope_name}{enum_member_name}",
             "C_enum_template": "{C_prefix}{flat_name}",

--- a/shroud/ast.py
+++ b/shroud/ast.py
@@ -260,6 +260,9 @@ class LibraryNode(AstNode, NamespaceMixin):
         self.language = language.lower()
         if self.language not in ["c", "c++"]:
             raise RuntimeError("language must be 'c' or 'c++'")
+        if self.language == "c++":
+            # Use a form which can be used as a variable name
+            self.language = "cxx"
         self.library = library
 
         self.classes = []

--- a/shroud/typemap.py
+++ b/shroud/typemap.py
@@ -1461,7 +1461,7 @@ def fill_struct_typemap_defaults(node, ntypemap):
 
     libnode = node.get_LibraryNode()
     language = libnode.language
-    if language == "c++":
+    if language == "cxx":
         # C++ pointer -> void pointer -> C pointer
         ntypemap.cxx_to_c = (
             "static_cast<{c_const}%s *>("

--- a/shroud/wrapc.py
+++ b/shroud/wrapc.py
@@ -28,6 +28,8 @@ from .util import append_format, wformat
 
 default_owner = "library"
 
+lang_map = {"c": "C", "cxx": "C++"}
+
 
 class Wrapc(util.WrapperMixin):
     """Generate C bindings for C++ classes
@@ -236,7 +238,7 @@ class Wrapc(util.WrapperMixin):
 
         output.extend(
             [
-                "// For C users and %s implementation" % self.language.upper(),
+                "// For C users and %s implementation" % lang_map[self.language],
                 "",
                 "#ifndef %s" % guard,
                 "#define %s" % guard,
@@ -248,7 +250,7 @@ class Wrapc(util.WrapperMixin):
             "c_header", {}, self.helper_shared_include.keys(), output
         )
 
-        if self.language == "c++":
+        if self.language == "cxx":
             output.append("")
             #            if self._create_splicer('CXX_declarations', output):
             #                write_file = True
@@ -259,7 +261,7 @@ class Wrapc(util.WrapperMixin):
         if self.shared_proto_c:
             output.extend(self.shared_proto_c)
 
-        if self.language == "c++":
+        if self.language == "cxx":
             output.extend(["", "#ifdef __cplusplus", "}", "#endif"])
 
         output.extend(["", "#endif  // " + guard])
@@ -290,7 +292,7 @@ class Wrapc(util.WrapperMixin):
 
         output.extend(
             [
-                "// For C users and %s implementation" % self.language.upper(),
+                "// For C users and %s implementation" % lang_map[self.language],
                 "",
                 "#ifndef %s" % guard,
                 "#define %s" % guard,
@@ -307,7 +309,7 @@ class Wrapc(util.WrapperMixin):
             output,
         )
 
-        if self.language == "c++":
+        if self.language == "cxx":
             output.append("")
             if self._create_splicer("CXX_declarations", output):
                 write_file = True
@@ -346,7 +348,7 @@ class Wrapc(util.WrapperMixin):
         if self.header_proto_c:
             write_file = True
             output.extend(self.header_proto_c)
-        if self.language == "c++":
+        if self.language == "cxx":
             output.extend(["", "#ifdef __cplusplus", "}", "#endif"])
         if cls and cls.cpp_if:
             output.append("#endif  // " + node.cpp_if)
@@ -392,7 +394,7 @@ class Wrapc(util.WrapperMixin):
             headers = self.header_impl_include.keys()
             self.write_headers(headers, output)
 
-        if self.language == "c++":
+        if self.language == "cxx":
             output.append("")
             if self._create_splicer("CXX_definitions", output):
                 write_file = True
@@ -409,7 +411,7 @@ class Wrapc(util.WrapperMixin):
             write_file = True
             output.extend(self.impl)
 
-        if self.language == "c++":
+        if self.language == "cxx":
             output.append("")
             output.append('}  // extern "C"')
 

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -646,7 +646,7 @@ return 1;""",
             wformat("PyArray_NewLikeArray"
                     "(\t{prototype},\t {order},\t {descr},\t {subok})", allocargs),
         )
-        if self.language == "c++":
+        if self.language == "cxx":
             cast = "{cxx_decl} = %s;" % do_cast(
                 self.language,
                 "static",
@@ -756,7 +756,7 @@ return 1;""",
                 "\t{pytmp_var},\t {numpy_type},\t {numpy_intent})",
             )
 
-        if self.language == "c++":
+        if self.language == "cxx":
             cast = "{cxx_decl} = %s;" % do_cast(
                 self.language,
                 "static",
@@ -1355,7 +1355,7 @@ return 1;""",
             fmt.PY_used_param_kwds = True
             need_blank = True
 
-            if self.language == "c++":
+            if self.language == "cxx":
                 kw_const = "const "
                 fmt.PyArg_kwlist = "const_cast<char **>(SHT_kwlist)"
             else:
@@ -1423,7 +1423,7 @@ return 1;""",
                 PY_code.extend(post_parse[:len_post_parse])
                 need_blank = True
 
-            if self.language == "c++" and goto_fail:
+            if self.language == "cxx" and goto_fail:
                 # Need an extra scope to deal with C++ error
                 # error: jump to label 'fail' crosses initialization of ...
                 PY_code.append("{")


### PR DESCRIPTION
It is only renamed internally. YAML still sets it as c++.
This change is to make it easier to use langage when
generating variable names.

dict(c++=[])  bad
dict(cxx=[])  good