### PR TITLE
Use cxx_header with template instantiation

### DIFF
--- a/regression/reference/example/example.json
+++ b/regression/reference/example/example.json
@@ -4881,6 +4881,12 @@
                                             "template_suffix": "_double",
                                             "underscore_name": "set_value"
                                         },
+                                        "gen_headers_typedef": [
+                                            "double",
+                                            "float",
+                                            "int",
+                                            "long"
+                                        ],
                                         "have_template_args": true,
                                         "linenumber": 212,
                                         "options": {
@@ -5190,6 +5196,10 @@
                                             "template_suffix": "_double",
                                             "underscore_name": "get_value"
                                         },
+                                        "gen_headers_typedef": [
+                                            "double",
+                                            "int"
+                                        ],
                                         "have_template_args": true,
                                         "linenumber": 219,
                                         "options": {

--- a/regression/reference/names/names.json
+++ b/regression/reference/names/names.json
@@ -1328,6 +1328,12 @@
                     "template_suffix": "_instantiation2",
                     "underscore_name": "function_tu"
                 },
+                "gen_headers_typedef": [
+                    "double",
+                    "float",
+                    "int",
+                    "long"
+                ],
                 "have_template_args": true,
                 "linenumber": 145,
                 "options": {
@@ -1509,6 +1515,9 @@
                     "template_suffix": "_instantiation3",
                     "underscore_name": "use_impl_worker"
                 },
+                "gen_headers_typedef": [
+                    "internal::ImplWorker1"
+                ],
                 "linenumber": 196,
                 "options": {
                     "wrap_c": true,

--- a/regression/reference/templates/pyImplWorker1type.cpp
+++ b/regression/reference/templates/pyImplWorker1type.cpp
@@ -1,7 +1,7 @@
 // pyImplWorker1type.cpp
 // This is generated code, do not edit
 #include "pytemplatesmodule.hpp"
-#include "templates.hpp"
+#include "implworker1.hpp"
 // splicer begin namespace.internal.class.ImplWorker1.impl.include
 // splicer end namespace.internal.class.ImplWorker1.impl.include
 

--- a/regression/reference/templates/templates.json
+++ b/regression/reference/templates/templates.json
@@ -107,7 +107,7 @@
                             "underscore_name": "nested"
                         },
                         "have_template_args": true,
-                        "linenumber": 62,
+                        "linenumber": 63,
                         "options": {
                             "wrap_c": false,
                             "wrap_fortran": false,
@@ -271,8 +271,11 @@
                             "template_suffix": "_double",
                             "underscore_name": "nested"
                         },
+                        "gen_headers_typedef": [
+                            "double"
+                        ],
                         "have_template_args": true,
-                        "linenumber": 62,
+                        "linenumber": 63,
                         "options": {
                             "wrap_c": true,
                             "wrap_fortran": true,
@@ -297,7 +300,7 @@
                         ]
                     }
                 ],
-                "linenumber": 57,
+                "linenumber": 58,
                 "name": "user",
                 "options": {},
                 "scope": "user::",
@@ -480,7 +483,7 @@
                 "decl": "template<T,U> void FunctionTU(T arg1, U arg2)",
                 "declgen": "void FunctionTU(T arg1 +intent(in)+value, U arg2 +intent(in)+value)",
                 "doxygen": {
-                    "__line__": 83,
+                    "__line__": 84,
                     "brief": "Function template with two template parameters."
                 },
                 "fmtdict": {
@@ -488,7 +491,7 @@
                     "underscore_name": "function_tu"
                 },
                 "have_template_args": true,
-                "linenumber": 82,
+                "linenumber": 83,
                 "options": {
                     "wrap_c": false,
                     "wrap_fortran": false,
@@ -650,7 +653,7 @@
                 "decl": "template<T,U> void FunctionTU(T arg1, U arg2)",
                 "declgen": "void FunctionTU(int arg1 +intent(in)+value, long arg2 +intent(in)+value)",
                 "doxygen": {
-                    "__line__": 83,
+                    "__line__": 84,
                     "brief": "Function template with two template parameters."
                 },
                 "fmtdict": {
@@ -677,7 +680,7 @@
                     "underscore_name": "function_tu"
                 },
                 "have_template_args": true,
-                "linenumber": 82,
+                "linenumber": 83,
                 "options": {
                     "wrap_c": true,
                     "wrap_fortran": true,
@@ -839,7 +842,7 @@
                 "decl": "template<T,U> void FunctionTU(T arg1, U arg2)",
                 "declgen": "void FunctionTU(float arg1 +intent(in)+value, double arg2 +intent(in)+value)",
                 "doxygen": {
-                    "__line__": 83,
+                    "__line__": 84,
                     "brief": "Function template with two template parameters."
                 },
                 "fmtdict": {
@@ -865,8 +868,14 @@
                     "template_suffix": "_1",
                     "underscore_name": "function_tu"
                 },
+                "gen_headers_typedef": [
+                    "double",
+                    "float",
+                    "int",
+                    "long"
+                ],
                 "have_template_args": true,
-                "linenumber": 82,
+                "linenumber": 83,
                 "options": {
                     "wrap_c": true,
                     "wrap_fortran": true,
@@ -935,14 +944,14 @@
                 "decl": "template<typename T> int UseImplWorker()",
                 "declgen": "int UseImplWorker()",
                 "doxygen": {
-                    "__line__": 97,
+                    "__line__": 98,
                     "brief": "Function which uses a templated T in the implemetation."
                 },
                 "fmtdict": {
                     "function_name": "UseImplWorker",
                     "underscore_name": "use_impl_worker"
                 },
-                "linenumber": 96,
+                "linenumber": 97,
                 "options": {
                     "wrap_c": false,
                     "wrap_fortran": false,
@@ -1007,7 +1016,7 @@
                 "decl": "template<typename T> int UseImplWorker()",
                 "declgen": "int UseImplWorker()",
                 "doxygen": {
-                    "__line__": 97,
+                    "__line__": 98,
                     "brief": "Function which uses a templated T in the implemetation."
                 },
                 "fmtdict": {
@@ -1035,7 +1044,10 @@
                     "template_suffix": "_internal_ImplWorker1",
                     "underscore_name": "use_impl_worker"
                 },
-                "linenumber": 96,
+                "gen_headers_typedef": [
+                    "internal::ImplWorker1"
+                ],
+                "linenumber": 97,
                 "options": {
                     "wrap_c": true,
                     "wrap_fortran": true,
@@ -2120,7 +2132,7 @@
             {
                 "classes": [
                     {
-                        "cxx_header": "",
+                        "cxx_header": "implworker1.hpp",
                         "fmtdict": {
                             "CXX_this_call": "SH_this->",
                             "C_header_filename": "wrapImplWorker1.h",
@@ -2144,7 +2156,7 @@
                         "linenumber": 53,
                         "name": "ImplWorker1",
                         "options": {
-                            "__line__": 54,
+                            "__line__": 55,
                             "wrap_fortran": false
                         },
                         "scope": "internal::ImplWorker1::",
@@ -2791,6 +2803,7 @@
             },
             "c_to_cxx": "static_cast<{c_const}internal::ImplWorker1 *>({c_var}{c_member}addr)",
             "c_type": "TEM_internal_ImplWorker1",
+            "cxx_header": "implworker1.hpp",
             "cxx_to_c": "static_cast<{c_const}void *>(\t{cxx_addr}{cxx_var})",
             "cxx_type": "internal::ImplWorker1",
             "f_c_module": {

--- a/regression/reference/templates/templates_types.yaml
+++ b/regression/reference/templates/templates_types.yaml
@@ -16,6 +16,7 @@ declarations:
     - type: ImplWorker1
       fields:
         base: shadow
+        cxx_header: implworker1.hpp
         cxx_type: internal::ImplWorker1
         c_type: TEM_internal_ImplWorker1
         f_module_name: templates_internal_mod

--- a/regression/reference/templates/wraptemplates.cpp
+++ b/regression/reference/templates/wraptemplates.cpp
@@ -6,6 +6,8 @@
 #include "templates.hpp"
 #include "typestemplates.h"
 
+#include "implworker1.hpp"
+
 // splicer begin CXX_definitions
 // splicer end CXX_definitions
 

--- a/regression/reference/tutorial/tutorial.json
+++ b/regression/reference/tutorial/tutorial.json
@@ -3275,6 +3275,10 @@
                     "template_suffix": "_double",
                     "underscore_name": "template_argument"
                 },
+                "gen_headers_typedef": [
+                    "double",
+                    "int"
+                ],
                 "have_template_args": true,
                 "linenumber": 77,
                 "options": {
@@ -3520,6 +3524,10 @@
                     "template_suffix": "_double",
                     "underscore_name": "template_return"
                 },
+                "gen_headers_typedef": [
+                    "double",
+                    "int"
+                ],
                 "have_template_args": true,
                 "linenumber": 84,
                 "options": {

--- a/regression/run/templates/implworker1.hpp
+++ b/regression/run/templates/implworker1.hpp
@@ -1,0 +1,19 @@
+// Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC and
+// other Shroud Project Developers.
+// See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+// Put internal class in its own header to test cxx_header for a
+// class.
+
+namespace internal
+{
+    class ImplWorker1
+    {
+    public:
+        static int getValue() {
+            return 1;
+        }
+    };
+}  // namespace internal

--- a/regression/run/templates/templates.hpp
+++ b/regression/run/templates/templates.hpp
@@ -1,17 +1,8 @@
-// Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
+// Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC and
+// other Shroud Project Developers.
+// See the top-level COPYRIGHT file for details.
 //
-// Produced at the Lawrence Livermore National Laboratory
-//
-// LLNL-CODE-738041.
-//
-// All rights reserved.
-//
-// This file is part of Shroud.
-//
-// For details about use and distribution, please read LICENSE.
-//
-// #######################################################################
-
+// SPDX-License-Identifier: (BSD-3-Clause)
 
 // example from http://www.cplusplus.com/doc/tutorial/templates/
 template <class T>
@@ -36,17 +27,6 @@ T mypair<T>::getmax ()
 class Worker
 {
 };
-
-namespace internal
-{
-class ImplWorker1
-{
-  public:
-  static int getValue() {
-    return 1;
-  }
-};
-}  // namespace internal
 
 // Function template with two template parameters.
 template<typename T, typename U> void FunctionTU(T arg1, U arg2)

--- a/regression/templates.yaml
+++ b/regression/templates.yaml
@@ -51,6 +51,7 @@ declarations:
 # Class which is used to instantiate the C++ template.
 # It is not part of the Fortran API.
   - decl: class ImplWorker1
+    cxx_header: implworker1.hpp
     options:
       wrap_fortran: false
 

--- a/shroud/ast.py
+++ b/shroud/ast.py
@@ -297,6 +297,8 @@ class LibraryNode(AstNode, NamespaceMixin):
         self.variables = []
         # Each is given a _function_index when created.
         self.function_index = []
+        # Headers required by template arguments.
+        self.gen_headers_typedef = {}
 
         # namespace
         self.scope = ""
@@ -775,6 +777,9 @@ class NamespaceNode(AstNode, NamespaceMixin):
             self.namespaces = []
             self.variables = []
 
+        # Headers required by template arguments.
+        self.gen_headers_typedef = {}
+
         # add to symbol table
         self.scope = self.parent.scope + self.name + "::"
         if skip:
@@ -959,6 +964,8 @@ class ClassNode(AstNode, NamespaceMixin):
         self.template_arguments = cxx_template
         for args in cxx_template:
             args.parse_instantiation(namespace=self)
+        # Headers required by template arguments.
+        self.gen_headers_typedef = {}
 
     # # # # # namespace behavior
 
@@ -1218,6 +1225,9 @@ class FunctionNode(AstNode):
         # possible values are '', '_buf'
         self.generated_suffix = ""
 
+        # Headers required by template arguments.
+        self.gen_headers_typedef = {}
+
         if not decl:
             raise RuntimeError("FunctionNode missing decl")
 
@@ -1441,6 +1451,8 @@ class EnumNode(AstNode):
 
             fmtmembers[member.name] = fmt
         self._fmtmembers = fmtmembers
+        # Headers required by template arguments.
+        self.gen_headers_typedef = {}
 
         # Add to namespace
         self.scope = self.parent.scope + self.name + "::"

--- a/shroud/generate.py
+++ b/shroud/generate.py
@@ -774,7 +774,9 @@ class GenFunctions(object):
             ordered_functions -
         """
         oldoptions = node.options
+        headers_typedef = {}
 
+        # targs - ast.TemplateArgument
         for iargs, targs in enumerate(node.template_arguments):
             new = node.clone()
             ordered_functions.append(new)
@@ -809,6 +811,11 @@ class GenFunctions(object):
             options.wrap_lua = oldoptions.wrap_lua
             fmt.CXX_template = targs.instantiation  # ex. <int>
 
+            # Gather headers required by template arguments.
+            for targ in targs.asts:
+                ntypemap = targ.typemap
+                headers_typedef[ntypemap.name] = ntypemap
+
             self.push_instantiate_scope(new, targs)
 
             if new.ast.typemap.base == "template":
@@ -817,6 +824,7 @@ class GenFunctions(object):
                 new._CXX_return_templated = True
 
             # Replace templated arguments.
+            # arg - declast.Declaration
             newparams = []
             for arg in new.ast.params:
                 if arg.typemap.base == "template":
@@ -827,6 +835,7 @@ class GenFunctions(object):
             new.ast.params = newparams
             self.pop_instantiate_scope()
 
+        new.gen_headers_typedef = headers_typedef
         # Do not process templated node, instead process
         # generated functions above.
         options = node.options

--- a/shroud/todict.py
+++ b/shroud/todict.py
@@ -17,6 +17,9 @@ class ToDict(visitor.Visitor):
     """Convert to dictionary.
     """
 
+    def visit_bool(self, node):
+        return str(node)
+
     def visit_str(self, node):
         return str(node)
 
@@ -258,6 +261,9 @@ class ToDict(visitor.Visitor):
                 # #- 'CXX_return_type', 'C_return_type', 'F_return_type',
             ],
         )
+        if node.gen_headers_typedef:
+            d['gen_headers_typedef'] = sorted(node.gen_headers_typedef.keys())
+
         return d
 
     def visit_EnumNode(self, node):

--- a/shroud/util.py
+++ b/shroud/util.py
@@ -287,17 +287,17 @@ class WrapperMixin(object):
             else:
                 output.append('#include "%s"' % header)
 
-    def write_headers_nodes(self, lang_header, types, hlist, output):
+    def write_headers_nodes(self, lang_header, types, hlist,
+                            output, skip={}):
         """Write out headers required by types
 
         lang_header - "c_header"
         types - dictionary of Typemap nodes.
-        hlist -
-        output - append lines of code.
-
-        types - dictionary[typedef.name] = typedef
+                types[typedef.name] = typedef
         hlist - list of headers to include
                 From helper routines
+        output - append lines of code.
+        skip - dictionary of headers to ignore.
 
         headers[hdr] [ typedef, None, ... ]
         None from helper files
@@ -312,12 +312,16 @@ class WrapperMixin(object):
             if hdr:
                 headers.setdefault(hdr, []).append(typedef)
 
-        if headers:
-            output.append("")
+        need_blank = True
         for hdr in sorted(headers):
+            if hdr in skip:
+                continue
+            if need_blank:
+                output.append("")
+                need_blank = False
             if len(headers[hdr]) == 1:
-                # Only one type uses the include, check for if_cpp
-                # For example, add conditional around mpi.h
+                # Only one type uses the include, check for if_cpp.
+                # For example, add conditional around mpi.h.
                 typedef = headers[hdr][0]
                 if typedef and typedef.cpp_if:
                     output.append("#" + typedef.cpp_if)

--- a/shroud/wrapc.py
+++ b/shroud/wrapc.py
@@ -370,7 +370,7 @@ class Wrapc(util.WrapperMixin):
 
     def write_impl(self, ns, cls, hname, fname):
         """Write implementation.
-        Writ struct, function, enum for a
+        Write struct, function, enum for a
         namespace or class.
 
         Args:
@@ -403,6 +403,17 @@ class Wrapc(util.WrapperMixin):
         if self.header_impl_include:
             headers = self.header_impl_include.keys()
             self.write_headers(headers, output)
+
+        # Headers required by implementations,
+        # for example template instantiation.
+        if self.header_typedef_nodes:
+            self.write_headers_nodes(
+                "cxx_header",
+                self.header_typedef_nodes,
+                [],
+                output,
+                self.header_impl_include,
+            )
 
         if self.language == "cxx":
             output.append("")
@@ -715,6 +726,7 @@ class Wrapc(util.WrapperMixin):
         is_union_scalar = False
         shadow_arg_decl = None
 
+        self.header_typedef_nodes.update(node.gen_headers_typedef)
         if result_typemap.c_header:
             # include any dependent header in generated header
             self.header_typedef_nodes[result_typemap.name] = result_typemap


### PR DESCRIPTION
A cxx_header defined for a class must be added to the
implementation file -- see template.yaml.
Added variable gen_headers_typedef to keep track of types
used with template instantiation.