### PR TITLE
Add options.F_create_generic

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -236,7 +236,6 @@ doxygen
   If True, create doxygen comments.
 
 F_create_bufferify_function
-
   Controls creation of a *bufferify* function.
   If *true*, an additional C function is created which receives
   *bufferified* arguments - i.e. the len, len_trim, and size may be
@@ -244,6 +243,16 @@ F_create_bufferify_function
   avoid passing this information.  This will avoid a copy of
   ``CHARACTER`` arguments required to append a trailing null.
   Defaults to *true*.
+
+F_create_generic
+  Controls creation of a generic interface.  It defaults to *true* for
+  most cases but will be set to *False* if a function is templated on
+  the return type since Fortran does not distiuguish generics based on
+  return type (similar to overloaded functions based on return type in
+  C++).
+
+.. should also be set to false when the templated argument in
+   cxx_template is part of the implementation and not the interface.
 
 F_line_length
   Control length of output line for generated Fortran.

--- a/regression/reference/clibrary/clibrary.json
+++ b/regression/reference/clibrary/clibrary.json
@@ -4080,6 +4080,7 @@
             "F_auto_reference_count": false,
             "F_capsule_data_type_class_template": "SHROUD_{F_name_scope}capsule",
             "F_create_bufferify_function": true,
+            "F_create_generic": true,
             "F_enum_member_template": "{F_name_scope}{enum_member_lower}",
             "F_flatten_namespace": false,
             "F_force_wrapper": false,

--- a/regression/reference/example/example.json
+++ b/regression/reference/example/example.json
@@ -5007,7 +5007,6 @@
                                         ]
                                     },
                                     {
-                                        "_CXX_return_templated": true,
                                         "_fmtresult": {
                                             "fmtc": {
                                                 "c_var": "SHC_rv",
@@ -5087,6 +5086,7 @@
                                         "have_template_args": true,
                                         "linenumber": 219,
                                         "options": {
+                                            "F_create_generic": false,
                                             "wrap_c": true,
                                             "wrap_fortran": true,
                                             "wrap_lua": true,
@@ -5121,7 +5121,6 @@
                                         ]
                                     },
                                     {
-                                        "_CXX_return_templated": true,
                                         "_fmtresult": {
                                             "fmtc": {
                                                 "c_var": "SHC_rv",
@@ -5203,6 +5202,7 @@
                                         "have_template_args": true,
                                         "linenumber": 219,
                                         "options": {
+                                            "F_create_generic": false,
                                             "wrap_c": true,
                                             "wrap_fortran": true,
                                             "wrap_lua": true,
@@ -9163,6 +9163,7 @@
             "F_auto_reference_count": false,
             "F_capsule_data_type_class_template": "SHROUD_{F_name_scope}capsule",
             "F_create_bufferify_function": true,
+            "F_create_generic": true,
             "F_enum_member_template": "{F_name_scope}{enum_member_lower}",
             "F_flatten_namespace": false,
             "F_force_wrapper": false,

--- a/regression/reference/forward/forward.json
+++ b/regression/reference/forward/forward.json
@@ -580,6 +580,7 @@
             "F_auto_reference_count": false,
             "F_capsule_data_type_class_template": "SHROUD_{F_name_scope}capsule",
             "F_create_bufferify_function": true,
+            "F_create_generic": true,
             "F_enum_member_template": "{F_name_scope}{enum_member_lower}",
             "F_flatten_namespace": false,
             "F_force_wrapper": false,

--- a/regression/reference/generic/generic.json
+++ b/regression/reference/generic/generic.json
@@ -1808,6 +1808,7 @@
             "F_auto_reference_count": false,
             "F_capsule_data_type_class_template": "SHROUD_{F_name_scope}capsule",
             "F_create_bufferify_function": true,
+            "F_create_generic": true,
             "F_enum_member_template": "{F_name_scope}{enum_member_lower}",
             "F_flatten_namespace": false,
             "F_force_wrapper": false,

--- a/regression/reference/include/include.json
+++ b/regression/reference/include/include.json
@@ -797,6 +797,7 @@
             "F_auto_reference_count": false,
             "F_capsule_data_type_class_template": "SHROUD_{F_name_scope}capsule",
             "F_create_bufferify_function": true,
+            "F_create_generic": true,
             "F_enum_member_template": "{F_name_scope}{enum_member_lower}",
             "F_flatten_namespace": false,
             "F_force_wrapper": false,

--- a/regression/reference/interface/interface.json
+++ b/regression/reference/interface/interface.json
@@ -291,6 +291,7 @@
             "F_auto_reference_count": false,
             "F_capsule_data_type_class_template": "SHROUD_{F_name_scope}capsule",
             "F_create_bufferify_function": true,
+            "F_create_generic": true,
             "F_enum_member_template": "{F_name_scope}{enum_member_lower}",
             "F_flatten_namespace": false,
             "F_force_wrapper": false,

--- a/regression/reference/memdoc/memdoc.json
+++ b/regression/reference/memdoc/memdoc.json
@@ -286,6 +286,7 @@
             "F_auto_reference_count": false,
             "F_capsule_data_type_class_template": "SHROUD_{F_name_scope}capsule",
             "F_create_bufferify_function": true,
+            "F_create_generic": true,
             "F_enum_member_template": "{F_name_scope}{enum_member_lower}",
             "F_flatten_namespace": false,
             "F_force_wrapper": false,

--- a/regression/reference/names/names.json
+++ b/regression/reference/names/names.json
@@ -2392,6 +2392,7 @@
             "F_auto_reference_count": false,
             "F_capsule_data_type_class_template": "SHROUD_{F_name_scope}capsule",
             "F_create_bufferify_function": true,
+            "F_create_generic": true,
             "F_enum_member_template": "{F_name_scope}{enum_member_lower}",
             "F_flatten_namespace": false,
             "F_force_wrapper": true,

--- a/regression/reference/names2/names2.json
+++ b/regression/reference/names2/names2.json
@@ -162,6 +162,7 @@
             "F_auto_reference_count": false,
             "F_capsule_data_type_class_template": "SHROUD_{F_name_scope}capsule",
             "F_create_bufferify_function": true,
+            "F_create_generic": true,
             "F_enum_member_template": "{F_name_scope}{enum_member_lower}",
             "F_flatten_namespace": false,
             "F_force_wrapper": false,

--- a/regression/reference/namespace/namespace.json
+++ b/regression/reference/namespace/namespace.json
@@ -739,6 +739,7 @@
             "F_auto_reference_count": false,
             "F_capsule_data_type_class_template": "SHROUD_{F_name_scope}capsule",
             "F_create_bufferify_function": true,
+            "F_create_generic": true,
             "F_enum_member_template": "{F_name_scope}{enum_member_lower}",
             "F_flatten_namespace": false,
             "F_force_wrapper": false,

--- a/regression/reference/none/none.json
+++ b/regression/reference/none/none.json
@@ -131,6 +131,7 @@
             "F_auto_reference_count": false,
             "F_capsule_data_type_class_template": "SHROUD_{F_name_scope}capsule",
             "F_create_bufferify_function": true,
+            "F_create_generic": true,
             "F_enum_member_template": "{F_name_scope}{enum_member_lower}",
             "F_flatten_namespace": false,
             "F_force_wrapper": false,

--- a/regression/reference/ownership/ownership.json
+++ b/regression/reference/ownership/ownership.json
@@ -2525,6 +2525,7 @@
             "F_auto_reference_count": false,
             "F_capsule_data_type_class_template": "SHROUD_{F_name_scope}capsule",
             "F_create_bufferify_function": true,
+            "F_create_generic": true,
             "F_enum_member_template": "{F_name_scope}{enum_member_lower}",
             "F_flatten_namespace": false,
             "F_force_wrapper": false,

--- a/regression/reference/pointers-list-c/pointers.json
+++ b/regression/reference/pointers-list-c/pointers.json
@@ -1075,6 +1075,7 @@
             "F_auto_reference_count": false,
             "F_capsule_data_type_class_template": "SHROUD_{F_name_scope}capsule",
             "F_create_bufferify_function": true,
+            "F_create_generic": true,
             "F_enum_member_template": "{F_name_scope}{enum_member_lower}",
             "F_flatten_namespace": false,
             "F_force_wrapper": false,

--- a/regression/reference/pointers-list-cpp/pointers.json
+++ b/regression/reference/pointers-list-cpp/pointers.json
@@ -1075,6 +1075,7 @@
             "F_auto_reference_count": false,
             "F_capsule_data_type_class_template": "SHROUD_{F_name_scope}capsule",
             "F_create_bufferify_function": true,
+            "F_create_generic": true,
             "F_enum_member_template": "{F_name_scope}{enum_member_lower}",
             "F_flatten_namespace": false,
             "F_force_wrapper": false,

--- a/regression/reference/pointers-numpy-c/pointers.json
+++ b/regression/reference/pointers-numpy-c/pointers.json
@@ -1075,6 +1075,7 @@
             "F_auto_reference_count": false,
             "F_capsule_data_type_class_template": "SHROUD_{F_name_scope}capsule",
             "F_create_bufferify_function": true,
+            "F_create_generic": true,
             "F_enum_member_template": "{F_name_scope}{enum_member_lower}",
             "F_flatten_namespace": false,
             "F_force_wrapper": false,

--- a/regression/reference/pointers-numpy-cpp/pointers.json
+++ b/regression/reference/pointers-numpy-cpp/pointers.json
@@ -1517,6 +1517,7 @@
             "F_auto_reference_count": false,
             "F_capsule_data_type_class_template": "SHROUD_{F_name_scope}capsule",
             "F_create_bufferify_function": true,
+            "F_create_generic": true,
             "F_enum_member_template": "{F_name_scope}{enum_member_lower}",
             "F_flatten_namespace": false,
             "F_force_wrapper": false,

--- a/regression/reference/preprocess/preprocess.json
+++ b/regression/reference/preprocess/preprocess.json
@@ -587,6 +587,7 @@
             "F_auto_reference_count": false,
             "F_capsule_data_type_class_template": "SHROUD_{F_name_scope}capsule",
             "F_create_bufferify_function": true,
+            "F_create_generic": true,
             "F_enum_member_template": "{F_name_scope}{enum_member_lower}",
             "F_flatten_namespace": false,
             "F_force_wrapper": false,

--- a/regression/reference/scope/scope.json
+++ b/regression/reference/scope/scope.json
@@ -645,6 +645,7 @@
             "F_auto_reference_count": false,
             "F_capsule_data_type_class_template": "SHROUD_{F_name_scope}capsule",
             "F_create_bufferify_function": true,
+            "F_create_generic": true,
             "F_enum_member_template": "{F_name_scope}{enum_member_lower}",
             "F_flatten_namespace": false,
             "F_force_wrapper": false,

--- a/regression/reference/strings/strings.json
+++ b/regression/reference/strings/strings.json
@@ -5435,6 +5435,7 @@
             "F_auto_reference_count": false,
             "F_capsule_data_type_class_template": "SHROUD_{F_name_scope}capsule",
             "F_create_bufferify_function": true,
+            "F_create_generic": true,
             "F_enum_member_template": "{F_name_scope}{enum_member_lower}",
             "F_flatten_namespace": false,
             "F_force_wrapper": false,

--- a/regression/reference/struct-c/struct.json
+++ b/regression/reference/struct-c/struct.json
@@ -1872,6 +1872,7 @@
             "F_auto_reference_count": false,
             "F_capsule_data_type_class_template": "SHROUD_{F_name_scope}capsule",
             "F_create_bufferify_function": true,
+            "F_create_generic": true,
             "F_enum_member_template": "{F_name_scope}{enum_member_lower}",
             "F_flatten_namespace": false,
             "F_force_wrapper": false,

--- a/regression/reference/struct-cxx/struct.json
+++ b/regression/reference/struct-cxx/struct.json
@@ -2018,6 +2018,7 @@
             "F_auto_reference_count": false,
             "F_capsule_data_type_class_template": "SHROUD_{F_name_scope}capsule",
             "F_create_bufferify_function": true,
+            "F_create_generic": true,
             "F_enum_member_template": "{F_name_scope}{enum_member_lower}",
             "F_flatten_namespace": false,
             "F_force_wrapper": false,

--- a/regression/reference/templates/output
+++ b/regression/reference/templates/output
@@ -15,6 +15,7 @@ Wrote pyvector_inttype.cpp
 Wrote pyvector_doubletype.cpp
 Wrote pytemplates_stdmodule.cpp
 Wrote pyImplWorker1type.cpp
+Wrote pyImplWorker2type.cpp
 Wrote pytemplates_internalmodule.cpp
 Wrote pyWorkertype.cpp
 Wrote pyuser_inttype.cpp

--- a/regression/reference/templates/pyImplWorker2type.cpp
+++ b/regression/reference/templates/pyImplWorker2type.cpp
@@ -1,0 +1,114 @@
+// pyImplWorker2type.cpp
+// This is generated code, do not edit
+#include "pytemplatesmodule.hpp"
+#include "implworker2.hpp"
+// splicer begin namespace.internal.class.ImplWorker2.impl.include
+// splicer end namespace.internal.class.ImplWorker2.impl.include
+
+#ifdef __cplusplus
+#define SHROUD_UNUSED(param)
+#else
+#define SHROUD_UNUSED(param) param
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+#define PyInt_AsLong PyLong_AsLong
+#define PyInt_FromLong PyLong_FromLong
+#define PyString_FromString PyUnicode_FromString
+#define PyString_FromStringAndSize PyUnicode_FromStringAndSize
+#endif
+// splicer begin namespace.internal.class.ImplWorker2.impl.C_definition
+// splicer end namespace.internal.class.ImplWorker2.impl.C_definition
+// splicer begin namespace.internal.class.ImplWorker2.impl.additional_methods
+// splicer end namespace.internal.class.ImplWorker2.impl.additional_methods
+static void
+PY_ImplWorker2_tp_del (PY_ImplWorker2 *self)
+{
+// splicer begin namespace.internal.class.ImplWorker2.type.del
+    PY_SHROUD_release_memory(self->idtor, self->obj);
+    self->obj = NULL;
+// splicer end namespace.internal.class.ImplWorker2.type.del
+}
+// splicer begin namespace.internal.class.ImplWorker2.impl.after_methods
+// splicer end namespace.internal.class.ImplWorker2.impl.after_methods
+static PyMethodDef PY_ImplWorker2_methods[] = {
+    // splicer begin namespace.internal.class.ImplWorker2.PyMethodDef
+    // splicer end namespace.internal.class.ImplWorker2.PyMethodDef
+    {NULL,   (PyCFunction)NULL, 0, NULL}            /* sentinel */
+};
+
+static char ImplWorker2__doc__[] =
+"virtual class"
+;
+
+/* static */
+PyTypeObject PY_ImplWorker2_Type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "templates.ImplWorker2",                       /* tp_name */
+    sizeof(PY_ImplWorker2),         /* tp_basicsize */
+    0,                              /* tp_itemsize */
+    /* Methods to implement standard operations */
+    (destructor)0,                 /* tp_dealloc */
+    (printfunc)0,                   /* tp_print */
+    (getattrfunc)0,                 /* tp_getattr */
+    (setattrfunc)0,                 /* tp_setattr */
+#if PY_MAJOR_VERSION >= 3
+    0,                               /* tp_reserved */
+#else
+    (cmpfunc)0,                     /* tp_compare */
+#endif
+    (reprfunc)0,                    /* tp_repr */
+    /* Method suites for standard classes */
+    0,                              /* tp_as_number */
+    0,                              /* tp_as_sequence */
+    0,                              /* tp_as_mapping */
+    /* More standard operations (here for binary compatibility) */
+    (hashfunc)0,                    /* tp_hash */
+    (ternaryfunc)0,                 /* tp_call */
+    (reprfunc)0,                    /* tp_str */
+    (getattrofunc)0,                /* tp_getattro */
+    (setattrofunc)0,                /* tp_setattro */
+    /* Functions to access object as input/output buffer */
+    0,                              /* tp_as_buffer */
+    /* Flags to define presence of optional/expanded features */
+    Py_TPFLAGS_DEFAULT,             /* tp_flags */
+    ImplWorker2__doc__,         /* tp_doc */
+    /* Assigned meaning in release 2.0 */
+    /* call function for all accessible objects */
+    (traverseproc)0,                /* tp_traverse */
+    /* delete references to contained objects */
+    (inquiry)0,                     /* tp_clear */
+    /* Assigned meaning in release 2.1 */
+    /* rich comparisons */
+    (richcmpfunc)0,                 /* tp_richcompare */
+    /* weak reference enabler */
+    0,                              /* tp_weaklistoffset */
+    /* Added in release 2.2 */
+    /* Iterators */
+    (getiterfunc)0,                 /* tp_iter */
+    (iternextfunc)0,                /* tp_iternext */
+    /* Attribute descriptor and subclassing stuff */
+    PY_ImplWorker2_methods,                             /* tp_methods */
+    0,                              /* tp_members */
+    0,                             /* tp_getset */
+    0,                              /* tp_base */
+    0,                              /* tp_dict */
+    (descrgetfunc)0,                /* tp_descr_get */
+    (descrsetfunc)0,                /* tp_descr_set */
+    0,                              /* tp_dictoffset */
+    (initproc)0,                   /* tp_init */
+    (allocfunc)0,                  /* tp_alloc */
+    (newfunc)0,                    /* tp_new */
+    (freefunc)0,                   /* tp_free */
+    (inquiry)0,                     /* tp_is_gc */
+    0,                              /* tp_bases */
+    0,                              /* tp_mro */
+    0,                              /* tp_cache */
+    0,                              /* tp_subclasses */
+    0,                              /* tp_weaklist */
+    (destructor)PY_ImplWorker2_tp_del,                 /* tp_del */
+    0,                              /* tp_version_tag */
+#if PY_MAJOR_VERSION >= 3
+    (destructor)0,                  /* tp_finalize */
+#endif
+};

--- a/regression/reference/templates/pytemplates_internalmodule.cpp
+++ b/regression/reference/templates/pytemplates_internalmodule.cpp
@@ -64,6 +64,14 @@ PyObject *PY_init_templates_internal(void)
     Py_INCREF(&PY_ImplWorker1_Type);
     PyModule_AddObject(m, "ImplWorker1", (PyObject *)&PY_ImplWorker1_Type);
 
+    // ImplWorker2
+    PY_ImplWorker2_Type.tp_new   = PyType_GenericNew;
+    PY_ImplWorker2_Type.tp_alloc = PyType_GenericAlloc;
+    if (PyType_Ready(&PY_ImplWorker2_Type) < 0)
+        return RETVAL;
+    Py_INCREF(&PY_ImplWorker2_Type);
+    PyModule_AddObject(m, "ImplWorker2", (PyObject *)&PY_ImplWorker2_Type);
+
     return m;
 }
 

--- a/regression/reference/templates/pytemplatesmodule.cpp
+++ b/regression/reference/templates/pytemplatesmodule.cpp
@@ -81,10 +81,6 @@ PY_FunctionTU_1(
 // splicer end function.function_tu_1
 }
 
-static char PY_UseImplWorker_internal_ImplWorker1__doc__[] =
-"documentation"
-;
-
 /**
  * \brief Function which uses a templated T in the implemetation.
  *
@@ -102,6 +98,25 @@ PY_UseImplWorker_internal_ImplWorker1(
     SHTPy_rv = PyInt_FromLong(rv);
     return (PyObject *) SHTPy_rv;
 // splicer end function.use_impl_worker_internal_ImplWorker1
+}
+
+/**
+ * \brief Function which uses a templated T in the implemetation.
+ *
+ */
+static PyObject *
+PY_UseImplWorker_internal_ImplWorker2(
+  PyObject *SHROUD_UNUSED(self),
+  PyObject *SHROUD_UNUSED(args),
+  PyObject *SHROUD_UNUSED(kwds))
+{
+// splicer begin function.use_impl_worker_internal_ImplWorker2
+    PyObject * SHTPy_rv = NULL;
+
+    int rv = UseImplWorker();
+    SHTPy_rv = PyInt_FromLong(rv);
+    return (PyObject *) SHTPy_rv;
+// splicer end function.use_impl_worker_internal_ImplWorker2
 }
 
 static char PY_FunctionTU__doc__[] =
@@ -141,12 +156,49 @@ PY_FunctionTU(
     return NULL;
 // splicer end function.function_tu
 }
+
+static char PY_UseImplWorker__doc__[] =
+"documentation"
+;
+
+static PyObject *
+PY_UseImplWorker(
+  PyObject *self,
+  PyObject *args,
+  PyObject *kwds)
+{
+// splicer begin function.use_impl_worker
+    Py_ssize_t SHT_nargs = 0;
+    if (args != NULL) SHT_nargs += PyTuple_Size(args);
+    if (kwds != NULL) SHT_nargs += PyDict_Size(args);
+    PyObject *rvobj;
+    if (SHT_nargs == 0) {
+        rvobj = PY_UseImplWorker_internal_ImplWorker1(self, args, kwds);
+        if (!PyErr_Occurred()) {
+            return rvobj;
+        } else if (! PyErr_ExceptionMatches(PyExc_TypeError)) {
+            return rvobj;
+        }
+        PyErr_Clear();
+    }
+    if (SHT_nargs == 0) {
+        rvobj = PY_UseImplWorker_internal_ImplWorker2(self, args, kwds);
+        if (!PyErr_Occurred()) {
+            return rvobj;
+        } else if (! PyErr_ExceptionMatches(PyExc_TypeError)) {
+            return rvobj;
+        }
+        PyErr_Clear();
+    }
+    PyErr_SetString(PyExc_TypeError, "wrong arguments multi-dispatch");
+    return NULL;
+// splicer end function.use_impl_worker
+}
 static PyMethodDef PY_methods[] = {
-{"UseImplWorker_internal_ImplWorker1",
-    (PyCFunction)PY_UseImplWorker_internal_ImplWorker1, METH_NOARGS,
-    PY_UseImplWorker_internal_ImplWorker1__doc__},
 {"FunctionTU", (PyCFunction)PY_FunctionTU, METH_VARARGS|METH_KEYWORDS,
     PY_FunctionTU__doc__},
+{"UseImplWorker", (PyCFunction)PY_UseImplWorker,
+    METH_VARARGS|METH_KEYWORDS, PY_UseImplWorker__doc__},
 {NULL,   (PyCFunction)NULL, 0, NULL}            /* sentinel */
 };
 

--- a/regression/reference/templates/pytemplatesmodule.hpp
+++ b/regression/reference/templates/pytemplatesmodule.hpp
@@ -72,6 +72,26 @@ PyObject *PP_ImplWorker1_to_Object(internal::ImplWorker1 *addr);
 int PP_ImplWorker1_from_Object(PyObject *obj, void **addr);
 
 // ------------------------------
+namespace internal {
+    class ImplWorker2;  // forward declare
+}
+extern PyTypeObject PY_ImplWorker2_Type;
+// splicer begin namespace.internal.class.ImplWorker2.C_declaration
+// splicer end namespace.internal.class.ImplWorker2.C_declaration
+
+typedef struct {
+PyObject_HEAD
+    internal::ImplWorker2 * obj;
+    int idtor;
+    // splicer begin namespace.internal.class.ImplWorker2.C_object
+    // splicer end namespace.internal.class.ImplWorker2.C_object
+} PY_ImplWorker2;
+
+extern const char *PY_ImplWorker2_capsule_name;
+PyObject *PP_ImplWorker2_to_Object(internal::ImplWorker2 *addr);
+int PP_ImplWorker2_from_Object(PyObject *obj, void **addr);
+
+// ------------------------------
 class Worker;  // forward declare
 extern PyTypeObject PY_Worker_Type;
 // splicer begin class.Worker.C_declaration

--- a/regression/reference/templates/pytemplatesutil.cpp
+++ b/regression/reference/templates/pytemplatesutil.cpp
@@ -6,6 +6,7 @@
 const char *PY_vector_int_capsule_name = "vector_int";
 const char *PY_vector_double_capsule_name = "vector_double";
 const char *PY_ImplWorker1_capsule_name = "ImplWorker1";
+const char *PY_ImplWorker2_capsule_name = "ImplWorker2";
 const char *PY_Worker_capsule_name = "Worker";
 const char *PY_user_int_capsule_name = "user_int";
 
@@ -95,6 +96,35 @@ int PP_ImplWorker1_from_Object(PyObject *obj, void **addr)
     *addr = self->obj;
     return 1;
     // splicer end namespace.internal.class.ImplWorker1.utility.from_object
+}
+
+PyObject *PP_ImplWorker2_to_Object(internal::ImplWorker2 *addr)
+{
+    // splicer begin namespace.internal.class.ImplWorker2.utility.to_object
+    PyObject *voidobj;
+    PyObject *args;
+    PyObject *rv;
+
+    voidobj = PyCapsule_New(addr, PY_ImplWorker2_capsule_name, NULL);
+    args = PyTuple_New(1);
+    PyTuple_SET_ITEM(args, 0, voidobj);
+    rv = PyObject_Call((PyObject *) &PY_ImplWorker2_Type, args, NULL);
+    Py_DECREF(args);
+    return rv;
+    // splicer end namespace.internal.class.ImplWorker2.utility.to_object
+}
+
+int PP_ImplWorker2_from_Object(PyObject *obj, void **addr)
+{
+    // splicer begin namespace.internal.class.ImplWorker2.utility.from_object
+    if (obj->ob_type != &PY_ImplWorker2_Type) {
+        // raise exception
+        return 0;
+    }
+    PY_ImplWorker2 * self = (PY_ImplWorker2 *) obj;
+    *addr = self->obj;
+    return 1;
+    // splicer end namespace.internal.class.ImplWorker2.utility.from_object
 }
 
 PyObject *PP_Worker_to_Object(Worker *addr)

--- a/regression/reference/templates/templates.json
+++ b/regression/reference/templates/templates.json
@@ -107,7 +107,7 @@
                             "underscore_name": "nested"
                         },
                         "have_template_args": true,
-                        "linenumber": 63,
+                        "linenumber": 67,
                         "options": {
                             "wrap_c": false,
                             "wrap_fortran": false,
@@ -275,7 +275,7 @@
                             "double"
                         ],
                         "have_template_args": true,
-                        "linenumber": 63,
+                        "linenumber": 67,
                         "options": {
                             "wrap_c": true,
                             "wrap_fortran": true,
@@ -300,7 +300,7 @@
                         ]
                     }
                 ],
-                "linenumber": 58,
+                "linenumber": 62,
                 "name": "user",
                 "options": {},
                 "scope": "user::",
@@ -483,7 +483,7 @@
                 "decl": "template<T,U> void FunctionTU(T arg1, U arg2)",
                 "declgen": "void FunctionTU(T arg1 +intent(in)+value, U arg2 +intent(in)+value)",
                 "doxygen": {
-                    "__line__": 84,
+                    "__line__": 88,
                     "brief": "Function template with two template parameters."
                 },
                 "fmtdict": {
@@ -491,7 +491,7 @@
                     "underscore_name": "function_tu"
                 },
                 "have_template_args": true,
-                "linenumber": 83,
+                "linenumber": 87,
                 "options": {
                     "wrap_c": false,
                     "wrap_fortran": false,
@@ -653,7 +653,7 @@
                 "decl": "template<T,U> void FunctionTU(T arg1, U arg2)",
                 "declgen": "void FunctionTU(int arg1 +intent(in)+value, long arg2 +intent(in)+value)",
                 "doxygen": {
-                    "__line__": 84,
+                    "__line__": 88,
                     "brief": "Function template with two template parameters."
                 },
                 "fmtdict": {
@@ -680,7 +680,7 @@
                     "underscore_name": "function_tu"
                 },
                 "have_template_args": true,
-                "linenumber": 83,
+                "linenumber": 87,
                 "options": {
                     "wrap_c": true,
                     "wrap_fortran": true,
@@ -842,7 +842,7 @@
                 "decl": "template<T,U> void FunctionTU(T arg1, U arg2)",
                 "declgen": "void FunctionTU(float arg1 +intent(in)+value, double arg2 +intent(in)+value)",
                 "doxygen": {
-                    "__line__": 84,
+                    "__line__": 88,
                     "brief": "Function template with two template parameters."
                 },
                 "fmtdict": {
@@ -875,7 +875,7 @@
                     "long"
                 ],
                 "have_template_args": true,
-                "linenumber": 83,
+                "linenumber": 87,
                 "options": {
                     "wrap_c": true,
                     "wrap_fortran": true,
@@ -938,21 +938,24 @@
                 },
                 "cxx_template": {
                     "T": [
-                        "internal::ImplWorker1"
+                        "internal::ImplWorker1",
+                        "internal::ImplWorker2"
                     ]
                 },
                 "decl": "template<typename T> int UseImplWorker()",
                 "declgen": "int UseImplWorker()",
                 "doxygen": {
-                    "__line__": 98,
+                    "__line__": 102,
                     "brief": "Function which uses a templated T in the implemetation."
                 },
                 "fmtdict": {
                     "function_name": "UseImplWorker",
                     "underscore_name": "use_impl_worker"
                 },
-                "linenumber": 97,
+                "linenumber": 101,
                 "options": {
+                    "F_create_generic": false,
+                    "__line__": 104,
                     "wrap_c": false,
                     "wrap_fortran": false,
                     "wrap_lua": false,
@@ -969,6 +972,17 @@
                             }
                         ],
                         "instantiation": "<internal::ImplWorker1>"
+                    },
+                    {
+                        "asts": [
+                            {
+                                "specifier": [
+                                    "internal::ImplWorker2"
+                                ],
+                                "typemap_name": "internal::ImplWorker2"
+                            }
+                        ],
+                        "instantiation": "<internal::ImplWorker2>"
                     }
                 ],
                 "template_parameters": [
@@ -1016,7 +1030,7 @@
                 "decl": "template<typename T> int UseImplWorker()",
                 "declgen": "int UseImplWorker()",
                 "doxygen": {
-                    "__line__": 98,
+                    "__line__": 102,
                     "brief": "Function which uses a templated T in the implemetation."
                 },
                 "fmtdict": {
@@ -1044,11 +1058,10 @@
                     "template_suffix": "_internal_ImplWorker1",
                     "underscore_name": "use_impl_worker"
                 },
-                "gen_headers_typedef": [
-                    "internal::ImplWorker1"
-                ],
-                "linenumber": 97,
+                "linenumber": 101,
                 "options": {
+                    "F_create_generic": false,
+                    "__line__": 104,
                     "wrap_c": true,
                     "wrap_fortran": true,
                     "wrap_lua": false,
@@ -1065,6 +1078,127 @@
                             }
                         ],
                         "instantiation": "<internal::ImplWorker1>"
+                    },
+                    {
+                        "asts": [
+                            {
+                                "specifier": [
+                                    "internal::ImplWorker2"
+                                ],
+                                "typemap_name": "internal::ImplWorker2"
+                            }
+                        ],
+                        "instantiation": "<internal::ImplWorker2>"
+                    }
+                ],
+                "template_parameters": [
+                    "T"
+                ]
+            },
+            {
+                "_fmtresult": {
+                    "fmtc": {
+                        "c_var": "SHC_rv",
+                        "cxx_addr": "&",
+                        "cxx_member": ".",
+                        "cxx_type": "int",
+                        "cxx_var": "SHC_rv",
+                        "idtor": "0"
+                    },
+                    "fmtf": {
+                        "cxx_type": "int",
+                        "f_var": "SHT_rv"
+                    },
+                    "fmtpy": {
+                        "c_deref": "",
+                        "c_var": "rv",
+                        "cxx_addr": "&",
+                        "cxx_member": ".",
+                        "cxx_var": "rv",
+                        "numpy_type": "NPY_INT",
+                        "py_var": "SHTPy_rv",
+                        "size_var": "SHSize_rv"
+                    }
+                },
+                "_generated": "cxx_template",
+                "_overloaded": true,
+                "ast": {
+                    "declarator": {
+                        "name": "UseImplWorker",
+                        "pointer": []
+                    },
+                    "params": [],
+                    "specifier": [
+                        "int"
+                    ],
+                    "typemap_name": "int"
+                },
+                "decl": "template<typename T> int UseImplWorker()",
+                "declgen": "int UseImplWorker()",
+                "doxygen": {
+                    "__line__": 102,
+                    "brief": "Function which uses a templated T in the implemetation."
+                },
+                "fmtdict": {
+                    "CXX_template": "<internal::ImplWorker2>",
+                    "C_call_code": "int SHC_rv =\t UseImplWorker<internal::ImplWorker2>(\t);",
+                    "C_call_list": "",
+                    "C_name": "TEM_use_impl_worker_internal_ImplWorker2",
+                    "C_prototype": "",
+                    "C_return_code": "return SHC_rv;",
+                    "C_return_type": "int",
+                    "F_C_call": "c_use_impl_worker_internal_implworker2",
+                    "F_C_name": "c_use_impl_worker_internal_implworker2",
+                    "F_arg_c_call": "",
+                    "F_arguments": "",
+                    "F_call_code": "SHT_rv = c_use_impl_worker_internal_implworker2()",
+                    "F_name_function": "use_impl_worker_internal_ImplWorker2",
+                    "F_name_generic": "use_impl_worker",
+                    "F_name_impl": "use_impl_worker_internal_ImplWorker2",
+                    "F_result_clause": "\fresult(SHT_rv)",
+                    "F_subprogram": "function",
+                    "PY_name_impl": "PY_UseImplWorker_internal_ImplWorker2",
+                    "c_const": "",
+                    "cxx_rv_decl": "int SHC_rv",
+                    "function_name": "UseImplWorker",
+                    "template_suffix": "_internal_ImplWorker2",
+                    "underscore_name": "use_impl_worker"
+                },
+                "gen_headers_typedef": [
+                    "internal::ImplWorker1",
+                    "internal::ImplWorker2"
+                ],
+                "linenumber": 101,
+                "options": {
+                    "F_create_generic": false,
+                    "__line__": 104,
+                    "wrap_c": true,
+                    "wrap_fortran": true,
+                    "wrap_lua": false,
+                    "wrap_python": true
+                },
+                "template_arguments": [
+                    {
+                        "asts": [
+                            {
+                                "specifier": [
+                                    "internal::ImplWorker1"
+                                ],
+                                "typemap_name": "internal::ImplWorker1"
+                            }
+                        ],
+                        "instantiation": "<internal::ImplWorker1>"
+                    },
+                    {
+                        "asts": [
+                            {
+                                "specifier": [
+                                    "internal::ImplWorker2"
+                                ],
+                                "typemap_name": "internal::ImplWorker2"
+                            }
+                        ],
+                        "instantiation": "<internal::ImplWorker2>"
                     }
                 ],
                 "template_parameters": [
@@ -1415,7 +1549,6 @@
                                 }
                             },
                             {
-                                "_CXX_return_templated": true,
                                 "_fmtargs": {
                                     "n": {
                                         "fmtc": {
@@ -1539,6 +1672,7 @@
                                 "have_template_args": true,
                                 "linenumber": 39,
                                 "options": {
+                                    "F_create_generic": false,
                                     "wrap_c": true,
                                     "wrap_fortran": true,
                                     "wrap_lua": false,
@@ -1928,7 +2062,6 @@
                                 }
                             },
                             {
-                                "_CXX_return_templated": true,
                                 "_fmtargs": {
                                     "n": {
                                         "fmtc": {
@@ -2052,6 +2185,7 @@
                                 "have_template_args": true,
                                 "linenumber": 39,
                                 "options": {
+                                    "F_create_generic": false,
                                     "wrap_c": true,
                                     "wrap_fortran": true,
                                     "wrap_lua": false,
@@ -2161,6 +2295,37 @@
                         },
                         "scope": "internal::ImplWorker1::",
                         "typemap_name": "internal::ImplWorker1"
+                    },
+                    {
+                        "cxx_header": "implworker2.hpp",
+                        "fmtdict": {
+                            "CXX_this_call": "SH_this->",
+                            "C_header_filename": "wrapImplWorker2.h",
+                            "C_impl_filename": "wrapImplWorker2.cpp",
+                            "C_name_scope": "internal_ImplWorker2_",
+                            "C_type_name": "TEM_internal_ImplWorker2",
+                            "F_capsule_data_type": "SHROUD_implworker2_capsule",
+                            "F_derived_name": "implworker2",
+                            "F_name_scope": "implworker2_",
+                            "PY_PyObject": "PY_ImplWorker2",
+                            "PY_PyTypeObject": "PY_ImplWorker2_Type",
+                            "PY_capsule_name": "PY_ImplWorker2_capsule_name",
+                            "PY_from_object_func": "PP_ImplWorker2_from_Object",
+                            "PY_this_call": "self->obj->",
+                            "PY_to_object_func": "PP_ImplWorker2_to_Object",
+                            "PY_type_filename": "pyImplWorker2type.cpp",
+                            "class_scope": "ImplWorker2::",
+                            "cxx_class": "ImplWorker2",
+                            "cxx_type": "ImplWorker2"
+                        },
+                        "linenumber": 57,
+                        "name": "ImplWorker2",
+                        "options": {
+                            "__line__": 59,
+                            "wrap_fortran": false
+                        },
+                        "scope": "internal::ImplWorker2::",
+                        "typemap_name": "internal::ImplWorker2"
                     }
                 ],
                 "fmtdict": {
@@ -2216,6 +2381,7 @@
             "F_auto_reference_count": false,
             "F_capsule_data_type_class_template": "SHROUD_{F_name_scope}capsule",
             "F_create_bufferify_function": true,
+            "F_create_generic": true,
             "F_enum_member_template": "{F_name_scope}{enum_member_lower}",
             "F_flatten_namespace": false,
             "F_force_wrapper": false,
@@ -2846,6 +3012,93 @@
                     "cxx_local_var": "pointer",
                     "post_parse": [
                         "{c_const}internal::ImplWorker1 * {cxx_var} =\t {py_var} ? {py_var}->{PY_type_obj} : NULL;"
+                    ]
+                },
+                "intent_out": {
+                    "decl": [
+                        "{PyObject} *{py_var} = NULL;"
+                    ],
+                    "fail": [
+                        "Py_XDECREF({py_var});"
+                    ],
+                    "goto_fail": true,
+                    "post_call": [
+                        "{py_var} =\t PyObject_New({PyObject}, &{PyTypeObject});",
+                        "if ({py_var} == NULL) goto fail;",
+                        "{py_var}->{PY_type_obj} = {cxx_addr}{cxx_var};"
+                    ]
+                },
+                "result": {
+                    "post_call": [
+                        "{PyObject} * {py_var} =\t PyObject_New({PyObject}, &{PyTypeObject});",
+                        "{py_var}->{PY_type_obj} = {cxx_addr}{cxx_var};"
+                    ]
+                }
+            }
+        },
+        "internal::ImplWorker2": {
+            "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",
+            "LUA_type": "LUA_TUSERDATA",
+            "PY_PyObject": "PY_ImplWorker2",
+            "PY_PyTypeObject": "PY_ImplWorker2_Type",
+            "PY_from_object": "PP_ImplWorker2_from_Object",
+            "PY_to_object": "PP_ImplWorker2_to_Object",
+            "base": "shadow",
+            "c_statements": {
+                "intent_in": {
+                    "buf_args": [
+                        "shadow"
+                    ]
+                },
+                "result": {
+                    "post_call": [
+                        "{c_var}->addr = {cxx_cast_to_void_ptr};",
+                        "{c_var}->idtor = {idtor};"
+                    ]
+                }
+            },
+            "c_to_cxx": "static_cast<{c_const}internal::ImplWorker2 *>({c_var}{c_member}addr)",
+            "c_type": "TEM_internal_ImplWorker2",
+            "cxx_to_c": "static_cast<{c_const}void *>(\t{cxx_addr}{cxx_var})",
+            "cxx_type": "internal::ImplWorker2",
+            "f_c_module": {
+                "--import--": [
+                    "SHROUD_implworker2_capsule"
+                ]
+            },
+            "f_c_type": "type(SHROUD_implworker2_capsule)",
+            "f_capsule_data_type": "SHROUD_implworker2_capsule",
+            "f_derived_type": "implworker2",
+            "f_module": {
+                "templates_internal_mod": [
+                    "implworker2"
+                ]
+            },
+            "f_module_name": "templates_internal_mod",
+            "f_statements": {
+                "result": {
+                    "call": [
+                        "{F_result_ptr} = {F_C_call}({F_arg_c_call})"
+                    ],
+                    "need_wrapper": true
+                }
+            },
+            "f_to_c": "{f_var}%cxxmem",
+            "f_type": "type(implworker2)",
+            "flat_name": "internal_ImplWorker2",
+            "forward": "internal::ImplWorker2",
+            "impl_header": "implworker2.hpp",
+            "py_statements": {
+                "intent_in": {
+                    "cxx_local_var": "pointer",
+                    "post_parse": [
+                        "{c_const}internal::ImplWorker2 * {cxx_var} =\t {py_var} ? {py_var}->{PY_type_obj} : NULL;"
+                    ]
+                },
+                "intent_inout": {
+                    "cxx_local_var": "pointer",
+                    "post_parse": [
+                        "{c_const}internal::ImplWorker2 * {cxx_var} =\t {py_var} ? {py_var}->{PY_type_obj} : NULL;"
                     ]
                 },
                 "intent_out": {

--- a/regression/reference/templates/templates.log
+++ b/regression/reference/templates/templates.log
@@ -15,6 +15,7 @@ C method double & at(size_type n +intent(in)+value)
 Close wrapvector_double.h
 Close wrapvector_double.cpp
 class ImplWorker1
+class ImplWorker2
 class Worker
 class user
 C method void nested(int arg1 +intent(in)+value, double arg2 +intent(in)+value)
@@ -22,6 +23,7 @@ Close wrapuser_int.h
 Close wrapuser_int.cpp
 C function void FunctionTU(int arg1 +intent(in)+value, long arg2 +intent(in)+value)
 C function void FunctionTU(float arg1 +intent(in)+value, double arg2 +intent(in)+value)
+C function int UseImplWorker()
 C function int UseImplWorker()
 Close wraptemplates.h
 Close wraptemplates.cpp
@@ -31,6 +33,7 @@ class user
 C-interface, Fortran method void nested(int arg1 +intent(in)+value, double arg2 +intent(in)+value)
 C-interface, Fortran function void FunctionTU(int arg1 +intent(in)+value, long arg2 +intent(in)+value)
 C-interface, Fortran function void FunctionTU(float arg1 +intent(in)+value, double arg2 +intent(in)+value)
+C-interface, Fortran function int UseImplWorker()
 C-interface, Fortran function int UseImplWorker()
 class vector
 C-interface, Fortran method vector()
@@ -60,6 +63,8 @@ Close pyvector_doubletype.cpp
 Close pytemplates_stdmodule.cpp
 class ImplWorker1
 Close pyImplWorker1type.cpp
+class ImplWorker2
+Close pyImplWorker2type.cpp
 Close pytemplates_internalmodule.cpp
 class Worker
 Close pyWorkertype.cpp
@@ -68,6 +73,7 @@ Python method void nested(int arg1 +intent(in)+value, double arg2 +intent(in)+va
 Close pyuser_inttype.cpp
 Python function void FunctionTU(int arg1 +intent(in)+value, long arg2 +intent(in)+value)
 Python function void FunctionTU(float arg1 +intent(in)+value, double arg2 +intent(in)+value)
+Python function int UseImplWorker()
 Python function int UseImplWorker()
 Close pytemplatesmodule.cpp
 Close pytemplatesutil.cpp

--- a/regression/reference/templates/templates_types.yaml
+++ b/regression/reference/templates/templates_types.yaml
@@ -23,6 +23,16 @@ declarations:
         f_derived_type: implworker1
         f_capsule_data_type: SHROUD_implworker1_capsule
         f_to_c: "{f_var}%cxxmem"
+    - type: ImplWorker2
+      fields:
+        base: shadow
+        impl_header: implworker2.hpp
+        cxx_type: internal::ImplWorker2
+        c_type: TEM_internal_ImplWorker2
+        f_module_name: templates_internal_mod
+        f_derived_type: implworker2
+        f_capsule_data_type: SHROUD_implworker2_capsule
+        f_to_c: "{f_var}%cxxmem"
   - namespace: std
     declarations: std
     - type: vector_double

--- a/regression/reference/templates/typestemplates.h
+++ b/regression/reference/templates/typestemplates.h
@@ -22,6 +22,12 @@ struct s_TEM_internal_ImplWorker1 {
 };
 typedef struct s_TEM_internal_ImplWorker1 TEM_internal_ImplWorker1;
 
+struct s_TEM_internal_ImplWorker2 {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TEM_internal_ImplWorker2 TEM_internal_ImplWorker2;
+
 struct s_TEM_user_int {
     void *addr;     /* address of C++ memory */
     int idtor;      /* index of destructor */

--- a/regression/reference/templates/wrapftemplates.f
+++ b/regression/reference/templates/wrapftemplates.f
@@ -102,6 +102,14 @@ module templates_mod
             integer(C_INT) :: SHT_rv
         end function c_use_impl_worker_internal_implworker1
 
+        function c_use_impl_worker_internal_implworker2() &
+                result(SHT_rv) &
+                bind(C, name="TEM_use_impl_worker_internal_ImplWorker2")
+            use iso_c_binding, only : C_INT
+            implicit none
+            integer(C_INT) :: SHT_rv
+        end function c_use_impl_worker_internal_implworker2
+
         ! splicer begin additional_interfaces
         ! splicer end additional_interfaces
     end interface
@@ -213,6 +221,19 @@ contains
         SHT_rv = c_use_impl_worker_internal_implworker1()
         ! splicer end function.use_impl_worker_internal_ImplWorker1
     end function use_impl_worker_internal_ImplWorker1
+
+    !>
+    !! \brief Function which uses a templated T in the implemetation.
+    !!
+    !<
+    function use_impl_worker_internal_ImplWorker2() &
+            result(SHT_rv)
+        use iso_c_binding, only : C_INT
+        integer(C_INT) :: SHT_rv
+        ! splicer begin function.use_impl_worker_internal_ImplWorker2
+        SHT_rv = c_use_impl_worker_internal_implworker2()
+        ! splicer end function.use_impl_worker_internal_ImplWorker2
+    end function use_impl_worker_internal_ImplWorker2
 
     ! splicer begin additional_functions
     ! splicer end additional_functions

--- a/regression/reference/templates/wraptemplates.cpp
+++ b/regression/reference/templates/wraptemplates.cpp
@@ -7,6 +7,7 @@
 
 #include <vector>
 #include "implworker1.hpp"
+#include "implworker2.hpp"
 
 // splicer begin CXX_definitions
 // splicer end CXX_definitions
@@ -50,6 +51,18 @@ int TEM_use_impl_worker_internal_ImplWorker1()
     int SHC_rv = UseImplWorker<internal::ImplWorker1>();
     return SHC_rv;
 // splicer end function.use_impl_worker_internal_ImplWorker1
+}
+
+/**
+ * \brief Function which uses a templated T in the implemetation.
+ *
+ */
+int TEM_use_impl_worker_internal_ImplWorker2()
+{
+// splicer begin function.use_impl_worker_internal_ImplWorker2
+    int SHC_rv = UseImplWorker<internal::ImplWorker2>();
+    return SHC_rv;
+// splicer end function.use_impl_worker_internal_ImplWorker2
 }
 
 // Release library allocated memory.

--- a/regression/reference/templates/wraptemplates.h
+++ b/regression/reference/templates/wraptemplates.h
@@ -27,6 +27,8 @@ void TEM_function_tu_1(float arg1, double arg2);
 
 int TEM_use_impl_worker_internal_ImplWorker1();
 
+int TEM_use_impl_worker_internal_ImplWorker2();
+
 #ifdef __cplusplus
 }
 #endif

--- a/regression/reference/tutorial/tutorial.json
+++ b/regression/reference/tutorial/tutorial.json
@@ -3378,7 +3378,6 @@
                 ]
             },
             {
-                "_CXX_return_templated": true,
                 "_fmtresult": {
                     "fmtc": {
                         "c_var": "SHC_rv",
@@ -3435,6 +3434,7 @@
                 "have_template_args": true,
                 "linenumber": 84,
                 "options": {
+                    "F_create_generic": false,
                     "__line__": 88,
                     "wrap_c": true,
                     "wrap_fortran": true,
@@ -3470,7 +3470,6 @@
                 ]
             },
             {
-                "_CXX_return_templated": true,
                 "_fmtresult": {
                     "fmtc": {
                         "c_var": "SHC_rv",
@@ -3531,6 +3530,7 @@
                 "have_template_args": true,
                 "linenumber": 84,
                 "options": {
+                    "F_create_generic": false,
                     "__line__": 88,
                     "wrap_c": true,
                     "wrap_fortran": true,
@@ -6986,6 +6986,7 @@
             "F_auto_reference_count": false,
             "F_capsule_data_type_class_template": "SHROUD_{F_name_scope}capsule",
             "F_create_bufferify_function": true,
+            "F_create_generic": true,
             "F_enum_member_template": "{F_name_scope}{enum_member_lower}",
             "F_flatten_namespace": false,
             "F_force_wrapper": false,

--- a/regression/reference/types/types.json
+++ b/regression/reference/types/types.json
@@ -2932,6 +2932,7 @@
             "F_auto_reference_count": false,
             "F_capsule_data_type_class_template": "SHROUD_{F_name_scope}capsule",
             "F_create_bufferify_function": true,
+            "F_create_generic": true,
             "F_enum_member_template": "{F_name_scope}{enum_member_lower}",
             "F_flatten_namespace": false,
             "F_force_wrapper": false,

--- a/regression/reference/vectors/vectors.json
+++ b/regression/reference/vectors/vectors.json
@@ -1281,6 +1281,7 @@
             "F_auto_reference_count": false,
             "F_capsule_data_type_class_template": "SHROUD_{F_name_scope}capsule",
             "F_create_bufferify_function": true,
+            "F_create_generic": true,
             "F_enum_member_template": "{F_name_scope}{enum_member_lower}",
             "F_flatten_namespace": false,
             "F_force_wrapper": false,

--- a/regression/run/templates/implworker2.hpp
+++ b/regression/run/templates/implworker2.hpp
@@ -1,0 +1,19 @@
+// Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC and
+// other Shroud Project Developers.
+// See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+// Put internal class in its own header to test cxx_header for a
+// class.
+
+namespace internal
+{
+    class ImplWorker2
+    {
+    public:
+        static int getValue() {
+            return 1;
+        }
+    };
+}  // namespace internal

--- a/regression/run/templates/main.f
+++ b/regression/run/templates/main.f
@@ -85,6 +85,9 @@ contains
     rv_int = use_impl_worker_internal_implworker1()
     call assert_equals(1, rv_int)
 
+    rv_int = use_impl_worker_internal_implworker2()
+    call assert_equals(1, rv_int)
+
   end subroutine function_templates
 
 end program tester

--- a/regression/run/templates/python/Makefile
+++ b/regression/run/templates/python/Makefile
@@ -22,6 +22,7 @@ VPATH = \
 
 OBJS = \
     pyImplWorker1type.o \
+    pyImplWorker2type.o \
     pyWorkertype.o \
     pytemplatesutil.o \
     pytemplatesmodule.o \

--- a/regression/templates.yaml
+++ b/regression/templates.yaml
@@ -54,6 +54,10 @@ declarations:
     cxx_header: implworker1.hpp
     options:
       wrap_fortran: false
+  - decl: class ImplWorker2
+    cxx_header: implworker2.hpp
+    options:
+      wrap_fortran: false
 
 - decl: template<typename T> class user
   # XXX - error if cxx_template is missing
@@ -97,5 +101,8 @@ declarations:
 - decl: template<typename T> int UseImplWorker()
   doxygen:
      brief: Function which uses a templated T in the implemetation.
+  options:
+    F_create_generic: False
   cxx_template:
   - instantiation: <internal::ImplWorker1>
+  - instantiation: <internal::ImplWorker2>

--- a/shroud/ast.py
+++ b/shroud/ast.py
@@ -422,6 +422,7 @@ class LibraryNode(AstNode, NamespaceMixin):
             F_standard=2003,
             F_auto_reference_count=False,
             F_create_bufferify_function=True,
+            F_create_generic=True,
             wrap_c=True,
             wrap_fortran=True,
             wrap_python=False,
@@ -1198,7 +1199,6 @@ class FunctionNode(AstNode):
         self.default_format(parent, format, kwargs)
 
         # working variables
-        self._CXX_return_templated = False
         self._PTR_C_CXX_index = None
         self._PTR_F_C_index = None
         self._cxx_overload = None

--- a/shroud/generate.py
+++ b/shroud/generate.py
@@ -706,6 +706,7 @@ class GenFunctions(object):
                 method._overloaded = True
                 self.template_function(method, ordered_functions)
             elif method.have_template_args:
+                # have_template_args is True if result/argument is templated.
                 #                method._overloaded = True
                 self.template_function2(method, ordered_functions)
 
@@ -715,6 +716,8 @@ class GenFunctions(object):
             # if not function.options.wrap_c:
             #     continue
             if function.cxx_template:
+                continue
+            if function.template_arguments:
                 continue
             if function.have_template_args:
                 # Stuff like push_back which is in a templated class, is not an overload
@@ -821,7 +824,8 @@ class GenFunctions(object):
             if new.ast.typemap.base == "template":
                 iast = getattr(self.instantiate_scope, new.ast.typemap.name)
                 new.ast = new.ast.instantiate(node.ast.instantiate(iast))
-                new._CXX_return_templated = True
+                # Generics cannot differentiate on return type
+                options.F_create_generic = False
 
             # Replace templated arguments.
             # arg - declast.Declaration
@@ -888,7 +892,8 @@ class GenFunctions(object):
         if new.ast.typemap.base == "template":
             iast = getattr(self.instantiate_scope, new.ast.typemap.name)
             new.ast = new.ast.instantiate(node.ast.instantiate(iast))
-            new._CXX_return_templated = True
+            # Generics cannot differentiate on return type
+            options.F_create_generic = False
 
         # Replace templated arguments.
         newparams = []

--- a/shroud/todict.py
+++ b/shroud/todict.py
@@ -229,7 +229,6 @@ class ToDict(visitor.Visitor):
                 "template_parameters",
                 "C_error_pattern",
                 "PY_error_pattern",
-                "_CXX_return_templated",
                 "_default_funcs",
                 "_generated",
                 "_has_default_arg",

--- a/shroud/wrapf.py
+++ b/shroud/wrapf.py
@@ -1594,7 +1594,7 @@ rv = .false.
 
             self.update_f_module(modules, imports, result_typemap.f_module)
 
-        if not node._CXX_return_templated:
+        if options.F_create_generic:
             # if return type is templated in C++,
             # then do not set up generic since only the
             # return type may be different (ex. getValue<T>())


### PR DESCRIPTION
User settable to control if a generic function is created. Useful for
templated functions when the template is part of the implementation
instead of the interface since all of the instantations will have the
same arguments.

Remove FunctionNode._CXX_return_templated - It prevented generics when
the return type was templated.  F_create_generic is more general.