### PR TITLE
Type defines

### DIFF
--- a/regression/reference/clibrary/clibrary.json
+++ b/regression/reference/clibrary/clibrary.json
@@ -176,7 +176,7 @@
                             "cxx_type": "double",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -219,7 +219,7 @@
                             "cxx_type": "int",
                             "cxx_var": "arg2",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -260,7 +260,7 @@
                         "cxx_type": "double",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -369,7 +369,7 @@
                             "cxx_type": "double",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_native_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -412,7 +412,7 @@
                             "cxx_type": "int",
                             "cxx_var": "arg2",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -536,7 +536,7 @@
                             "cxx_type": "bool",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_BOOL",
                             "stmt0": "c_bool_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -581,7 +581,7 @@
                             "cxx_type": "bool",
                             "cxx_var": "arg2",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_BOOL",
                             "stmt0": "c_bool_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -625,7 +625,7 @@
                             "cxx_type": "bool",
                             "cxx_var": "arg3",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_BOOL",
                             "stmt0": "c_bool_pointer_inout_",
                             "stmt1": "c_default"
                         },
@@ -770,7 +770,7 @@
                             "cxx_type": "char",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -804,7 +804,7 @@
                             "cxx_type": "char",
                             "cxx_var": "arg2",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -836,7 +836,7 @@
                         "cxx_type": "char",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "c_char_pointer_result_",
                         "stmt1": "c_char_result"
                     },
@@ -964,7 +964,7 @@
                             "cxx_type": "char",
                             "cxx_var": "SHC_rv",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_result_buf_",
                             "stmt1": "c_char_result_buf"
                         },
@@ -991,7 +991,7 @@
                             "cxx_type": "char",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -1013,7 +1013,7 @@
                             "cxx_type": "char",
                             "cxx_var": "arg2",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -1032,7 +1032,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_CPTR",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -1149,7 +1149,7 @@
                             "cxx_type": "char",
                             "cxx_var": "name",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -1252,7 +1252,7 @@
                             "cxx_type": "char",
                             "cxx_var": "name1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1357,7 +1357,7 @@
                             "cxx_type": "char",
                             "cxx_var": "name1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_out_buf",
                             "stmt1": "c_char_out_buf"
                         },
@@ -1449,7 +1449,7 @@
                             "cxx_type": "char",
                             "cxx_var": "name1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1484,7 +1484,7 @@
                             "cxx_type": "char",
                             "cxx_var": "name2",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1605,7 +1605,7 @@
                             "cxx_type": "char",
                             "cxx_var": "name1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_out_buf",
                             "stmt1": "c_char_out_buf"
                         },
@@ -1633,7 +1633,7 @@
                             "cxx_type": "char",
                             "cxx_var": "name2",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_out_buf",
                             "stmt1": "c_char_out_buf"
                         },
@@ -1744,7 +1744,7 @@
                             "cxx_type": "int",
                             "cxx_var": "ltext",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1779,7 +1779,7 @@
                             "cxx_type": "char",
                             "cxx_var": "text",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1897,7 +1897,7 @@
                             "cxx_type": "int",
                             "cxx_var": "ltext",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_buf",
                             "stmt1": "c_default"
                         },
@@ -1921,7 +1921,7 @@
                             "cxx_type": "char",
                             "cxx_var": "text",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_out_buf",
                             "stmt1": "c_char_out_buf"
                         },
@@ -2028,7 +2028,7 @@
                             "cxx_type": "bool",
                             "cxx_var": "flag",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_BOOL",
                             "stmt0": "c_bool_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2069,7 +2069,7 @@
                             "cxx_type": "int",
                             "cxx_var": "ltext",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2109,7 +2109,7 @@
                             "cxx_type": "char",
                             "cxx_var": "text",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -2145,7 +2145,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2281,7 +2281,7 @@
                             "cxx_type": "bool",
                             "cxx_var": "flag",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_BOOL",
                             "stmt0": "c_bool_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2322,7 +2322,7 @@
                             "cxx_type": "int",
                             "cxx_var": "ltext",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2362,7 +2362,7 @@
                             "cxx_type": "char",
                             "cxx_var": "text",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -2398,7 +2398,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2534,7 +2534,7 @@
                             "cxx_type": "bool",
                             "cxx_var": "flag",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_BOOL",
                             "stmt0": "c_bool_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2573,7 +2573,7 @@
                         "cxx_type": "bool",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_BOOL",
                         "stmt0": "c_bool_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2671,7 +2671,7 @@
                             "cxx_type": "bool",
                             "cxx_var": "flag",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_BOOL",
                             "stmt0": "c_bool_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2710,7 +2710,7 @@
                         "cxx_type": "bool",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_BOOL",
                         "stmt0": "c_bool_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2853,7 +2853,7 @@
                             "cxx_type": "char",
                             "cxx_var": "outbuf",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_out_",
                             "stmt1": "c_default"
                         }
@@ -2940,7 +2940,7 @@
                             "cxx_type": "char",
                             "cxx_var": "outbuf",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_out_buf",
                             "stmt1": "c_char_out_buf"
                         },
@@ -3032,7 +3032,7 @@
                             "cxx_type": "void",
                             "cxx_var": "in",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_CPTR",
                             "stmt0": "c_unknown_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -3059,7 +3059,7 @@
                             "cxx_type": "void",
                             "cxx_var": "out",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_CPTR",
                             "stmt0": "c_unknown_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -3175,7 +3175,7 @@
                             "cxx_type": "void",
                             "cxx_var": "arg",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_CPTR",
                             "stmt0": "c_unknown_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -3195,7 +3195,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -3288,7 +3288,7 @@
                             "cxx_type": "void",
                             "cxx_var": "arg",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_CPTR",
                             "stmt0": "c_unknown_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -3379,7 +3379,7 @@
                             "cxx_type": "void",
                             "cxx_var": "arg",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_CPTR",
                             "stmt0": "c_unknown_pointer_in_",
                             "stmt1": "c_default"
                         }
@@ -3397,7 +3397,7 @@
                             "cxx_type": "char",
                             "cxx_var": "outbuf",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_out_",
                             "stmt1": "c_default"
                         }
@@ -3413,7 +3413,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -3523,7 +3523,7 @@
                             "cxx_type": "void",
                             "cxx_var": "arg",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_CPTR",
                             "stmt0": "c_unknown_pointer_in_buf",
                             "stmt1": "c_default"
                         },
@@ -3546,7 +3546,7 @@
                             "cxx_type": "char",
                             "cxx_var": "outbuf",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_out_buf",
                             "stmt1": "c_char_out_buf"
                         },
@@ -3571,7 +3571,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -3672,7 +3672,7 @@
                             "cxx_type": "void",
                             "cxx_var": "incr",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_CPTR",
                             "stmt0": "c_unknown_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -3694,7 +3694,7 @@
                             "cxx_type": "int",
                             "cxx_var": "type",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -3719,7 +3719,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -3830,7 +3830,7 @@
                             "cxx_type": "void",
                             "cxx_var": "in",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_CPTR",
                             "stmt0": "c_unknown_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -3852,7 +3852,7 @@
                             "cxx_type": "void",
                             "cxx_var": "incr",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_CPTR",
                             "stmt0": "c_unknown_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -3874,7 +3874,7 @@
                             "cxx_type": "int",
                             "cxx_var": "type",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -4023,7 +4023,7 @@
                             "cxx_type": "void",
                             "cxx_var": "in",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_CPTR",
                             "stmt0": "c_unknown_pointer_in_",
                             "stmt1": "c_default"
                         }
@@ -4041,7 +4041,7 @@
                             "cxx_type": "void",
                             "cxx_var": "incr",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_CPTR",
                             "stmt0": "c_unknown_scalar_in_",
                             "stmt1": "c_default"
                         }
@@ -4059,7 +4059,7 @@
                             "cxx_type": "char",
                             "cxx_var": "outbuf",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_out_",
                             "stmt1": "c_default"
                         }
@@ -4077,7 +4077,7 @@
                             "cxx_type": "char",
                             "cxx_var": "type",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_in_",
                             "stmt1": "c_default"
                         }
@@ -4242,7 +4242,7 @@
                             "cxx_type": "void",
                             "cxx_var": "in",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_CPTR",
                             "stmt0": "c_unknown_pointer_in_buf",
                             "stmt1": "c_default"
                         },
@@ -4264,7 +4264,7 @@
                             "cxx_type": "void",
                             "cxx_var": "incr",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_CPTR",
                             "stmt0": "c_unknown_scalar_in_buf",
                             "stmt1": "c_default"
                         },
@@ -4287,7 +4287,7 @@
                             "cxx_type": "char",
                             "cxx_var": "outbuf",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_out_buf",
                             "stmt1": "c_char_out_buf"
                         },
@@ -4314,7 +4314,7 @@
                             "cxx_type": "char",
                             "cxx_var": "type",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_in_",
                             "stmt1": "c_default"
                         },

--- a/regression/reference/clibrary/clibrary.json
+++ b/regression/reference/clibrary/clibrary.json
@@ -176,6 +176,7 @@
                             "cxx_type": "double",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -218,6 +219,7 @@
                             "cxx_type": "int",
                             "cxx_var": "arg2",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -258,6 +260,7 @@
                         "cxx_type": "double",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -366,6 +369,7 @@
                             "cxx_type": "double",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -408,6 +412,7 @@
                             "cxx_type": "int",
                             "cxx_var": "arg2",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -531,6 +536,7 @@
                             "cxx_type": "bool",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_bool_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -575,6 +581,7 @@
                             "cxx_type": "bool",
                             "cxx_var": "arg2",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_bool_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -618,6 +625,7 @@
                             "cxx_type": "bool",
                             "cxx_var": "arg3",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_bool_pointer_inout_",
                             "stmt1": "c_default"
                         },
@@ -762,6 +770,7 @@
                             "cxx_type": "char",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -795,6 +804,7 @@
                             "cxx_type": "char",
                             "cxx_var": "arg2",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -826,6 +836,7 @@
                         "cxx_type": "char",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_char_pointer_result_",
                         "stmt1": "c_char_result"
                     },
@@ -953,6 +964,7 @@
                             "cxx_type": "char",
                             "cxx_var": "SHC_rv",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_result_buf_",
                             "stmt1": "c_char_result_buf"
                         },
@@ -979,6 +991,7 @@
                             "cxx_type": "char",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -1000,6 +1013,7 @@
                             "cxx_type": "char",
                             "cxx_var": "arg2",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -1018,6 +1032,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -1134,6 +1149,7 @@
                             "cxx_type": "char",
                             "cxx_var": "name",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -1236,6 +1252,7 @@
                             "cxx_type": "char",
                             "cxx_var": "name1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1340,6 +1357,7 @@
                             "cxx_type": "char",
                             "cxx_var": "name1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_out_buf",
                             "stmt1": "c_char_out_buf"
                         },
@@ -1431,6 +1449,7 @@
                             "cxx_type": "char",
                             "cxx_var": "name1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1465,6 +1484,7 @@
                             "cxx_type": "char",
                             "cxx_var": "name2",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1585,6 +1605,7 @@
                             "cxx_type": "char",
                             "cxx_var": "name1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_out_buf",
                             "stmt1": "c_char_out_buf"
                         },
@@ -1612,6 +1633,7 @@
                             "cxx_type": "char",
                             "cxx_var": "name2",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_out_buf",
                             "stmt1": "c_char_out_buf"
                         },
@@ -1722,6 +1744,7 @@
                             "cxx_type": "int",
                             "cxx_var": "ltext",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1756,6 +1779,7 @@
                             "cxx_type": "char",
                             "cxx_var": "text",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1873,6 +1897,7 @@
                             "cxx_type": "int",
                             "cxx_var": "ltext",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_buf",
                             "stmt1": "c_default"
                         },
@@ -1896,6 +1921,7 @@
                             "cxx_type": "char",
                             "cxx_var": "text",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_out_buf",
                             "stmt1": "c_char_out_buf"
                         },
@@ -2002,6 +2028,7 @@
                             "cxx_type": "bool",
                             "cxx_var": "flag",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_bool_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2042,6 +2069,7 @@
                             "cxx_type": "int",
                             "cxx_var": "ltext",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2081,6 +2109,7 @@
                             "cxx_type": "char",
                             "cxx_var": "text",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -2116,6 +2145,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2251,6 +2281,7 @@
                             "cxx_type": "bool",
                             "cxx_var": "flag",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_bool_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2291,6 +2322,7 @@
                             "cxx_type": "int",
                             "cxx_var": "ltext",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2330,6 +2362,7 @@
                             "cxx_type": "char",
                             "cxx_var": "text",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -2365,6 +2398,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2500,6 +2534,7 @@
                             "cxx_type": "bool",
                             "cxx_var": "flag",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_bool_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2538,6 +2573,7 @@
                         "cxx_type": "bool",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_bool_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2635,6 +2671,7 @@
                             "cxx_type": "bool",
                             "cxx_var": "flag",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_bool_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2673,6 +2710,7 @@
                         "cxx_type": "bool",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_bool_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2815,6 +2853,7 @@
                             "cxx_type": "char",
                             "cxx_var": "outbuf",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_out_",
                             "stmt1": "c_default"
                         }
@@ -2901,6 +2940,7 @@
                             "cxx_type": "char",
                             "cxx_var": "outbuf",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_out_buf",
                             "stmt1": "c_char_out_buf"
                         },
@@ -2992,6 +3032,7 @@
                             "cxx_type": "void",
                             "cxx_var": "in",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_unknown_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -3018,6 +3059,7 @@
                             "cxx_type": "void",
                             "cxx_var": "out",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_unknown_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -3133,6 +3175,7 @@
                             "cxx_type": "void",
                             "cxx_var": "arg",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_unknown_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -3152,6 +3195,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -3244,6 +3288,7 @@
                             "cxx_type": "void",
                             "cxx_var": "arg",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_unknown_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -3334,6 +3379,7 @@
                             "cxx_type": "void",
                             "cxx_var": "arg",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_unknown_pointer_in_",
                             "stmt1": "c_default"
                         }
@@ -3351,6 +3397,7 @@
                             "cxx_type": "char",
                             "cxx_var": "outbuf",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_out_",
                             "stmt1": "c_default"
                         }
@@ -3366,6 +3413,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -3475,6 +3523,7 @@
                             "cxx_type": "void",
                             "cxx_var": "arg",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_unknown_pointer_in_buf",
                             "stmt1": "c_default"
                         },
@@ -3497,6 +3546,7 @@
                             "cxx_type": "char",
                             "cxx_var": "outbuf",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_out_buf",
                             "stmt1": "c_char_out_buf"
                         },
@@ -3521,6 +3571,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -3621,6 +3672,7 @@
                             "cxx_type": "void",
                             "cxx_var": "incr",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_unknown_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -3642,6 +3694,7 @@
                             "cxx_type": "int",
                             "cxx_var": "type",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -3666,6 +3719,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -3776,6 +3830,7 @@
                             "cxx_type": "void",
                             "cxx_var": "in",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_unknown_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -3797,6 +3852,7 @@
                             "cxx_type": "void",
                             "cxx_var": "incr",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_unknown_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -3818,6 +3874,7 @@
                             "cxx_type": "int",
                             "cxx_var": "type",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -3966,6 +4023,7 @@
                             "cxx_type": "void",
                             "cxx_var": "in",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_unknown_pointer_in_",
                             "stmt1": "c_default"
                         }
@@ -3983,6 +4041,7 @@
                             "cxx_type": "void",
                             "cxx_var": "incr",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_unknown_scalar_in_",
                             "stmt1": "c_default"
                         }
@@ -4000,6 +4059,7 @@
                             "cxx_type": "char",
                             "cxx_var": "outbuf",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_out_",
                             "stmt1": "c_default"
                         }
@@ -4017,6 +4077,7 @@
                             "cxx_type": "char",
                             "cxx_var": "type",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_in_",
                             "stmt1": "c_default"
                         }
@@ -4181,6 +4242,7 @@
                             "cxx_type": "void",
                             "cxx_var": "in",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_unknown_pointer_in_buf",
                             "stmt1": "c_default"
                         },
@@ -4202,6 +4264,7 @@
                             "cxx_type": "void",
                             "cxx_var": "incr",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_unknown_scalar_in_buf",
                             "stmt1": "c_default"
                         },
@@ -4224,6 +4287,7 @@
                             "cxx_type": "char",
                             "cxx_var": "outbuf",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_out_buf",
                             "stmt1": "c_char_out_buf"
                         },
@@ -4250,6 +4314,7 @@
                             "cxx_type": "char",
                             "cxx_var": "type",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_in_",
                             "stmt1": "c_default"
                         },

--- a/regression/reference/example/example.json
+++ b/regression/reference/example/example.json
@@ -200,6 +200,7 @@
                                                 "cxx_type": "example::nested::ExClass1",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_shadow_scalar_ctor_",
                                                 "stmt1": "c_shadow_ctor"
                                             },
@@ -291,6 +292,7 @@
                                                     "cxx_type": "std::string",
                                                     "cxx_var": "SHCXX_name",
                                                     "idtor": "0",
+                                                    "sh_type": "0",
                                                     "stmt0": "c_string_pointer_in_",
                                                     "stmt1": "c_string_in"
                                                 },
@@ -332,6 +334,7 @@
                                                 "cxx_type": "example::nested::ExClass1",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_shadow_scalar_ctor_",
                                                 "stmt1": "c_shadow_ctor"
                                             },
@@ -449,6 +452,7 @@
                                                     "cxx_type": "std::string",
                                                     "cxx_var": "SHCXX_name",
                                                     "idtor": "0",
+                                                    "sh_type": "0",
                                                     "stmt0": "c_string_pointer_in_buf",
                                                     "stmt1": "c_string_in_buf"
                                                 },
@@ -472,6 +476,7 @@
                                                 "cxx_type": "example::nested::ExClass1",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_shadow_scalar_ctor_buf",
                                                 "stmt1": "c_shadow_ctor"
                                             }
@@ -602,6 +607,7 @@
                                                     "cxx_type": "int",
                                                     "cxx_var": "incr",
                                                     "idtor": "0",
+                                                    "sh_type": "0",
                                                     "stmt0": "c_native_scalar_in_",
                                                     "stmt1": "c_default"
                                                 },
@@ -653,6 +659,7 @@
                                                 "cxx_type": "int",
                                                 "cxx_var": "SHC_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_native_scalar_result_",
                                                 "stmt1": "c_default"
                                             },
@@ -754,6 +761,7 @@
                                                 "cxx_type": "std::string",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_string_pointer_result_",
                                                 "stmt1": "c_string_result"
                                             },
@@ -856,6 +864,7 @@
                                                     "cxx_type": "std::string",
                                                     "cxx_var": "SHCXX_rv",
                                                     "idtor": "0",
+                                                    "sh_type": "0",
                                                     "stmt0": "c_string_pointer_result_buf_",
                                                     "stmt1": "c_string_result_buf"
                                                 },
@@ -879,6 +888,7 @@
                                                 "cxx_type": "void",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_unknown_scalar_result_buf",
                                                 "stmt1": "c_default"
                                             }
@@ -956,6 +966,7 @@
                                                 "cxx_type": "int",
                                                 "cxx_var": "SHC_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_native_scalar_result_",
                                                 "stmt1": "c_default"
                                             },
@@ -1050,6 +1061,7 @@
                                                 "cxx_type": "std::string",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_string_pointer_result_",
                                                 "stmt1": "c_string_result"
                                             },
@@ -1148,6 +1160,7 @@
                                                     "cxx_type": "std::string",
                                                     "cxx_var": "SHCXX_rv",
                                                     "idtor": "0",
+                                                    "sh_type": "0",
                                                     "stmt0": "c_string_pointer_result_buf_allocatable",
                                                     "stmt1": "c_string_result_buf_allocatable"
                                                 },
@@ -1172,6 +1185,7 @@
                                                 "cxx_type": "void",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_unknown_scalar_result_buf",
                                                 "stmt1": "c_default"
                                             }
@@ -1247,6 +1261,7 @@
                                                 "cxx_type": "std::string",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_string_pointer_result_",
                                                 "stmt1": "c_string_result"
                                             },
@@ -1332,6 +1347,7 @@
                                                     "cxx_type": "std::string",
                                                     "cxx_var": "SHCXX_rv",
                                                     "idtor": "0",
+                                                    "sh_type": "0",
                                                     "stmt0": "c_string_pointer_result_buf_",
                                                     "stmt1": "c_string_result_buf"
                                                 },
@@ -1355,6 +1371,7 @@
                                                 "cxx_type": "void",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_unknown_scalar_result_buf",
                                                 "stmt1": "c_default"
                                             }
@@ -1491,6 +1508,7 @@
                                                 "cxx_type": "void",
                                                 "cxx_var": "SHC_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_unknown_pointer_result_",
                                                 "stmt1": "c_default"
                                             },
@@ -1581,6 +1599,7 @@
                                                     "cxx_type": "int",
                                                     "cxx_var": "value",
                                                     "idtor": "0",
+                                                    "sh_type": "0",
                                                     "stmt0": "c_native_scalar_in_",
                                                     "stmt1": "c_default"
                                                 },
@@ -1632,6 +1651,7 @@
                                                 "cxx_type": "int",
                                                 "cxx_var": "SHC_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_native_scalar_result_",
                                                 "stmt1": "c_default"
                                             },
@@ -1737,6 +1757,7 @@
                                                     "cxx_type": "long",
                                                     "cxx_var": "value",
                                                     "idtor": "0",
+                                                    "sh_type": "0",
                                                     "stmt0": "c_native_scalar_in_",
                                                     "stmt1": "c_default"
                                                 },
@@ -1788,6 +1809,7 @@
                                                 "cxx_type": "long",
                                                 "cxx_var": "SHC_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_native_scalar_result_",
                                                 "stmt1": "c_default"
                                             },
@@ -1886,6 +1908,7 @@
                                                 "cxx_type": "void",
                                                 "cxx_var": "SHC_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_unknown_pointer_result_",
                                                 "stmt1": "c_default"
                                             },
@@ -1976,6 +1999,7 @@
                                                     "cxx_type": "bool",
                                                     "cxx_var": "in",
                                                     "idtor": "0",
+                                                    "sh_type": "0",
                                                     "stmt0": "c_bool_scalar_in_",
                                                     "stmt1": "c_default"
                                                 },
@@ -2029,6 +2053,7 @@
                                                 "cxx_type": "bool",
                                                 "cxx_var": "SHC_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_bool_scalar_result_",
                                                 "stmt1": "c_default"
                                             },
@@ -2221,6 +2246,7 @@
                                                     "cxx_type": "std::string",
                                                     "cxx_var": "SHCXX_name",
                                                     "idtor": "0",
+                                                    "sh_type": "0",
                                                     "stmt0": "c_string_pointer_in_",
                                                     "stmt1": "c_string_in"
                                                 },
@@ -2262,6 +2288,7 @@
                                                 "cxx_type": "example::nested::ExClass2",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_shadow_scalar_ctor_",
                                                 "stmt1": "c_shadow_ctor"
                                             },
@@ -2379,6 +2406,7 @@
                                                     "cxx_type": "std::string",
                                                     "cxx_var": "SHCXX_name",
                                                     "idtor": "0",
+                                                    "sh_type": "0",
                                                     "stmt0": "c_string_pointer_in_buf",
                                                     "stmt1": "c_string_in_buf"
                                                 },
@@ -2402,6 +2430,7 @@
                                                 "cxx_type": "example::nested::ExClass2",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_shadow_scalar_ctor_buf",
                                                 "stmt1": "c_shadow_ctor"
                                             }
@@ -2526,6 +2555,7 @@
                                                 "cxx_type": "std::string",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_string_pointer_result_",
                                                 "stmt1": "c_string_result"
                                             },
@@ -2626,6 +2656,7 @@
                                                     "cxx_type": "std::string",
                                                     "cxx_var": "SHCXX_rv",
                                                     "idtor": "0",
+                                                    "sh_type": "0",
                                                     "stmt0": "c_string_pointer_result_buf_",
                                                     "stmt1": "c_string_result_buf"
                                                 },
@@ -2649,6 +2680,7 @@
                                                 "cxx_type": "void",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_unknown_scalar_result_buf",
                                                 "stmt1": "c_default"
                                             }
@@ -2727,6 +2759,7 @@
                                                 "cxx_type": "std::string",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_string_pointer_result_",
                                                 "stmt1": "c_string_result"
                                             },
@@ -2824,6 +2857,7 @@
                                                     "cxx_type": "std::string",
                                                     "cxx_var": "SHCXX_rv",
                                                     "idtor": "0",
+                                                    "sh_type": "0",
                                                     "stmt0": "c_string_pointer_result_buf_allocatable",
                                                     "stmt1": "c_string_result_buf_allocatable"
                                                 },
@@ -2848,6 +2882,7 @@
                                                 "cxx_type": "void",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_unknown_scalar_result_buf",
                                                 "stmt1": "c_default"
                                             }
@@ -2922,6 +2957,7 @@
                                                 "cxx_type": "std::string",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_string_pointer_result_",
                                                 "stmt1": "c_string_result"
                                             },
@@ -3019,6 +3055,7 @@
                                                     "cxx_type": "std::string",
                                                     "cxx_var": "SHCXX_rv",
                                                     "idtor": "0",
+                                                    "sh_type": "0",
                                                     "stmt0": "c_string_pointer_result_buf_allocatable",
                                                     "stmt1": "c_string_result_buf_allocatable"
                                                 },
@@ -3043,6 +3080,7 @@
                                                 "cxx_type": "void",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_unknown_scalar_result_buf",
                                                 "stmt1": "c_default"
                                             }
@@ -3117,6 +3155,7 @@
                                                 "cxx_type": "std::string",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_string_pointer_result_",
                                                 "stmt1": "c_string_result"
                                             },
@@ -3213,6 +3252,7 @@
                                                     "cxx_type": "std::string",
                                                     "cxx_var": "SHCXX_rv",
                                                     "idtor": "0",
+                                                    "sh_type": "0",
                                                     "stmt0": "c_string_pointer_result_buf_allocatable",
                                                     "stmt1": "c_string_result_buf_allocatable"
                                                 },
@@ -3237,6 +3277,7 @@
                                                 "cxx_type": "void",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_unknown_scalar_result_buf",
                                                 "stmt1": "c_default"
                                             }
@@ -3309,6 +3350,7 @@
                                                 "cxx_type": "int",
                                                 "cxx_var": "SHC_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_native_scalar_result_",
                                                 "stmt1": "c_default"
                                             },
@@ -3406,6 +3448,7 @@
                                                     "cxx_type": "example::nested::ExClass1",
                                                     "cxx_var": "SHCXX_in",
                                                     "idtor": "0",
+                                                    "sh_type": "0",
                                                     "stmt0": "c_shadow_pointer_in_",
                                                     "stmt1": "c_shadow_in"
                                                 },
@@ -3460,6 +3503,7 @@
                                                 "cxx_type": "example::nested::ExClass1",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_shadow_pointer_result_",
                                                 "stmt1": "c_shadow_result"
                                             },
@@ -3575,6 +3619,7 @@
                                                     "cxx_val": "getTypeID(type)",
                                                     "cxx_var": "SHCXX_type",
                                                     "idtor": "0",
+                                                    "sh_type": "0",
                                                     "stmt0": "c_native_scalar_in_",
                                                     "stmt1": "c_default"
                                                 },
@@ -3886,6 +3931,7 @@
                                                     "cxx_type": "SidreLength",
                                                     "cxx_var": "len",
                                                     "idtor": "0",
+                                                    "sh_type": "0",
                                                     "stmt0": "c_native_scalar_in_",
                                                     "stmt1": "c_default"
                                                 },
@@ -3941,6 +3987,7 @@
                                                     "cxx_val": "getTypeID(type)",
                                                     "cxx_var": "SHCXX_type",
                                                     "idtor": "0",
+                                                    "sh_type": "0",
                                                     "stmt0": "c_native_scalar_in_",
                                                     "stmt1": "c_default"
                                                 },
@@ -4353,6 +4400,7 @@
                                                 "cxx_type": "TypeID",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_native_scalar_result_",
                                                 "stmt1": "c_default"
                                             },
@@ -4541,6 +4589,7 @@
                                                     "cxx_type": "int",
                                                     "cxx_var": "value",
                                                     "idtor": "0",
+                                                    "sh_type": "0",
                                                     "stmt0": "c_native_scalar_in_",
                                                     "stmt1": "c_default"
                                                 },
@@ -4714,6 +4763,7 @@
                                                     "cxx_type": "long",
                                                     "cxx_var": "value",
                                                     "idtor": "0",
+                                                    "sh_type": "0",
                                                     "stmt0": "c_native_scalar_in_",
                                                     "stmt1": "c_default"
                                                 },
@@ -4885,6 +4935,7 @@
                                                     "cxx_type": "float",
                                                     "cxx_var": "value",
                                                     "idtor": "0",
+                                                    "sh_type": "0",
                                                     "stmt0": "c_native_scalar_in_",
                                                     "stmt1": "c_default"
                                                 },
@@ -5056,6 +5107,7 @@
                                                     "cxx_type": "double",
                                                     "cxx_var": "value",
                                                     "idtor": "0",
+                                                    "sh_type": "0",
                                                     "stmt0": "c_native_scalar_in_",
                                                     "stmt1": "c_default"
                                                 },
@@ -5290,6 +5342,7 @@
                                                 "cxx_type": "int",
                                                 "cxx_var": "SHC_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_native_scalar_result_",
                                                 "stmt1": "c_default"
                                             },
@@ -5410,6 +5463,7 @@
                                                 "cxx_type": "double",
                                                 "cxx_var": "SHC_rv",
                                                 "idtor": "0",
+                                                "sh_type": "0",
                                                 "stmt0": "c_native_scalar_result_",
                                                 "stmt1": "c_default"
                                             },
@@ -5622,6 +5676,7 @@
                                             "cxx_type": "std::string",
                                             "cxx_var": "SHCXX_name",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_string_pointer_in_",
                                             "stmt1": "c_string_in"
                                         },
@@ -5664,6 +5719,7 @@
                                         "cxx_type": "bool",
                                         "cxx_var": "SHC_rv",
                                         "idtor": "0",
+                                        "sh_type": "0",
                                         "stmt0": "c_bool_scalar_result_",
                                         "stmt1": "c_default"
                                     },
@@ -5779,6 +5835,7 @@
                                             "cxx_type": "std::string",
                                             "cxx_var": "SHCXX_name",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_string_pointer_in_buf",
                                             "stmt1": "c_string_in_buf"
                                         },
@@ -5803,6 +5860,7 @@
                                         "cxx_type": "bool",
                                         "cxx_var": "SHC_rv",
                                         "idtor": "0",
+                                        "sh_type": "0",
                                         "stmt0": "c_bool_scalar_result_buf",
                                         "stmt1": "c_default"
                                     }
@@ -5883,6 +5941,7 @@
                                         "cxx_type": "bool",
                                         "cxx_var": "SHC_rv",
                                         "idtor": "0",
+                                        "sh_type": "0",
                                         "stmt0": "c_bool_scalar_result_",
                                         "stmt1": "c_default"
                                     },
@@ -5966,6 +6025,7 @@
                                             "cxx_type": "std::string",
                                             "cxx_var": "SHCXX_name",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_string_pointer_in_",
                                             "stmt1": "c_string_in"
                                         },
@@ -6077,6 +6137,7 @@
                                             "cxx_type": "std::string",
                                             "cxx_var": "SHCXX_name",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_string_pointer_in_buf",
                                             "stmt1": "c_string_in_buf"
                                         },
@@ -6163,6 +6224,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "flag",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -6207,6 +6269,7 @@
                                             "cxx_type": "std::string",
                                             "cxx_var": "SHCXX_name",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_string_pointer_in_",
                                             "stmt1": "c_string_in"
                                         },
@@ -6329,6 +6392,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "flag",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_scalar_in_buf",
                                             "stmt1": "c_default"
                                         },
@@ -6356,6 +6420,7 @@
                                             "cxx_type": "std::string",
                                             "cxx_var": "SHCXX_name",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_string_pointer_in_buf",
                                             "stmt1": "c_string_in_buf"
                                         },
@@ -6501,6 +6566,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "i",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -6595,6 +6661,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "i",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -6648,6 +6715,7 @@
                                             "cxx_type": "long",
                                             "cxx_var": "j",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -6778,6 +6846,7 @@
                                         "cxx_type": "size_t",
                                         "cxx_var": "SHC_rv",
                                         "idtor": "0",
+                                        "sh_type": "0",
                                         "stmt0": "c_native_scalar_result_",
                                         "stmt1": "c_default"
                                     },
@@ -6862,6 +6931,7 @@
                                             "cxx_val": "MPI_Comm_f2c(comm)",
                                             "cxx_var": "SHCXX_comm",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_unknown_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -7017,6 +7087,7 @@
                                             "cxx_type": "axom::sidre::Group",
                                             "cxx_var": "SHCXX_grp",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_shadow_pointer_in_",
                                             "stmt1": "c_shadow_in"
                                         },
@@ -7134,6 +7205,7 @@
                                             "cxx_type": "axom::sidre::Group",
                                             "cxx_var": "SHCXX_grp",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_shadow_pointer_in_",
                                             "stmt1": "c_shadow_in"
                                         },
@@ -7252,6 +7324,7 @@
                                             "cxx_type": "void",
                                             "cxx_var": "get",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_unknown_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -7370,6 +7443,7 @@
                                             "cxx_type": "double",
                                             "cxx_var": "get",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_pointer_in_",
                                             "stmt1": "c_default"
                                         },
@@ -7492,6 +7566,7 @@
                                             "cxx_type": "double",
                                             "cxx_var": "get",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -7636,6 +7711,7 @@
                                             "cxx_type": "double",
                                             "cxx_var": "get",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -7750,6 +7826,7 @@
                                             "cxx_type": "void",
                                             "cxx_var": "get",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_unknown_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -7995,6 +8072,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname1",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_pointer_inout_",
                                             "stmt1": "c_default"
                                         },
@@ -8048,6 +8126,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname10",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_pointer_inout_",
                                             "stmt1": "c_default"
                                         },
@@ -8101,6 +8180,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname2",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_pointer_inout_",
                                             "stmt1": "c_default"
                                         },
@@ -8154,6 +8234,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname3",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_pointer_inout_",
                                             "stmt1": "c_default"
                                         },
@@ -8207,6 +8288,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname4",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_pointer_inout_",
                                             "stmt1": "c_default"
                                         },
@@ -8260,6 +8342,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname5",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_pointer_inout_",
                                             "stmt1": "c_default"
                                         },
@@ -8313,6 +8396,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname6",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_pointer_inout_",
                                             "stmt1": "c_default"
                                         },
@@ -8366,6 +8450,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname7",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_pointer_inout_",
                                             "stmt1": "c_default"
                                         },
@@ -8419,6 +8504,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname8",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_pointer_inout_",
                                             "stmt1": "c_default"
                                         },
@@ -8472,6 +8558,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname9",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_pointer_inout_",
                                             "stmt1": "c_default"
                                         },
@@ -8752,6 +8839,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname1",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -8805,6 +8893,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname10",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -8858,6 +8947,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname2",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -8911,6 +9001,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname3",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -8964,6 +9055,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname4",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -9017,6 +9109,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname5",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -9070,6 +9163,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname6",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -9123,6 +9217,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname7",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -9176,6 +9271,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname8",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -9229,6 +9325,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname9",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -9280,6 +9377,7 @@
                                         "cxx_type": "int",
                                         "cxx_var": "SHC_rv",
                                         "idtor": "0",
+                                        "sh_type": "0",
                                         "stmt0": "c_native_scalar_result_",
                                         "stmt1": "c_default"
                                     },
@@ -9510,6 +9608,7 @@
                                             "cxx_type": "double",
                                             "cxx_var": "in",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_pointer_in_",
                                             "stmt1": "c_default"
                                         },
@@ -9564,6 +9663,7 @@
                                             "cxx_type": "double",
                                             "cxx_var": "out",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_pointer_out_",
                                             "stmt1": "c_default"
                                         },
@@ -9623,6 +9723,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "sizein",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },

--- a/regression/reference/example/example.json
+++ b/regression/reference/example/example.json
@@ -200,7 +200,7 @@
                                                 "cxx_type": "example::nested::ExClass1",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_OTHER",
                                                 "stmt0": "c_shadow_scalar_ctor_",
                                                 "stmt1": "c_shadow_ctor"
                                             },
@@ -292,7 +292,7 @@
                                                     "cxx_type": "std::string",
                                                     "cxx_var": "SHCXX_name",
                                                     "idtor": "0",
-                                                    "sh_type": "0",
+                                                    "sh_type": "SH_TYPE_OTHER",
                                                     "stmt0": "c_string_pointer_in_",
                                                     "stmt1": "c_string_in"
                                                 },
@@ -334,7 +334,7 @@
                                                 "cxx_type": "example::nested::ExClass1",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_OTHER",
                                                 "stmt0": "c_shadow_scalar_ctor_",
                                                 "stmt1": "c_shadow_ctor"
                                             },
@@ -452,7 +452,7 @@
                                                     "cxx_type": "std::string",
                                                     "cxx_var": "SHCXX_name",
                                                     "idtor": "0",
-                                                    "sh_type": "0",
+                                                    "sh_type": "SH_TYPE_OTHER",
                                                     "stmt0": "c_string_pointer_in_buf",
                                                     "stmt1": "c_string_in_buf"
                                                 },
@@ -476,7 +476,7 @@
                                                 "cxx_type": "example::nested::ExClass1",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_OTHER",
                                                 "stmt0": "c_shadow_scalar_ctor_buf",
                                                 "stmt1": "c_shadow_ctor"
                                             }
@@ -607,7 +607,7 @@
                                                     "cxx_type": "int",
                                                     "cxx_var": "incr",
                                                     "idtor": "0",
-                                                    "sh_type": "0",
+                                                    "sh_type": "SH_TYPE_INT",
                                                     "stmt0": "c_native_scalar_in_",
                                                     "stmt1": "c_default"
                                                 },
@@ -659,7 +659,7 @@
                                                 "cxx_type": "int",
                                                 "cxx_var": "SHC_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_INT",
                                                 "stmt0": "c_native_scalar_result_",
                                                 "stmt1": "c_default"
                                             },
@@ -761,7 +761,7 @@
                                                 "cxx_type": "std::string",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_OTHER",
                                                 "stmt0": "c_string_pointer_result_",
                                                 "stmt1": "c_string_result"
                                             },
@@ -864,7 +864,7 @@
                                                     "cxx_type": "std::string",
                                                     "cxx_var": "SHCXX_rv",
                                                     "idtor": "0",
-                                                    "sh_type": "0",
+                                                    "sh_type": "SH_TYPE_OTHER",
                                                     "stmt0": "c_string_pointer_result_buf_",
                                                     "stmt1": "c_string_result_buf"
                                                 },
@@ -888,7 +888,7 @@
                                                 "cxx_type": "void",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_CPTR",
                                                 "stmt0": "c_unknown_scalar_result_buf",
                                                 "stmt1": "c_default"
                                             }
@@ -966,7 +966,7 @@
                                                 "cxx_type": "int",
                                                 "cxx_var": "SHC_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_INT",
                                                 "stmt0": "c_native_scalar_result_",
                                                 "stmt1": "c_default"
                                             },
@@ -1061,7 +1061,7 @@
                                                 "cxx_type": "std::string",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_OTHER",
                                                 "stmt0": "c_string_pointer_result_",
                                                 "stmt1": "c_string_result"
                                             },
@@ -1160,7 +1160,7 @@
                                                     "cxx_type": "std::string",
                                                     "cxx_var": "SHCXX_rv",
                                                     "idtor": "0",
-                                                    "sh_type": "0",
+                                                    "sh_type": "SH_TYPE_OTHER",
                                                     "stmt0": "c_string_pointer_result_buf_allocatable",
                                                     "stmt1": "c_string_result_buf_allocatable"
                                                 },
@@ -1185,7 +1185,7 @@
                                                 "cxx_type": "void",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_CPTR",
                                                 "stmt0": "c_unknown_scalar_result_buf",
                                                 "stmt1": "c_default"
                                             }
@@ -1261,7 +1261,7 @@
                                                 "cxx_type": "std::string",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_OTHER",
                                                 "stmt0": "c_string_pointer_result_",
                                                 "stmt1": "c_string_result"
                                             },
@@ -1347,7 +1347,7 @@
                                                     "cxx_type": "std::string",
                                                     "cxx_var": "SHCXX_rv",
                                                     "idtor": "0",
-                                                    "sh_type": "0",
+                                                    "sh_type": "SH_TYPE_OTHER",
                                                     "stmt0": "c_string_pointer_result_buf_",
                                                     "stmt1": "c_string_result_buf"
                                                 },
@@ -1371,7 +1371,7 @@
                                                 "cxx_type": "void",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_CPTR",
                                                 "stmt0": "c_unknown_scalar_result_buf",
                                                 "stmt1": "c_default"
                                             }
@@ -1508,7 +1508,7 @@
                                                 "cxx_type": "void",
                                                 "cxx_var": "SHC_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_CPTR",
                                                 "stmt0": "c_unknown_pointer_result_",
                                                 "stmt1": "c_default"
                                             },
@@ -1599,7 +1599,7 @@
                                                     "cxx_type": "int",
                                                     "cxx_var": "value",
                                                     "idtor": "0",
-                                                    "sh_type": "0",
+                                                    "sh_type": "SH_TYPE_INT",
                                                     "stmt0": "c_native_scalar_in_",
                                                     "stmt1": "c_default"
                                                 },
@@ -1651,7 +1651,7 @@
                                                 "cxx_type": "int",
                                                 "cxx_var": "SHC_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_INT",
                                                 "stmt0": "c_native_scalar_result_",
                                                 "stmt1": "c_default"
                                             },
@@ -1757,7 +1757,7 @@
                                                     "cxx_type": "long",
                                                     "cxx_var": "value",
                                                     "idtor": "0",
-                                                    "sh_type": "0",
+                                                    "sh_type": "SH_TYPE_LONG",
                                                     "stmt0": "c_native_scalar_in_",
                                                     "stmt1": "c_default"
                                                 },
@@ -1809,7 +1809,7 @@
                                                 "cxx_type": "long",
                                                 "cxx_var": "SHC_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_LONG",
                                                 "stmt0": "c_native_scalar_result_",
                                                 "stmt1": "c_default"
                                             },
@@ -1908,7 +1908,7 @@
                                                 "cxx_type": "void",
                                                 "cxx_var": "SHC_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_CPTR",
                                                 "stmt0": "c_unknown_pointer_result_",
                                                 "stmt1": "c_default"
                                             },
@@ -1999,7 +1999,7 @@
                                                     "cxx_type": "bool",
                                                     "cxx_var": "in",
                                                     "idtor": "0",
-                                                    "sh_type": "0",
+                                                    "sh_type": "SH_TYPE_BOOL",
                                                     "stmt0": "c_bool_scalar_in_",
                                                     "stmt1": "c_default"
                                                 },
@@ -2053,7 +2053,7 @@
                                                 "cxx_type": "bool",
                                                 "cxx_var": "SHC_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_BOOL",
                                                 "stmt0": "c_bool_scalar_result_",
                                                 "stmt1": "c_default"
                                             },
@@ -2246,7 +2246,7 @@
                                                     "cxx_type": "std::string",
                                                     "cxx_var": "SHCXX_name",
                                                     "idtor": "0",
-                                                    "sh_type": "0",
+                                                    "sh_type": "SH_TYPE_OTHER",
                                                     "stmt0": "c_string_pointer_in_",
                                                     "stmt1": "c_string_in"
                                                 },
@@ -2288,7 +2288,7 @@
                                                 "cxx_type": "example::nested::ExClass2",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_OTHER",
                                                 "stmt0": "c_shadow_scalar_ctor_",
                                                 "stmt1": "c_shadow_ctor"
                                             },
@@ -2406,7 +2406,7 @@
                                                     "cxx_type": "std::string",
                                                     "cxx_var": "SHCXX_name",
                                                     "idtor": "0",
-                                                    "sh_type": "0",
+                                                    "sh_type": "SH_TYPE_OTHER",
                                                     "stmt0": "c_string_pointer_in_buf",
                                                     "stmt1": "c_string_in_buf"
                                                 },
@@ -2430,7 +2430,7 @@
                                                 "cxx_type": "example::nested::ExClass2",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_OTHER",
                                                 "stmt0": "c_shadow_scalar_ctor_buf",
                                                 "stmt1": "c_shadow_ctor"
                                             }
@@ -2555,7 +2555,7 @@
                                                 "cxx_type": "std::string",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_OTHER",
                                                 "stmt0": "c_string_pointer_result_",
                                                 "stmt1": "c_string_result"
                                             },
@@ -2656,7 +2656,7 @@
                                                     "cxx_type": "std::string",
                                                     "cxx_var": "SHCXX_rv",
                                                     "idtor": "0",
-                                                    "sh_type": "0",
+                                                    "sh_type": "SH_TYPE_OTHER",
                                                     "stmt0": "c_string_pointer_result_buf_",
                                                     "stmt1": "c_string_result_buf"
                                                 },
@@ -2680,7 +2680,7 @@
                                                 "cxx_type": "void",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_CPTR",
                                                 "stmt0": "c_unknown_scalar_result_buf",
                                                 "stmt1": "c_default"
                                             }
@@ -2759,7 +2759,7 @@
                                                 "cxx_type": "std::string",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_OTHER",
                                                 "stmt0": "c_string_pointer_result_",
                                                 "stmt1": "c_string_result"
                                             },
@@ -2857,7 +2857,7 @@
                                                     "cxx_type": "std::string",
                                                     "cxx_var": "SHCXX_rv",
                                                     "idtor": "0",
-                                                    "sh_type": "0",
+                                                    "sh_type": "SH_TYPE_OTHER",
                                                     "stmt0": "c_string_pointer_result_buf_allocatable",
                                                     "stmt1": "c_string_result_buf_allocatable"
                                                 },
@@ -2882,7 +2882,7 @@
                                                 "cxx_type": "void",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_CPTR",
                                                 "stmt0": "c_unknown_scalar_result_buf",
                                                 "stmt1": "c_default"
                                             }
@@ -2957,7 +2957,7 @@
                                                 "cxx_type": "std::string",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_OTHER",
                                                 "stmt0": "c_string_pointer_result_",
                                                 "stmt1": "c_string_result"
                                             },
@@ -3055,7 +3055,7 @@
                                                     "cxx_type": "std::string",
                                                     "cxx_var": "SHCXX_rv",
                                                     "idtor": "0",
-                                                    "sh_type": "0",
+                                                    "sh_type": "SH_TYPE_OTHER",
                                                     "stmt0": "c_string_pointer_result_buf_allocatable",
                                                     "stmt1": "c_string_result_buf_allocatable"
                                                 },
@@ -3080,7 +3080,7 @@
                                                 "cxx_type": "void",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_CPTR",
                                                 "stmt0": "c_unknown_scalar_result_buf",
                                                 "stmt1": "c_default"
                                             }
@@ -3155,7 +3155,7 @@
                                                 "cxx_type": "std::string",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_OTHER",
                                                 "stmt0": "c_string_pointer_result_",
                                                 "stmt1": "c_string_result"
                                             },
@@ -3252,7 +3252,7 @@
                                                     "cxx_type": "std::string",
                                                     "cxx_var": "SHCXX_rv",
                                                     "idtor": "0",
-                                                    "sh_type": "0",
+                                                    "sh_type": "SH_TYPE_OTHER",
                                                     "stmt0": "c_string_pointer_result_buf_allocatable",
                                                     "stmt1": "c_string_result_buf_allocatable"
                                                 },
@@ -3277,7 +3277,7 @@
                                                 "cxx_type": "void",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_CPTR",
                                                 "stmt0": "c_unknown_scalar_result_buf",
                                                 "stmt1": "c_default"
                                             }
@@ -3350,7 +3350,7 @@
                                                 "cxx_type": "int",
                                                 "cxx_var": "SHC_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_INT",
                                                 "stmt0": "c_native_scalar_result_",
                                                 "stmt1": "c_default"
                                             },
@@ -3448,7 +3448,7 @@
                                                     "cxx_type": "example::nested::ExClass1",
                                                     "cxx_var": "SHCXX_in",
                                                     "idtor": "0",
-                                                    "sh_type": "0",
+                                                    "sh_type": "SH_TYPE_OTHER",
                                                     "stmt0": "c_shadow_pointer_in_",
                                                     "stmt1": "c_shadow_in"
                                                 },
@@ -3503,7 +3503,7 @@
                                                 "cxx_type": "example::nested::ExClass1",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_OTHER",
                                                 "stmt0": "c_shadow_pointer_result_",
                                                 "stmt1": "c_shadow_result"
                                             },
@@ -3619,7 +3619,7 @@
                                                     "cxx_val": "getTypeID(type)",
                                                     "cxx_var": "SHCXX_type",
                                                     "idtor": "0",
-                                                    "sh_type": "0",
+                                                    "sh_type": "SH_TYPE_INT",
                                                     "stmt0": "c_native_scalar_in_",
                                                     "stmt1": "c_default"
                                                 },
@@ -3931,7 +3931,7 @@
                                                     "cxx_type": "SidreLength",
                                                     "cxx_var": "len",
                                                     "idtor": "0",
-                                                    "sh_type": "0",
+                                                    "sh_type": "SH_TYPE_LONG",
                                                     "stmt0": "c_native_scalar_in_",
                                                     "stmt1": "c_default"
                                                 },
@@ -3987,7 +3987,7 @@
                                                     "cxx_val": "getTypeID(type)",
                                                     "cxx_var": "SHCXX_type",
                                                     "idtor": "0",
-                                                    "sh_type": "0",
+                                                    "sh_type": "SH_TYPE_INT",
                                                     "stmt0": "c_native_scalar_in_",
                                                     "stmt1": "c_default"
                                                 },
@@ -4400,7 +4400,7 @@
                                                 "cxx_type": "TypeID",
                                                 "cxx_var": "SHCXX_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_INT",
                                                 "stmt0": "c_native_scalar_result_",
                                                 "stmt1": "c_default"
                                             },
@@ -4589,7 +4589,7 @@
                                                     "cxx_type": "int",
                                                     "cxx_var": "value",
                                                     "idtor": "0",
-                                                    "sh_type": "0",
+                                                    "sh_type": "SH_TYPE_INT",
                                                     "stmt0": "c_native_scalar_in_",
                                                     "stmt1": "c_default"
                                                 },
@@ -4763,7 +4763,7 @@
                                                     "cxx_type": "long",
                                                     "cxx_var": "value",
                                                     "idtor": "0",
-                                                    "sh_type": "0",
+                                                    "sh_type": "SH_TYPE_LONG",
                                                     "stmt0": "c_native_scalar_in_",
                                                     "stmt1": "c_default"
                                                 },
@@ -4935,7 +4935,7 @@
                                                     "cxx_type": "float",
                                                     "cxx_var": "value",
                                                     "idtor": "0",
-                                                    "sh_type": "0",
+                                                    "sh_type": "SH_TYPE_FLOAT",
                                                     "stmt0": "c_native_scalar_in_",
                                                     "stmt1": "c_default"
                                                 },
@@ -5107,7 +5107,7 @@
                                                     "cxx_type": "double",
                                                     "cxx_var": "value",
                                                     "idtor": "0",
-                                                    "sh_type": "0",
+                                                    "sh_type": "SH_TYPE_DOUBLE",
                                                     "stmt0": "c_native_scalar_in_",
                                                     "stmt1": "c_default"
                                                 },
@@ -5342,7 +5342,7 @@
                                                 "cxx_type": "int",
                                                 "cxx_var": "SHC_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_INT",
                                                 "stmt0": "c_native_scalar_result_",
                                                 "stmt1": "c_default"
                                             },
@@ -5463,7 +5463,7 @@
                                                 "cxx_type": "double",
                                                 "cxx_var": "SHC_rv",
                                                 "idtor": "0",
-                                                "sh_type": "0",
+                                                "sh_type": "SH_TYPE_DOUBLE",
                                                 "stmt0": "c_native_scalar_result_",
                                                 "stmt1": "c_default"
                                             },
@@ -5676,7 +5676,7 @@
                                             "cxx_type": "std::string",
                                             "cxx_var": "SHCXX_name",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_OTHER",
                                             "stmt0": "c_string_pointer_in_",
                                             "stmt1": "c_string_in"
                                         },
@@ -5719,7 +5719,7 @@
                                         "cxx_type": "bool",
                                         "cxx_var": "SHC_rv",
                                         "idtor": "0",
-                                        "sh_type": "0",
+                                        "sh_type": "SH_TYPE_BOOL",
                                         "stmt0": "c_bool_scalar_result_",
                                         "stmt1": "c_default"
                                     },
@@ -5835,7 +5835,7 @@
                                             "cxx_type": "std::string",
                                             "cxx_var": "SHCXX_name",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_OTHER",
                                             "stmt0": "c_string_pointer_in_buf",
                                             "stmt1": "c_string_in_buf"
                                         },
@@ -5860,7 +5860,7 @@
                                         "cxx_type": "bool",
                                         "cxx_var": "SHC_rv",
                                         "idtor": "0",
-                                        "sh_type": "0",
+                                        "sh_type": "SH_TYPE_BOOL",
                                         "stmt0": "c_bool_scalar_result_buf",
                                         "stmt1": "c_default"
                                     }
@@ -5941,7 +5941,7 @@
                                         "cxx_type": "bool",
                                         "cxx_var": "SHC_rv",
                                         "idtor": "0",
-                                        "sh_type": "0",
+                                        "sh_type": "SH_TYPE_BOOL",
                                         "stmt0": "c_bool_scalar_result_",
                                         "stmt1": "c_default"
                                     },
@@ -6025,7 +6025,7 @@
                                             "cxx_type": "std::string",
                                             "cxx_var": "SHCXX_name",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_OTHER",
                                             "stmt0": "c_string_pointer_in_",
                                             "stmt1": "c_string_in"
                                         },
@@ -6137,7 +6137,7 @@
                                             "cxx_type": "std::string",
                                             "cxx_var": "SHCXX_name",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_OTHER",
                                             "stmt0": "c_string_pointer_in_buf",
                                             "stmt1": "c_string_in_buf"
                                         },
@@ -6224,7 +6224,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "flag",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_INT",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -6269,7 +6269,7 @@
                                             "cxx_type": "std::string",
                                             "cxx_var": "SHCXX_name",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_OTHER",
                                             "stmt0": "c_string_pointer_in_",
                                             "stmt1": "c_string_in"
                                         },
@@ -6392,7 +6392,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "flag",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_INT",
                                             "stmt0": "c_native_scalar_in_buf",
                                             "stmt1": "c_default"
                                         },
@@ -6420,7 +6420,7 @@
                                             "cxx_type": "std::string",
                                             "cxx_var": "SHCXX_name",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_OTHER",
                                             "stmt0": "c_string_pointer_in_buf",
                                             "stmt1": "c_string_in_buf"
                                         },
@@ -6566,7 +6566,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "i",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_INT",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -6661,7 +6661,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "i",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_INT",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -6715,7 +6715,7 @@
                                             "cxx_type": "long",
                                             "cxx_var": "j",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_LONG",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -6846,7 +6846,7 @@
                                         "cxx_type": "size_t",
                                         "cxx_var": "SHC_rv",
                                         "idtor": "0",
-                                        "sh_type": "0",
+                                        "sh_type": "SH_TYPE_SIZE_T",
                                         "stmt0": "c_native_scalar_result_",
                                         "stmt1": "c_default"
                                     },
@@ -6931,7 +6931,7 @@
                                             "cxx_val": "MPI_Comm_f2c(comm)",
                                             "cxx_var": "SHCXX_comm",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_OTHER",
                                             "stmt0": "c_unknown_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -7087,7 +7087,7 @@
                                             "cxx_type": "axom::sidre::Group",
                                             "cxx_var": "SHCXX_grp",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_OTHER",
                                             "stmt0": "c_shadow_pointer_in_",
                                             "stmt1": "c_shadow_in"
                                         },
@@ -7205,7 +7205,7 @@
                                             "cxx_type": "axom::sidre::Group",
                                             "cxx_var": "SHCXX_grp",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_OTHER",
                                             "stmt0": "c_shadow_pointer_in_",
                                             "stmt1": "c_shadow_in"
                                         },
@@ -7324,7 +7324,7 @@
                                             "cxx_type": "void",
                                             "cxx_var": "get",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_CPTR",
                                             "stmt0": "c_unknown_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -7443,7 +7443,7 @@
                                             "cxx_type": "double",
                                             "cxx_var": "get",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_DOUBLE",
                                             "stmt0": "c_native_pointer_in_",
                                             "stmt1": "c_default"
                                         },
@@ -7566,7 +7566,7 @@
                                             "cxx_type": "double",
                                             "cxx_var": "get",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_DOUBLE",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -7711,7 +7711,7 @@
                                             "cxx_type": "double",
                                             "cxx_var": "get",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_DOUBLE",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -7826,7 +7826,7 @@
                                             "cxx_type": "void",
                                             "cxx_var": "get",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_CPTR",
                                             "stmt0": "c_unknown_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -8072,7 +8072,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname1",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_INT",
                                             "stmt0": "c_native_pointer_inout_",
                                             "stmt1": "c_default"
                                         },
@@ -8126,7 +8126,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname10",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_INT",
                                             "stmt0": "c_native_pointer_inout_",
                                             "stmt1": "c_default"
                                         },
@@ -8180,7 +8180,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname2",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_INT",
                                             "stmt0": "c_native_pointer_inout_",
                                             "stmt1": "c_default"
                                         },
@@ -8234,7 +8234,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname3",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_INT",
                                             "stmt0": "c_native_pointer_inout_",
                                             "stmt1": "c_default"
                                         },
@@ -8288,7 +8288,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname4",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_INT",
                                             "stmt0": "c_native_pointer_inout_",
                                             "stmt1": "c_default"
                                         },
@@ -8342,7 +8342,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname5",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_INT",
                                             "stmt0": "c_native_pointer_inout_",
                                             "stmt1": "c_default"
                                         },
@@ -8396,7 +8396,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname6",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_INT",
                                             "stmt0": "c_native_pointer_inout_",
                                             "stmt1": "c_default"
                                         },
@@ -8450,7 +8450,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname7",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_INT",
                                             "stmt0": "c_native_pointer_inout_",
                                             "stmt1": "c_default"
                                         },
@@ -8504,7 +8504,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname8",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_INT",
                                             "stmt0": "c_native_pointer_inout_",
                                             "stmt1": "c_default"
                                         },
@@ -8558,7 +8558,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname9",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_INT",
                                             "stmt0": "c_native_pointer_inout_",
                                             "stmt1": "c_default"
                                         },
@@ -8839,7 +8839,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname1",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_INT",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -8893,7 +8893,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname10",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_INT",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -8947,7 +8947,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname2",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_INT",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -9001,7 +9001,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname3",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_INT",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -9055,7 +9055,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname4",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_INT",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -9109,7 +9109,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname5",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_INT",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -9163,7 +9163,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname6",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_INT",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -9217,7 +9217,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname7",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_INT",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -9271,7 +9271,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname8",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_INT",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -9325,7 +9325,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "verylongname9",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_INT",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -9377,7 +9377,7 @@
                                         "cxx_type": "int",
                                         "cxx_var": "SHC_rv",
                                         "idtor": "0",
-                                        "sh_type": "0",
+                                        "sh_type": "SH_TYPE_INT",
                                         "stmt0": "c_native_scalar_result_",
                                         "stmt1": "c_default"
                                     },
@@ -9608,7 +9608,7 @@
                                             "cxx_type": "double",
                                             "cxx_var": "in",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_DOUBLE",
                                             "stmt0": "c_native_pointer_in_",
                                             "stmt1": "c_default"
                                         },
@@ -9663,7 +9663,7 @@
                                             "cxx_type": "double",
                                             "cxx_var": "out",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_DOUBLE",
                                             "stmt0": "c_native_pointer_out_",
                                             "stmt1": "c_default"
                                         },
@@ -9723,7 +9723,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "sizein",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_INT",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },

--- a/regression/reference/example/typesUserLibrary.h
+++ b/regression/reference/example/typesUserLibrary.h
@@ -37,6 +37,7 @@ struct s_AA_SHROUD_array {
         const void * base;
         const char * ccharp;
     } addr;
+    int type;        /* type of element */
     size_t elem_len; /* bytes-per-item or character len in c++ */
     size_t size;     /* size of data in c++ */
 };

--- a/regression/reference/example/wrapfUserLibrary_example_nested.f
+++ b/regression/reference/example/wrapfUserLibrary_example_nested.f
@@ -39,6 +39,8 @@ module userlibrary_example_nested_mod
         type(SHROUD_capsule_data) :: cxx
         ! address of data in cxx
         type(C_PTR) :: base_addr = C_NULL_PTR
+        ! type of element
+        integer(C_INT) :: type
         ! bytes-per-item or character len of data in cxx
         integer(C_SIZE_T) :: elem_len = 0_C_SIZE_T
         ! size of data in cxx

--- a/regression/reference/forward/forward.json
+++ b/regression/reference/forward/forward.json
@@ -79,6 +79,7 @@
                                 "cxx_type": "tutorial::Class2",
                                 "cxx_var": "SHCXX_rv",
                                 "idtor": "0",
+                                "sh_type": "0",
                                 "stmt0": "c_shadow_scalar_ctor_",
                                 "stmt1": "c_shadow_ctor"
                             },
@@ -210,6 +211,7 @@
                                     "cxx_type": "tutorial::Class1",
                                     "cxx_var": "SHCXX_arg",
                                     "idtor": "0",
+                                    "sh_type": "0",
                                     "stmt0": "c_shadow_pointer_in_",
                                     "stmt1": "c_shadow_in"
                                 },
@@ -328,6 +330,7 @@
                                     "cxx_type": "tutorial::Class3",
                                     "cxx_var": "SHCXX_arg",
                                     "idtor": "0",
+                                    "sh_type": "0",
                                     "stmt0": "c_shadow_pointer_in_",
                                     "stmt1": "c_shadow_in"
                                 },

--- a/regression/reference/forward/forward.json
+++ b/regression/reference/forward/forward.json
@@ -79,7 +79,7 @@
                                 "cxx_type": "tutorial::Class2",
                                 "cxx_var": "SHCXX_rv",
                                 "idtor": "0",
-                                "sh_type": "0",
+                                "sh_type": "SH_TYPE_OTHER",
                                 "stmt0": "c_shadow_scalar_ctor_",
                                 "stmt1": "c_shadow_ctor"
                             },
@@ -211,7 +211,7 @@
                                     "cxx_type": "tutorial::Class1",
                                     "cxx_var": "SHCXX_arg",
                                     "idtor": "0",
-                                    "sh_type": "0",
+                                    "sh_type": "SH_TYPE_OTHER",
                                     "stmt0": "c_shadow_pointer_in_",
                                     "stmt1": "c_shadow_in"
                                 },
@@ -330,7 +330,7 @@
                                     "cxx_type": "tutorial::Class3",
                                     "cxx_var": "SHCXX_arg",
                                     "idtor": "0",
-                                    "sh_type": "0",
+                                    "sh_type": "SH_TYPE_OTHER",
                                     "stmt0": "c_shadow_pointer_in_",
                                     "stmt1": "c_shadow_in"
                                 },

--- a/regression/reference/generic/generic.json
+++ b/regression/reference/generic/generic.json
@@ -113,7 +113,7 @@
                         "cxx_type": "double",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -175,7 +175,7 @@
                             "cxx_type": "double",
                             "cxx_var": "arg",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -419,7 +419,7 @@
                             "cxx_type": "long",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_LONG",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -446,7 +446,7 @@
                             "cxx_type": "long",
                             "cxx_var": "arg2",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_LONG",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -471,7 +471,7 @@
                         "cxx_type": "long",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_LONG",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     }
@@ -789,7 +789,7 @@
                             "cxx_type": "void",
                             "cxx_var": "addr",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_CPTR",
                             "stmt0": "c_unknown_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -816,7 +816,7 @@
                             "cxx_type": "size_t",
                             "cxx_var": "size",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_SIZE_T",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -839,7 +839,7 @@
                             "cxx_type": "int",
                             "cxx_var": "type",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1234,7 +1234,7 @@
                             "cxx_type": "void",
                             "cxx_var": "addr",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_CPTR",
                             "stmt0": "c_unknown_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1261,7 +1261,7 @@
                             "cxx_type": "size_t",
                             "cxx_var": "size",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_SIZE_T",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1288,7 +1288,7 @@
                             "cxx_type": "int",
                             "cxx_var": "type",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1413,7 +1413,7 @@
                             "cxx_type": "void",
                             "cxx_var": "addr",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_CPTR",
                             "stmt0": "c_unknown_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1440,7 +1440,7 @@
                             "cxx_type": "size_t",
                             "cxx_var": "size",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_SIZE_T",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1467,7 +1467,7 @@
                             "cxx_type": "int",
                             "cxx_var": "type",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },

--- a/regression/reference/generic/generic.json
+++ b/regression/reference/generic/generic.json
@@ -113,6 +113,7 @@
                         "cxx_type": "double",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -174,6 +175,7 @@
                             "cxx_type": "double",
                             "cxx_var": "arg",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -417,6 +419,7 @@
                             "cxx_type": "long",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -443,6 +446,7 @@
                             "cxx_type": "long",
                             "cxx_var": "arg2",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -467,6 +471,7 @@
                         "cxx_type": "long",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     }
@@ -784,6 +789,7 @@
                             "cxx_type": "void",
                             "cxx_var": "addr",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_unknown_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -810,6 +816,7 @@
                             "cxx_type": "size_t",
                             "cxx_var": "size",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -832,6 +839,7 @@
                             "cxx_type": "int",
                             "cxx_var": "type",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1226,6 +1234,7 @@
                             "cxx_type": "void",
                             "cxx_var": "addr",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_unknown_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1252,6 +1261,7 @@
                             "cxx_type": "size_t",
                             "cxx_var": "size",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1278,6 +1288,7 @@
                             "cxx_type": "int",
                             "cxx_var": "type",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1402,6 +1413,7 @@
                             "cxx_type": "void",
                             "cxx_var": "addr",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_unknown_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1428,6 +1440,7 @@
                             "cxx_type": "size_t",
                             "cxx_var": "size",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1454,6 +1467,7 @@
                             "cxx_type": "int",
                             "cxx_var": "type",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },

--- a/regression/reference/include/include.json
+++ b/regression/reference/include/include.json
@@ -36,7 +36,7 @@
                                     "cxx_val": "MPI_Comm_f2c(comm)",
                                     "cxx_var": "SHCXX_comm",
                                     "idtor": "0",
-                                    "sh_type": "0",
+                                    "sh_type": "SH_TYPE_OTHER",
                                     "stmt0": "c_unknown_scalar_in_",
                                     "stmt1": "c_default"
                                 },
@@ -121,7 +121,7 @@
                                     "cxx_type": "three::Class1",
                                     "cxx_var": "SHCXX_c2",
                                     "idtor": "0",
-                                    "sh_type": "0",
+                                    "sh_type": "SH_TYPE_OTHER",
                                     "stmt0": "c_shadow_pointer_in_",
                                     "stmt1": "c_shadow_in"
                                 },
@@ -438,7 +438,7 @@
                                             "cxx_type": "CustomType",
                                             "cxx_var": "arg1",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_INT",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },

--- a/regression/reference/include/include.json
+++ b/regression/reference/include/include.json
@@ -36,6 +36,7 @@
                                     "cxx_val": "MPI_Comm_f2c(comm)",
                                     "cxx_var": "SHCXX_comm",
                                     "idtor": "0",
+                                    "sh_type": "0",
                                     "stmt0": "c_unknown_scalar_in_",
                                     "stmt1": "c_default"
                                 },
@@ -120,6 +121,7 @@
                                     "cxx_type": "three::Class1",
                                     "cxx_var": "SHCXX_c2",
                                     "idtor": "0",
+                                    "sh_type": "0",
                                     "stmt0": "c_shadow_pointer_in_",
                                     "stmt1": "c_shadow_in"
                                 },
@@ -436,6 +438,7 @@
                                             "cxx_type": "CustomType",
                                             "cxx_var": "arg1",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },

--- a/regression/reference/interface/interface.json
+++ b/regression/reference/interface/interface.json
@@ -161,7 +161,7 @@
                             "cxx_type": "double",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -188,7 +188,7 @@
                             "cxx_type": "int",
                             "cxx_var": "arg2",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -213,7 +213,7 @@
                         "cxx_type": "double",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },

--- a/regression/reference/interface/interface.json
+++ b/regression/reference/interface/interface.json
@@ -161,6 +161,7 @@
                             "cxx_type": "double",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -187,6 +188,7 @@
                             "cxx_type": "int",
                             "cxx_var": "arg2",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -211,6 +213,7 @@
                         "cxx_type": "double",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },

--- a/regression/reference/memdoc/memdoc.json
+++ b/regression/reference/memdoc/memdoc.json
@@ -114,7 +114,7 @@
                         "cxx_type": "std::string",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "c_string_pointer_result_",
                         "stmt1": "c_string_result"
                     },
@@ -189,7 +189,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_pointer_result_buf_allocatable",
                             "stmt1": "c_string_result_buf_allocatable"
                         },
@@ -214,7 +214,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_CPTR",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }

--- a/regression/reference/memdoc/memdoc.json
+++ b/regression/reference/memdoc/memdoc.json
@@ -114,6 +114,7 @@
                         "cxx_type": "std::string",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_string_pointer_result_",
                         "stmt1": "c_string_result"
                     },
@@ -188,6 +189,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_string_pointer_result_buf_allocatable",
                             "stmt1": "c_string_result_buf_allocatable"
                         },
@@ -212,6 +214,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }

--- a/regression/reference/memdoc/typesmemdoc.h
+++ b/regression/reference/memdoc/typesmemdoc.h
@@ -31,6 +31,7 @@ struct s_STR_SHROUD_array {
         const void * base;
         const char * ccharp;
     } addr;
+    int type;        /* type of element */
     size_t elem_len; /* bytes-per-item or character len in c++ */
     size_t size;     /* size of data in c++ */
 };

--- a/regression/reference/memdoc/wrapfmemdoc.f
+++ b/regression/reference/memdoc/wrapfmemdoc.f
@@ -32,6 +32,8 @@ module memdoc_mod
         type(SHROUD_capsule_data) :: cxx
         ! address of data in cxx
         type(C_PTR) :: base_addr = C_NULL_PTR
+        ! type of element
+        integer(C_INT) :: type
         ! bytes-per-item or character len of data in cxx
         integer(C_SIZE_T) :: elem_len = 0_C_SIZE_T
         ! size of data in cxx

--- a/regression/reference/names/names.json
+++ b/regression/reference/names/names.json
@@ -457,7 +457,7 @@
                             "cxx_type": "int",
                             "cxx_var": "i",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -559,7 +559,7 @@
                             "cxx_type": "long",
                             "cxx_var": "i",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_LONG",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -661,7 +661,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "ARG_rv",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_pointer_in_",
                             "stmt1": "c_string_in"
                         },
@@ -693,7 +693,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -791,7 +791,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "ARG_rv",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_pointer_in_buf",
                             "stmt1": "c_string_in_buf"
                         },
@@ -816,7 +816,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -1050,7 +1050,7 @@
                             "cxx_type": "int",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1093,7 +1093,7 @@
                             "cxx_type": "long",
                             "cxx_var": "arg2",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_LONG",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1272,7 +1272,7 @@
                             "cxx_type": "float",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_FLOAT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1315,7 +1315,7 @@
                             "cxx_type": "double",
                             "cxx_var": "arg2",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1548,7 +1548,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },

--- a/regression/reference/names/names.json
+++ b/regression/reference/names/names.json
@@ -457,6 +457,7 @@
                             "cxx_type": "int",
                             "cxx_var": "i",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -558,6 +559,7 @@
                             "cxx_type": "long",
                             "cxx_var": "i",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -659,6 +661,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "ARG_rv",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_string_pointer_in_",
                             "stmt1": "c_string_in"
                         },
@@ -690,6 +693,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -787,6 +791,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "ARG_rv",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_string_pointer_in_buf",
                             "stmt1": "c_string_in_buf"
                         },
@@ -811,6 +816,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -1044,6 +1050,7 @@
                             "cxx_type": "int",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1086,6 +1093,7 @@
                             "cxx_type": "long",
                             "cxx_var": "arg2",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1264,6 +1272,7 @@
                             "cxx_type": "float",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1306,6 +1315,7 @@
                             "cxx_type": "double",
                             "cxx_var": "arg2",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1538,6 +1548,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },

--- a/regression/reference/namespace/namespace.json
+++ b/regression/reference/namespace/namespace.json
@@ -125,6 +125,7 @@
                         "cxx_type": "std::string",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_string_pointer_result_",
                         "stmt1": "c_string_result"
                     },
@@ -211,6 +212,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_string_pointer_result_buf_allocatable",
                             "stmt1": "c_string_result_buf_allocatable"
                         },
@@ -235,6 +237,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }

--- a/regression/reference/namespace/namespace.json
+++ b/regression/reference/namespace/namespace.json
@@ -125,7 +125,7 @@
                         "cxx_type": "std::string",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "c_string_pointer_result_",
                         "stmt1": "c_string_result"
                     },
@@ -212,7 +212,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_pointer_result_buf_allocatable",
                             "stmt1": "c_string_result_buf_allocatable"
                         },
@@ -237,7 +237,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_CPTR",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }

--- a/regression/reference/namespace/typesns.h
+++ b/regression/reference/namespace/typesns.h
@@ -24,6 +24,7 @@ struct s_NS_SHROUD_array {
         const void * base;
         const char * ccharp;
     } addr;
+    int type;        /* type of element */
     size_t elem_len; /* bytes-per-item or character len in c++ */
     size_t size;     /* size of data in c++ */
 };

--- a/regression/reference/namespace/wrapfns.f
+++ b/regression/reference/namespace/wrapfns.f
@@ -25,6 +25,8 @@ module ns_mod
         type(SHROUD_capsule_data) :: cxx
         ! address of data in cxx
         type(C_PTR) :: base_addr = C_NULL_PTR
+        ! type of element
+        integer(C_INT) :: type
         ! bytes-per-item or character len of data in cxx
         integer(C_SIZE_T) :: elem_len = 0_C_SIZE_T
         ! size of data in cxx

--- a/regression/reference/none/def_types.yaml
+++ b/regression/reference/none/def_types.yaml
@@ -48,7 +48,7 @@ MPI_Comm: !!python/object:shroud.typemap.Typemap
   name: MPI_Comm
   result_as_arg: null
   sgroup: unknown
-  sh_type: '0'
+  sh_type: SH_TYPE_OTHER
   template_suffix: null
   typedef: null
 bool: !!python/object:shroud.typemap.Typemap
@@ -101,7 +101,7 @@ bool: !!python/object:shroud.typemap.Typemap
   name: bool
   result_as_arg: null
   sgroup: bool
-  sh_type: '0'
+  sh_type: SH_TYPE_BOOL
   template_suffix: null
   typedef: null
 char: !!python/object:shroud.typemap.Typemap
@@ -154,7 +154,7 @@ char: !!python/object:shroud.typemap.Typemap
   name: char
   result_as_arg: null
   sgroup: char
-  sh_type: '0'
+  sh_type: SH_TYPE_OTHER
   template_suffix: null
   typedef: null
 char_scalar: !!python/object:shroud.typemap.Typemap
@@ -207,7 +207,7 @@ char_scalar: !!python/object:shroud.typemap.Typemap
   name: char_scalar
   result_as_arg: null
   sgroup: schar
-  sh_type: '0'
+  sh_type: SH_TYPE_OTHER
   template_suffix: null
   typedef: null
 double: !!python/object:shroud.typemap.Typemap
@@ -260,7 +260,7 @@ double: !!python/object:shroud.typemap.Typemap
   name: double
   result_as_arg: null
   sgroup: native
-  sh_type: '0'
+  sh_type: SH_TYPE_DOUBLE
   template_suffix: null
   typedef: null
 float: !!python/object:shroud.typemap.Typemap
@@ -313,7 +313,7 @@ float: !!python/object:shroud.typemap.Typemap
   name: float
   result_as_arg: null
   sgroup: native
-  sh_type: '0'
+  sh_type: SH_TYPE_FLOAT
   template_suffix: null
   typedef: null
 int: !!python/object:shroud.typemap.Typemap
@@ -366,7 +366,7 @@ int: !!python/object:shroud.typemap.Typemap
   name: int
   result_as_arg: null
   sgroup: native
-  sh_type: '0'
+  sh_type: SH_TYPE_INT
   template_suffix: null
   typedef: null
 int16_t: !!python/object:shroud.typemap.Typemap
@@ -419,7 +419,7 @@ int16_t: !!python/object:shroud.typemap.Typemap
   name: int16_t
   result_as_arg: null
   sgroup: native
-  sh_type: '0'
+  sh_type: SH_TYPE_INT16_T
   template_suffix: null
   typedef: null
 int32_t: !!python/object:shroud.typemap.Typemap
@@ -472,7 +472,7 @@ int32_t: !!python/object:shroud.typemap.Typemap
   name: int32_t
   result_as_arg: null
   sgroup: native
-  sh_type: '0'
+  sh_type: SH_TYPE_INT32_T
   template_suffix: null
   typedef: null
 int64_t: !!python/object:shroud.typemap.Typemap
@@ -525,7 +525,7 @@ int64_t: !!python/object:shroud.typemap.Typemap
   name: int64_t
   result_as_arg: null
   sgroup: native
-  sh_type: '0'
+  sh_type: SH_TYPE_INT64_T
   template_suffix: null
   typedef: null
 int8_t: !!python/object:shroud.typemap.Typemap
@@ -578,7 +578,7 @@ int8_t: !!python/object:shroud.typemap.Typemap
   name: int8_t
   result_as_arg: null
   sgroup: native
-  sh_type: '0'
+  sh_type: SH_TYPE_INT8_T
   template_suffix: null
   typedef: null
 long: !!python/object:shroud.typemap.Typemap
@@ -631,7 +631,7 @@ long: !!python/object:shroud.typemap.Typemap
   name: long
   result_as_arg: null
   sgroup: native
-  sh_type: '0'
+  sh_type: SH_TYPE_LONG
   template_suffix: null
   typedef: null
 long_long: !!python/object:shroud.typemap.Typemap
@@ -684,7 +684,7 @@ long_long: !!python/object:shroud.typemap.Typemap
   name: long_long
   result_as_arg: null
   sgroup: native
-  sh_type: '0'
+  sh_type: SH_TYPE_LONG_LONG
   template_suffix: null
   typedef: null
 short: !!python/object:shroud.typemap.Typemap
@@ -737,7 +737,7 @@ short: !!python/object:shroud.typemap.Typemap
   name: short
   result_as_arg: null
   sgroup: native
-  sh_type: '0'
+  sh_type: SH_TYPE_SHORT
   template_suffix: null
   typedef: null
 size_t: !!python/object:shroud.typemap.Typemap
@@ -790,7 +790,7 @@ size_t: !!python/object:shroud.typemap.Typemap
   name: size_t
   result_as_arg: null
   sgroup: native
-  sh_type: '0'
+  sh_type: SH_TYPE_SIZE_T
   template_suffix: null
   typedef: null
 std::string: !!python/object:shroud.typemap.Typemap
@@ -843,7 +843,7 @@ std::string: !!python/object:shroud.typemap.Typemap
   name: std::string
   result_as_arg: null
   sgroup: string
-  sh_type: '0'
+  sh_type: SH_TYPE_OTHER
   template_suffix: null
   typedef: null
 std::vector: !!python/object:shroud.typemap.Typemap
@@ -894,7 +894,7 @@ std::vector: !!python/object:shroud.typemap.Typemap
   name: std::vector
   result_as_arg: null
   sgroup: vector
-  sh_type: '0'
+  sh_type: SH_TYPE_OTHER
   template_suffix: null
   typedef: null
 uint16_t: !!python/object:shroud.typemap.Typemap
@@ -947,7 +947,7 @@ uint16_t: !!python/object:shroud.typemap.Typemap
   name: uint16_t
   result_as_arg: null
   sgroup: native
-  sh_type: '0'
+  sh_type: SH_TYPE_UINT16_T
   template_suffix: null
   typedef: null
 uint32_t: !!python/object:shroud.typemap.Typemap
@@ -1000,7 +1000,7 @@ uint32_t: !!python/object:shroud.typemap.Typemap
   name: uint32_t
   result_as_arg: null
   sgroup: native
-  sh_type: '0'
+  sh_type: SH_TYPE_UINT32_T
   template_suffix: null
   typedef: null
 uint64_t: !!python/object:shroud.typemap.Typemap
@@ -1053,7 +1053,7 @@ uint64_t: !!python/object:shroud.typemap.Typemap
   name: uint64_t
   result_as_arg: null
   sgroup: native
-  sh_type: '0'
+  sh_type: SH_TYPE_UINT64_T
   template_suffix: null
   typedef: null
 uint8_t: !!python/object:shroud.typemap.Typemap
@@ -1106,7 +1106,7 @@ uint8_t: !!python/object:shroud.typemap.Typemap
   name: uint8_t
   result_as_arg: null
   sgroup: native
-  sh_type: '0'
+  sh_type: SH_TYPE_UINT8_T
   template_suffix: null
   typedef: null
 unsigned_int: !!python/object:shroud.typemap.Typemap
@@ -1159,7 +1159,7 @@ unsigned_int: !!python/object:shroud.typemap.Typemap
   name: unsigned_int
   result_as_arg: null
   sgroup: native
-  sh_type: '0'
+  sh_type: SH_TYPE_UNSIGNED_INT
   template_suffix: null
   typedef: null
 unsigned_long: !!python/object:shroud.typemap.Typemap
@@ -1212,7 +1212,7 @@ unsigned_long: !!python/object:shroud.typemap.Typemap
   name: unsigned_long
   result_as_arg: null
   sgroup: native
-  sh_type: '0'
+  sh_type: SH_TYPE_UNSIGNED_LONG
   template_suffix: null
   typedef: null
 unsigned_long_long: !!python/object:shroud.typemap.Typemap
@@ -1265,7 +1265,7 @@ unsigned_long_long: !!python/object:shroud.typemap.Typemap
   name: unsigned_long_long
   result_as_arg: null
   sgroup: native
-  sh_type: '0'
+  sh_type: SH_TYPE_UNSIGNED_LONG_LONG
   template_suffix: null
   typedef: null
 unsigned_short: !!python/object:shroud.typemap.Typemap
@@ -1318,7 +1318,7 @@ unsigned_short: !!python/object:shroud.typemap.Typemap
   name: unsigned_short
   result_as_arg: null
   sgroup: native
-  sh_type: '0'
+  sh_type: SH_TYPE_UNSIGNED_SHORT
   template_suffix: null
   typedef: null
 void: !!python/object:shroud.typemap.Typemap
@@ -1374,6 +1374,6 @@ void: !!python/object:shroud.typemap.Typemap
   name: void
   result_as_arg: null
   sgroup: unknown
-  sh_type: '0'
+  sh_type: SH_TYPE_CPTR
   template_suffix: null
   typedef: null

--- a/regression/reference/none/def_types.yaml
+++ b/regression/reference/none/def_types.yaml
@@ -48,6 +48,7 @@ MPI_Comm: !!python/object:shroud.typemap.Typemap
   name: MPI_Comm
   result_as_arg: null
   sgroup: unknown
+  sh_type: '0'
   template_suffix: null
   typedef: null
 bool: !!python/object:shroud.typemap.Typemap
@@ -100,6 +101,7 @@ bool: !!python/object:shroud.typemap.Typemap
   name: bool
   result_as_arg: null
   sgroup: bool
+  sh_type: '0'
   template_suffix: null
   typedef: null
 char: !!python/object:shroud.typemap.Typemap
@@ -152,6 +154,7 @@ char: !!python/object:shroud.typemap.Typemap
   name: char
   result_as_arg: null
   sgroup: char
+  sh_type: '0'
   template_suffix: null
   typedef: null
 char_scalar: !!python/object:shroud.typemap.Typemap
@@ -204,6 +207,7 @@ char_scalar: !!python/object:shroud.typemap.Typemap
   name: char_scalar
   result_as_arg: null
   sgroup: schar
+  sh_type: '0'
   template_suffix: null
   typedef: null
 double: !!python/object:shroud.typemap.Typemap
@@ -256,6 +260,7 @@ double: !!python/object:shroud.typemap.Typemap
   name: double
   result_as_arg: null
   sgroup: native
+  sh_type: '0'
   template_suffix: null
   typedef: null
 float: !!python/object:shroud.typemap.Typemap
@@ -308,6 +313,7 @@ float: !!python/object:shroud.typemap.Typemap
   name: float
   result_as_arg: null
   sgroup: native
+  sh_type: '0'
   template_suffix: null
   typedef: null
 int: !!python/object:shroud.typemap.Typemap
@@ -360,6 +366,7 @@ int: !!python/object:shroud.typemap.Typemap
   name: int
   result_as_arg: null
   sgroup: native
+  sh_type: '0'
   template_suffix: null
   typedef: null
 int16_t: !!python/object:shroud.typemap.Typemap
@@ -412,6 +419,7 @@ int16_t: !!python/object:shroud.typemap.Typemap
   name: int16_t
   result_as_arg: null
   sgroup: native
+  sh_type: '0'
   template_suffix: null
   typedef: null
 int32_t: !!python/object:shroud.typemap.Typemap
@@ -464,6 +472,7 @@ int32_t: !!python/object:shroud.typemap.Typemap
   name: int32_t
   result_as_arg: null
   sgroup: native
+  sh_type: '0'
   template_suffix: null
   typedef: null
 int64_t: !!python/object:shroud.typemap.Typemap
@@ -516,6 +525,7 @@ int64_t: !!python/object:shroud.typemap.Typemap
   name: int64_t
   result_as_arg: null
   sgroup: native
+  sh_type: '0'
   template_suffix: null
   typedef: null
 int8_t: !!python/object:shroud.typemap.Typemap
@@ -568,6 +578,7 @@ int8_t: !!python/object:shroud.typemap.Typemap
   name: int8_t
   result_as_arg: null
   sgroup: native
+  sh_type: '0'
   template_suffix: null
   typedef: null
 long: !!python/object:shroud.typemap.Typemap
@@ -620,6 +631,7 @@ long: !!python/object:shroud.typemap.Typemap
   name: long
   result_as_arg: null
   sgroup: native
+  sh_type: '0'
   template_suffix: null
   typedef: null
 long_long: !!python/object:shroud.typemap.Typemap
@@ -672,6 +684,7 @@ long_long: !!python/object:shroud.typemap.Typemap
   name: long_long
   result_as_arg: null
   sgroup: native
+  sh_type: '0'
   template_suffix: null
   typedef: null
 short: !!python/object:shroud.typemap.Typemap
@@ -724,6 +737,7 @@ short: !!python/object:shroud.typemap.Typemap
   name: short
   result_as_arg: null
   sgroup: native
+  sh_type: '0'
   template_suffix: null
   typedef: null
 size_t: !!python/object:shroud.typemap.Typemap
@@ -776,6 +790,7 @@ size_t: !!python/object:shroud.typemap.Typemap
   name: size_t
   result_as_arg: null
   sgroup: native
+  sh_type: '0'
   template_suffix: null
   typedef: null
 std::string: !!python/object:shroud.typemap.Typemap
@@ -828,6 +843,7 @@ std::string: !!python/object:shroud.typemap.Typemap
   name: std::string
   result_as_arg: null
   sgroup: string
+  sh_type: '0'
   template_suffix: null
   typedef: null
 std::vector: !!python/object:shroud.typemap.Typemap
@@ -878,6 +894,7 @@ std::vector: !!python/object:shroud.typemap.Typemap
   name: std::vector
   result_as_arg: null
   sgroup: vector
+  sh_type: '0'
   template_suffix: null
   typedef: null
 uint16_t: !!python/object:shroud.typemap.Typemap
@@ -930,6 +947,7 @@ uint16_t: !!python/object:shroud.typemap.Typemap
   name: uint16_t
   result_as_arg: null
   sgroup: native
+  sh_type: '0'
   template_suffix: null
   typedef: null
 uint32_t: !!python/object:shroud.typemap.Typemap
@@ -982,6 +1000,7 @@ uint32_t: !!python/object:shroud.typemap.Typemap
   name: uint32_t
   result_as_arg: null
   sgroup: native
+  sh_type: '0'
   template_suffix: null
   typedef: null
 uint64_t: !!python/object:shroud.typemap.Typemap
@@ -1034,6 +1053,7 @@ uint64_t: !!python/object:shroud.typemap.Typemap
   name: uint64_t
   result_as_arg: null
   sgroup: native
+  sh_type: '0'
   template_suffix: null
   typedef: null
 uint8_t: !!python/object:shroud.typemap.Typemap
@@ -1086,6 +1106,7 @@ uint8_t: !!python/object:shroud.typemap.Typemap
   name: uint8_t
   result_as_arg: null
   sgroup: native
+  sh_type: '0'
   template_suffix: null
   typedef: null
 unsigned_int: !!python/object:shroud.typemap.Typemap
@@ -1138,6 +1159,7 @@ unsigned_int: !!python/object:shroud.typemap.Typemap
   name: unsigned_int
   result_as_arg: null
   sgroup: native
+  sh_type: '0'
   template_suffix: null
   typedef: null
 unsigned_long: !!python/object:shroud.typemap.Typemap
@@ -1190,6 +1212,7 @@ unsigned_long: !!python/object:shroud.typemap.Typemap
   name: unsigned_long
   result_as_arg: null
   sgroup: native
+  sh_type: '0'
   template_suffix: null
   typedef: null
 unsigned_long_long: !!python/object:shroud.typemap.Typemap
@@ -1242,6 +1265,7 @@ unsigned_long_long: !!python/object:shroud.typemap.Typemap
   name: unsigned_long_long
   result_as_arg: null
   sgroup: native
+  sh_type: '0'
   template_suffix: null
   typedef: null
 unsigned_short: !!python/object:shroud.typemap.Typemap
@@ -1294,6 +1318,7 @@ unsigned_short: !!python/object:shroud.typemap.Typemap
   name: unsigned_short
   result_as_arg: null
   sgroup: native
+  sh_type: '0'
   template_suffix: null
   typedef: null
 void: !!python/object:shroud.typemap.Typemap
@@ -1349,5 +1374,6 @@ void: !!python/object:shroud.typemap.Typemap
   name: void
   result_as_arg: null
   sgroup: unknown
+  sh_type: '0'
   template_suffix: null
   typedef: null

--- a/regression/reference/none/none.json
+++ b/regression/reference/none/none.json
@@ -215,7 +215,8 @@
             "f_c_type": "integer(C_INT)",
             "f_kind": "C_INT",
             "f_type": "integer",
-            "flat_name": "MPI_Comm"
+            "flat_name": "MPI_Comm",
+            "sh_type": "0"
         },
         "bool": {
             "LUA_pop": "lua_toboolean({LUA_state_var}, {LUA_index})",
@@ -236,7 +237,8 @@
             },
             "f_type": "logical",
             "flat_name": "bool",
-            "sgroup": "bool"
+            "sgroup": "bool",
+            "sh_type": "0"
         },
         "char": {
             "LUA_pop": "lua_tostring({LUA_state_var}, {LUA_index})",
@@ -257,7 +259,8 @@
             "f_type": "character(*)",
             "f_type_allocatable": "character(len=:)",
             "flat_name": "char",
-            "sgroup": "char"
+            "sgroup": "char",
+            "sh_type": "0"
         },
         "char_scalar": {
             "LUA_pop": "lua_tostring({LUA_state_var}, {LUA_index})",
@@ -277,7 +280,8 @@
             "f_kind": "C_CHAR",
             "f_type": "character",
             "flat_name": "char",
-            "sgroup": "schar"
+            "sgroup": "schar",
+            "sh_type": "0"
         },
         "double": {
             "LUA_pop": "lua_tonumber({LUA_state_var}, {LUA_index})",
@@ -298,7 +302,8 @@
             },
             "f_type": "real(C_DOUBLE)",
             "flat_name": "double",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "0"
         },
         "float": {
             "LUA_pop": "lua_tonumber({LUA_state_var}, {LUA_index})",
@@ -319,7 +324,8 @@
             },
             "f_type": "real(C_FLOAT)",
             "flat_name": "float",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "0"
         },
         "int": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -340,7 +346,8 @@
             },
             "f_type": "integer(C_INT)",
             "flat_name": "int",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "0"
         },
         "int16_t": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -363,7 +370,8 @@
             },
             "f_type": "integer(C_INT16_T)",
             "flat_name": "int16_t",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "0"
         },
         "int32_t": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -386,7 +394,8 @@
             },
             "f_type": "integer(C_INT32_T)",
             "flat_name": "int32_t",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "0"
         },
         "int64_t": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -409,7 +418,8 @@
             },
             "f_type": "integer(C_INT64_T)",
             "flat_name": "int64_t",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "0"
         },
         "int8_t": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -432,7 +442,8 @@
             },
             "f_type": "integer(C_INT8_T)",
             "flat_name": "int8_t",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "0"
         },
         "long": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -453,7 +464,8 @@
             },
             "f_type": "integer(C_LONG)",
             "flat_name": "long",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "0"
         },
         "long_long": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -472,7 +484,8 @@
             },
             "f_type": "integer(C_LONG_LONG)",
             "flat_name": "long_long",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "0"
         },
         "short": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -493,7 +506,8 @@
             },
             "f_type": "integer(C_SHORT)",
             "flat_name": "short",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "0"
         },
         "size_t": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -514,7 +528,8 @@
             },
             "f_type": "integer(C_SIZE_T)",
             "flat_name": "size_t",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "0"
         },
         "std::string": {
             "LUA_pop": "lua_tostring({LUA_state_var}, {LUA_index})",
@@ -539,14 +554,16 @@
             "f_type_allocatable": "character(len=:)",
             "flat_name": "std_string",
             "impl_header": "<string>",
-            "sgroup": "string"
+            "sgroup": "string",
+            "sh_type": "0"
         },
         "std::vector": {
             "base": "vector",
             "cxx_header": "<vector>",
             "cxx_type": "std::vector<{cxx_T}>",
             "flat_name": "std_vector_{cxx_T}",
-            "sgroup": "vector"
+            "sgroup": "vector",
+            "sh_type": "0"
         },
         "uint16_t": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -569,7 +586,8 @@
             },
             "f_type": "integer(C_INT16_T)",
             "flat_name": "uint16_t",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "0"
         },
         "uint32_t": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -592,7 +610,8 @@
             },
             "f_type": "integer(C_INT32_T)",
             "flat_name": "uint32_t",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "0"
         },
         "uint64_t": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -615,7 +634,8 @@
             },
             "f_type": "integer(C_INT64_T)",
             "flat_name": "uint64_t",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "0"
         },
         "uint8_t": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -638,7 +658,8 @@
             },
             "f_type": "integer(C_INT8_T)",
             "flat_name": "uint8_t",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "0"
         },
         "unsigned_int": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -659,7 +680,8 @@
             },
             "f_type": "integer(C_INT)",
             "flat_name": "unsigned_int",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "0"
         },
         "unsigned_long": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -680,7 +702,8 @@
             },
             "f_type": "integer(C_LONG)",
             "flat_name": "unsigned_long",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "0"
         },
         "unsigned_long_long": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -699,7 +722,8 @@
             },
             "f_type": "integer(C_LONG_LONG)",
             "flat_name": "unsigned_long_long",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "0"
         },
         "unsigned_short": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -720,7 +744,8 @@
             },
             "f_type": "integer(C_SHORT)",
             "flat_name": "unsigned_short",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "0"
         },
         "void": {
             "PY_ctor": "PyCapsule_New({cxx_var}, NULL, NULL)",
@@ -741,7 +766,8 @@
                 ]
             },
             "f_type": "type(C_PTR)",
-            "flat_name": "void"
+            "flat_name": "void",
+            "sh_type": "0"
         }
     }
 }

--- a/regression/reference/none/none.json
+++ b/regression/reference/none/none.json
@@ -236,7 +236,8 @@
             },
             "f_type": "logical",
             "flat_name": "bool",
-            "sgroup": "bool"
+            "sgroup": "bool",
+            "sh_type": "SH_TYPE_BOOL"
         },
         "char": {
             "LUA_pop": "lua_tostring({LUA_state_var}, {LUA_index})",
@@ -298,7 +299,8 @@
             },
             "f_type": "real(C_DOUBLE)",
             "flat_name": "double",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "SH_TYPE_DOUBLE"
         },
         "float": {
             "LUA_pop": "lua_tonumber({LUA_state_var}, {LUA_index})",
@@ -319,7 +321,8 @@
             },
             "f_type": "real(C_FLOAT)",
             "flat_name": "float",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "SH_TYPE_FLOAT"
         },
         "int": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -340,7 +343,8 @@
             },
             "f_type": "integer(C_INT)",
             "flat_name": "int",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "SH_TYPE_INT"
         },
         "int16_t": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -363,7 +367,8 @@
             },
             "f_type": "integer(C_INT16_T)",
             "flat_name": "int16_t",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "SH_TYPE_INT16_T"
         },
         "int32_t": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -386,7 +391,8 @@
             },
             "f_type": "integer(C_INT32_T)",
             "flat_name": "int32_t",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "SH_TYPE_INT32_T"
         },
         "int64_t": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -409,7 +415,8 @@
             },
             "f_type": "integer(C_INT64_T)",
             "flat_name": "int64_t",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "SH_TYPE_INT64_T"
         },
         "int8_t": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -432,7 +439,8 @@
             },
             "f_type": "integer(C_INT8_T)",
             "flat_name": "int8_t",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "SH_TYPE_INT8_T"
         },
         "long": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -453,7 +461,8 @@
             },
             "f_type": "integer(C_LONG)",
             "flat_name": "long",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "SH_TYPE_LONG"
         },
         "long_long": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -472,7 +481,8 @@
             },
             "f_type": "integer(C_LONG_LONG)",
             "flat_name": "long_long",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "SH_TYPE_LONG_LONG"
         },
         "short": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -493,7 +503,8 @@
             },
             "f_type": "integer(C_SHORT)",
             "flat_name": "short",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "SH_TYPE_SHORT"
         },
         "size_t": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -514,7 +525,8 @@
             },
             "f_type": "integer(C_SIZE_T)",
             "flat_name": "size_t",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "SH_TYPE_SIZE_T"
         },
         "std::string": {
             "LUA_pop": "lua_tostring({LUA_state_var}, {LUA_index})",
@@ -569,7 +581,8 @@
             },
             "f_type": "integer(C_INT16_T)",
             "flat_name": "uint16_t",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "SH_TYPE_UINT16_T"
         },
         "uint32_t": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -592,7 +605,8 @@
             },
             "f_type": "integer(C_INT32_T)",
             "flat_name": "uint32_t",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "SH_TYPE_UINT32_T"
         },
         "uint64_t": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -615,7 +629,8 @@
             },
             "f_type": "integer(C_INT64_T)",
             "flat_name": "uint64_t",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "SH_TYPE_UINT64_T"
         },
         "uint8_t": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -638,7 +653,8 @@
             },
             "f_type": "integer(C_INT8_T)",
             "flat_name": "uint8_t",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "SH_TYPE_UINT8_T"
         },
         "unsigned_int": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -659,7 +675,8 @@
             },
             "f_type": "integer(C_INT)",
             "flat_name": "unsigned_int",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "SH_TYPE_UNSIGNED_INT"
         },
         "unsigned_long": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -680,7 +697,8 @@
             },
             "f_type": "integer(C_LONG)",
             "flat_name": "unsigned_long",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "SH_TYPE_UNSIGNED_LONG"
         },
         "unsigned_long_long": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -699,7 +717,8 @@
             },
             "f_type": "integer(C_LONG_LONG)",
             "flat_name": "unsigned_long_long",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "SH_TYPE_UNSIGNED_LONG_LONG"
         },
         "unsigned_short": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -720,7 +739,8 @@
             },
             "f_type": "integer(C_SHORT)",
             "flat_name": "unsigned_short",
-            "sgroup": "native"
+            "sgroup": "native",
+            "sh_type": "SH_TYPE_UNSIGNED_SHORT"
         },
         "void": {
             "PY_ctor": "PyCapsule_New({cxx_var}, NULL, NULL)",
@@ -741,7 +761,8 @@
                 ]
             },
             "f_type": "type(C_PTR)",
-            "flat_name": "void"
+            "flat_name": "void",
+            "sh_type": "SH_TYPE_CPTR"
         }
     }
 }

--- a/regression/reference/none/none.json
+++ b/regression/reference/none/none.json
@@ -215,8 +215,7 @@
             "f_c_type": "integer(C_INT)",
             "f_kind": "C_INT",
             "f_type": "integer",
-            "flat_name": "MPI_Comm",
-            "sh_type": "0"
+            "flat_name": "MPI_Comm"
         },
         "bool": {
             "LUA_pop": "lua_toboolean({LUA_state_var}, {LUA_index})",
@@ -237,8 +236,7 @@
             },
             "f_type": "logical",
             "flat_name": "bool",
-            "sgroup": "bool",
-            "sh_type": "0"
+            "sgroup": "bool"
         },
         "char": {
             "LUA_pop": "lua_tostring({LUA_state_var}, {LUA_index})",
@@ -259,8 +257,7 @@
             "f_type": "character(*)",
             "f_type_allocatable": "character(len=:)",
             "flat_name": "char",
-            "sgroup": "char",
-            "sh_type": "0"
+            "sgroup": "char"
         },
         "char_scalar": {
             "LUA_pop": "lua_tostring({LUA_state_var}, {LUA_index})",
@@ -280,8 +277,7 @@
             "f_kind": "C_CHAR",
             "f_type": "character",
             "flat_name": "char",
-            "sgroup": "schar",
-            "sh_type": "0"
+            "sgroup": "schar"
         },
         "double": {
             "LUA_pop": "lua_tonumber({LUA_state_var}, {LUA_index})",
@@ -302,8 +298,7 @@
             },
             "f_type": "real(C_DOUBLE)",
             "flat_name": "double",
-            "sgroup": "native",
-            "sh_type": "0"
+            "sgroup": "native"
         },
         "float": {
             "LUA_pop": "lua_tonumber({LUA_state_var}, {LUA_index})",
@@ -324,8 +319,7 @@
             },
             "f_type": "real(C_FLOAT)",
             "flat_name": "float",
-            "sgroup": "native",
-            "sh_type": "0"
+            "sgroup": "native"
         },
         "int": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -346,8 +340,7 @@
             },
             "f_type": "integer(C_INT)",
             "flat_name": "int",
-            "sgroup": "native",
-            "sh_type": "0"
+            "sgroup": "native"
         },
         "int16_t": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -370,8 +363,7 @@
             },
             "f_type": "integer(C_INT16_T)",
             "flat_name": "int16_t",
-            "sgroup": "native",
-            "sh_type": "0"
+            "sgroup": "native"
         },
         "int32_t": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -394,8 +386,7 @@
             },
             "f_type": "integer(C_INT32_T)",
             "flat_name": "int32_t",
-            "sgroup": "native",
-            "sh_type": "0"
+            "sgroup": "native"
         },
         "int64_t": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -418,8 +409,7 @@
             },
             "f_type": "integer(C_INT64_T)",
             "flat_name": "int64_t",
-            "sgroup": "native",
-            "sh_type": "0"
+            "sgroup": "native"
         },
         "int8_t": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -442,8 +432,7 @@
             },
             "f_type": "integer(C_INT8_T)",
             "flat_name": "int8_t",
-            "sgroup": "native",
-            "sh_type": "0"
+            "sgroup": "native"
         },
         "long": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -464,8 +453,7 @@
             },
             "f_type": "integer(C_LONG)",
             "flat_name": "long",
-            "sgroup": "native",
-            "sh_type": "0"
+            "sgroup": "native"
         },
         "long_long": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -484,8 +472,7 @@
             },
             "f_type": "integer(C_LONG_LONG)",
             "flat_name": "long_long",
-            "sgroup": "native",
-            "sh_type": "0"
+            "sgroup": "native"
         },
         "short": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -506,8 +493,7 @@
             },
             "f_type": "integer(C_SHORT)",
             "flat_name": "short",
-            "sgroup": "native",
-            "sh_type": "0"
+            "sgroup": "native"
         },
         "size_t": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -528,8 +514,7 @@
             },
             "f_type": "integer(C_SIZE_T)",
             "flat_name": "size_t",
-            "sgroup": "native",
-            "sh_type": "0"
+            "sgroup": "native"
         },
         "std::string": {
             "LUA_pop": "lua_tostring({LUA_state_var}, {LUA_index})",
@@ -554,16 +539,14 @@
             "f_type_allocatable": "character(len=:)",
             "flat_name": "std_string",
             "impl_header": "<string>",
-            "sgroup": "string",
-            "sh_type": "0"
+            "sgroup": "string"
         },
         "std::vector": {
             "base": "vector",
             "cxx_header": "<vector>",
             "cxx_type": "std::vector<{cxx_T}>",
             "flat_name": "std_vector_{cxx_T}",
-            "sgroup": "vector",
-            "sh_type": "0"
+            "sgroup": "vector"
         },
         "uint16_t": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -586,8 +569,7 @@
             },
             "f_type": "integer(C_INT16_T)",
             "flat_name": "uint16_t",
-            "sgroup": "native",
-            "sh_type": "0"
+            "sgroup": "native"
         },
         "uint32_t": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -610,8 +592,7 @@
             },
             "f_type": "integer(C_INT32_T)",
             "flat_name": "uint32_t",
-            "sgroup": "native",
-            "sh_type": "0"
+            "sgroup": "native"
         },
         "uint64_t": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -634,8 +615,7 @@
             },
             "f_type": "integer(C_INT64_T)",
             "flat_name": "uint64_t",
-            "sgroup": "native",
-            "sh_type": "0"
+            "sgroup": "native"
         },
         "uint8_t": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -658,8 +638,7 @@
             },
             "f_type": "integer(C_INT8_T)",
             "flat_name": "uint8_t",
-            "sgroup": "native",
-            "sh_type": "0"
+            "sgroup": "native"
         },
         "unsigned_int": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -680,8 +659,7 @@
             },
             "f_type": "integer(C_INT)",
             "flat_name": "unsigned_int",
-            "sgroup": "native",
-            "sh_type": "0"
+            "sgroup": "native"
         },
         "unsigned_long": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -702,8 +680,7 @@
             },
             "f_type": "integer(C_LONG)",
             "flat_name": "unsigned_long",
-            "sgroup": "native",
-            "sh_type": "0"
+            "sgroup": "native"
         },
         "unsigned_long_long": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -722,8 +699,7 @@
             },
             "f_type": "integer(C_LONG_LONG)",
             "flat_name": "unsigned_long_long",
-            "sgroup": "native",
-            "sh_type": "0"
+            "sgroup": "native"
         },
         "unsigned_short": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
@@ -744,8 +720,7 @@
             },
             "f_type": "integer(C_SHORT)",
             "flat_name": "unsigned_short",
-            "sgroup": "native",
-            "sh_type": "0"
+            "sgroup": "native"
         },
         "void": {
             "PY_ctor": "PyCapsule_New({cxx_var}, NULL, NULL)",
@@ -766,8 +741,7 @@
                 ]
             },
             "f_type": "type(C_PTR)",
-            "flat_name": "void",
-            "sh_type": "0"
+            "flat_name": "void"
         }
     }
 }

--- a/regression/reference/ownership/ownership.json
+++ b/regression/reference/ownership/ownership.json
@@ -86,7 +86,7 @@
                                 "cxx_type": "int",
                                 "cxx_var": "SHC_rv",
                                 "idtor": "0",
-                                "sh_type": "0",
+                                "sh_type": "SH_TYPE_INT",
                                 "stmt0": "c_native_scalar_result_",
                                 "stmt1": "c_default"
                             },
@@ -328,7 +328,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_pointer_result_",
                         "stmt1": "c_default"
                     }
@@ -383,7 +383,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_pointer_result_",
                         "stmt1": "c_default"
                     },
@@ -466,7 +466,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_pointer_result_",
                         "stmt1": "c_default"
                     },
@@ -553,7 +553,7 @@
                             "cxx_type": "int",
                             "cxx_var": "len",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         }
@@ -569,7 +569,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_pointer_result_",
                         "stmt1": "c_default"
                     }
@@ -649,7 +649,7 @@
                             "cxx_type": "int",
                             "cxx_var": "len",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -690,7 +690,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_pointer_result_",
                         "stmt1": "c_default"
                     },
@@ -806,7 +806,7 @@
                             "cxx_type": "int",
                             "cxx_var": "len",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -838,7 +838,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_pointer_result_",
                         "stmt1": "c_default"
                     },
@@ -956,7 +956,7 @@
                             "cxx_type": "int",
                             "cxx_var": "len",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_pointer_out_buf",
                             "stmt1": "c_default"
                         },
@@ -983,7 +983,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_pointer_result_buf",
                         "stmt1": "c_native_pointer_result_buf"
                     }
@@ -1070,7 +1070,7 @@
                             "cxx_type": "int",
                             "cxx_var": "len",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1111,7 +1111,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_pointer_result_",
                         "stmt1": "c_default"
                     },
@@ -1226,7 +1226,7 @@
                             "cxx_type": "int",
                             "cxx_var": "len",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         }
@@ -1242,7 +1242,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "2",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_pointer_result_",
                         "stmt1": "c_default"
                     }
@@ -1324,7 +1324,7 @@
                             "cxx_type": "int",
                             "cxx_var": "len",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1365,7 +1365,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "2",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_pointer_result_",
                         "stmt1": "c_default"
                     },
@@ -1482,7 +1482,7 @@
                             "cxx_type": "int",
                             "cxx_var": "len",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1514,7 +1514,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "2",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_pointer_result_",
                         "stmt1": "c_default"
                     },
@@ -1613,7 +1613,7 @@
                             "cxx_type": "int",
                             "cxx_var": "len",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1654,7 +1654,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "2",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_pointer_result_",
                         "stmt1": "c_default"
                     },
@@ -2341,7 +2341,7 @@
                             "cxx_type": "int",
                             "cxx_var": "flag",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2439,7 +2439,7 @@
                         "cxx_type": "Class1",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "c_shadow_pointer_result_",
                         "stmt1": "c_shadow_result"
                     },
@@ -2527,7 +2527,7 @@
                             "cxx_type": "int",
                             "cxx_var": "flag",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2568,7 +2568,7 @@
                         "cxx_type": "Class1",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "1",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "c_shadow_pointer_result_",
                         "stmt1": "c_shadow_result"
                     },

--- a/regression/reference/ownership/ownership.json
+++ b/regression/reference/ownership/ownership.json
@@ -86,6 +86,7 @@
                                 "cxx_type": "int",
                                 "cxx_var": "SHC_rv",
                                 "idtor": "0",
+                                "sh_type": "0",
                                 "stmt0": "c_native_scalar_result_",
                                 "stmt1": "c_default"
                             },
@@ -327,6 +328,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_pointer_result_",
                         "stmt1": "c_default"
                     }
@@ -381,6 +383,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_pointer_result_",
                         "stmt1": "c_default"
                     },
@@ -463,6 +466,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_pointer_result_",
                         "stmt1": "c_default"
                     },
@@ -549,6 +553,7 @@
                             "cxx_type": "int",
                             "cxx_var": "len",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         }
@@ -564,6 +569,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_pointer_result_",
                         "stmt1": "c_default"
                     }
@@ -643,6 +649,7 @@
                             "cxx_type": "int",
                             "cxx_var": "len",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -683,6 +690,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_pointer_result_",
                         "stmt1": "c_default"
                     },
@@ -798,6 +806,7 @@
                             "cxx_type": "int",
                             "cxx_var": "len",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -829,6 +838,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_pointer_result_",
                         "stmt1": "c_default"
                     },
@@ -946,6 +956,7 @@
                             "cxx_type": "int",
                             "cxx_var": "len",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_out_buf",
                             "stmt1": "c_default"
                         },
@@ -972,6 +983,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_pointer_result_buf",
                         "stmt1": "c_native_pointer_result_buf"
                     }
@@ -1058,6 +1070,7 @@
                             "cxx_type": "int",
                             "cxx_var": "len",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1098,6 +1111,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_pointer_result_",
                         "stmt1": "c_default"
                     },
@@ -1212,6 +1226,7 @@
                             "cxx_type": "int",
                             "cxx_var": "len",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         }
@@ -1227,6 +1242,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "2",
+                        "sh_type": "0",
                         "stmt0": "c_native_pointer_result_",
                         "stmt1": "c_default"
                     }
@@ -1308,6 +1324,7 @@
                             "cxx_type": "int",
                             "cxx_var": "len",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1348,6 +1365,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "2",
+                        "sh_type": "0",
                         "stmt0": "c_native_pointer_result_",
                         "stmt1": "c_default"
                     },
@@ -1464,6 +1482,7 @@
                             "cxx_type": "int",
                             "cxx_var": "len",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1495,6 +1514,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "2",
+                        "sh_type": "0",
                         "stmt0": "c_native_pointer_result_",
                         "stmt1": "c_default"
                     },
@@ -1593,6 +1613,7 @@
                             "cxx_type": "int",
                             "cxx_var": "len",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1633,6 +1654,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "2",
+                        "sh_type": "0",
                         "stmt0": "c_native_pointer_result_",
                         "stmt1": "c_default"
                     },
@@ -2319,6 +2341,7 @@
                             "cxx_type": "int",
                             "cxx_var": "flag",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2416,6 +2439,7 @@
                         "cxx_type": "Class1",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_shadow_pointer_result_",
                         "stmt1": "c_shadow_result"
                     },
@@ -2503,6 +2527,7 @@
                             "cxx_type": "int",
                             "cxx_var": "flag",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2543,6 +2568,7 @@
                         "cxx_type": "Class1",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "1",
+                        "sh_type": "0",
                         "stmt0": "c_shadow_pointer_result_",
                         "stmt1": "c_shadow_result"
                     },

--- a/regression/reference/ownership/typesownership.h
+++ b/regression/reference/ownership/typesownership.h
@@ -38,6 +38,7 @@ struct s_OWN_SHROUD_array {
         const void * base;
         const char * ccharp;
     } addr;
+    int type;        /* type of element */
     size_t elem_len; /* bytes-per-item or character len in c++ */
     size_t size;     /* size of data in c++ */
 };

--- a/regression/reference/ownership/typesownership.h
+++ b/regression/reference/ownership/typesownership.h
@@ -26,6 +26,46 @@
 extern "C" {
 #endif
 
+/* Shroud type defines */
+#define SH_TYPE_SIGNED_CHAR 1
+#define SH_TYPE_SHORT       2
+#define SH_TYPE_INT         3
+#define SH_TYPE_LONG        4
+#define SH_TYPE_LONG_LONG   5
+#define SH_TYPE_SIZE_T      6
+
+#define SH_TYPE_UNSIGNED_SHORT       SH_TYPE_SHORT + 100
+#define SH_TYPE_UNSIGNED_INT         SH_TYPE_INT + 100
+#define SH_TYPE_UNSIGNED_LONG        SH_TYPE_LONG + 100
+#define SH_TYPE_UNSIGNED_LONG_LONG   SH_TYPE_LONG_LONG + 100
+
+#define SH_TYPE_INT8_T      7
+#define SH_TYPE_INT16_T     8
+#define SH_TYPE_INT32_T     9
+#define SH_TYPE_INT64_T    10
+
+#define SH_TYPE_UINT8_T    SH_TYPE_INT8_T + 100
+#define SH_TYPE_UINT16_T   SH_TYPE_INT16_T + 100
+#define SH_TYPE_UINT32_T   SH_TYPE_INT32_T + 100
+#define SH_TYPE_UINT64_T   SH_TYPE_INT64_T + 100
+
+/* least8 least16 least32 least64 */
+/* fast8 fast16 fast32 fast64 */
+/* intmax_t intptr_t ptrdiff_t */
+
+#define SH_TYPE_FLOAT        22
+#define SH_TYPE_DOUBLE       23
+#define SH_TYPE_LONG_DOUBLE  24
+#define SH_TYPE_FLOAT_COMPLEX       25
+#define SH_TYPE_DOUBLE_COMPLEX      26
+#define SH_TYPE_LONG_DOUBLE_COMPLEX 27
+
+#define SH_TYPE_BOOL       28
+#define SH_TYPE_CHAR       29
+#define SH_TYPE_CPTR       30
+#define SH_TYPE_STRUCT     31
+#define SH_TYPE_OTHER      32
+
 struct s_OWN_SHROUD_capsule_data {
     void *addr;     /* address of C++ memory */
     int idtor;      /* index of destructor */

--- a/regression/reference/ownership/wrapfownership.f
+++ b/regression/reference/ownership/wrapfownership.f
@@ -39,6 +39,8 @@ module ownership_mod
         type(SHROUD_capsule_data) :: cxx
         ! address of data in cxx
         type(C_PTR) :: base_addr = C_NULL_PTR
+        ! type of element
+        integer(C_INT) :: type
         ! bytes-per-item or character len of data in cxx
         integer(C_SIZE_T) :: elem_len = 0_C_SIZE_T
         ! size of data in cxx

--- a/regression/reference/ownership/wrapownership.cpp
+++ b/regression/reference/ownership/wrapownership.cpp
@@ -105,7 +105,7 @@ int * OWN_return_int_ptr_dim_alloc_bufferify(OWN_SHROUD_array *DSHC_rv,
     DSHC_rv->cxx.addr  = SHC_rv;
     DSHC_rv->cxx.idtor = 0;
     DSHC_rv->addr.base = SHC_rv;
-    DSHC_rv->type = 0;
+    DSHC_rv->type = SH_TYPE_INT;
     DSHC_rv->elem_len = sizeof(int);
     DSHC_rv->size = *len;
     return SHC_rv;

--- a/regression/reference/ownership/wrapownership.cpp
+++ b/regression/reference/ownership/wrapownership.cpp
@@ -105,6 +105,7 @@ int * OWN_return_int_ptr_dim_alloc_bufferify(OWN_SHROUD_array *DSHC_rv,
     DSHC_rv->cxx.addr  = SHC_rv;
     DSHC_rv->cxx.idtor = 0;
     DSHC_rv->addr.base = SHC_rv;
+    DSHC_rv->type = 0;
     DSHC_rv->elem_len = sizeof(int);
     DSHC_rv->size = *len;
     return SHC_rv;

--- a/regression/reference/pointers-numpy-cpp/pointers.json
+++ b/regression/reference/pointers-numpy-cpp/pointers.json
@@ -144,6 +144,7 @@
                             "cxx_type": "int",
                             "cxx_var": "argin",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -186,6 +187,7 @@
                             "cxx_type": "int",
                             "cxx_var": "arginout",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_inout_",
                             "stmt1": "c_default"
                         },
@@ -228,6 +230,7 @@
                             "cxx_type": "int",
                             "cxx_var": "argout",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -363,6 +366,7 @@
                             "cxx_type": "double",
                             "cxx_var": "in",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -406,6 +410,7 @@
                             "cxx_type": "double",
                             "cxx_var": "out",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -454,6 +459,7 @@
                             "cxx_type": "int",
                             "cxx_var": "sizein",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -593,6 +599,7 @@
                             "cxx_type": "double",
                             "cxx_var": "in",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -636,6 +643,7 @@
                             "cxx_type": "int",
                             "cxx_var": "out",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -684,6 +692,7 @@
                             "cxx_type": "int",
                             "cxx_var": "sizein",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -823,6 +832,7 @@
                             "cxx_type": "int",
                             "cxx_var": "nvalues",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -865,6 +875,7 @@
                             "cxx_type": "int",
                             "cxx_var": "values",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -995,6 +1006,7 @@
                             "cxx_type": "int",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1041,6 +1053,7 @@
                             "cxx_type": "int",
                             "cxx_var": "arg2",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1172,6 +1185,7 @@
                             "cxx_type": "int",
                             "cxx_var": "len",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1211,6 +1225,7 @@
                             "cxx_type": "int",
                             "cxx_var": "result",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1253,6 +1268,7 @@
                             "cxx_type": "int",
                             "cxx_var": "values",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -1394,6 +1410,7 @@
                             "cxx_type": "int",
                             "cxx_var": "out",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1505,6 +1522,7 @@
                             "cxx_type": "int",
                             "cxx_var": "array",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_inout_",
                             "stmt1": "c_default"
                         },
@@ -1548,6 +1566,7 @@
                             "cxx_type": "int",
                             "cxx_var": "sizein",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },

--- a/regression/reference/pointers-numpy-cpp/pointers.json
+++ b/regression/reference/pointers-numpy-cpp/pointers.json
@@ -144,7 +144,7 @@
                             "cxx_type": "int",
                             "cxx_var": "argin",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -187,7 +187,7 @@
                             "cxx_type": "int",
                             "cxx_var": "arginout",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_pointer_inout_",
                             "stmt1": "c_default"
                         },
@@ -230,7 +230,7 @@
                             "cxx_type": "int",
                             "cxx_var": "argout",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -366,7 +366,7 @@
                             "cxx_type": "double",
                             "cxx_var": "in",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_native_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -410,7 +410,7 @@
                             "cxx_type": "double",
                             "cxx_var": "out",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -459,7 +459,7 @@
                             "cxx_type": "int",
                             "cxx_var": "sizein",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -599,7 +599,7 @@
                             "cxx_type": "double",
                             "cxx_var": "in",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_native_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -643,7 +643,7 @@
                             "cxx_type": "int",
                             "cxx_var": "out",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -692,7 +692,7 @@
                             "cxx_type": "int",
                             "cxx_var": "sizein",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -832,7 +832,7 @@
                             "cxx_type": "int",
                             "cxx_var": "nvalues",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -875,7 +875,7 @@
                             "cxx_type": "int",
                             "cxx_var": "values",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1006,7 +1006,7 @@
                             "cxx_type": "int",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1053,7 +1053,7 @@
                             "cxx_type": "int",
                             "cxx_var": "arg2",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1185,7 +1185,7 @@
                             "cxx_type": "int",
                             "cxx_var": "len",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1225,7 +1225,7 @@
                             "cxx_type": "int",
                             "cxx_var": "result",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1268,7 +1268,7 @@
                             "cxx_type": "int",
                             "cxx_var": "values",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -1410,7 +1410,7 @@
                             "cxx_type": "int",
                             "cxx_var": "out",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1522,7 +1522,7 @@
                             "cxx_type": "int",
                             "cxx_var": "array",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_pointer_inout_",
                             "stmt1": "c_default"
                         },
@@ -1566,7 +1566,7 @@
                             "cxx_type": "int",
                             "cxx_var": "sizein",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },

--- a/regression/reference/preprocess/preprocess.json
+++ b/regression/reference/preprocess/preprocess.json
@@ -174,6 +174,7 @@
                                     "cxx_type": "int",
                                     "cxx_var": "i",
                                     "idtor": "0",
+                                    "sh_type": "0",
                                     "stmt0": "c_native_scalar_in_",
                                     "stmt1": "c_default"
                                 },
@@ -357,6 +358,7 @@
                                     "cxx_type": "int",
                                     "cxx_var": "flag",
                                     "idtor": "0",
+                                    "sh_type": "0",
                                     "stmt0": "c_native_scalar_in_",
                                     "stmt1": "c_default"
                                 },

--- a/regression/reference/preprocess/preprocess.json
+++ b/regression/reference/preprocess/preprocess.json
@@ -174,7 +174,7 @@
                                     "cxx_type": "int",
                                     "cxx_var": "i",
                                     "idtor": "0",
-                                    "sh_type": "0",
+                                    "sh_type": "SH_TYPE_INT",
                                     "stmt0": "c_native_scalar_in_",
                                     "stmt1": "c_default"
                                 },
@@ -358,7 +358,7 @@
                                     "cxx_type": "int",
                                     "cxx_var": "flag",
                                     "idtor": "0",
-                                    "sh_type": "0",
+                                    "sh_type": "SH_TYPE_INT",
                                     "stmt0": "c_native_scalar_in_",
                                     "stmt1": "c_default"
                                 },

--- a/regression/reference/strings/strings.json
+++ b/regression/reference/strings/strings.json
@@ -144,6 +144,7 @@
                             "cxx_type": "char",
                             "cxx_var": "status",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_schar_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -242,6 +243,7 @@
                         "cxx_type": "char",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_schar_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -322,6 +324,7 @@
                             "cxx_type": "char",
                             "cxx_var": "SHC_rv",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_schar_scalar_result_buf_",
                             "stmt1": "c_schar_result_buf"
                         },
@@ -345,6 +348,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -421,6 +425,7 @@
                             "cxx_type": "char",
                             "cxx_var": "dest",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -455,6 +460,7 @@
                             "cxx_type": "char",
                             "cxx_var": "src",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -579,6 +585,7 @@
                             "cxx_type": "char",
                             "cxx_var": "dest",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_out_buf",
                             "stmt1": "c_char_out_buf"
                         },
@@ -605,6 +612,7 @@
                             "cxx_type": "char",
                             "cxx_var": "src",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -712,6 +720,7 @@
                             "cxx_type": "char",
                             "cxx_var": "s",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_inout_",
                             "stmt1": "c_default"
                         },
@@ -812,6 +821,7 @@
                             "cxx_type": "char",
                             "cxx_var": "SHCXX_s",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_inout_buf",
                             "stmt1": "c_char_inout_buf"
                         },
@@ -897,6 +907,7 @@
                         "cxx_type": "char",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_char_pointer_result_",
                         "stmt1": "c_char_result"
                     },
@@ -989,6 +1000,7 @@
                             "cxx_type": "char",
                             "cxx_var": "SHC_rv",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_result_buf_allocatable",
                             "stmt1": "c_char_result_buf_allocatable"
                         },
@@ -1013,6 +1025,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -1089,6 +1102,7 @@
                         "cxx_type": "char",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_char_pointer_result_",
                         "stmt1": "c_char_result"
                     },
@@ -1182,6 +1196,7 @@
                             "cxx_type": "char",
                             "cxx_var": "SHC_rv",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_result_buf_",
                             "stmt1": "c_char_result_buf"
                         },
@@ -1205,6 +1220,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -1282,6 +1298,7 @@
                         "cxx_type": "char",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_char_pointer_result_",
                         "stmt1": "c_char_result"
                     },
@@ -1360,6 +1377,7 @@
                             "cxx_type": "char",
                             "cxx_var": "SHC_rv",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_result_buf_",
                             "stmt1": "c_char_result_buf"
                         },
@@ -1383,6 +1401,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -1597,6 +1616,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "1",
+                            "sh_type": "0",
                             "stmt0": "c_string_scalar_result_buf_allocatable",
                             "stmt1": "c_string_scalar_result_buf_allocatable"
                         },
@@ -1621,6 +1641,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -1767,6 +1788,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_string_scalar_result_buf_",
                             "stmt1": "c_string_result_buf"
                         },
@@ -1790,6 +1812,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -1922,6 +1945,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_string_scalar_result_buf_",
                             "stmt1": "c_string_result_buf"
                         },
@@ -1945,6 +1969,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -2150,6 +2175,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "1",
+                            "sh_type": "0",
                             "stmt0": "c_string_scalar_result_buf_allocatable",
                             "stmt1": "c_string_scalar_result_buf_allocatable"
                         },
@@ -2174,6 +2200,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -2245,6 +2272,7 @@
                         "cxx_type": "std::string",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_string_pointer_result_",
                         "stmt1": "c_string_result"
                     },
@@ -2338,6 +2366,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_string_pointer_result_buf_allocatable",
                             "stmt1": "c_string_result_buf_allocatable"
                         },
@@ -2362,6 +2391,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -2440,6 +2470,7 @@
                         "cxx_type": "std::string",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_string_pointer_result_",
                         "stmt1": "c_string_result"
                     },
@@ -2533,6 +2564,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_string_pointer_result_buf_",
                             "stmt1": "c_string_result_buf"
                         },
@@ -2556,6 +2588,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -2634,6 +2667,7 @@
                         "cxx_type": "std::string",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_string_pointer_result_",
                         "stmt1": "c_string_result"
                     },
@@ -2713,6 +2747,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_string_pointer_result_buf_",
                             "stmt1": "c_string_result_buf"
                         },
@@ -2736,6 +2771,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -2880,6 +2916,7 @@
                         "cxx_type": "std::string",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_string_pointer_result_",
                         "stmt1": "c_string_result"
                     },
@@ -2972,6 +3009,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_string_pointer_result_buf_",
                             "stmt1": "c_string_result_buf"
                         },
@@ -2995,6 +3033,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -3071,6 +3110,7 @@
                         "cxx_type": "std::string",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_string_pointer_result_",
                         "stmt1": "c_string_result"
                     },
@@ -3157,6 +3197,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_string_pointer_result_buf_allocatable",
                             "stmt1": "c_string_result_buf_allocatable"
                         },
@@ -3181,6 +3222,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -3252,6 +3294,7 @@
                         "cxx_type": "std::string",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_string_pointer_result_",
                         "stmt1": "c_string_result"
                     },
@@ -3346,6 +3389,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_string_pointer_result_buf_",
                             "stmt1": "c_string_result_buf"
                         },
@@ -3369,6 +3413,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -3448,6 +3493,7 @@
                         "cxx_type": "std::string",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_string_pointer_result_",
                         "stmt1": "c_string_result"
                     },
@@ -3535,6 +3581,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_string_pointer_result_buf_allocatable",
                             "stmt1": "c_string_result_buf_allocatable"
                         },
@@ -3559,6 +3606,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -3631,6 +3679,7 @@
                         "cxx_type": "std::string",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "2",
+                        "sh_type": "0",
                         "stmt0": "c_string_pointer_result_",
                         "stmt1": "c_string_result"
                     },
@@ -3722,6 +3771,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "2",
+                            "sh_type": "0",
                             "stmt0": "c_string_pointer_result_buf_allocatable",
                             "stmt1": "c_string_result_buf_allocatable"
                         },
@@ -3746,6 +3796,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -3822,6 +3873,7 @@
                         "cxx_type": "std::string",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "3",
+                        "sh_type": "0",
                         "stmt0": "c_string_pointer_result_",
                         "stmt1": "c_string_result"
                     },
@@ -3915,6 +3967,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "3",
+                            "sh_type": "0",
                             "stmt0": "c_string_pointer_result_buf_allocatable",
                             "stmt1": "c_string_result_buf_allocatable"
                         },
@@ -3939,6 +3992,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -4023,6 +4077,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_string_pointer_in_",
                             "stmt1": "c_string_in"
                         },
@@ -4123,6 +4178,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_string_pointer_in_buf",
                             "stmt1": "c_string_in_buf"
                         },
@@ -4212,6 +4268,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_string_pointer_out_",
                             "stmt1": "c_string_out"
                         },
@@ -4311,6 +4368,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_string_pointer_out_buf",
                             "stmt1": "c_string_out_buf"
                         },
@@ -4399,6 +4457,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_string_pointer_inout_",
                             "stmt1": "c_string_inout"
                         },
@@ -4502,6 +4561,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_string_pointer_inout_buf",
                             "stmt1": "c_string_inout_buf"
                         },
@@ -4593,6 +4653,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_string_pointer_inout_",
                             "stmt1": "c_string_inout"
                         },
@@ -4692,6 +4753,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_string_pointer_inout_buf",
                             "stmt1": "c_string_inout_buf"
                         },
@@ -4935,6 +4997,7 @@
                             "cxx_type": "char",
                             "cxx_var": "name",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -5036,6 +5099,7 @@
                             "cxx_type": "char",
                             "cxx_var": "name",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_out_",
                             "stmt1": "c_default"
                         }
@@ -5118,6 +5182,7 @@
                             "cxx_type": "char",
                             "cxx_var": "name",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_out_buf",
                             "stmt1": "c_char_out_buf"
                         },
@@ -5203,6 +5268,7 @@
                             "cxx_type": "char",
                             "cxx_var": "status",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_schar_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -5304,6 +5370,7 @@
                         "cxx_type": "char",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_schar_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -5387,6 +5454,7 @@
                             "cxx_type": "char",
                             "cxx_var": "SHC_rv",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_schar_scalar_result_buf_",
                             "stmt1": "c_schar_result_buf"
                         },
@@ -5410,6 +5478,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -5488,6 +5557,7 @@
                             "cxx_type": "char",
                             "cxx_var": "dest",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_out_",
                             "stmt1": "c_default"
                         }
@@ -5505,6 +5575,7 @@
                             "cxx_type": "char",
                             "cxx_var": "src",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_in_",
                             "stmt1": "c_default"
                         }
@@ -5612,6 +5683,7 @@
                             "cxx_type": "char",
                             "cxx_var": "dest",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_out_buf",
                             "stmt1": "c_char_out_buf"
                         },
@@ -5638,6 +5710,7 @@
                             "cxx_type": "char",
                             "cxx_var": "src",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_in_",
                             "stmt1": "c_default"
                         },

--- a/regression/reference/strings/strings.json
+++ b/regression/reference/strings/strings.json
@@ -144,7 +144,7 @@
                             "cxx_type": "char",
                             "cxx_var": "status",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_schar_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -243,7 +243,7 @@
                         "cxx_type": "char",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "c_schar_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -324,7 +324,7 @@
                             "cxx_type": "char",
                             "cxx_var": "SHC_rv",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_schar_scalar_result_buf_",
                             "stmt1": "c_schar_result_buf"
                         },
@@ -348,7 +348,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_CPTR",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -425,7 +425,7 @@
                             "cxx_type": "char",
                             "cxx_var": "dest",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -460,7 +460,7 @@
                             "cxx_type": "char",
                             "cxx_var": "src",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -585,7 +585,7 @@
                             "cxx_type": "char",
                             "cxx_var": "dest",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_out_buf",
                             "stmt1": "c_char_out_buf"
                         },
@@ -612,7 +612,7 @@
                             "cxx_type": "char",
                             "cxx_var": "src",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -720,7 +720,7 @@
                             "cxx_type": "char",
                             "cxx_var": "s",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_inout_",
                             "stmt1": "c_default"
                         },
@@ -821,7 +821,7 @@
                             "cxx_type": "char",
                             "cxx_var": "SHCXX_s",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_inout_buf",
                             "stmt1": "c_char_inout_buf"
                         },
@@ -907,7 +907,7 @@
                         "cxx_type": "char",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "c_char_pointer_result_",
                         "stmt1": "c_char_result"
                     },
@@ -1000,7 +1000,7 @@
                             "cxx_type": "char",
                             "cxx_var": "SHC_rv",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_result_buf_allocatable",
                             "stmt1": "c_char_result_buf_allocatable"
                         },
@@ -1025,7 +1025,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_CPTR",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -1102,7 +1102,7 @@
                         "cxx_type": "char",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "c_char_pointer_result_",
                         "stmt1": "c_char_result"
                     },
@@ -1196,7 +1196,7 @@
                             "cxx_type": "char",
                             "cxx_var": "SHC_rv",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_result_buf_",
                             "stmt1": "c_char_result_buf"
                         },
@@ -1220,7 +1220,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_CPTR",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -1298,7 +1298,7 @@
                         "cxx_type": "char",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "c_char_pointer_result_",
                         "stmt1": "c_char_result"
                     },
@@ -1377,7 +1377,7 @@
                             "cxx_type": "char",
                             "cxx_var": "SHC_rv",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_result_buf_",
                             "stmt1": "c_char_result_buf"
                         },
@@ -1401,7 +1401,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_CPTR",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -1616,7 +1616,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "1",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_scalar_result_buf_allocatable",
                             "stmt1": "c_string_scalar_result_buf_allocatable"
                         },
@@ -1641,7 +1641,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_CPTR",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -1788,7 +1788,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_scalar_result_buf_",
                             "stmt1": "c_string_result_buf"
                         },
@@ -1812,7 +1812,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_CPTR",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -1945,7 +1945,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_scalar_result_buf_",
                             "stmt1": "c_string_result_buf"
                         },
@@ -1969,7 +1969,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_CPTR",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -2175,7 +2175,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "1",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_scalar_result_buf_allocatable",
                             "stmt1": "c_string_scalar_result_buf_allocatable"
                         },
@@ -2200,7 +2200,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_CPTR",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -2272,7 +2272,7 @@
                         "cxx_type": "std::string",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "c_string_pointer_result_",
                         "stmt1": "c_string_result"
                     },
@@ -2366,7 +2366,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_pointer_result_buf_allocatable",
                             "stmt1": "c_string_result_buf_allocatable"
                         },
@@ -2391,7 +2391,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_CPTR",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -2470,7 +2470,7 @@
                         "cxx_type": "std::string",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "c_string_pointer_result_",
                         "stmt1": "c_string_result"
                     },
@@ -2564,7 +2564,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_pointer_result_buf_",
                             "stmt1": "c_string_result_buf"
                         },
@@ -2588,7 +2588,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_CPTR",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -2667,7 +2667,7 @@
                         "cxx_type": "std::string",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "c_string_pointer_result_",
                         "stmt1": "c_string_result"
                     },
@@ -2747,7 +2747,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_pointer_result_buf_",
                             "stmt1": "c_string_result_buf"
                         },
@@ -2771,7 +2771,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_CPTR",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -2916,7 +2916,7 @@
                         "cxx_type": "std::string",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "c_string_pointer_result_",
                         "stmt1": "c_string_result"
                     },
@@ -3009,7 +3009,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_pointer_result_buf_",
                             "stmt1": "c_string_result_buf"
                         },
@@ -3033,7 +3033,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_CPTR",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -3110,7 +3110,7 @@
                         "cxx_type": "std::string",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "c_string_pointer_result_",
                         "stmt1": "c_string_result"
                     },
@@ -3197,7 +3197,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_pointer_result_buf_allocatable",
                             "stmt1": "c_string_result_buf_allocatable"
                         },
@@ -3222,7 +3222,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_CPTR",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -3294,7 +3294,7 @@
                         "cxx_type": "std::string",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "c_string_pointer_result_",
                         "stmt1": "c_string_result"
                     },
@@ -3389,7 +3389,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_pointer_result_buf_",
                             "stmt1": "c_string_result_buf"
                         },
@@ -3413,7 +3413,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_CPTR",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -3493,7 +3493,7 @@
                         "cxx_type": "std::string",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "c_string_pointer_result_",
                         "stmt1": "c_string_result"
                     },
@@ -3581,7 +3581,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_pointer_result_buf_allocatable",
                             "stmt1": "c_string_result_buf_allocatable"
                         },
@@ -3606,7 +3606,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_CPTR",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -3679,7 +3679,7 @@
                         "cxx_type": "std::string",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "2",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "c_string_pointer_result_",
                         "stmt1": "c_string_result"
                     },
@@ -3771,7 +3771,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "2",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_pointer_result_buf_allocatable",
                             "stmt1": "c_string_result_buf_allocatable"
                         },
@@ -3796,7 +3796,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_CPTR",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -3873,7 +3873,7 @@
                         "cxx_type": "std::string",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "3",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "c_string_pointer_result_",
                         "stmt1": "c_string_result"
                     },
@@ -3967,7 +3967,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "3",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_pointer_result_buf_allocatable",
                             "stmt1": "c_string_result_buf_allocatable"
                         },
@@ -3992,7 +3992,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_CPTR",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -4077,7 +4077,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_pointer_in_",
                             "stmt1": "c_string_in"
                         },
@@ -4178,7 +4178,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_pointer_in_buf",
                             "stmt1": "c_string_in_buf"
                         },
@@ -4268,7 +4268,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_pointer_out_",
                             "stmt1": "c_string_out"
                         },
@@ -4368,7 +4368,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_pointer_out_buf",
                             "stmt1": "c_string_out_buf"
                         },
@@ -4457,7 +4457,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_pointer_inout_",
                             "stmt1": "c_string_inout"
                         },
@@ -4561,7 +4561,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_pointer_inout_buf",
                             "stmt1": "c_string_inout_buf"
                         },
@@ -4653,7 +4653,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_pointer_inout_",
                             "stmt1": "c_string_inout"
                         },
@@ -4753,7 +4753,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_pointer_inout_buf",
                             "stmt1": "c_string_inout_buf"
                         },
@@ -4997,7 +4997,7 @@
                             "cxx_type": "char",
                             "cxx_var": "name",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_in_",
                             "stmt1": "c_default"
                         },
@@ -5099,7 +5099,7 @@
                             "cxx_type": "char",
                             "cxx_var": "name",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_out_",
                             "stmt1": "c_default"
                         }
@@ -5182,7 +5182,7 @@
                             "cxx_type": "char",
                             "cxx_var": "name",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_out_buf",
                             "stmt1": "c_char_out_buf"
                         },
@@ -5268,7 +5268,7 @@
                             "cxx_type": "char",
                             "cxx_var": "status",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_schar_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -5370,7 +5370,7 @@
                         "cxx_type": "char",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "c_schar_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -5454,7 +5454,7 @@
                             "cxx_type": "char",
                             "cxx_var": "SHC_rv",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_schar_scalar_result_buf_",
                             "stmt1": "c_schar_result_buf"
                         },
@@ -5478,7 +5478,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_CPTR",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -5557,7 +5557,7 @@
                             "cxx_type": "char",
                             "cxx_var": "dest",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_out_",
                             "stmt1": "c_default"
                         }
@@ -5575,7 +5575,7 @@
                             "cxx_type": "char",
                             "cxx_var": "src",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_in_",
                             "stmt1": "c_default"
                         }
@@ -5683,7 +5683,7 @@
                             "cxx_type": "char",
                             "cxx_var": "dest",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_out_buf",
                             "stmt1": "c_char_out_buf"
                         },
@@ -5710,7 +5710,7 @@
                             "cxx_type": "char",
                             "cxx_var": "src",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_in_",
                             "stmt1": "c_default"
                         },

--- a/regression/reference/strings/typesstrings.h
+++ b/regression/reference/strings/typesstrings.h
@@ -39,6 +39,7 @@ struct s_STR_SHROUD_array {
         const void * base;
         const char * ccharp;
     } addr;
+    int type;        /* type of element */
     size_t elem_len; /* bytes-per-item or character len in c++ */
     size_t size;     /* size of data in c++ */
 };

--- a/regression/reference/strings/typesstrings.h
+++ b/regression/reference/strings/typesstrings.h
@@ -46,6 +46,46 @@ struct s_STR_SHROUD_array {
 typedef struct s_STR_SHROUD_array STR_SHROUD_array;
 // end array_context
 
+/* Shroud type defines */
+#define SH_TYPE_SIGNED_CHAR 1
+#define SH_TYPE_SHORT       2
+#define SH_TYPE_INT         3
+#define SH_TYPE_LONG        4
+#define SH_TYPE_LONG_LONG   5
+#define SH_TYPE_SIZE_T      6
+
+#define SH_TYPE_UNSIGNED_SHORT       SH_TYPE_SHORT + 100
+#define SH_TYPE_UNSIGNED_INT         SH_TYPE_INT + 100
+#define SH_TYPE_UNSIGNED_LONG        SH_TYPE_LONG + 100
+#define SH_TYPE_UNSIGNED_LONG_LONG   SH_TYPE_LONG_LONG + 100
+
+#define SH_TYPE_INT8_T      7
+#define SH_TYPE_INT16_T     8
+#define SH_TYPE_INT32_T     9
+#define SH_TYPE_INT64_T    10
+
+#define SH_TYPE_UINT8_T    SH_TYPE_INT8_T + 100
+#define SH_TYPE_UINT16_T   SH_TYPE_INT16_T + 100
+#define SH_TYPE_UINT32_T   SH_TYPE_INT32_T + 100
+#define SH_TYPE_UINT64_T   SH_TYPE_INT64_T + 100
+
+/* least8 least16 least32 least64 */
+/* fast8 fast16 fast32 fast64 */
+/* intmax_t intptr_t ptrdiff_t */
+
+#define SH_TYPE_FLOAT        22
+#define SH_TYPE_DOUBLE       23
+#define SH_TYPE_LONG_DOUBLE  24
+#define SH_TYPE_FLOAT_COMPLEX       25
+#define SH_TYPE_DOUBLE_COMPLEX      26
+#define SH_TYPE_LONG_DOUBLE_COMPLEX 27
+
+#define SH_TYPE_BOOL       28
+#define SH_TYPE_CHAR       29
+#define SH_TYPE_CPTR       30
+#define SH_TYPE_STRUCT     31
+#define SH_TYPE_OTHER      32
+
 void STR_SHROUD_memory_destructor(STR_SHROUD_capsule_data *cap);
 
 #ifdef __cplusplus

--- a/regression/reference/strings/wrapfstrings.f
+++ b/regression/reference/strings/wrapfstrings.f
@@ -40,6 +40,8 @@ module strings_mod
         type(SHROUD_capsule_data) :: cxx
         ! address of data in cxx
         type(C_PTR) :: base_addr = C_NULL_PTR
+        ! type of element
+        integer(C_INT) :: type
         ! bytes-per-item or character len of data in cxx
         integer(C_SIZE_T) :: elem_len = 0_C_SIZE_T
         ! size of data in cxx

--- a/regression/reference/strings/wrapstrings.cpp
+++ b/regression/reference/strings/wrapstrings.cpp
@@ -245,6 +245,7 @@ void STR_get_char_ptr1_bufferify(STR_SHROUD_array *DSHF_rv)
     DSHF_rv->cxx.addr = static_cast<void *>(const_cast<char *>(SHC_rv));
     DSHF_rv->cxx.idtor = 0;
     DSHF_rv->addr.ccharp = SHC_rv;
+    DSHF_rv->type = 0;
     DSHF_rv->elem_len = SHC_rv == NULL ? 0 : std::strlen(SHC_rv);
     DSHF_rv->size = 1;
     return;

--- a/regression/reference/strings/wrapstrings.cpp
+++ b/regression/reference/strings/wrapstrings.cpp
@@ -245,7 +245,7 @@ void STR_get_char_ptr1_bufferify(STR_SHROUD_array *DSHF_rv)
     DSHF_rv->cxx.addr = static_cast<void *>(const_cast<char *>(SHC_rv));
     DSHF_rv->cxx.idtor = 0;
     DSHF_rv->addr.ccharp = SHC_rv;
-    DSHF_rv->type = 0;
+    DSHF_rv->type = SH_TYPE_OTHER;
     DSHF_rv->elem_len = SHC_rv == NULL ? 0 : std::strlen(SHC_rv);
     DSHF_rv->size = 1;
     return;

--- a/regression/reference/struct-c/struct.json
+++ b/regression/reference/struct-c/struct.json
@@ -212,7 +212,7 @@
                             "cxx_type": "Cstruct1",
                             "cxx_var": "arg",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_STRUCT",
                             "stmt0": "c_struct_scalar_in_",
                             "stmt1": "c_struct"
                         },
@@ -257,7 +257,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -352,7 +352,7 @@
                             "cxx_type": "Cstruct1",
                             "cxx_var": "arg",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_STRUCT",
                             "stmt0": "c_struct_pointer_in_",
                             "stmt1": "c_struct"
                         },
@@ -397,7 +397,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -496,7 +496,7 @@
                             "cxx_type": "char",
                             "cxx_var": "outbuf",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -531,7 +531,7 @@
                             "cxx_type": "Cstruct1",
                             "cxx_var": "s1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_STRUCT",
                             "stmt0": "c_struct_pointer_in_",
                             "stmt1": "c_struct"
                         },
@@ -567,7 +567,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -687,7 +687,7 @@
                             "cxx_type": "char",
                             "cxx_var": "outbuf",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_out_buf",
                             "stmt1": "c_char_out_buf"
                         },
@@ -714,7 +714,7 @@
                             "cxx_type": "Cstruct1",
                             "cxx_var": "s1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_STRUCT",
                             "stmt0": "c_struct_pointer_in_buf",
                             "stmt1": "c_struct"
                         },
@@ -739,7 +739,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -838,7 +838,7 @@
                             "cxx_type": "Cstruct1",
                             "cxx_var": "arg",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_STRUCT",
                             "stmt0": "c_struct_pointer_in_",
                             "stmt1": "c_struct"
                         },
@@ -863,7 +863,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -949,7 +949,7 @@
                             "cxx_type": "Cstruct1",
                             "cxx_var": "arg",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_STRUCT",
                             "stmt0": "c_struct_pointer_out_",
                             "stmt1": "c_struct"
                         },
@@ -995,7 +995,7 @@
                             "cxx_type": "double",
                             "cxx_var": "d",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1038,7 +1038,7 @@
                             "cxx_type": "int",
                             "cxx_var": "i",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1173,7 +1173,7 @@
                             "cxx_type": "Cstruct1",
                             "cxx_var": "arg",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_STRUCT",
                             "stmt0": "c_struct_pointer_inout_",
                             "stmt1": "c_struct"
                         },
@@ -1280,7 +1280,7 @@
                             "cxx_type": "double",
                             "cxx_var": "d",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1323,7 +1323,7 @@
                             "cxx_type": "int",
                             "cxx_var": "i",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1364,7 +1364,7 @@
                         "cxx_type": "Cstruct1",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_STRUCT",
                         "stmt0": "c_struct_scalar_result_",
                         "stmt1": "c_struct_result"
                     },
@@ -1476,7 +1476,7 @@
                             "cxx_type": "double",
                             "cxx_var": "d",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1519,7 +1519,7 @@
                             "cxx_type": "int",
                             "cxx_var": "i",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1560,7 +1560,7 @@
                         "cxx_type": "Cstruct1",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_STRUCT",
                         "stmt0": "c_struct_scalar_result_",
                         "stmt1": "c_struct_result"
                     },
@@ -1673,7 +1673,7 @@
                             "cxx_type": "double",
                             "cxx_var": "d",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1716,7 +1716,7 @@
                             "cxx_type": "int",
                             "cxx_var": "i",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1757,7 +1757,7 @@
                         "cxx_type": "Cstruct1",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_STRUCT",
                         "stmt0": "c_struct_pointer_result_",
                         "stmt1": "c_struct_result"
                     },
@@ -1876,7 +1876,7 @@
                             "cxx_type": "double",
                             "cxx_var": "d",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1910,7 +1910,7 @@
                             "cxx_type": "int",
                             "cxx_var": "i",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1944,7 +1944,7 @@
                             "cxx_type": "char",
                             "cxx_var": "outbuf",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1977,7 +1977,7 @@
                         "cxx_type": "Cstruct1",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_STRUCT",
                         "stmt0": "c_struct_pointer_result_",
                         "stmt1": "c_struct_result"
                     },
@@ -2115,7 +2115,7 @@
                             "cxx_type": "double",
                             "cxx_var": "d",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_native_scalar_in_buf",
                             "stmt1": "c_default"
                         },
@@ -2142,7 +2142,7 @@
                             "cxx_type": "int",
                             "cxx_var": "i",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_buf",
                             "stmt1": "c_default"
                         },
@@ -2170,7 +2170,7 @@
                             "cxx_type": "char",
                             "cxx_var": "outbuf",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_out_buf",
                             "stmt1": "c_char_out_buf"
                         },
@@ -2195,7 +2195,7 @@
                         "cxx_type": "Cstruct1",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_STRUCT",
                         "stmt0": "c_struct_pointer_result_buf",
                         "stmt1": "c_struct_result"
                     }

--- a/regression/reference/struct-c/struct.json
+++ b/regression/reference/struct-c/struct.json
@@ -212,6 +212,7 @@
                             "cxx_type": "Cstruct1",
                             "cxx_var": "arg",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_struct_scalar_in_",
                             "stmt1": "c_struct"
                         },
@@ -256,6 +257,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -350,6 +352,7 @@
                             "cxx_type": "Cstruct1",
                             "cxx_var": "arg",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_struct_pointer_in_",
                             "stmt1": "c_struct"
                         },
@@ -394,6 +397,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -492,6 +496,7 @@
                             "cxx_type": "char",
                             "cxx_var": "outbuf",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -526,6 +531,7 @@
                             "cxx_type": "Cstruct1",
                             "cxx_var": "s1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_struct_pointer_in_",
                             "stmt1": "c_struct"
                         },
@@ -561,6 +567,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -680,6 +687,7 @@
                             "cxx_type": "char",
                             "cxx_var": "outbuf",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_out_buf",
                             "stmt1": "c_char_out_buf"
                         },
@@ -706,6 +714,7 @@
                             "cxx_type": "Cstruct1",
                             "cxx_var": "s1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_struct_pointer_in_buf",
                             "stmt1": "c_struct"
                         },
@@ -730,6 +739,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -828,6 +838,7 @@
                             "cxx_type": "Cstruct1",
                             "cxx_var": "arg",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_struct_pointer_in_",
                             "stmt1": "c_struct"
                         },
@@ -852,6 +863,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -937,6 +949,7 @@
                             "cxx_type": "Cstruct1",
                             "cxx_var": "arg",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_struct_pointer_out_",
                             "stmt1": "c_struct"
                         },
@@ -982,6 +995,7 @@
                             "cxx_type": "double",
                             "cxx_var": "d",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1024,6 +1038,7 @@
                             "cxx_type": "int",
                             "cxx_var": "i",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1158,6 +1173,7 @@
                             "cxx_type": "Cstruct1",
                             "cxx_var": "arg",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_struct_pointer_inout_",
                             "stmt1": "c_struct"
                         },
@@ -1264,6 +1280,7 @@
                             "cxx_type": "double",
                             "cxx_var": "d",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1306,6 +1323,7 @@
                             "cxx_type": "int",
                             "cxx_var": "i",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1346,6 +1364,7 @@
                         "cxx_type": "Cstruct1",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_struct_scalar_result_",
                         "stmt1": "c_struct_result"
                     },
@@ -1457,6 +1476,7 @@
                             "cxx_type": "double",
                             "cxx_var": "d",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1499,6 +1519,7 @@
                             "cxx_type": "int",
                             "cxx_var": "i",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1539,6 +1560,7 @@
                         "cxx_type": "Cstruct1",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_struct_scalar_result_",
                         "stmt1": "c_struct_result"
                     },
@@ -1651,6 +1673,7 @@
                             "cxx_type": "double",
                             "cxx_var": "d",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1693,6 +1716,7 @@
                             "cxx_type": "int",
                             "cxx_var": "i",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1733,6 +1757,7 @@
                         "cxx_type": "Cstruct1",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_struct_pointer_result_",
                         "stmt1": "c_struct_result"
                     },
@@ -1851,6 +1876,7 @@
                             "cxx_type": "double",
                             "cxx_var": "d",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1884,6 +1910,7 @@
                             "cxx_type": "int",
                             "cxx_var": "i",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1917,6 +1944,7 @@
                             "cxx_type": "char",
                             "cxx_var": "outbuf",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -1949,6 +1977,7 @@
                         "cxx_type": "Cstruct1",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_struct_pointer_result_",
                         "stmt1": "c_struct_result"
                     },
@@ -2086,6 +2115,7 @@
                             "cxx_type": "double",
                             "cxx_var": "d",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_buf",
                             "stmt1": "c_default"
                         },
@@ -2112,6 +2142,7 @@
                             "cxx_type": "int",
                             "cxx_var": "i",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_buf",
                             "stmt1": "c_default"
                         },
@@ -2139,6 +2170,7 @@
                             "cxx_type": "char",
                             "cxx_var": "outbuf",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_out_buf",
                             "stmt1": "c_char_out_buf"
                         },
@@ -2163,6 +2195,7 @@
                         "cxx_type": "Cstruct1",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_struct_pointer_result_buf",
                         "stmt1": "c_struct_result"
                     }

--- a/regression/reference/struct-cxx/struct.json
+++ b/regression/reference/struct-cxx/struct.json
@@ -333,6 +333,7 @@
                             "cxx_type": "Cstruct1",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_struct_scalar_in_",
                             "stmt1": "c_struct"
                         },
@@ -377,6 +378,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -471,6 +473,7 @@
                             "cxx_type": "Cstruct1",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_struct_pointer_in_",
                             "stmt1": "c_struct"
                         },
@@ -515,6 +518,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -613,6 +617,7 @@
                             "cxx_type": "char",
                             "cxx_var": "outbuf",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -647,6 +652,7 @@
                             "cxx_type": "Cstruct1",
                             "cxx_var": "SHCXX_s1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_struct_pointer_in_",
                             "stmt1": "c_struct"
                         },
@@ -682,6 +688,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -801,6 +808,7 @@
                             "cxx_type": "char",
                             "cxx_var": "outbuf",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_out_buf",
                             "stmt1": "c_char_out_buf"
                         },
@@ -827,6 +835,7 @@
                             "cxx_type": "Cstruct1",
                             "cxx_var": "SHCXX_s1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_struct_pointer_in_buf",
                             "stmt1": "c_struct"
                         },
@@ -851,6 +860,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -949,6 +959,7 @@
                             "cxx_type": "Cstruct1",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_struct_pointer_in_",
                             "stmt1": "c_struct"
                         },
@@ -973,6 +984,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -1058,6 +1070,7 @@
                             "cxx_type": "Cstruct1",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_struct_pointer_out_",
                             "stmt1": "c_struct"
                         },
@@ -1103,6 +1116,7 @@
                             "cxx_type": "double",
                             "cxx_var": "d",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1145,6 +1159,7 @@
                             "cxx_type": "int",
                             "cxx_var": "i",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1279,6 +1294,7 @@
                             "cxx_type": "Cstruct1",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_struct_pointer_inout_",
                             "stmt1": "c_struct"
                         },
@@ -1385,6 +1401,7 @@
                             "cxx_type": "double",
                             "cxx_var": "d",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1427,6 +1444,7 @@
                             "cxx_type": "int",
                             "cxx_var": "i",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1468,6 +1486,7 @@
                         "cxx_type": "Cstruct1",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_struct_scalar_result_",
                         "stmt1": "c_struct_result"
                     },
@@ -1579,6 +1598,7 @@
                             "cxx_type": "double",
                             "cxx_var": "d",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1621,6 +1641,7 @@
                             "cxx_type": "int",
                             "cxx_var": "i",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1662,6 +1683,7 @@
                         "cxx_type": "Cstruct1",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_struct_scalar_result_",
                         "stmt1": "c_struct_result"
                     },
@@ -1774,6 +1796,7 @@
                             "cxx_type": "double",
                             "cxx_var": "d",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1816,6 +1839,7 @@
                             "cxx_type": "int",
                             "cxx_var": "i",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1857,6 +1881,7 @@
                         "cxx_type": "Cstruct1",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_struct_pointer_result_",
                         "stmt1": "c_struct_result"
                     },
@@ -1975,6 +2000,7 @@
                             "cxx_type": "double",
                             "cxx_var": "d",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2008,6 +2034,7 @@
                             "cxx_type": "int",
                             "cxx_var": "i",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2041,6 +2068,7 @@
                             "cxx_type": "char",
                             "cxx_var": "outbuf",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -2074,6 +2102,7 @@
                         "cxx_type": "Cstruct1",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_struct_pointer_result_",
                         "stmt1": "c_struct_result"
                     },
@@ -2211,6 +2240,7 @@
                             "cxx_type": "double",
                             "cxx_var": "d",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_buf",
                             "stmt1": "c_default"
                         },
@@ -2237,6 +2267,7 @@
                             "cxx_type": "int",
                             "cxx_var": "i",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_buf",
                             "stmt1": "c_default"
                         },
@@ -2264,6 +2295,7 @@
                             "cxx_type": "char",
                             "cxx_var": "outbuf",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_char_pointer_out_buf",
                             "stmt1": "c_char_out_buf"
                         },
@@ -2289,6 +2321,7 @@
                         "cxx_type": "Cstruct1",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_struct_pointer_result_buf",
                         "stmt1": "c_struct_result"
                     }

--- a/regression/reference/struct-cxx/struct.json
+++ b/regression/reference/struct-cxx/struct.json
@@ -333,7 +333,7 @@
                             "cxx_type": "Cstruct1",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_STRUCT",
                             "stmt0": "c_struct_scalar_in_",
                             "stmt1": "c_struct"
                         },
@@ -378,7 +378,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -473,7 +473,7 @@
                             "cxx_type": "Cstruct1",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_STRUCT",
                             "stmt0": "c_struct_pointer_in_",
                             "stmt1": "c_struct"
                         },
@@ -518,7 +518,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -617,7 +617,7 @@
                             "cxx_type": "char",
                             "cxx_var": "outbuf",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -652,7 +652,7 @@
                             "cxx_type": "Cstruct1",
                             "cxx_var": "SHCXX_s1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_STRUCT",
                             "stmt0": "c_struct_pointer_in_",
                             "stmt1": "c_struct"
                         },
@@ -688,7 +688,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -808,7 +808,7 @@
                             "cxx_type": "char",
                             "cxx_var": "outbuf",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_out_buf",
                             "stmt1": "c_char_out_buf"
                         },
@@ -835,7 +835,7 @@
                             "cxx_type": "Cstruct1",
                             "cxx_var": "SHCXX_s1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_STRUCT",
                             "stmt0": "c_struct_pointer_in_buf",
                             "stmt1": "c_struct"
                         },
@@ -860,7 +860,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -959,7 +959,7 @@
                             "cxx_type": "Cstruct1",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_STRUCT",
                             "stmt0": "c_struct_pointer_in_",
                             "stmt1": "c_struct"
                         },
@@ -984,7 +984,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -1070,7 +1070,7 @@
                             "cxx_type": "Cstruct1",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_STRUCT",
                             "stmt0": "c_struct_pointer_out_",
                             "stmt1": "c_struct"
                         },
@@ -1116,7 +1116,7 @@
                             "cxx_type": "double",
                             "cxx_var": "d",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1159,7 +1159,7 @@
                             "cxx_type": "int",
                             "cxx_var": "i",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1294,7 +1294,7 @@
                             "cxx_type": "Cstruct1",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_STRUCT",
                             "stmt0": "c_struct_pointer_inout_",
                             "stmt1": "c_struct"
                         },
@@ -1401,7 +1401,7 @@
                             "cxx_type": "double",
                             "cxx_var": "d",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1444,7 +1444,7 @@
                             "cxx_type": "int",
                             "cxx_var": "i",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1486,7 +1486,7 @@
                         "cxx_type": "Cstruct1",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_STRUCT",
                         "stmt0": "c_struct_scalar_result_",
                         "stmt1": "c_struct_result"
                     },
@@ -1598,7 +1598,7 @@
                             "cxx_type": "double",
                             "cxx_var": "d",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1641,7 +1641,7 @@
                             "cxx_type": "int",
                             "cxx_var": "i",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1683,7 +1683,7 @@
                         "cxx_type": "Cstruct1",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_STRUCT",
                         "stmt0": "c_struct_scalar_result_",
                         "stmt1": "c_struct_result"
                     },
@@ -1796,7 +1796,7 @@
                             "cxx_type": "double",
                             "cxx_var": "d",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1839,7 +1839,7 @@
                             "cxx_type": "int",
                             "cxx_var": "i",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1881,7 +1881,7 @@
                         "cxx_type": "Cstruct1",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_STRUCT",
                         "stmt0": "c_struct_pointer_result_",
                         "stmt1": "c_struct_result"
                     },
@@ -2000,7 +2000,7 @@
                             "cxx_type": "double",
                             "cxx_var": "d",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2034,7 +2034,7 @@
                             "cxx_type": "int",
                             "cxx_var": "i",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2068,7 +2068,7 @@
                             "cxx_type": "char",
                             "cxx_var": "outbuf",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -2102,7 +2102,7 @@
                         "cxx_type": "Cstruct1",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_STRUCT",
                         "stmt0": "c_struct_pointer_result_",
                         "stmt1": "c_struct_result"
                     },
@@ -2240,7 +2240,7 @@
                             "cxx_type": "double",
                             "cxx_var": "d",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_native_scalar_in_buf",
                             "stmt1": "c_default"
                         },
@@ -2267,7 +2267,7 @@
                             "cxx_type": "int",
                             "cxx_var": "i",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_buf",
                             "stmt1": "c_default"
                         },
@@ -2295,7 +2295,7 @@
                             "cxx_type": "char",
                             "cxx_var": "outbuf",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_pointer_out_buf",
                             "stmt1": "c_char_out_buf"
                         },
@@ -2321,7 +2321,7 @@
                         "cxx_type": "Cstruct1",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_STRUCT",
                         "stmt0": "c_struct_pointer_result_buf",
                         "stmt1": "c_struct_result"
                     }

--- a/regression/reference/templates/templates.json
+++ b/regression/reference/templates/templates.json
@@ -148,6 +148,7 @@
                                     "cxx_type": "int",
                                     "cxx_var": "arg1",
                                     "idtor": "0",
+                                    "sh_type": "0",
                                     "stmt0": "c_native_scalar_in_",
                                     "stmt1": "c_default"
                                 },
@@ -190,6 +191,7 @@
                                     "cxx_type": "double",
                                     "cxx_var": "arg2",
                                     "idtor": "0",
+                                    "sh_type": "0",
                                     "stmt0": "c_native_scalar_in_",
                                     "stmt1": "c_default"
                                 },
@@ -577,6 +579,7 @@
                             "cxx_type": "int",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -619,6 +622,7 @@
                             "cxx_type": "long",
                             "cxx_var": "arg2",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -785,6 +789,7 @@
                             "cxx_type": "float",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -827,6 +832,7 @@
                             "cxx_type": "double",
                             "cxx_var": "arg2",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1061,6 +1067,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -1173,6 +1180,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -1319,6 +1327,7 @@
                                         "cxx_type": "std::vector<int>",
                                         "cxx_var": "SHCXX_rv",
                                         "idtor": "0",
+                                        "sh_type": "0",
                                         "stmt0": "c_shadow_scalar_ctor_",
                                         "stmt1": "c_shadow_ctor"
                                     },
@@ -1487,6 +1496,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "value",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_pointer_in_",
                                             "stmt1": "c_default"
                                         },
@@ -1647,6 +1657,7 @@
                                             "cxx_type": "std::vector::size_type",
                                             "cxx_var": "n",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -1687,6 +1698,7 @@
                                         "cxx_type": "int",
                                         "cxx_var": "SHC_rv",
                                         "idtor": "0",
+                                        "sh_type": "0",
                                         "stmt0": "c_native_pointer_result_",
                                         "stmt1": "c_default"
                                     },
@@ -1859,6 +1871,7 @@
                                         "cxx_type": "std::vector<double>",
                                         "cxx_var": "SHCXX_rv",
                                         "idtor": "0",
+                                        "sh_type": "0",
                                         "stmt0": "c_shadow_scalar_ctor_",
                                         "stmt1": "c_shadow_ctor"
                                     },
@@ -2027,6 +2040,7 @@
                                             "cxx_type": "double",
                                             "cxx_var": "value",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_pointer_in_",
                                             "stmt1": "c_default"
                                         },
@@ -2187,6 +2201,7 @@
                                             "cxx_type": "std::vector::size_type",
                                             "cxx_var": "n",
                                             "idtor": "0",
+                                            "sh_type": "0",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -2227,6 +2242,7 @@
                                         "cxx_type": "double",
                                         "cxx_var": "SHC_rv",
                                         "idtor": "0",
+                                        "sh_type": "0",
                                         "stmt0": "c_native_pointer_result_",
                                         "stmt1": "c_default"
                                     },

--- a/regression/reference/templates/templates.json
+++ b/regression/reference/templates/templates.json
@@ -148,7 +148,7 @@
                                     "cxx_type": "int",
                                     "cxx_var": "arg1",
                                     "idtor": "0",
-                                    "sh_type": "0",
+                                    "sh_type": "SH_TYPE_INT",
                                     "stmt0": "c_native_scalar_in_",
                                     "stmt1": "c_default"
                                 },
@@ -191,7 +191,7 @@
                                     "cxx_type": "double",
                                     "cxx_var": "arg2",
                                     "idtor": "0",
-                                    "sh_type": "0",
+                                    "sh_type": "SH_TYPE_DOUBLE",
                                     "stmt0": "c_native_scalar_in_",
                                     "stmt1": "c_default"
                                 },
@@ -579,7 +579,7 @@
                             "cxx_type": "int",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -622,7 +622,7 @@
                             "cxx_type": "long",
                             "cxx_var": "arg2",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_LONG",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -789,7 +789,7 @@
                             "cxx_type": "float",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_FLOAT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -832,7 +832,7 @@
                             "cxx_type": "double",
                             "cxx_var": "arg2",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1067,7 +1067,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -1180,7 +1180,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -1327,7 +1327,7 @@
                                         "cxx_type": "std::vector<int>",
                                         "cxx_var": "SHCXX_rv",
                                         "idtor": "0",
-                                        "sh_type": "0",
+                                        "sh_type": "SH_TYPE_OTHER",
                                         "stmt0": "c_shadow_scalar_ctor_",
                                         "stmt1": "c_shadow_ctor"
                                     },
@@ -1496,7 +1496,7 @@
                                             "cxx_type": "int",
                                             "cxx_var": "value",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_INT",
                                             "stmt0": "c_native_pointer_in_",
                                             "stmt1": "c_default"
                                         },
@@ -1657,7 +1657,7 @@
                                             "cxx_type": "std::vector::size_type",
                                             "cxx_var": "n",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_SIZE_T",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -1698,7 +1698,7 @@
                                         "cxx_type": "int",
                                         "cxx_var": "SHC_rv",
                                         "idtor": "0",
-                                        "sh_type": "0",
+                                        "sh_type": "SH_TYPE_INT",
                                         "stmt0": "c_native_pointer_result_",
                                         "stmt1": "c_default"
                                     },
@@ -1871,7 +1871,7 @@
                                         "cxx_type": "std::vector<double>",
                                         "cxx_var": "SHCXX_rv",
                                         "idtor": "0",
-                                        "sh_type": "0",
+                                        "sh_type": "SH_TYPE_OTHER",
                                         "stmt0": "c_shadow_scalar_ctor_",
                                         "stmt1": "c_shadow_ctor"
                                     },
@@ -2040,7 +2040,7 @@
                                             "cxx_type": "double",
                                             "cxx_var": "value",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_DOUBLE",
                                             "stmt0": "c_native_pointer_in_",
                                             "stmt1": "c_default"
                                         },
@@ -2201,7 +2201,7 @@
                                             "cxx_type": "std::vector::size_type",
                                             "cxx_var": "n",
                                             "idtor": "0",
-                                            "sh_type": "0",
+                                            "sh_type": "SH_TYPE_SIZE_T",
                                             "stmt0": "c_native_scalar_in_",
                                             "stmt1": "c_default"
                                         },
@@ -2242,7 +2242,7 @@
                                         "cxx_type": "double",
                                         "cxx_var": "SHC_rv",
                                         "idtor": "0",
-                                        "sh_type": "0",
+                                        "sh_type": "SH_TYPE_DOUBLE",
                                         "stmt0": "c_native_pointer_result_",
                                         "stmt1": "c_default"
                                     },

--- a/regression/reference/tutorial/tutorial.json
+++ b/regression/reference/tutorial/tutorial.json
@@ -118,7 +118,7 @@
                                 "cxx_type": "tutorial::Class1",
                                 "cxx_var": "SHCXX_rv",
                                 "idtor": "0",
-                                "sh_type": "0",
+                                "sh_type": "SH_TYPE_OTHER",
                                 "stmt0": "c_shadow_scalar_ctor_",
                                 "stmt1": "c_shadow_ctor"
                             },
@@ -212,7 +212,7 @@
                                     "cxx_type": "int",
                                     "cxx_var": "flag",
                                     "idtor": "0",
-                                    "sh_type": "0",
+                                    "sh_type": "SH_TYPE_INT",
                                     "stmt0": "c_native_scalar_in_",
                                     "stmt1": "c_default"
                                 },
@@ -263,7 +263,7 @@
                                 "cxx_type": "tutorial::Class1",
                                 "cxx_var": "SHCXX_rv",
                                 "idtor": "0",
-                                "sh_type": "0",
+                                "sh_type": "SH_TYPE_OTHER",
                                 "stmt0": "c_shadow_scalar_ctor_",
                                 "stmt1": "c_shadow_ctor"
                             },
@@ -410,7 +410,7 @@
                                 "cxx_type": "int",
                                 "cxx_var": "SHC_rv",
                                 "idtor": "0",
-                                "sh_type": "0",
+                                "sh_type": "SH_TYPE_INT",
                                 "stmt0": "c_native_scalar_result_",
                                 "stmt1": "c_default"
                             },
@@ -501,7 +501,7 @@
                                     "cxx_type": "tutorial::Class1",
                                     "cxx_var": "SHCXX_obj2",
                                     "idtor": "0",
-                                    "sh_type": "0",
+                                    "sh_type": "SH_TYPE_OTHER",
                                     "stmt0": "c_shadow_pointer_in_",
                                     "stmt1": "c_shadow_in"
                                 },
@@ -545,7 +545,7 @@
                                 "cxx_type": "bool",
                                 "cxx_var": "SHC_rv",
                                 "idtor": "0",
-                                "sh_type": "0",
+                                "sh_type": "SH_TYPE_BOOL",
                                 "stmt0": "c_bool_scalar_result_",
                                 "stmt1": "c_default"
                             },
@@ -707,7 +707,7 @@
                                     "cxx_type": "bool",
                                     "cxx_var": "flag",
                                     "idtor": "0",
-                                    "sh_type": "0",
+                                    "sh_type": "SH_TYPE_BOOL",
                                     "stmt0": "c_bool_scalar_in_",
                                     "stmt1": "c_default"
                                 }
@@ -725,7 +725,7 @@
                                     "cxx_type": "std::string",
                                     "cxx_var": "SHCXX_name",
                                     "idtor": "0",
-                                    "sh_type": "0",
+                                    "sh_type": "SH_TYPE_OTHER",
                                     "stmt0": "c_string_pointer_in_",
                                     "stmt1": "c_string_in"
                                 }
@@ -741,7 +741,7 @@
                                 "cxx_type": "tutorial::Class1",
                                 "cxx_var": "SHCXX_rv",
                                 "idtor": "0",
-                                "sh_type": "0",
+                                "sh_type": "SH_TYPE_OTHER",
                                 "stmt0": "c_shadow_pointer_result_",
                                 "stmt1": "c_shadow_result"
                             },
@@ -853,7 +853,7 @@
                                     "cxx_type": "bool",
                                     "cxx_var": "flag",
                                     "idtor": "0",
-                                    "sh_type": "0",
+                                    "sh_type": "SH_TYPE_BOOL",
                                     "stmt0": "c_bool_scalar_in_buf",
                                     "stmt1": "c_default"
                                 },
@@ -881,7 +881,7 @@
                                     "cxx_type": "std::string",
                                     "cxx_var": "SHCXX_name",
                                     "idtor": "0",
-                                    "sh_type": "0",
+                                    "sh_type": "SH_TYPE_OTHER",
                                     "stmt0": "c_string_pointer_in_buf",
                                     "stmt1": "c_string_in_buf"
                                 },
@@ -906,7 +906,7 @@
                                 "cxx_type": "tutorial::Class1",
                                 "cxx_var": "SHCXX_rv",
                                 "idtor": "0",
-                                "sh_type": "0",
+                                "sh_type": "SH_TYPE_OTHER",
                                 "stmt0": "c_shadow_pointer_result_buf",
                                 "stmt1": "c_shadow_result"
                             }
@@ -1004,7 +1004,7 @@
                                 "cxx_type": "tutorial::Class1",
                                 "cxx_var": "SHCXX_rv",
                                 "idtor": "0",
-                                "sh_type": "0",
+                                "sh_type": "SH_TYPE_OTHER",
                                 "stmt0": "c_shadow_pointer_result_",
                                 "stmt1": "c_shadow_result"
                             },
@@ -1099,7 +1099,7 @@
                                     "cxx_val": "static_cast<tutorial::Class1::DIRECTION>(arg)",
                                     "cxx_var": "SHCXX_arg",
                                     "idtor": "0",
-                                    "sh_type": "0",
+                                    "sh_type": "SH_TYPE_INT",
                                     "stmt0": "c_native_scalar_in_",
                                     "stmt1": "c_default"
                                 },
@@ -1154,7 +1154,7 @@
                                 "cxx_type": "tutorial::Class1::DIRECTION",
                                 "cxx_var": "SHCXX_rv",
                                 "idtor": "0",
-                                "sh_type": "0",
+                                "sh_type": "SH_TYPE_INT",
                                 "stmt0": "c_native_scalar_result_",
                                 "stmt1": "c_default"
                             },
@@ -1254,7 +1254,7 @@
                                 "cxx_type": "int",
                                 "cxx_var": "SHC_rv",
                                 "idtor": "0",
-                                "sh_type": "0",
+                                "sh_type": "SH_TYPE_INT",
                                 "stmt0": "c_native_scalar_result_",
                                 "stmt1": "c_default"
                             },
@@ -1324,7 +1324,7 @@
                                 "cxx_type": "int",
                                 "cxx_var": "SHC_rv",
                                 "idtor": "0",
-                                "sh_type": "0",
+                                "sh_type": "SH_TYPE_INT",
                                 "stmt0": "c_native_scalar_result_",
                                 "stmt1": "c_default"
                             },
@@ -1398,7 +1398,7 @@
                                     "cxx_type": "int",
                                     "cxx_var": "val",
                                     "idtor": "0",
-                                    "sh_type": "0",
+                                    "sh_type": "SH_TYPE_INT",
                                     "stmt0": "c_native_scalar_in_",
                                     "stmt1": "c_default"
                                 },
@@ -1576,7 +1576,7 @@
                                 "cxx_type": "tutorial::Singleton",
                                 "cxx_var": "SHCXX_rv",
                                 "idtor": "0",
-                                "sh_type": "0",
+                                "sh_type": "SH_TYPE_OTHER",
                                 "stmt0": "c_shadow_pointer_result_",
                                 "stmt1": "c_shadow_result"
                             },
@@ -1902,7 +1902,7 @@
                             "cxx_type": "double",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1956,7 +1956,7 @@
                             "cxx_type": "int",
                             "cxx_var": "arg2",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2008,7 +2008,7 @@
                         "cxx_type": "double",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2294,7 +2294,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "2",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_scalar_result_buf_allocatable",
                             "stmt1": "c_string_scalar_result_buf_allocatable"
                         },
@@ -2323,7 +2323,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_pointer_in_buf",
                             "stmt1": "c_string_in_buf"
                         },
@@ -2351,7 +2351,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_arg2",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_pointer_in_buf",
                             "stmt1": "c_string_in_buf"
                         },
@@ -2375,7 +2375,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_CPTR",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -2493,7 +2493,7 @@
                         "cxx_type": "double",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2570,7 +2570,7 @@
                             "cxx_type": "double",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2595,7 +2595,7 @@
                         "cxx_type": "double",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2694,7 +2694,7 @@
                             "cxx_type": "double",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2748,7 +2748,7 @@
                             "cxx_type": "bool",
                             "cxx_var": "arg2",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_BOOL",
                             "stmt0": "c_bool_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2802,7 +2802,7 @@
                         "cxx_type": "double",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2933,7 +2933,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_name",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_pointer_in_",
                             "stmt1": "c_string_in"
                         },
@@ -3045,7 +3045,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_name",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_pointer_in_buf",
                             "stmt1": "c_string_in_buf"
                         },
@@ -3132,7 +3132,7 @@
                             "cxx_type": "int",
                             "cxx_var": "indx",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -3321,7 +3321,7 @@
                             "cxx_type": "int",
                             "cxx_var": "arg",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -3470,7 +3470,7 @@
                             "cxx_type": "double",
                             "cxx_var": "arg",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -3679,7 +3679,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -3776,7 +3776,7 @@
                         "cxx_type": "double",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -3922,7 +3922,7 @@
                             "cxx_type": "double",
                             "cxx_var": "arg2",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -3967,7 +3967,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_name",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_pointer_in_",
                             "stmt1": "c_string_in"
                         },
@@ -4314,7 +4314,7 @@
                             "cxx_type": "double",
                             "cxx_var": "arg2",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_native_scalar_in_buf",
                             "stmt1": "c_default"
                         },
@@ -4342,7 +4342,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_name",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_pointer_in_buf",
                             "stmt1": "c_string_in_buf"
                         },
@@ -4525,7 +4525,7 @@
                             "cxx_type": "int",
                             "cxx_var": "num",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -4550,7 +4550,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -4642,7 +4642,7 @@
                             "cxx_type": "int",
                             "cxx_var": "num",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -4669,7 +4669,7 @@
                             "cxx_type": "int",
                             "cxx_var": "offset",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -4694,7 +4694,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -4805,7 +4805,7 @@
                             "cxx_type": "int",
                             "cxx_var": "num",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -4859,7 +4859,7 @@
                             "cxx_type": "int",
                             "cxx_var": "offset",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -4913,7 +4913,7 @@
                             "cxx_type": "int",
                             "cxx_var": "stride",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -4965,7 +4965,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -5107,7 +5107,7 @@
                             "cxx_type": "int",
                             "cxx_var": "num",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -5134,7 +5134,7 @@
                             "cxx_type": "double",
                             "cxx_var": "type",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -5159,7 +5159,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -5260,7 +5260,7 @@
                             "cxx_type": "int",
                             "cxx_var": "num",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -5287,7 +5287,7 @@
                             "cxx_type": "int",
                             "cxx_var": "offset",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -5314,7 +5314,7 @@
                             "cxx_type": "double",
                             "cxx_var": "type",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -5339,7 +5339,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -5459,7 +5459,7 @@
                             "cxx_type": "int",
                             "cxx_var": "num",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -5513,7 +5513,7 @@
                             "cxx_type": "int",
                             "cxx_var": "offset",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -5567,7 +5567,7 @@
                             "cxx_type": "int",
                             "cxx_var": "stride",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -5621,7 +5621,7 @@
                             "cxx_type": "double",
                             "cxx_var": "type",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -5673,7 +5673,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -5822,7 +5822,7 @@
                             "cxx_type": "tutorial::TypeID",
                             "cxx_var": "arg",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -5874,7 +5874,7 @@
                         "cxx_type": "tutorial::TypeID",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -5976,7 +5976,7 @@
                             "cxx_val": "static_cast<tutorial::EnumTypeID>(arg)",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -6031,7 +6031,7 @@
                         "cxx_type": "tutorial::EnumTypeID",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -6134,7 +6134,7 @@
                             "cxx_val": "static_cast<tutorial::Color>(arg)",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -6189,7 +6189,7 @@
                         "cxx_type": "tutorial::Color",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -6290,7 +6290,7 @@
                             "cxx_type": "int",
                             "cxx_var": "max",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -6333,7 +6333,7 @@
                             "cxx_type": "int",
                             "cxx_var": "min",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -6464,7 +6464,7 @@
                             "cxx_val": "static_cast<tutorial::Class1::DIRECTION>(arg)",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -6519,7 +6519,7 @@
                         "cxx_type": "tutorial::Class1::DIRECTION",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -6620,7 +6620,7 @@
                             "cxx_type": "tutorial::Class1",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_shadow_scalar_in_",
                             "stmt1": "c_shadow_in"
                         },
@@ -6729,7 +6729,7 @@
                             "cxx_type": "tutorial::Class1",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_shadow_pointer_in_",
                             "stmt1": "c_shadow_in"
                         },
@@ -6773,7 +6773,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -6869,7 +6869,7 @@
                         "cxx_type": "tutorial::Class1",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "c_shadow_pointer_result_",
                         "stmt1": "c_shadow_result"
                     },
@@ -6937,7 +6937,7 @@
                         "cxx_type": "tutorial::Class1",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "c_shadow_pointer_result_",
                         "stmt1": "c_shadow_result"
                     },
@@ -7018,7 +7018,7 @@
                         "cxx_type": "tutorial::Class1",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "c_shadow_pointer_result_",
                         "stmt1": "c_shadow_result"
                     },
@@ -7086,7 +7086,7 @@
                         "cxx_type": "tutorial::Class1",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "c_shadow_pointer_result_",
                         "stmt1": "c_shadow_result"
                     },
@@ -7171,7 +7171,7 @@
                             "cxx_type": "int",
                             "cxx_var": "flag",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -7196,7 +7196,7 @@
                         "cxx_type": "tutorial::Class1",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "1",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "c_shadow_scalar_result_",
                         "stmt1": "c_shadow_scalar_result"
                     },
@@ -7283,7 +7283,7 @@
                             "cxx_type": "int",
                             "cxx_var": "in",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -7310,7 +7310,7 @@
                             "cxx_type": "int",
                             "cxx_var": "incr",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -7330,7 +7330,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -7450,7 +7450,7 @@
                             "cxx_type": "int",
                             "cxx_var": "arg",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -7558,7 +7558,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -7638,7 +7638,7 @@
                         "cxx_type": "std::string",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "c_string_pointer_result_",
                         "stmt1": "c_string_result"
                     },
@@ -7734,7 +7734,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_string_pointer_result_buf_",
                             "stmt1": "c_string_result_buf"
                         },
@@ -7758,7 +7758,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_CPTR",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }

--- a/regression/reference/tutorial/tutorial.json
+++ b/regression/reference/tutorial/tutorial.json
@@ -118,6 +118,7 @@
                                 "cxx_type": "tutorial::Class1",
                                 "cxx_var": "SHCXX_rv",
                                 "idtor": "0",
+                                "sh_type": "0",
                                 "stmt0": "c_shadow_scalar_ctor_",
                                 "stmt1": "c_shadow_ctor"
                             },
@@ -211,6 +212,7 @@
                                     "cxx_type": "int",
                                     "cxx_var": "flag",
                                     "idtor": "0",
+                                    "sh_type": "0",
                                     "stmt0": "c_native_scalar_in_",
                                     "stmt1": "c_default"
                                 },
@@ -261,6 +263,7 @@
                                 "cxx_type": "tutorial::Class1",
                                 "cxx_var": "SHCXX_rv",
                                 "idtor": "0",
+                                "sh_type": "0",
                                 "stmt0": "c_shadow_scalar_ctor_",
                                 "stmt1": "c_shadow_ctor"
                             },
@@ -407,6 +410,7 @@
                                 "cxx_type": "int",
                                 "cxx_var": "SHC_rv",
                                 "idtor": "0",
+                                "sh_type": "0",
                                 "stmt0": "c_native_scalar_result_",
                                 "stmt1": "c_default"
                             },
@@ -497,6 +501,7 @@
                                     "cxx_type": "tutorial::Class1",
                                     "cxx_var": "SHCXX_obj2",
                                     "idtor": "0",
+                                    "sh_type": "0",
                                     "stmt0": "c_shadow_pointer_in_",
                                     "stmt1": "c_shadow_in"
                                 },
@@ -540,6 +545,7 @@
                                 "cxx_type": "bool",
                                 "cxx_var": "SHC_rv",
                                 "idtor": "0",
+                                "sh_type": "0",
                                 "stmt0": "c_bool_scalar_result_",
                                 "stmt1": "c_default"
                             },
@@ -701,6 +707,7 @@
                                     "cxx_type": "bool",
                                     "cxx_var": "flag",
                                     "idtor": "0",
+                                    "sh_type": "0",
                                     "stmt0": "c_bool_scalar_in_",
                                     "stmt1": "c_default"
                                 }
@@ -718,6 +725,7 @@
                                     "cxx_type": "std::string",
                                     "cxx_var": "SHCXX_name",
                                     "idtor": "0",
+                                    "sh_type": "0",
                                     "stmt0": "c_string_pointer_in_",
                                     "stmt1": "c_string_in"
                                 }
@@ -733,6 +741,7 @@
                                 "cxx_type": "tutorial::Class1",
                                 "cxx_var": "SHCXX_rv",
                                 "idtor": "0",
+                                "sh_type": "0",
                                 "stmt0": "c_shadow_pointer_result_",
                                 "stmt1": "c_shadow_result"
                             },
@@ -844,6 +853,7 @@
                                     "cxx_type": "bool",
                                     "cxx_var": "flag",
                                     "idtor": "0",
+                                    "sh_type": "0",
                                     "stmt0": "c_bool_scalar_in_buf",
                                     "stmt1": "c_default"
                                 },
@@ -871,6 +881,7 @@
                                     "cxx_type": "std::string",
                                     "cxx_var": "SHCXX_name",
                                     "idtor": "0",
+                                    "sh_type": "0",
                                     "stmt0": "c_string_pointer_in_buf",
                                     "stmt1": "c_string_in_buf"
                                 },
@@ -895,6 +906,7 @@
                                 "cxx_type": "tutorial::Class1",
                                 "cxx_var": "SHCXX_rv",
                                 "idtor": "0",
+                                "sh_type": "0",
                                 "stmt0": "c_shadow_pointer_result_buf",
                                 "stmt1": "c_shadow_result"
                             }
@@ -992,6 +1004,7 @@
                                 "cxx_type": "tutorial::Class1",
                                 "cxx_var": "SHCXX_rv",
                                 "idtor": "0",
+                                "sh_type": "0",
                                 "stmt0": "c_shadow_pointer_result_",
                                 "stmt1": "c_shadow_result"
                             },
@@ -1086,6 +1099,7 @@
                                     "cxx_val": "static_cast<tutorial::Class1::DIRECTION>(arg)",
                                     "cxx_var": "SHCXX_arg",
                                     "idtor": "0",
+                                    "sh_type": "0",
                                     "stmt0": "c_native_scalar_in_",
                                     "stmt1": "c_default"
                                 },
@@ -1140,6 +1154,7 @@
                                 "cxx_type": "tutorial::Class1::DIRECTION",
                                 "cxx_var": "SHCXX_rv",
                                 "idtor": "0",
+                                "sh_type": "0",
                                 "stmt0": "c_native_scalar_result_",
                                 "stmt1": "c_default"
                             },
@@ -1239,6 +1254,7 @@
                                 "cxx_type": "int",
                                 "cxx_var": "SHC_rv",
                                 "idtor": "0",
+                                "sh_type": "0",
                                 "stmt0": "c_native_scalar_result_",
                                 "stmt1": "c_default"
                             },
@@ -1308,6 +1324,7 @@
                                 "cxx_type": "int",
                                 "cxx_var": "SHC_rv",
                                 "idtor": "0",
+                                "sh_type": "0",
                                 "stmt0": "c_native_scalar_result_",
                                 "stmt1": "c_default"
                             },
@@ -1381,6 +1398,7 @@
                                     "cxx_type": "int",
                                     "cxx_var": "val",
                                     "idtor": "0",
+                                    "sh_type": "0",
                                     "stmt0": "c_native_scalar_in_",
                                     "stmt1": "c_default"
                                 },
@@ -1558,6 +1576,7 @@
                                 "cxx_type": "tutorial::Singleton",
                                 "cxx_var": "SHCXX_rv",
                                 "idtor": "0",
+                                "sh_type": "0",
                                 "stmt0": "c_shadow_pointer_result_",
                                 "stmt1": "c_shadow_result"
                             },
@@ -1883,6 +1902,7 @@
                             "cxx_type": "double",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1936,6 +1956,7 @@
                             "cxx_type": "int",
                             "cxx_var": "arg2",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1987,6 +2008,7 @@
                         "cxx_type": "double",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2272,6 +2294,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "2",
+                            "sh_type": "0",
                             "stmt0": "c_string_scalar_result_buf_allocatable",
                             "stmt1": "c_string_scalar_result_buf_allocatable"
                         },
@@ -2300,6 +2323,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_string_pointer_in_buf",
                             "stmt1": "c_string_in_buf"
                         },
@@ -2327,6 +2351,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_arg2",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_string_pointer_in_buf",
                             "stmt1": "c_string_in_buf"
                         },
@@ -2350,6 +2375,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -2467,6 +2493,7 @@
                         "cxx_type": "double",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2543,6 +2570,7 @@
                             "cxx_type": "double",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2567,6 +2595,7 @@
                         "cxx_type": "double",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2665,6 +2694,7 @@
                             "cxx_type": "double",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2718,6 +2748,7 @@
                             "cxx_type": "bool",
                             "cxx_var": "arg2",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_bool_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2771,6 +2802,7 @@
                         "cxx_type": "double",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2901,6 +2933,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_name",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_string_pointer_in_",
                             "stmt1": "c_string_in"
                         },
@@ -3012,6 +3045,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_name",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_string_pointer_in_buf",
                             "stmt1": "c_string_in_buf"
                         },
@@ -3098,6 +3132,7 @@
                             "cxx_type": "int",
                             "cxx_var": "indx",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -3286,6 +3321,7 @@
                             "cxx_type": "int",
                             "cxx_var": "arg",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -3434,6 +3470,7 @@
                             "cxx_type": "double",
                             "cxx_var": "arg",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -3642,6 +3679,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -3738,6 +3776,7 @@
                         "cxx_type": "double",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -3883,6 +3922,7 @@
                             "cxx_type": "double",
                             "cxx_var": "arg2",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -3927,6 +3967,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_name",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_string_pointer_in_",
                             "stmt1": "c_string_in"
                         },
@@ -4273,6 +4314,7 @@
                             "cxx_type": "double",
                             "cxx_var": "arg2",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_buf",
                             "stmt1": "c_default"
                         },
@@ -4300,6 +4342,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_name",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_string_pointer_in_buf",
                             "stmt1": "c_string_in_buf"
                         },
@@ -4482,6 +4525,7 @@
                             "cxx_type": "int",
                             "cxx_var": "num",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -4506,6 +4550,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -4597,6 +4642,7 @@
                             "cxx_type": "int",
                             "cxx_var": "num",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -4623,6 +4669,7 @@
                             "cxx_type": "int",
                             "cxx_var": "offset",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -4647,6 +4694,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -4757,6 +4805,7 @@
                             "cxx_type": "int",
                             "cxx_var": "num",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -4810,6 +4859,7 @@
                             "cxx_type": "int",
                             "cxx_var": "offset",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -4863,6 +4913,7 @@
                             "cxx_type": "int",
                             "cxx_var": "stride",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -4914,6 +4965,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -5055,6 +5107,7 @@
                             "cxx_type": "int",
                             "cxx_var": "num",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -5081,6 +5134,7 @@
                             "cxx_type": "double",
                             "cxx_var": "type",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -5105,6 +5159,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -5205,6 +5260,7 @@
                             "cxx_type": "int",
                             "cxx_var": "num",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -5231,6 +5287,7 @@
                             "cxx_type": "int",
                             "cxx_var": "offset",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -5257,6 +5314,7 @@
                             "cxx_type": "double",
                             "cxx_var": "type",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -5281,6 +5339,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -5400,6 +5459,7 @@
                             "cxx_type": "int",
                             "cxx_var": "num",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -5453,6 +5513,7 @@
                             "cxx_type": "int",
                             "cxx_var": "offset",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -5506,6 +5567,7 @@
                             "cxx_type": "int",
                             "cxx_var": "stride",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -5559,6 +5621,7 @@
                             "cxx_type": "double",
                             "cxx_var": "type",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -5610,6 +5673,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -5758,6 +5822,7 @@
                             "cxx_type": "tutorial::TypeID",
                             "cxx_var": "arg",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -5809,6 +5874,7 @@
                         "cxx_type": "tutorial::TypeID",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -5910,6 +5976,7 @@
                             "cxx_val": "static_cast<tutorial::EnumTypeID>(arg)",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -5964,6 +6031,7 @@
                         "cxx_type": "tutorial::EnumTypeID",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -6066,6 +6134,7 @@
                             "cxx_val": "static_cast<tutorial::Color>(arg)",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -6120,6 +6189,7 @@
                         "cxx_type": "tutorial::Color",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -6220,6 +6290,7 @@
                             "cxx_type": "int",
                             "cxx_var": "max",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -6262,6 +6333,7 @@
                             "cxx_type": "int",
                             "cxx_var": "min",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -6392,6 +6464,7 @@
                             "cxx_val": "static_cast<tutorial::Class1::DIRECTION>(arg)",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -6446,6 +6519,7 @@
                         "cxx_type": "tutorial::Class1::DIRECTION",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -6546,6 +6620,7 @@
                             "cxx_type": "tutorial::Class1",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_shadow_scalar_in_",
                             "stmt1": "c_shadow_in"
                         },
@@ -6654,6 +6729,7 @@
                             "cxx_type": "tutorial::Class1",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_shadow_pointer_in_",
                             "stmt1": "c_shadow_in"
                         },
@@ -6697,6 +6773,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -6792,6 +6869,7 @@
                         "cxx_type": "tutorial::Class1",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_shadow_pointer_result_",
                         "stmt1": "c_shadow_result"
                     },
@@ -6859,6 +6937,7 @@
                         "cxx_type": "tutorial::Class1",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_shadow_pointer_result_",
                         "stmt1": "c_shadow_result"
                     },
@@ -6939,6 +7018,7 @@
                         "cxx_type": "tutorial::Class1",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_shadow_pointer_result_",
                         "stmt1": "c_shadow_result"
                     },
@@ -7006,6 +7086,7 @@
                         "cxx_type": "tutorial::Class1",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_shadow_pointer_result_",
                         "stmt1": "c_shadow_result"
                     },
@@ -7090,6 +7171,7 @@
                             "cxx_type": "int",
                             "cxx_var": "flag",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -7114,6 +7196,7 @@
                         "cxx_type": "tutorial::Class1",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "1",
+                        "sh_type": "0",
                         "stmt0": "c_shadow_scalar_result_",
                         "stmt1": "c_shadow_scalar_result"
                     },
@@ -7200,6 +7283,7 @@
                             "cxx_type": "int",
                             "cxx_var": "in",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -7226,6 +7310,7 @@
                             "cxx_type": "int",
                             "cxx_var": "incr",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -7245,6 +7330,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -7364,6 +7450,7 @@
                             "cxx_type": "int",
                             "cxx_var": "arg",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -7471,6 +7558,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -7550,6 +7638,7 @@
                         "cxx_type": "std::string",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_string_pointer_result_",
                         "stmt1": "c_string_result"
                     },
@@ -7645,6 +7734,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_rv",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_string_pointer_result_buf_",
                             "stmt1": "c_string_result_buf"
                         },
@@ -7668,6 +7758,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHCXX_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }

--- a/regression/reference/tutorial/typesTutorial.h
+++ b/regression/reference/tutorial/typesTutorial.h
@@ -31,6 +31,7 @@ struct s_TUT_SHROUD_array {
         const void * base;
         const char * ccharp;
     } addr;
+    int type;        /* type of element */
     size_t elem_len; /* bytes-per-item or character len in c++ */
     size_t size;     /* size of data in c++ */
 };

--- a/regression/reference/tutorial/wrapftutorial.f
+++ b/regression/reference/tutorial/wrapftutorial.f
@@ -32,6 +32,8 @@ module tutorial_mod
         type(SHROUD_capsule_data) :: cxx
         ! address of data in cxx
         type(C_PTR) :: base_addr = C_NULL_PTR
+        ! type of element
+        integer(C_INT) :: type
         ! bytes-per-item or character len of data in cxx
         integer(C_SIZE_T) :: elem_len = 0_C_SIZE_T
         ! size of data in cxx

--- a/regression/reference/types/types.json
+++ b/regression/reference/types/types.json
@@ -145,6 +145,7 @@
                             "cxx_type": "short",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -185,6 +186,7 @@
                         "cxx_type": "short",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -276,6 +278,7 @@
                             "cxx_type": "int",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -316,6 +319,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -407,6 +411,7 @@
                             "cxx_type": "long",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -447,6 +452,7 @@
                         "cxx_type": "long",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -538,6 +544,7 @@
                             "cxx_type": "long long",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -578,6 +585,7 @@
                         "cxx_type": "long long",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -673,6 +681,7 @@
                             "cxx_type": "short",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -713,6 +722,7 @@
                         "cxx_type": "short",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -806,6 +816,7 @@
                             "cxx_type": "long",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -846,6 +857,7 @@
                         "cxx_type": "long",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -939,6 +951,7 @@
                             "cxx_type": "long long",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -979,6 +992,7 @@
                         "cxx_type": "long long",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -1076,6 +1090,7 @@
                             "cxx_type": "unsigned int",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1116,6 +1131,7 @@
                         "cxx_type": "unsigned int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -1207,6 +1223,7 @@
                             "cxx_type": "unsigned short",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1247,6 +1264,7 @@
                         "cxx_type": "unsigned short",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -1340,6 +1358,7 @@
                             "cxx_type": "unsigned int",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1380,6 +1399,7 @@
                         "cxx_type": "unsigned int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -1473,6 +1493,7 @@
                             "cxx_type": "unsigned long",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1513,6 +1534,7 @@
                         "cxx_type": "unsigned long",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -1606,6 +1628,7 @@
                             "cxx_type": "unsigned long long",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1646,6 +1669,7 @@
                         "cxx_type": "unsigned long long",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -1743,6 +1767,7 @@
                             "cxx_type": "unsigned long",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1783,6 +1808,7 @@
                         "cxx_type": "unsigned long",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -1878,6 +1904,7 @@
                             "cxx_type": "int8_t",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1918,6 +1945,7 @@
                         "cxx_type": "int8_t",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2009,6 +2037,7 @@
                             "cxx_type": "int16_t",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2049,6 +2078,7 @@
                         "cxx_type": "int16_t",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2140,6 +2170,7 @@
                             "cxx_type": "int32_t",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2180,6 +2211,7 @@
                         "cxx_type": "int32_t",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2271,6 +2303,7 @@
                             "cxx_type": "int64_t",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2311,6 +2344,7 @@
                         "cxx_type": "int64_t",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2402,6 +2436,7 @@
                             "cxx_type": "uint8_t",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2442,6 +2477,7 @@
                         "cxx_type": "uint8_t",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2533,6 +2569,7 @@
                             "cxx_type": "uint16_t",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2573,6 +2610,7 @@
                         "cxx_type": "uint16_t",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2664,6 +2702,7 @@
                             "cxx_type": "uint32_t",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2704,6 +2743,7 @@
                         "cxx_type": "uint32_t",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2795,6 +2835,7 @@
                             "cxx_type": "uint64_t",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2835,6 +2876,7 @@
                         "cxx_type": "uint64_t",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2926,6 +2968,7 @@
                             "cxx_type": "size_t",
                             "cxx_var": "arg1",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2966,6 +3009,7 @@
                         "cxx_type": "size_t",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -3057,6 +3101,7 @@
                             "cxx_type": "bool",
                             "cxx_var": "arg",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_bool_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -3099,6 +3144,7 @@
                         "cxx_type": "bool",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_bool_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -3191,6 +3237,7 @@
                             "cxx_type": "int",
                             "cxx_var": "flag",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -3231,6 +3278,7 @@
                         "cxx_type": "bool",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_bool_scalar_result_",
                         "stmt1": "c_default"
                     },

--- a/regression/reference/types/types.json
+++ b/regression/reference/types/types.json
@@ -145,7 +145,7 @@
                             "cxx_type": "short",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_SHORT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -186,7 +186,7 @@
                         "cxx_type": "short",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_SHORT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -278,7 +278,7 @@
                             "cxx_type": "int",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -319,7 +319,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -411,7 +411,7 @@
                             "cxx_type": "long",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_LONG",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -452,7 +452,7 @@
                         "cxx_type": "long",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_LONG",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -544,7 +544,7 @@
                             "cxx_type": "long long",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_LONG_LONG",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -585,7 +585,7 @@
                         "cxx_type": "long long",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_LONG_LONG",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -681,7 +681,7 @@
                             "cxx_type": "short",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_SHORT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -722,7 +722,7 @@
                         "cxx_type": "short",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_SHORT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -816,7 +816,7 @@
                             "cxx_type": "long",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_LONG",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -857,7 +857,7 @@
                         "cxx_type": "long",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_LONG",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -951,7 +951,7 @@
                             "cxx_type": "long long",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_LONG_LONG",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -992,7 +992,7 @@
                         "cxx_type": "long long",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_LONG_LONG",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -1090,7 +1090,7 @@
                             "cxx_type": "unsigned int",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_UNSIGNED_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1131,7 +1131,7 @@
                         "cxx_type": "unsigned int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_UNSIGNED_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -1223,7 +1223,7 @@
                             "cxx_type": "unsigned short",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_UNSIGNED_SHORT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1264,7 +1264,7 @@
                         "cxx_type": "unsigned short",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_UNSIGNED_SHORT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -1358,7 +1358,7 @@
                             "cxx_type": "unsigned int",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_UNSIGNED_INT",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1399,7 +1399,7 @@
                         "cxx_type": "unsigned int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_UNSIGNED_INT",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -1493,7 +1493,7 @@
                             "cxx_type": "unsigned long",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_UNSIGNED_LONG",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1534,7 +1534,7 @@
                         "cxx_type": "unsigned long",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_UNSIGNED_LONG",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -1628,7 +1628,7 @@
                             "cxx_type": "unsigned long long",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_UNSIGNED_LONG_LONG",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1669,7 +1669,7 @@
                         "cxx_type": "unsigned long long",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_UNSIGNED_LONG_LONG",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -1767,7 +1767,7 @@
                             "cxx_type": "unsigned long",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_UNSIGNED_LONG",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1808,7 +1808,7 @@
                         "cxx_type": "unsigned long",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_UNSIGNED_LONG",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -1904,7 +1904,7 @@
                             "cxx_type": "int8_t",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT8_T",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -1945,7 +1945,7 @@
                         "cxx_type": "int8_t",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT8_T",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2037,7 +2037,7 @@
                             "cxx_type": "int16_t",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT16_T",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2078,7 +2078,7 @@
                         "cxx_type": "int16_t",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT16_T",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2170,7 +2170,7 @@
                             "cxx_type": "int32_t",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT32_T",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2211,7 +2211,7 @@
                         "cxx_type": "int32_t",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT32_T",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2303,7 +2303,7 @@
                             "cxx_type": "int64_t",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT64_T",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2344,7 +2344,7 @@
                         "cxx_type": "int64_t",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT64_T",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2436,7 +2436,7 @@
                             "cxx_type": "uint8_t",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_UINT8_T",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2477,7 +2477,7 @@
                         "cxx_type": "uint8_t",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_UINT8_T",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2569,7 +2569,7 @@
                             "cxx_type": "uint16_t",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_UINT16_T",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2610,7 +2610,7 @@
                         "cxx_type": "uint16_t",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_UINT16_T",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2702,7 +2702,7 @@
                             "cxx_type": "uint32_t",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_UINT32_T",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2743,7 +2743,7 @@
                         "cxx_type": "uint32_t",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_UINT32_T",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2835,7 +2835,7 @@
                             "cxx_type": "uint64_t",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_UINT64_T",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -2876,7 +2876,7 @@
                         "cxx_type": "uint64_t",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_UINT64_T",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -2968,7 +2968,7 @@
                             "cxx_type": "size_t",
                             "cxx_var": "arg1",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_SIZE_T",
                             "stmt0": "c_native_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -3009,7 +3009,7 @@
                         "cxx_type": "size_t",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_SIZE_T",
                         "stmt0": "c_native_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -3101,7 +3101,7 @@
                             "cxx_type": "bool",
                             "cxx_var": "arg",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_BOOL",
                             "stmt0": "c_bool_scalar_in_",
                             "stmt1": "c_default"
                         },
@@ -3144,7 +3144,7 @@
                         "cxx_type": "bool",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_BOOL",
                         "stmt0": "c_bool_scalar_result_",
                         "stmt1": "c_default"
                     },
@@ -3237,7 +3237,7 @@
                             "cxx_type": "int",
                             "cxx_var": "flag",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_pointer_out_",
                             "stmt1": "c_default"
                         },
@@ -3278,7 +3278,7 @@
                         "cxx_type": "bool",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_BOOL",
                         "stmt0": "c_bool_scalar_result_",
                         "stmt1": "c_default"
                     },

--- a/regression/reference/vectors/typesvectors.h
+++ b/regression/reference/vectors/typesvectors.h
@@ -39,6 +39,7 @@ struct s_VEC_SHROUD_array {
         const void * base;
         const char * ccharp;
     } addr;
+    int type;        /* type of element */
     size_t elem_len; /* bytes-per-item or character len in c++ */
     size_t size;     /* size of data in c++ */
 };

--- a/regression/reference/vectors/typesvectors.h
+++ b/regression/reference/vectors/typesvectors.h
@@ -26,6 +26,46 @@
 extern "C" {
 #endif
 
+/* Shroud type defines */
+#define SH_TYPE_SIGNED_CHAR 1
+#define SH_TYPE_SHORT       2
+#define SH_TYPE_INT         3
+#define SH_TYPE_LONG        4
+#define SH_TYPE_LONG_LONG   5
+#define SH_TYPE_SIZE_T      6
+
+#define SH_TYPE_UNSIGNED_SHORT       SH_TYPE_SHORT + 100
+#define SH_TYPE_UNSIGNED_INT         SH_TYPE_INT + 100
+#define SH_TYPE_UNSIGNED_LONG        SH_TYPE_LONG + 100
+#define SH_TYPE_UNSIGNED_LONG_LONG   SH_TYPE_LONG_LONG + 100
+
+#define SH_TYPE_INT8_T      7
+#define SH_TYPE_INT16_T     8
+#define SH_TYPE_INT32_T     9
+#define SH_TYPE_INT64_T    10
+
+#define SH_TYPE_UINT8_T    SH_TYPE_INT8_T + 100
+#define SH_TYPE_UINT16_T   SH_TYPE_INT16_T + 100
+#define SH_TYPE_UINT32_T   SH_TYPE_INT32_T + 100
+#define SH_TYPE_UINT64_T   SH_TYPE_INT64_T + 100
+
+/* least8 least16 least32 least64 */
+/* fast8 fast16 fast32 fast64 */
+/* intmax_t intptr_t ptrdiff_t */
+
+#define SH_TYPE_FLOAT        22
+#define SH_TYPE_DOUBLE       23
+#define SH_TYPE_LONG_DOUBLE  24
+#define SH_TYPE_FLOAT_COMPLEX       25
+#define SH_TYPE_DOUBLE_COMPLEX      26
+#define SH_TYPE_LONG_DOUBLE_COMPLEX 27
+
+#define SH_TYPE_BOOL       28
+#define SH_TYPE_CHAR       29
+#define SH_TYPE_CPTR       30
+#define SH_TYPE_STRUCT     31
+#define SH_TYPE_OTHER      32
+
 struct s_VEC_SHROUD_capsule_data {
     void *addr;     /* address of C++ memory */
     int idtor;      /* index of destructor */

--- a/regression/reference/vectors/vectors.json
+++ b/regression/reference/vectors/vectors.json
@@ -201,6 +201,7 @@
                             "cxx_type": "int",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_vector_pointer_in_buf_native",
                             "stmt1": "c_vector_in_buf"
                         },
@@ -226,6 +227,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -384,6 +386,7 @@
                             "cxx_type": "int",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "1",
+                            "sh_type": "0",
                             "stmt0": "c_vector_pointer_out_buf_native",
                             "stmt1": "c_vector_out_buf"
                         },
@@ -586,6 +589,7 @@
                             "cxx_type": "int",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "1",
+                            "sh_type": "0",
                             "stmt0": "c_vector_pointer_out_buf_native",
                             "stmt1": "c_vector_out_buf"
                         },
@@ -807,6 +811,7 @@
                             "cxx_type": "int",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "1",
+                            "sh_type": "0",
                             "stmt0": "c_vector_pointer_out_buf_native",
                             "stmt1": "c_vector_out_buf"
                         },
@@ -1001,6 +1006,7 @@
                             "cxx_type": "int",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "1",
+                            "sh_type": "0",
                             "stmt0": "c_vector_pointer_out_buf_native",
                             "stmt1": "c_vector_out_buf"
                         },
@@ -1178,6 +1184,7 @@
                             "cxx_type": "int",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "1",
+                            "sh_type": "0",
                             "stmt0": "c_vector_pointer_inout_buf_native",
                             "stmt1": "c_vector_inout_buf"
                         },
@@ -1350,6 +1357,7 @@
                             "cxx_type": "int",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "1",
+                            "sh_type": "0",
                             "stmt0": "c_vector_pointer_inout_buf_native",
                             "stmt1": "c_vector_inout_buf"
                         },
@@ -1518,6 +1526,7 @@
                             "cxx_type": "double",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "2",
+                            "sh_type": "0",
                             "stmt0": "c_vector_pointer_out_buf_native",
                             "stmt1": "c_vector_out_buf"
                         },
@@ -1700,6 +1709,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_vector_pointer_in_buf_string",
                             "stmt1": "c_vector_in_buf_string"
                         },
@@ -1725,6 +1735,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_native_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -2014,6 +2025,7 @@
                             "cxx_type": "int",
                             "cxx_var": "SHC_rv",
                             "idtor": "1",
+                            "sh_type": "0",
                             "stmt0": "c_vector_scalar_result_buf_allocatable",
                             "stmt1": "c_vector_result_buf"
                         },
@@ -2043,6 +2055,7 @@
                             "cxx_type": "int",
                             "cxx_var": "n",
                             "idtor": "0",
+                            "sh_type": "0",
                             "stmt0": "c_native_scalar_in_buf",
                             "stmt1": "c_default"
                         },
@@ -2066,6 +2079,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
+                        "sh_type": "0",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }

--- a/regression/reference/vectors/vectors.json
+++ b/regression/reference/vectors/vectors.json
@@ -201,7 +201,7 @@
                             "cxx_type": "int",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_vector_pointer_in_buf_native",
                             "stmt1": "c_vector_in_buf"
                         },
@@ -227,7 +227,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -386,7 +386,7 @@
                             "cxx_type": "int",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "1",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_vector_pointer_out_buf_native",
                             "stmt1": "c_vector_out_buf"
                         },
@@ -589,7 +589,7 @@
                             "cxx_type": "int",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "1",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_vector_pointer_out_buf_native",
                             "stmt1": "c_vector_out_buf"
                         },
@@ -811,7 +811,7 @@
                             "cxx_type": "int",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "1",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_vector_pointer_out_buf_native",
                             "stmt1": "c_vector_out_buf"
                         },
@@ -1006,7 +1006,7 @@
                             "cxx_type": "int",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "1",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_vector_pointer_out_buf_native",
                             "stmt1": "c_vector_out_buf"
                         },
@@ -1184,7 +1184,7 @@
                             "cxx_type": "int",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "1",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_vector_pointer_inout_buf_native",
                             "stmt1": "c_vector_inout_buf"
                         },
@@ -1357,7 +1357,7 @@
                             "cxx_type": "int",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "1",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_vector_pointer_inout_buf_native",
                             "stmt1": "c_vector_inout_buf"
                         },
@@ -1526,7 +1526,7 @@
                             "cxx_type": "double",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "2",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_DOUBLE",
                             "stmt0": "c_vector_pointer_out_buf_native",
                             "stmt1": "c_vector_out_buf"
                         },
@@ -1709,7 +1709,7 @@
                             "cxx_type": "std::string",
                             "cxx_var": "SHCXX_arg",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_vector_pointer_in_buf_string",
                             "stmt1": "c_vector_in_buf_string"
                         },
@@ -1735,7 +1735,7 @@
                         "cxx_type": "int",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_native_scalar_result_buf",
                         "stmt1": "c_default"
                     }
@@ -2025,7 +2025,7 @@
                             "cxx_type": "int",
                             "cxx_var": "SHC_rv",
                             "idtor": "1",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_vector_scalar_result_buf_allocatable",
                             "stmt1": "c_vector_result_buf"
                         },
@@ -2055,7 +2055,7 @@
                             "cxx_type": "int",
                             "cxx_var": "n",
                             "idtor": "0",
-                            "sh_type": "0",
+                            "sh_type": "SH_TYPE_INT",
                             "stmt0": "c_native_scalar_in_buf",
                             "stmt1": "c_default"
                         },
@@ -2079,7 +2079,7 @@
                         "cxx_type": "void",
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
-                        "sh_type": "0",
+                        "sh_type": "SH_TYPE_CPTR",
                         "stmt0": "c_unknown_scalar_result_buf",
                         "stmt1": "c_default"
                     }

--- a/regression/reference/vectors/wrapfvectors.f
+++ b/regression/reference/vectors/wrapfvectors.f
@@ -40,6 +40,8 @@ module vectors_mod
         type(SHROUD_capsule_data) :: cxx
         ! address of data in cxx
         type(C_PTR) :: base_addr = C_NULL_PTR
+        ! type of element
+        integer(C_INT) :: type
         ! bytes-per-item or character len of data in cxx
         integer(C_SIZE_T) :: elem_len = 0_C_SIZE_T
         ! size of data in cxx

--- a/regression/reference/vectors/wrapvectors.cpp
+++ b/regression/reference/vectors/wrapvectors.cpp
@@ -86,7 +86,7 @@ void VEC_vector_iota_out_bufferify(VEC_SHROUD_array *Darg)
     Darg->cxx.addr  = static_cast<void *>(SHCXX_arg);
     Darg->cxx.idtor = 1;
     Darg->addr.base = SHCXX_arg->empty() ? NULL : &SHCXX_arg->front();
-    Darg->type = 0;
+    Darg->type = SH_TYPE_INT;
     Darg->elem_len = sizeof(int);
     Darg->size = SHCXX_arg->size();
     return;
@@ -110,7 +110,7 @@ long VEC_vector_iota_out_with_num_bufferify(VEC_SHROUD_array *Darg)
     Darg->cxx.addr  = static_cast<void *>(SHCXX_arg);
     Darg->cxx.idtor = 1;
     Darg->addr.base = SHCXX_arg->empty() ? NULL : &SHCXX_arg->front();
-    Darg->type = 0;
+    Darg->type = SH_TYPE_INT;
     Darg->elem_len = sizeof(int);
     Darg->size = SHCXX_arg->size();
     return Darg->size;
@@ -134,7 +134,7 @@ void VEC_vector_iota_out_with_num2_bufferify(VEC_SHROUD_array *Darg)
     Darg->cxx.addr  = static_cast<void *>(SHCXX_arg);
     Darg->cxx.idtor = 1;
     Darg->addr.base = SHCXX_arg->empty() ? NULL : &SHCXX_arg->front();
-    Darg->type = 0;
+    Darg->type = SH_TYPE_INT;
     Darg->elem_len = sizeof(int);
     Darg->size = SHCXX_arg->size();
     return;
@@ -156,7 +156,7 @@ void VEC_vector_iota_out_alloc_bufferify(VEC_SHROUD_array *Darg)
     Darg->cxx.addr  = static_cast<void *>(SHCXX_arg);
     Darg->cxx.idtor = 1;
     Darg->addr.base = SHCXX_arg->empty() ? NULL : &SHCXX_arg->front();
-    Darg->type = 0;
+    Darg->type = SH_TYPE_INT;
     Darg->elem_len = sizeof(int);
     Darg->size = SHCXX_arg->size();
     return;
@@ -179,7 +179,7 @@ void VEC_vector_iota_inout_alloc_bufferify(int * arg, long Sarg,
     Darg->cxx.addr  = static_cast<void *>(SHCXX_arg);
     Darg->cxx.idtor = 1;
     Darg->addr.base = SHCXX_arg->empty() ? NULL : &SHCXX_arg->front();
-    Darg->type = 0;
+    Darg->type = SH_TYPE_INT;
     Darg->elem_len = sizeof(int);
     Darg->size = SHCXX_arg->size();
     return;
@@ -197,7 +197,7 @@ void VEC_vector_increment_bufferify(int * arg, long Sarg,
     Darg->cxx.addr  = static_cast<void *>(SHCXX_arg);
     Darg->cxx.idtor = 1;
     Darg->addr.base = SHCXX_arg->empty() ? NULL : &SHCXX_arg->front();
-    Darg->type = 0;
+    Darg->type = SH_TYPE_INT;
     Darg->elem_len = sizeof(int);
     Darg->size = SHCXX_arg->size();
     return;
@@ -217,7 +217,7 @@ void VEC_vector_iota_out_d_bufferify(VEC_SHROUD_array *Darg)
     Darg->cxx.addr  = static_cast<void *>(SHCXX_arg);
     Darg->cxx.idtor = 2;
     Darg->addr.base = SHCXX_arg->empty() ? NULL : &SHCXX_arg->front();
-    Darg->type = 0;
+    Darg->type = SH_TYPE_DOUBLE;
     Darg->elem_len = sizeof(double);
     Darg->size = SHCXX_arg->size();
     return;
@@ -263,7 +263,7 @@ void VEC_return_vector_alloc_bufferify(int n, VEC_SHROUD_array *DSHF_rv)
     DSHF_rv->cxx.addr  = static_cast<void *>(SHC_rv);
     DSHF_rv->cxx.idtor = 1;
     DSHF_rv->addr.base = SHC_rv->empty() ? NULL : &SHC_rv->front();
-    DSHF_rv->type = 0;
+    DSHF_rv->type = SH_TYPE_INT;
     DSHF_rv->elem_len = sizeof(int);
     DSHF_rv->size = SHC_rv->size();
     return;

--- a/regression/reference/vectors/wrapvectors.cpp
+++ b/regression/reference/vectors/wrapvectors.cpp
@@ -86,6 +86,7 @@ void VEC_vector_iota_out_bufferify(VEC_SHROUD_array *Darg)
     Darg->cxx.addr  = static_cast<void *>(SHCXX_arg);
     Darg->cxx.idtor = 1;
     Darg->addr.base = SHCXX_arg->empty() ? NULL : &SHCXX_arg->front();
+    Darg->type = 0;
     Darg->elem_len = sizeof(int);
     Darg->size = SHCXX_arg->size();
     return;
@@ -109,6 +110,7 @@ long VEC_vector_iota_out_with_num_bufferify(VEC_SHROUD_array *Darg)
     Darg->cxx.addr  = static_cast<void *>(SHCXX_arg);
     Darg->cxx.idtor = 1;
     Darg->addr.base = SHCXX_arg->empty() ? NULL : &SHCXX_arg->front();
+    Darg->type = 0;
     Darg->elem_len = sizeof(int);
     Darg->size = SHCXX_arg->size();
     return Darg->size;
@@ -132,6 +134,7 @@ void VEC_vector_iota_out_with_num2_bufferify(VEC_SHROUD_array *Darg)
     Darg->cxx.addr  = static_cast<void *>(SHCXX_arg);
     Darg->cxx.idtor = 1;
     Darg->addr.base = SHCXX_arg->empty() ? NULL : &SHCXX_arg->front();
+    Darg->type = 0;
     Darg->elem_len = sizeof(int);
     Darg->size = SHCXX_arg->size();
     return;
@@ -153,6 +156,7 @@ void VEC_vector_iota_out_alloc_bufferify(VEC_SHROUD_array *Darg)
     Darg->cxx.addr  = static_cast<void *>(SHCXX_arg);
     Darg->cxx.idtor = 1;
     Darg->addr.base = SHCXX_arg->empty() ? NULL : &SHCXX_arg->front();
+    Darg->type = 0;
     Darg->elem_len = sizeof(int);
     Darg->size = SHCXX_arg->size();
     return;
@@ -175,6 +179,7 @@ void VEC_vector_iota_inout_alloc_bufferify(int * arg, long Sarg,
     Darg->cxx.addr  = static_cast<void *>(SHCXX_arg);
     Darg->cxx.idtor = 1;
     Darg->addr.base = SHCXX_arg->empty() ? NULL : &SHCXX_arg->front();
+    Darg->type = 0;
     Darg->elem_len = sizeof(int);
     Darg->size = SHCXX_arg->size();
     return;
@@ -192,6 +197,7 @@ void VEC_vector_increment_bufferify(int * arg, long Sarg,
     Darg->cxx.addr  = static_cast<void *>(SHCXX_arg);
     Darg->cxx.idtor = 1;
     Darg->addr.base = SHCXX_arg->empty() ? NULL : &SHCXX_arg->front();
+    Darg->type = 0;
     Darg->elem_len = sizeof(int);
     Darg->size = SHCXX_arg->size();
     return;
@@ -211,6 +217,7 @@ void VEC_vector_iota_out_d_bufferify(VEC_SHROUD_array *Darg)
     Darg->cxx.addr  = static_cast<void *>(SHCXX_arg);
     Darg->cxx.idtor = 2;
     Darg->addr.base = SHCXX_arg->empty() ? NULL : &SHCXX_arg->front();
+    Darg->type = 0;
     Darg->elem_len = sizeof(double);
     Darg->size = SHCXX_arg->size();
     return;
@@ -256,6 +263,7 @@ void VEC_return_vector_alloc_bufferify(int n, VEC_SHROUD_array *DSHF_rv)
     DSHF_rv->cxx.addr  = static_cast<void *>(SHC_rv);
     DSHF_rv->cxx.idtor = 1;
     DSHF_rv->addr.base = SHC_rv->empty() ? NULL : &SHC_rv->front();
+    DSHF_rv->type = 0;
     DSHF_rv->elem_len = sizeof(int);
     DSHF_rv->size = SHC_rv->size();
     return;

--- a/shroud/typemap.py
+++ b/shroud/typemap.py
@@ -1409,8 +1409,7 @@ fc_statements = dict(
     ),
     c_char_result_buf_allocatable=dict(
         buf_args=["context"],
-#        c_helper="copy_string",
-        c_helper="capsule_data_helper ShroudTypeDefines",
+        c_helper="array_context copy_string ShroudTypeDefines",
         # Copy address of result into c_var and save length.
         # When returning a std::string (and not a reference or pointer)
         # an intermediate object is created to save the results
@@ -1604,7 +1603,7 @@ fc_statements = dict(
     c_vector_out_buf=dict(
         buf_args=["context"],
         cxx_local_var="pointer",
-        c_helper="capsule_data_helper copy_array ShroudTypeDefines",
+        c_helper="array_context copy_array ShroudTypeDefines",
         pre_call=[
             "{c_const}std::vector<{cxx_T}>"
             "\t *{cxx_var} = new std::vector<{cxx_T}>;"
@@ -1629,8 +1628,7 @@ fc_statements = dict(
     c_vector_inout_buf=dict(
         buf_args=["arg", "size", "context"],
         cxx_local_var="pointer",
-#        c_helper="capsule_data_helper copy_array ShroudTypeDefines",
-        c_helper="capsule_data_helper ShroudTypeDefines",
+        c_helper="array_context copy_array ShroudTypeDefines",
         pre_call=[
             "std::vector<{cxx_T}> *{cxx_var} = \tnew std::vector<{cxx_T}>\t("
             "\t{c_var}, {c_var} + {c_var_size});"
@@ -1656,7 +1654,7 @@ fc_statements = dict(
     c_vector_result_buf=dict(
         buf_args=["context"],
         cxx_local_var="pointer",
-        c_helper="capsule_data_helper ShroudTypeDefines",
+        c_helper="array_context ShroudTypeDefines",
         pre_call=[
             "{c_const}std::vector<{cxx_T}>"
             "\t *{cxx_var} = new std::vector<{cxx_T}>;"

--- a/shroud/typemap.py
+++ b/shroud/typemap.py
@@ -156,8 +156,7 @@ class Typemap(object):
         ("LUA_push", "PUSH"),
         ("LUA_statements", {}),
         ("sgroup", "unknown"),  # statement group. ex. native, string, vector
-#XXX        ("sh_type", "SH_TYPE_OTHER"),
-        ("sh_type", "0"),
+        ("sh_type", "SH_TYPE_OTHER"),
         ("__line__", None),
     )
 
@@ -311,7 +310,7 @@ def initialize():
             f_cast_module=dict(iso_c_binding=["C_LOC"]),
             f_cast_keywords=dict(is_target=True),
             PY_ctor="PyCapsule_New({cxx_var}, NULL, NULL)",
-            sh_type="SH_TYPE_VOID",
+            sh_type="SH_TYPE_CPTR",
         ),
         short=Typemap(
             "short",
@@ -795,10 +794,6 @@ def initialize():
     def_types["std::vector"] = def_types["vector"]
     del def_types["vector"]
 
-    # XXX - zero out sh_type until defines are in place.
-    for ntypemap in def_types.values():
-        ntypemap.sh_type = "0";
-
     set_global_types(def_types)
 
     return def_types
@@ -901,8 +896,7 @@ def create_class_typemap(node, fields=None):
         f_module={fmt_class.F_module_name: [fmt_class.F_derived_name]},
         # #- f_to_c='{f_var}%%%s()' % fmt_class.F_name_instance_get, # XXX - develop test
         f_to_c="{f_var}%%%s" % fmt_class.F_derived_member,
-#XXX        sh_type="SH_TYPE_OTHER",
-        sh_type="0",
+        sh_type="SH_TYPE_OTHER",
     )
     # import classes which are wrapped by this module
     # XXX - deal with namespaces vs modules
@@ -990,8 +984,7 @@ def create_struct_typemap(node, fields=None):
         f_derived_type=fmt_class.F_derived_name,
         f_module={fmt_class.F_module_name: [fmt_class.F_derived_name]},
         PYN_descr=fmt_class.PY_struct_array_descr_variable,
-#XXX        sh_type="SH_TYPE_STRUCT",
-        sh_type="0",
+        sh_type="SH_TYPE_STRUCT",
     )
     if fields is not None:
         ntypemap.update(fields)
@@ -1309,7 +1302,7 @@ fc_statements = dict(
     #        c_step2(context, Fout, size(len))
     c_native_pointer_result_buf=dict(
         buf_args=["context"],
-        c_helper="array_context copy_array",
+        c_helper="array_context copy_array ShroudTypeDefines",
         post_call=[
             "{c_var_context}->cxx.addr  = {cxx_var};",
             "{c_var_context}->cxx.idtor = {idtor};",

--- a/shroud/typemap.py
+++ b/shroud/typemap.py
@@ -1656,7 +1656,7 @@ fc_statements = dict(
     c_vector_result_buf=dict(
         buf_args=["context"],
         cxx_local_var="pointer",
-        c_helper="capsule_data_helper copy_array ShroudTypeDefines",
+        c_helper="capsule_data_helper ShroudTypeDefines",
         pre_call=[
             "{c_const}std::vector<{cxx_T}>"
             "\t *{cxx_var} = new std::vector<{cxx_T}>;"

--- a/shroud/typemap.py
+++ b/shroud/typemap.py
@@ -156,6 +156,8 @@ class Typemap(object):
         ("LUA_push", "PUSH"),
         ("LUA_statements", {}),
         ("sgroup", "unknown"),  # statement group. ex. native, string, vector
+#XXX        ("sh_type", "SH_TYPE_OTHER"),
+        ("sh_type", "0"),
         ("__line__", None),
     )
 
@@ -309,6 +311,7 @@ def initialize():
             f_cast_module=dict(iso_c_binding=["C_LOC"]),
             f_cast_keywords=dict(is_target=True),
             PY_ctor="PyCapsule_New({cxx_var}, NULL, NULL)",
+            sh_type="SH_TYPE_VOID",
         ),
         short=Typemap(
             "short",
@@ -326,6 +329,7 @@ def initialize():
             LUA_pop="lua_tointeger({LUA_state_var}, {LUA_index})",
             LUA_push="lua_pushinteger({LUA_state_var}, {c_var})",
             sgroup="native",
+            sh_type="SH_TYPE_SHORT",
         ),
         int=Typemap(
             "int",
@@ -343,6 +347,7 @@ def initialize():
             LUA_pop="lua_tointeger({LUA_state_var}, {LUA_index})",
             LUA_push="lua_pushinteger({LUA_state_var}, {c_var})",
             sgroup="native",
+            sh_type="SH_TYPE_INT",
         ),
         long=Typemap(
             "long",
@@ -360,6 +365,7 @@ def initialize():
             LUA_pop="lua_tointeger({LUA_state_var}, {LUA_index})",
             LUA_push="lua_pushinteger({LUA_state_var}, {c_var})",
             sgroup="native",
+            sh_type="SH_TYPE_LONG",
         ),
         long_long=Typemap(
             "long_long",
@@ -376,6 +382,7 @@ def initialize():
             LUA_pop="lua_tointeger({LUA_state_var}, {LUA_index})",
             LUA_push="lua_pushinteger({LUA_state_var}, {c_var})",
             sgroup="native",
+            sh_type="SH_TYPE_LONG_LONG",
         ),
         unsigned_short=Typemap(
             "unsigned_short",
@@ -393,6 +400,7 @@ def initialize():
             LUA_pop="lua_tointeger({LUA_state_var}, {LUA_index})",
             LUA_push="lua_pushinteger({LUA_state_var}, {c_var})",
             sgroup="native",
+            sh_type="SH_TYPE_UNSIGNED_SHORT",
         ),
         unsigned_int=Typemap(
             "unsigned_int",
@@ -410,6 +418,7 @@ def initialize():
             LUA_pop="lua_tointeger({LUA_state_var}, {LUA_index})",
             LUA_push="lua_pushinteger({LUA_state_var}, {c_var})",
             sgroup="native",
+            sh_type="SH_TYPE_UNSIGNED_INT",
         ),
         unsigned_long=Typemap(
             "unsigned_long",
@@ -427,6 +436,7 @@ def initialize():
             LUA_pop="lua_tointeger({LUA_state_var}, {LUA_index})",
             LUA_push="lua_pushinteger({LUA_state_var}, {c_var})",
             sgroup="native",
+            sh_type="SH_TYPE_UNSIGNED_LONG",
         ),
         unsigned_long_long=Typemap(
             "unsigned_long_long",
@@ -443,6 +453,7 @@ def initialize():
             LUA_pop="lua_tointeger({LUA_state_var}, {LUA_index})",
             LUA_push="lua_pushinteger({LUA_state_var}, {c_var})",
             sgroup="native",
+            sh_type="SH_TYPE_UNSIGNED_LONG_LONG",
         ),
         size_t=Typemap(
             "size_t",
@@ -460,6 +471,7 @@ def initialize():
             LUA_pop="lua_tointeger({LUA_state_var}, {LUA_index})",
             LUA_push="lua_pushinteger({LUA_state_var}, {c_var})",
             sgroup="native",
+            sh_type="SH_TYPE_SIZE_T",
         ),
         # XXX- sized based types for Python
         int8_t=Typemap(
@@ -480,6 +492,7 @@ def initialize():
             LUA_pop="lua_tointeger({LUA_state_var}, {LUA_index})",
             LUA_push="lua_pushinteger({LUA_state_var}, {c_var})",
             sgroup="native",
+            sh_type="SH_TYPE_INT8_T",
         ),
         int16_t=Typemap(
             "int16_t",
@@ -499,6 +512,7 @@ def initialize():
             LUA_pop="lua_tointeger({LUA_state_var}, {LUA_index})",
             LUA_push="lua_pushinteger({LUA_state_var}, {c_var})",
             sgroup="native",
+            sh_type="SH_TYPE_INT16_T",
         ),
         int32_t=Typemap(
             "int32_t",
@@ -518,6 +532,7 @@ def initialize():
             LUA_pop="lua_tointeger({LUA_state_var}, {LUA_index})",
             LUA_push="lua_pushinteger({LUA_state_var}, {c_var})",
             sgroup="native",
+            sh_type="SH_TYPE_INT32_T",
         ),
         int64_t=Typemap(
             "int64_t",
@@ -537,6 +552,7 @@ def initialize():
             LUA_pop="lua_tointeger({LUA_state_var}, {LUA_index})",
             LUA_push="lua_pushinteger({LUA_state_var}, {c_var})",
             sgroup="native",
+            sh_type="SH_TYPE_INT64_T",
         ),
         # XXX- sized based types for Python
         uint8_t=Typemap(
@@ -557,6 +573,7 @@ def initialize():
             LUA_pop="lua_tointeger({LUA_state_var}, {LUA_index})",
             LUA_push="lua_pushinteger({LUA_state_var}, {c_var})",
             sgroup="native",
+            sh_type="SH_TYPE_UINT8_T",
         ),
         uint16_t=Typemap(
             "uint16_t",
@@ -576,6 +593,7 @@ def initialize():
             LUA_pop="lua_tointeger({LUA_state_var}, {LUA_index})",
             LUA_push="lua_pushinteger({LUA_state_var}, {c_var})",
             sgroup="native",
+            sh_type="SH_TYPE_UINT16_T",
         ),
         uint32_t=Typemap(
             "uint32_t",
@@ -595,6 +613,7 @@ def initialize():
             LUA_pop="lua_tointeger({LUA_state_var}, {LUA_index})",
             LUA_push="lua_pushinteger({LUA_state_var}, {c_var})",
             sgroup="native",
+            sh_type="SH_TYPE_UINT32_T",
         ),
         uint64_t=Typemap(
             "uint64_t",
@@ -614,6 +633,7 @@ def initialize():
             LUA_pop="lua_tointeger({LUA_state_var}, {LUA_index})",
             LUA_push="lua_pushinteger({LUA_state_var}, {c_var})",
             sgroup="native",
+            sh_type="SH_TYPE_UINT64_T",
         ),
         float=Typemap(
             "float",
@@ -631,6 +651,7 @@ def initialize():
             LUA_pop="lua_tonumber({LUA_state_var}, {LUA_index})",
             LUA_push="lua_pushnumber({LUA_state_var}, {c_var})",
             sgroup="native",
+            sh_type="SH_TYPE_FLOAT",
         ),
         double=Typemap(
             "double",
@@ -648,6 +669,7 @@ def initialize():
             LUA_pop="lua_tonumber({LUA_state_var}, {LUA_index})",
             LUA_push="lua_pushnumber({LUA_state_var}, {c_var})",
             sgroup="native",
+            sh_type="SH_TYPE_DOUBLE",
         ),
         bool=Typemap(
             "bool",
@@ -670,6 +692,7 @@ def initialize():
             LUA_push="lua_pushboolean({LUA_state_var}, {c_var})",
             base="bool",
             sgroup="bool",
+            sh_type="SH_TYPE_BOOL",
         ),
         # implies null terminated string
         char=Typemap(
@@ -771,6 +794,10 @@ def initialize():
     del def_types["string"]
     def_types["std::vector"] = def_types["vector"]
     del def_types["vector"]
+
+    # XXX - zero out sh_type until defines are in place.
+    for ntypemap in def_types.values():
+        ntypemap.sh_type = "0";
 
     set_global_types(def_types)
 
@@ -874,6 +901,8 @@ def create_class_typemap(node, fields=None):
         f_module={fmt_class.F_module_name: [fmt_class.F_derived_name]},
         # #- f_to_c='{f_var}%%%s()' % fmt_class.F_name_instance_get, # XXX - develop test
         f_to_c="{f_var}%%%s" % fmt_class.F_derived_member,
+#XXX        sh_type="SH_TYPE_OTHER",
+        sh_type="0",
     )
     # import classes which are wrapped by this module
     # XXX - deal with namespaces vs modules
@@ -961,6 +990,8 @@ def create_struct_typemap(node, fields=None):
         f_derived_type=fmt_class.F_derived_name,
         f_module={fmt_class.F_module_name: [fmt_class.F_derived_name]},
         PYN_descr=fmt_class.PY_struct_array_descr_variable,
+#XXX        sh_type="SH_TYPE_STRUCT",
+        sh_type="0",
     )
     if fields is not None:
         ntypemap.update(fields)
@@ -1283,6 +1314,7 @@ fc_statements = dict(
             "{c_var_context}->cxx.addr  = {cxx_var};",
             "{c_var_context}->cxx.idtor = {idtor};",
             "{c_var_context}->addr.base = {cxx_var};",
+            "{c_var_context}->type = {sh_type};",
             "{c_var_context}->elem_len = sizeof({cxx_type});",
             "{c_var_context}->size = *{c_var_dimension};",
         ],
@@ -1377,7 +1409,8 @@ fc_statements = dict(
     ),
     c_char_result_buf_allocatable=dict(
         buf_args=["context"],
-        c_helper="copy_string",
+#        c_helper="copy_string",
+        c_helper="capsule_data_helper ShroudTypeDefines",
         # Copy address of result into c_var and save length.
         # When returning a std::string (and not a reference or pointer)
         # an intermediate object is created to save the results
@@ -1386,6 +1419,7 @@ fc_statements = dict(
             "{c_var_context}->cxx.addr = {cxx_cast_to_void_ptr};",
             "{c_var_context}->cxx.idtor = {idtor};",
             "{c_var_context}->addr.ccharp = {cxx_var};",
+            "{c_var_context}->type = {sh_type};",
             "{c_var_context}->elem_len = {cxx_var} == NULL ? 0 : {stdlib}strlen({cxx_var});",
             "{c_var_context}->size = 1;",
         ],
@@ -1570,7 +1604,7 @@ fc_statements = dict(
     c_vector_out_buf=dict(
         buf_args=["context"],
         cxx_local_var="pointer",
-        c_helper="capsule_data_helper copy_array",
+        c_helper="capsule_data_helper copy_array ShroudTypeDefines",
         pre_call=[
             "{c_const}std::vector<{cxx_T}>"
             "\t *{cxx_var} = new std::vector<{cxx_T}>;"
@@ -1581,6 +1615,7 @@ fc_statements = dict(
             "{c_var_context}->cxx.idtor = {idtor};",
             "{c_var_context}->addr.base = {cxx_var}->empty()"
             " ? NULL : &{cxx_var}->front();",
+            "{c_var_context}->type = {sh_type};",
             "{c_var_context}->elem_len = sizeof({cxx_T});",
             "{c_var_context}->size = {cxx_var}->size();",
         ],
@@ -1594,6 +1629,8 @@ fc_statements = dict(
     c_vector_inout_buf=dict(
         buf_args=["arg", "size", "context"],
         cxx_local_var="pointer",
+#        c_helper="capsule_data_helper copy_array ShroudTypeDefines",
+        c_helper="capsule_data_helper ShroudTypeDefines",
         pre_call=[
             "std::vector<{cxx_T}> *{cxx_var} = \tnew std::vector<{cxx_T}>\t("
             "\t{c_var}, {c_var} + {c_var_size});"
@@ -1604,6 +1641,7 @@ fc_statements = dict(
             "{c_var_context}->cxx.idtor = {idtor};",
             "{c_var_context}->addr.base = {cxx_var}->empty()"
             " ? NULL : &{cxx_var}->front();",
+            "{c_var_context}->type = {sh_type};",
             "{c_var_context}->elem_len = sizeof({cxx_T});",
             "{c_var_context}->size = {cxx_var}->size();",
         ],
@@ -1618,7 +1656,7 @@ fc_statements = dict(
     c_vector_result_buf=dict(
         buf_args=["context"],
         cxx_local_var="pointer",
-        c_helper="capsule_data_helper copy_array",
+        c_helper="capsule_data_helper copy_array ShroudTypeDefines",
         pre_call=[
             "{c_const}std::vector<{cxx_T}>"
             "\t *{cxx_var} = new std::vector<{cxx_T}>;"
@@ -1629,6 +1667,7 @@ fc_statements = dict(
             "{c_var_context}->cxx.idtor = {idtor};",
             "{c_var_context}->addr.base = {cxx_var}->empty()"
             " ? NULL : &{cxx_var}->front();",
+            "{c_var_context}->type = {sh_type};",
             "{c_var_context}->elem_len = sizeof({cxx_T});",
             "{c_var_context}->size = {cxx_var}->size();",
         ],

--- a/shroud/whelpers.py
+++ b/shroud/whelpers.py
@@ -346,6 +346,7 @@ union {{+
 const void * base;
 const char * ccharp;
 -}} addr;
+int type;        /* type of element */
 size_t elem_len; /* bytes-per-item or character len in c++ */
 size_t size;     /* size of data in c++ */
 -}};
@@ -370,6 +371,8 @@ typedef struct s_{C_array_type} {C_array_type};{lend}""",
 type({F_capsule_data_type}) :: cxx
 ! address of data in cxx
 type(C_PTR) :: base_addr = C_NULL_PTR
+! type of element
+integer(C_INT) :: type
 ! bytes-per-item or character len of data in cxx
 integer(C_SIZE_T) :: elem_len = 0_C_SIZE_T
 ! size of data in cxx
@@ -730,6 +733,50 @@ if (PyList_Check(seq))
 # Static helpers
 
 CHelpers = dict(
+    ShroudTypeDefines=dict(
+        # Order derived from TS 29113
+        # with the addition of unsigned types
+        temp_source="""
+#define SH_TYPE_SIGNED_CHAR 1
+#define SH_TYPE_SHORT       2
+#define SH_TYPE_INT         3
+#define SH_TYPE_LONG        4
+#define SH_TYPE_LONG_LONG   5
+#define SH_TYPE_SIZE_T      6
+
+#define SH_TYPE_UNSIGNED_SHORT       SH_TYPE_SHORT + 100
+#define SH_TYPE_UNSIGNED_INT         SH_TYPE_INT + 100
+#define SH_TYPE_UNSIGNED_LONG        SH_TYPE_LONG + 100
+#define SH_TYPE_UNSIGNED_LONG_LONG   SH_TYPE_LONG_LONG + 100
+
+#define SH_TYPE_INT8_T      7
+#define SH_TYPE_INT16_T     8
+#define SH_TYPE_INT32_T     9
+#define SH_TYPE_INT64_T    10
+
+#define SH_TYPE_UINT8_T    SH_TYPE_INT8_T + 100
+#define SH_TYPE_UINT16_T   SH_TYPE_INT16_T + 100
+#define SH_TYPE_UINT32_T   SH_TYPE_INT32_T + 100
+#define SH_TYPE_UINT64_T   SH_TYPE_INT64_T + 100
+
+/* least8 least16 least32 least64 */
+/* fast8 fast16 fast32 fast64 */
+/* intmax_t intptr_t ptrdiff_t */
+
+#define SH_TYPE_FLOAT        22
+#define SH_TYPE_DOUBLE       23
+#define SH_TYPE_LONG_DOUBLE  24
+#define SH_TYPE_FLOAT_COMPLEX       25
+#define SH_TYPE_DOUBLE_COMPLEX      26
+#define SH_TYPE_LONG_DOUBLE_COMPLEX 27
+
+#define SH_TYPE_BOOL       28
+#define SH_TYPE_CHAR       29
+#define SH_TYPE_CPTR       30
+#define SH_TYPE_STRUCT     31
+#define SH_TYPE_OTHER      32
+        """,
+    ),
     ShroudStrCopy=dict(
         c_header="<string.h>",
         c_source="""

--- a/shroud/whelpers.py
+++ b/shroud/whelpers.py
@@ -736,7 +736,9 @@ CHelpers = dict(
     ShroudTypeDefines=dict(
         # Order derived from TS 29113
         # with the addition of unsigned types
-        temp_source="""
+        scope="utility",
+        source="""
+/* Shroud type defines */
 #define SH_TYPE_SIGNED_CHAR 1
 #define SH_TYPE_SHORT       2
 #define SH_TYPE_INT         3
@@ -774,8 +776,7 @@ CHelpers = dict(
 #define SH_TYPE_CHAR       29
 #define SH_TYPE_CPTR       30
 #define SH_TYPE_STRUCT     31
-#define SH_TYPE_OTHER      32
-        """,
+#define SH_TYPE_OTHER      32""",
     ),
     ShroudStrCopy=dict(
         c_header="<string.h>",

--- a/shroud/wrapc.py
+++ b/shroud/wrapc.py
@@ -772,6 +772,7 @@ class Wrapc(util.WrapperMixin):
             fmt_result.c_var = fmt_result.C_local + fmt_result.C_result
             fmt_result.c_type = result_typemap.c_type
             fmt_result.cxx_type = result_typemap.cxx_type
+            fmt_result.sh_type = result_typemap.sh_type
             c_local_var = ""
             if self.language == "c":
                 fmt_result.cxx_var = fmt_result.c_var
@@ -886,6 +887,7 @@ class Wrapc(util.WrapperMixin):
                 fmt_arg.c_const = ""
             compute_c_deref(arg, None, fmt_arg)
             fmt_arg.cxx_type = arg_typemap.cxx_type
+            fmt_arg.sh_type = arg_typemap.sh_type
             fmt_arg.idtor = "0"
             cxx_local_var = ""
 


### PR DESCRIPTION
Add a type field to the context struct.
Inspired by TS 29113 and will eventually allow a single C function to deal with several
generic fortran function by passing the type down.