### PR TITLE
Do not use c++ headers when language=c

### DIFF
--- a/regression/reference/clibrary/wrapClibrary.h
+++ b/regression/reference/clibrary/wrapClibrary.h
@@ -16,10 +16,8 @@
 #define WRAPCLIBRARY_H
 
 #include "typesClibrary.h"
-#ifndef __cplusplus
 #include <stdbool.h>
 #include "clibrary.h"
-#endif
 
 // splicer begin C_declarations
 // splicer end C_declarations

--- a/regression/reference/generic/wrapgeneric.h
+++ b/regression/reference/generic/wrapgeneric.h
@@ -16,11 +16,7 @@
 #define WRAPGENERIC_H
 
 #include "typesgeneric.h"
-#ifdef __cplusplus
-#include <cstddef>
-#else
 #include <stddef.h>
-#endif
 
 // splicer begin C_declarations
 // splicer end C_declarations

--- a/regression/reference/struct-c/wrapstruct.h
+++ b/regression/reference/struct-c/wrapstruct.h
@@ -16,9 +16,7 @@
 #define WRAPSTRUCT_H
 
 #include "typesstruct.h"
-#ifndef __cplusplus
 #include "struct.h"
-#endif
 
 // splicer begin C_declarations
 // splicer end C_declarations

--- a/regression/run/clibrary/python/test.py
+++ b/regression/run/clibrary/python/test.py
@@ -57,7 +57,7 @@ class Tutorial(unittest.TestCase):
 
     def testpassCharPtrInOut(self):
         """char * +intent(out)"""
-        self.assertEqual('DOG', strings.passCharPtrInOut('dog'))
+        self.assertEqual('DOG', clibrary.passCharPtrInOut('dog'))
 
     def testReturnOneName(self):
         name1 = clibrary.returnOneName()

--- a/shroud/util.py
+++ b/shroud/util.py
@@ -387,7 +387,9 @@ class WrapperMixin(object):
         lines = []
         self.write_include_group(wrap_headers, lines)
         self.write_include_group(always, lines)
-        if cxx_headers:
+        if self.language == "c":
+            self.write_include_group(c_headers, lines)
+        elif cxx_headers:
             lines.append("#ifdef __cplusplus")
             self.write_include_group(cxx_headers, lines)
             if c_headers:


### PR DESCRIPTION
The generated headers are for use from C, and the implementation is
also compiled with C.