### PR TITLE
Allow impl_header to be a blank delimited list

### DIFF
--- a/regression/forward.yaml
+++ b/regression/forward.yaml
@@ -34,6 +34,7 @@ declarations:
 - decl: class Class3
   # forward declaration
   # Will add declarations later, but need the type defined now.
+  cxx_header: header1.hpp header2.hpp
 
 - decl: class Class2
   declarations:

--- a/regression/reference/forward/forward.json
+++ b/regression/reference/forward/forward.json
@@ -3,7 +3,7 @@
     "library": {
         "classes": [
             {
-                "cxx_header": "",
+                "cxx_header": "header1.hpp header2.hpp",
                 "fmtdict": {
                     "CXX_this_call": "SH_this->",
                     "C_header_filename": "wrapClass3.h",
@@ -151,7 +151,7 @@
                             "function_name": "ctor",
                             "underscore_name": "ctor"
                         },
-                        "linenumber": 40,
+                        "linenumber": 41,
                         "options": {}
                     },
                     {
@@ -193,7 +193,7 @@
                             "stmtc1": "c_shadow_dtor",
                             "underscore_name": "dtor"
                         },
-                        "linenumber": 41,
+                        "linenumber": 42,
                         "options": {}
                     },
                     {
@@ -312,7 +312,7 @@
                             "stmtc1": "c_default",
                             "underscore_name": "func1"
                         },
-                        "linenumber": 42,
+                        "linenumber": 43,
                         "options": {}
                     },
                     {
@@ -434,11 +434,11 @@
                             "stmtc1": "c_default",
                             "underscore_name": "accept_class3"
                         },
-                        "linenumber": 43,
+                        "linenumber": 44,
                         "options": {}
                     }
                 ],
-                "linenumber": 38,
+                "linenumber": 39,
                 "name": "Class2",
                 "options": {},
                 "scope": "tutorial::Class2::",

--- a/regression/reference/forward/forward_types.yaml
+++ b/regression/reference/forward/forward_types.yaml
@@ -22,6 +22,7 @@ declarations:
     - type: Class3
       fields:
         base: shadow
+        impl_header: header1.hpp header2.hpp
         cxx_type: tutorial::Class3
         c_type: FOR_Class3
         f_module_name: forward_mod

--- a/regression/reference/forward/pyClass3type.cpp
+++ b/regression/reference/forward/pyClass3type.cpp
@@ -7,7 +7,8 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pyforwardmodule.hpp"
-#include "tutorial.hpp"
+#include "header1.hpp"
+#include "header2.hpp"
 // splicer begin class.Class3.impl.include
 // splicer end class.Class3.impl.include
 

--- a/regression/reference/forward/wrapClass2.cpp
+++ b/regression/reference/forward/wrapClass2.cpp
@@ -7,6 +7,8 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "wrapClass2.h"
+#include "header1.hpp"
+#include "header2.hpp"
 #include "tutorial.hpp"
 
 // splicer begin class.Class2.CXX_definitions

--- a/shroud/util.py
+++ b/shroud/util.py
@@ -258,7 +258,7 @@ class WrapperMixin(object):
                     output.append("}")
 
     def find_header(self, node):
-        """Add cxx_header for node or for parent to header_impl_include."""
+        """Add cxx_header for node or its parent to header_impl_include."""
         if node.cxx_header:
             for hdr in node.cxx_header.split():
                 self.header_impl_include[hdr] = True
@@ -309,8 +309,9 @@ class WrapperMixin(object):
 
         for typedef in types.values():
             hdr = getattr(typedef, lang_header)
-            if hdr:
-                headers.setdefault(hdr, []).append(typedef)
+            if hdr is not None:
+                for h in hdr.split():
+                    headers.setdefault(h, []).append(typedef)
 
         need_blank = True
         for hdr in sorted(headers):

--- a/shroud/wrapc.py
+++ b/shroud/wrapc.py
@@ -879,8 +879,9 @@ class Wrapc(util.WrapperMixin):
             if arg_typemap.base == "vector":
                 fmt_arg.cxx_T = arg.template_arguments[0].typemap.name
 
-            if arg_typemap.impl_header:
-                self.header_impl_include[arg_typemap.impl_header] = True
+            if arg_typemap.impl_header is not None:
+                for hdr in arg_typemap.impl_header.split():
+                    self.header_impl_include[hdr] = True
             arg_typemap, specialize = typemap.lookup_c_statements(arg)
             self.header_typedef_nodes[arg_typemap.name] = arg_typemap
 
@@ -1121,8 +1122,9 @@ class Wrapc(util.WrapperMixin):
                         return_code, "{c_rv_decl} =\t {c_val};", fmt_result
                     )
 
-                if result_typemap.impl_header:
-                    self.header_impl_include[result_typemap.impl_header] = True
+                if result_typemap.impl_header is not None:
+                    for hdr in result_typemap.impl_header.split():
+                        self.header_impl_include[hdr] = True
 
         need_wrapper = self.add_code_from_statements(
             fmt_result, result_blk, pre_call, post_call, need_wrapper


### PR DESCRIPTION
It was putting both includes on the same line:
    #include "header1.h header2.h"
Should be
    #include "header1.h"
    #include "header2.h"