### PR TITLE
Python template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   They were using the C++ function name. This was a problem since a
   C++ function may produce several wrapper via overloading or
   adding bufferify arguments.
+- Improved support for templates in the Python wrappers.
 
 ## v0.11.0 - 2020-01-08
 ### Added

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -251,7 +251,7 @@ F_create_generic
   return type (similar to overloaded functions based on return type in
   C++).
 
-.. should also be set to false when the templated argument in
+.. XXX should also be set to false when the templated argument in
    cxx_template is part of the implementation and not the interface.
 
 F_line_length
@@ -310,6 +310,18 @@ literalinclude2
   Each Fortran interface will be encluded in its own ``interface`` block.
   This is to provide the interface context when code is added to the
   documentation.
+
+PY_create_generic
+  Controls creation of a multi-dispatch function with
+  overloaded/templated functions.
+  It defaults to *true* for
+  most cases but will be set to *False* if a function is templated on
+  the return type since Fortran does not distiuguish generics based on
+  return type (similar to overloaded functions based on return type in
+  C++).
+
+.. XXX should also be set to false when the templated argument in
+   cxx_template is part of the implementation and not the interface.
 
 return_scalar_pointer
   Determines how to treat a function which returns a pointer to a scalar

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -765,6 +765,10 @@ namespace_scope
     The current C++ namespace delimited with ``::`` and a trailing ``::``.
     Used when referencing identifiers: ``{namespace_scope}id``.
 
+PY_ARRAY_UNIQUE_SYMBOL
+   C preprocessor define used by NumPy to allow NumPy to be
+   imported by several source files.
+    
 PY_header_filename_suffix
    Suffix added to Python header files.
    Defaults to ``h``.

--- a/regression/reference/cdesc/cdesc.json
+++ b/regression/reference/cdesc/cdesc.json
@@ -68,6 +68,7 @@
             "LUA_result": "rv",
             "LUA_state_var": "L",
             "LUA_this_call": "",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_CDESC_ARRAY_API",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",
             "PY_dtor_context_typedef": "PY_SHROUD_dtor_context",

--- a/regression/reference/cdesc/cdesc.json
+++ b/regression/reference/cdesc/cdesc.json
@@ -257,6 +257,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "numpy",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/classes/classes.json
+++ b/regression/reference/classes/classes.json
@@ -2977,6 +2977,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "numpy",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/classes/classes.json
+++ b/regression/reference/classes/classes.json
@@ -1686,6 +1686,7 @@
             "LUA_result": "rv",
             "LUA_state_var": "L",
             "LUA_this_call": "",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_CLASSES_ARRAY_API",
             "PY_PyObject": "PyObject",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",

--- a/regression/reference/classes/pyClass1type.cpp
+++ b/regression/reference/classes/pyClass1type.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pyclassesmodule.hpp"
-#include "classes.hpp"
 // splicer begin class.Class1.impl.include
 // splicer end class.Class1.impl.include
 

--- a/regression/reference/classes/pySingletontype.cpp
+++ b/regression/reference/classes/pySingletontype.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pyclassesmodule.hpp"
-#include "classes.hpp"
 // splicer begin class.Singleton.impl.include
 // splicer end class.Singleton.impl.include
 

--- a/regression/reference/classes/pyclassesmodule.cpp
+++ b/regression/reference/classes/pyclassesmodule.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pyclassesmodule.hpp"
-#include "classes.hpp"
 
 // splicer begin include
 // splicer end include

--- a/regression/reference/classes/pyclassesmodule.hpp
+++ b/regression/reference/classes/pyclassesmodule.hpp
@@ -9,6 +9,7 @@
 #ifndef PYCLASSESMODULE_HPP
 #define PYCLASSESMODULE_HPP
 #include <Python.h>
+#include "classes.hpp"
 // splicer begin header.include
 // splicer end header.include
 
@@ -18,9 +19,6 @@ extern void *PY_SHROUD_fetch_context(int icontext);
 extern void PY_SHROUD_capsule_destructor(PyObject *cap);
 
 // ------------------------------
-namespace classes {
-    class Class1;  // forward declare
-}
 extern PyTypeObject PY_Class1_Type;
 // splicer begin class.Class1.C_declaration
 // splicer end class.Class1.C_declaration
@@ -40,9 +38,6 @@ PyObject *PP_Class1_to_Object(classes::Class1 *addr);
 int PP_Class1_from_Object(PyObject *obj, void **addr);
 
 // ------------------------------
-namespace classes {
-    class Singleton;  // forward declare
-}
 extern PyTypeObject PY_Singleton_Type;
 // splicer begin class.Singleton.C_declaration
 // splicer end class.Singleton.C_declaration

--- a/regression/reference/classes/pyclassesutil.cpp
+++ b/regression/reference/classes/pyclassesutil.cpp
@@ -7,8 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pyclassesmodule.hpp"
-#include "classes.hpp"
-
 const char *PY_Class1_capsule_name = "Class1";
 const char *PY_Singleton_capsule_name = "Singleton";
 

--- a/regression/reference/clibrary/clibrary.json
+++ b/regression/reference/clibrary/clibrary.json
@@ -4982,6 +4982,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "numpy",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/clibrary/clibrary.json
+++ b/regression/reference/clibrary/clibrary.json
@@ -122,6 +122,7 @@
             "LUA_result": "rv",
             "LUA_state_var": "L",
             "LUA_this_call": "",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_CLIBRARY_ARRAY_API",
             "PY_PyObject": "PyObject",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",

--- a/regression/reference/clibrary/pyClibrarymodule.c
+++ b/regression/reference/clibrary/pyClibrarymodule.c
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pyClibrarymodule.h"
-#include "clibrary.h"
 
 // splicer begin include
 // splicer end include

--- a/regression/reference/clibrary/pyClibrarymodule.h
+++ b/regression/reference/clibrary/pyClibrarymodule.h
@@ -9,6 +9,7 @@
 #ifndef PYCLIBRARYMODULE_H
 #define PYCLIBRARYMODULE_H
 #include <Python.h>
+#include "clibrary.h"
 // splicer begin header.include
 // splicer end header.include
 

--- a/regression/reference/enum-c/enum.json
+++ b/regression/reference/enum-c/enum.json
@@ -368,6 +368,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "numpy",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/enum-c/enum.json
+++ b/regression/reference/enum-c/enum.json
@@ -257,6 +257,7 @@
             "LUA_result": "rv",
             "LUA_state_var": "L",
             "LUA_this_call": "",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_ENUM_ARRAY_API",
             "PY_PyObject": "PyObject",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",

--- a/regression/reference/enum-c/pyenummodule.c
+++ b/regression/reference/enum-c/pyenummodule.c
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pyenummodule.h"
-#include "enum.h"
 
 // splicer begin include
 // splicer end include

--- a/regression/reference/enum-c/pyenummodule.h
+++ b/regression/reference/enum-c/pyenummodule.h
@@ -9,6 +9,7 @@
 #ifndef PYENUMMODULE_H
 #define PYENUMMODULE_H
 #include <Python.h>
+#include "enum.h"
 // splicer begin header.include
 // splicer end header.include
 

--- a/regression/reference/enum-cxx/enum.json
+++ b/regression/reference/enum-cxx/enum.json
@@ -368,6 +368,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "numpy",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/enum-cxx/enum.json
+++ b/regression/reference/enum-cxx/enum.json
@@ -257,6 +257,7 @@
             "LUA_result": "rv",
             "LUA_state_var": "L",
             "LUA_this_call": "",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_ENUM_ARRAY_API",
             "PY_PyObject": "PyObject",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",

--- a/regression/reference/enum-cxx/pyenummodule.cpp
+++ b/regression/reference/enum-cxx/pyenummodule.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pyenummodule.hpp"
-#include "enum.h"
 
 // splicer begin include
 // splicer end include

--- a/regression/reference/enum-cxx/pyenummodule.hpp
+++ b/regression/reference/enum-cxx/pyenummodule.hpp
@@ -9,6 +9,7 @@
 #ifndef PYENUMMODULE_HPP
 #define PYENUMMODULE_HPP
 #include <Python.h>
+#include "enum.h"
 // splicer begin header.include
 // splicer end header.include
 

--- a/regression/reference/example/example.json
+++ b/regression/reference/example/example.json
@@ -72,6 +72,7 @@
             "LUA_this_call": "",
             "LUA_used_param_state": false,
             "LUA_userdata_type": "XXLUA_userdata_type",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_USERLIBRARY_ARRAY_API",
             "PY_PyObject": "PyObject",
             "PY_capsule_destructor_function": "PP_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PP_SHROUD_capsule_context",

--- a/regression/reference/example/example.json
+++ b/regression/reference/example/example.json
@@ -9543,6 +9543,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "numpy",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/example/pyUserLibrarymodule.cpp
+++ b/regression/reference/example/pyUserLibrarymodule.cpp
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pyUserLibrarymodule.hpp"
+#define PY_ARRAY_UNIQUE_SYMBOL SHROUD_USERLIBRARY_ARRAY_API
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include "numpy/arrayobject.h"
 

--- a/regression/reference/example/pyUserLibrarymodule.hpp
+++ b/regression/reference/example/pyUserLibrarymodule.hpp
@@ -9,6 +9,8 @@
 #ifndef PYUSERLIBRARYMODULE_HPP
 #define PYUSERLIBRARYMODULE_HPP
 #include <Python.h>
+#include "ExClass1.hpp"
+#include "ExClass2.hpp"
 // splicer begin header.include
 // splicer end header.include
 
@@ -18,11 +20,6 @@ extern void *PP_SHROUD_fetch_context(int icontext);
 extern void PP_SHROUD_capsule_destructor(PyObject *cap);
 
 // ------------------------------
-namespace example {
-    namespace nested {
-        class ExClass1;  // forward declare
-    }
-}
 extern PyTypeObject PP_ExClass1_Type;
 // splicer begin namespace.example::nested.class.ExClass1.C_declaration
 // splicer end namespace.example::nested.class.ExClass1.C_declaration
@@ -40,11 +37,6 @@ PyObject *PP_ExClass1_to_Object(example::nested::ExClass1 *addr);
 int PP_ExClass1_from_Object(PyObject *obj, void **addr);
 
 // ------------------------------
-namespace example {
-    namespace nested {
-        class ExClass2;  // forward declare
-    }
-}
 extern PyTypeObject PP_ExClass2_Type;
 // splicer begin namespace.example::nested.class.ExClass2.C_declaration
 // splicer end namespace.example::nested.class.ExClass2.C_declaration

--- a/regression/reference/example/pyUserLibraryutil.cpp
+++ b/regression/reference/example/pyUserLibraryutil.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pyUserLibrarymodule.hpp"
-
 const char *PY_ExClass1_capsule_name = "ExClass1";
 const char *PY_ExClass2_capsule_name = "ExClass2";
 

--- a/regression/reference/example/pyexample_nested_ExClass1type.cpp
+++ b/regression/reference/example/pyexample_nested_ExClass1type.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pyUserLibrarymodule.hpp"
-#include "ExClass1.hpp"
 // splicer begin namespace.example::nested.class.ExClass1.impl.include
 // splicer end namespace.example::nested.class.ExClass1.impl.include
 

--- a/regression/reference/example/pyexample_nested_ExClass2type.cpp
+++ b/regression/reference/example/pyexample_nested_ExClass2type.cpp
@@ -447,7 +447,7 @@ PP_setValue_int(
         const_cast<char **>(SHT_kwlist), &value))
         return NULL;
 
-    self->obj->setValue(value);
+    self->obj->setValue<int>(value);
     Py_RETURN_NONE;
 // splicer end namespace.example::nested.class.ExClass2.method.set_value_int
 }
@@ -469,7 +469,7 @@ PP_setValue_long(
         const_cast<char **>(SHT_kwlist), &value))
         return NULL;
 
-    self->obj->setValue(value);
+    self->obj->setValue<long>(value);
     Py_RETURN_NONE;
 // splicer end namespace.example::nested.class.ExClass2.method.set_value_long
 }
@@ -491,7 +491,7 @@ PP_setValue_float(
         const_cast<char **>(SHT_kwlist), &value))
         return NULL;
 
-    self->obj->setValue(value);
+    self->obj->setValue<float>(value);
     Py_RETURN_NONE;
 // splicer end namespace.example::nested.class.ExClass2.method.set_value_float
 }
@@ -513,7 +513,7 @@ PP_setValue_double(
         const_cast<char **>(SHT_kwlist), &value))
         return NULL;
 
-    self->obj->setValue(value);
+    self->obj->setValue<double>(value);
     Py_RETURN_NONE;
 // splicer end namespace.example::nested.class.ExClass2.method.set_value_double
 }
@@ -528,7 +528,7 @@ PP_getValue_int(
 // splicer begin namespace.example::nested.class.ExClass2.method.get_value_int
     PyObject * SHTPy_rv = NULL;
 
-    int SHCXX_rv = self->obj->getValue();
+    int SHCXX_rv = self->obj->getValue<int>();
 
     // post_call
     SHTPy_rv = PyInt_FromLong(SHCXX_rv);
@@ -547,7 +547,7 @@ PP_getValue_double(
 // splicer begin namespace.example::nested.class.ExClass2.method.get_value_double
     PyObject * SHTPy_rv = NULL;
 
-    double SHCXX_rv = self->obj->getValue();
+    double SHCXX_rv = self->obj->getValue<double>();
 
     // post_call
     SHTPy_rv = PyFloat_FromDouble(SHCXX_rv);

--- a/regression/reference/example/pyexample_nested_ExClass2type.cpp
+++ b/regression/reference/example/pyexample_nested_ExClass2type.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pyUserLibrarymodule.hpp"
-#include "ExClass2.hpp"
 // splicer begin namespace.example::nested.class.ExClass2.impl.include
 // splicer end namespace.example::nested.class.ExClass2.impl.include
 

--- a/regression/reference/forward/forward.json
+++ b/regression/reference/forward/forward.json
@@ -636,6 +636,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "numpy",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/forward/forward.json
+++ b/regression/reference/forward/forward.json
@@ -527,6 +527,7 @@
             "LUA_this_call": "",
             "LUA_used_param_state": false,
             "LUA_userdata_type": "XXLUA_userdata_type",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_FORWARD_ARRAY_API",
             "PY_PyObject": "PyObject",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",

--- a/regression/reference/forward/pyClass2type.cpp
+++ b/regression/reference/forward/pyClass2type.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pyforwardmodule.hpp"
-#include "forward.hpp"
 // splicer begin class.Class2.impl.include
 // splicer end class.Class2.impl.include
 

--- a/regression/reference/forward/pyClass3type.cpp
+++ b/regression/reference/forward/pyClass3type.cpp
@@ -7,9 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pyforwardmodule.hpp"
-#include "forward.hpp"
-#include "header1.hpp"
-#include "header2.hpp"
 // splicer begin class.Class3.impl.include
 // splicer end class.Class3.impl.include
 

--- a/regression/reference/forward/pyforwardmodule.cpp
+++ b/regression/reference/forward/pyforwardmodule.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pyforwardmodule.hpp"
-#include "forward.hpp"
 
 // splicer begin include
 // splicer end include

--- a/regression/reference/forward/pyforwardmodule.hpp
+++ b/regression/reference/forward/pyforwardmodule.hpp
@@ -9,6 +9,9 @@
 #ifndef PYFORWARDMODULE_HPP
 #define PYFORWARDMODULE_HPP
 #include <Python.h>
+#include "forward.hpp"
+#include "header1.hpp"
+#include "header2.hpp"
 // splicer begin header.include
 // splicer end header.include
 
@@ -18,9 +21,6 @@ extern void *PY_SHROUD_fetch_context(int icontext);
 extern void PY_SHROUD_capsule_destructor(PyObject *cap);
 
 // ------------------------------
-namespace forward {
-    class Class3;  // forward declare
-}
 extern PyTypeObject PY_Class3_Type;
 // splicer begin class.Class3.C_declaration
 // splicer end class.Class3.C_declaration
@@ -38,9 +38,6 @@ PyObject *PP_Class3_to_Object(forward::Class3 *addr);
 int PP_Class3_from_Object(PyObject *obj, void **addr);
 
 // ------------------------------
-namespace forward {
-    class Class2;  // forward declare
-}
 extern PyTypeObject PY_Class2_Type;
 // splicer begin class.Class2.C_declaration
 // splicer end class.Class2.C_declaration

--- a/regression/reference/forward/pyforwardutil.cpp
+++ b/regression/reference/forward/pyforwardutil.cpp
@@ -7,8 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pyforwardmodule.hpp"
-#include "forward.hpp"
-
 const char *PY_Class3_capsule_name = "Class3";
 const char *PY_Class2_capsule_name = "Class2";
 

--- a/regression/reference/generic/generic.json
+++ b/regression/reference/generic/generic.json
@@ -69,6 +69,7 @@
             "LUA_result": "rv",
             "LUA_state_var": "L",
             "LUA_this_call": "",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_GENERIC_ARRAY_API",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",
             "PY_dtor_context_typedef": "PY_SHROUD_dtor_context",

--- a/regression/reference/generic/generic.json
+++ b/regression/reference/generic/generic.json
@@ -2430,6 +2430,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "numpy",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/include/include.json
+++ b/regression/reference/include/include.json
@@ -271,6 +271,7 @@
             "LUA_result": "rv",
             "LUA_state_var": "L",
             "LUA_this_call": "",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_LIBRARY_ARRAY_API",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",
             "PY_dtor_context_typedef": "PY_SHROUD_dtor_context",

--- a/regression/reference/include/include.json
+++ b/regression/reference/include/include.json
@@ -856,6 +856,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "numpy",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/interface/interface.json
+++ b/regression/reference/interface/interface.json
@@ -345,6 +345,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "numpy",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/interface/interface.json
+++ b/regression/reference/interface/interface.json
@@ -68,6 +68,7 @@
             "LUA_result": "rv",
             "LUA_state_var": "L",
             "LUA_this_call": "",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_INTERFACE_ARRAY_API",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",
             "PY_dtor_context_typedef": "PY_SHROUD_dtor_context",

--- a/regression/reference/memdoc/memdoc.json
+++ b/regression/reference/memdoc/memdoc.json
@@ -333,6 +333,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "numpy",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/memdoc/memdoc.json
+++ b/regression/reference/memdoc/memdoc.json
@@ -65,6 +65,7 @@
             "LUA_result": "rv",
             "LUA_state_var": "L",
             "LUA_this_call": "",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_MEMDOC_ARRAY_API",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",
             "PY_dtor_context_typedef": "PY_SHROUD_dtor_context",

--- a/regression/reference/names/names.json
+++ b/regression/reference/names/names.json
@@ -303,6 +303,7 @@
             "LUA_result": "rv",
             "LUA_state_var": "L",
             "LUA_this_call": "",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_TESTNAMES_ARRAY_API",
             "PY_PyObject": "PyObject",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",

--- a/regression/reference/names/names.json
+++ b/regression/reference/names/names.json
@@ -2845,6 +2845,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "numpy",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/names/pystd_vector_doubletype.cpp
+++ b/regression/reference/names/pystd_vector_doubletype.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pytestnamesmodule.hpp"
-#include <vector>
 // splicer begin namespace.std.class.vector.impl.include
 // splicer end namespace.std.class.vector.impl.include
 

--- a/regression/reference/names/pystd_vector_instantiation3type.cpp
+++ b/regression/reference/names/pystd_vector_instantiation3type.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pytestnamesmodule.hpp"
-#include <vector>
 // splicer begin namespace.std.class.vector.impl.include
 // splicer end namespace.std.class.vector.impl.include
 

--- a/regression/reference/names/pystd_vector_instantiation5type.cpp
+++ b/regression/reference/names/pystd_vector_instantiation5type.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pytestnamesmodule.hpp"
-#include <vector>
 // splicer begin namespace.std.class.vector.impl.include
 // splicer end namespace.std.class.vector.impl.include
 

--- a/regression/reference/names/pystd_vector_inttype.cpp
+++ b/regression/reference/names/pystd_vector_inttype.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pytestnamesmodule.hpp"
-#include <vector>
 // splicer begin namespace.std.class.vector.impl.include
 // splicer end namespace.std.class.vector.impl.include
 

--- a/regression/reference/names/pytestnamesmodule.cpp
+++ b/regression/reference/names/pytestnamesmodule.cpp
@@ -206,7 +206,7 @@ PY_name_instantiation1(
         const_cast<char **>(SHT_kwlist), &arg1, &arg2))
         return NULL;
 
-    FunctionTU(arg1, arg2);
+    FunctionTU<int, long>(arg1, arg2);
     Py_RETURN_NONE;
 // splicer end function.function_tu_0
 }
@@ -234,7 +234,7 @@ PY_FunctionTU_instantiation2(
         const_cast<char **>(SHT_kwlist), &arg1, &arg2))
         return NULL;
 
-    FunctionTU(arg1, arg2);
+    FunctionTU<float, double>(arg1, arg2);
     Py_RETURN_NONE;
 // splicer end function.function_tu_instantiation2
 }
@@ -257,7 +257,7 @@ PY_UseImplWorker_instantiation3(
 // splicer begin function.use_impl_worker_instantiation3
     PyObject * SHTPy_rv = NULL;
 
-    int ARG_rv = UseImplWorker();
+    int ARG_rv = UseImplWorker<internal::ImplWorker1>();
 
     // post_call
     SHTPy_rv = PyInt_FromLong(ARG_rv);

--- a/regression/reference/names/pytestnamesmodule.hpp
+++ b/regression/reference/names/pytestnamesmodule.hpp
@@ -54,7 +54,7 @@ PyObject_HEAD
 } PY_Vvv1;
 
 extern const char *PY_Vvv1_capsule_name;
-PyObject *PP_Vvv1_to_Object(std::Vvv1 *addr);
+PyObject *PP_Vvv1_to_Object(std::vector<int> *addr);
 int PP_Vvv1_from_Object(PyObject *obj, void **addr);
 
 // ------------------------------
@@ -74,7 +74,7 @@ PyObject_HEAD
 } PY_vector_double;
 
 extern const char *PY_vector_double_capsule_name;
-PyObject *PP_vector_double_to_Object(std::vector_double *addr);
+PyObject *PP_vector_double_to_Object(std::vector<double> *addr);
 int PP_vector_double_from_Object(PyObject *obj, void **addr);
 
 // ------------------------------
@@ -94,7 +94,7 @@ PyObject_HEAD
 } PY_vector_instantiation5;
 
 extern const char *PY_vector_instantiation5_capsule_name;
-PyObject *PP_vector_instantiation5_to_Object(std::vector_instantiation5 *addr);
+PyObject *PP_vector_instantiation5_to_Object(std::vector<long> *addr);
 int PP_vector_instantiation5_from_Object(PyObject *obj, void **addr);
 
 // ------------------------------
@@ -114,7 +114,7 @@ PyObject_HEAD
 } PY_vector_instantiation3;
 
 extern const char *PY_vector_instantiation3_capsule_name;
-PyObject *PP_vector_instantiation3_to_Object(std::vector_instantiation3 *addr);
+PyObject *PP_vector_instantiation3_to_Object(std::vector<internal::ImplWorker1> *addr);
 int PP_vector_instantiation3_from_Object(PyObject *obj, void **addr);
 
 // ------------------------------
@@ -150,7 +150,7 @@ PyObject_HEAD
 } PY_twoTs_0;
 
 extern const char *PY_twoTs_0_capsule_name;
-PyObject *PP_twoTs_0_to_Object(twoTs_0 *addr);
+PyObject *PP_twoTs_0_to_Object(twoTs<int, long> *addr);
 int PP_twoTs_0_from_Object(PyObject *obj, void **addr);
 
 // ------------------------------
@@ -168,7 +168,7 @@ PyObject_HEAD
 } PY_twoTs_instantiation4;
 
 extern const char *PY_twoTs_instantiation4_capsule_name;
-PyObject *PP_twoTs_instantiation4_to_Object(twoTs_instantiation4 *addr);
+PyObject *PP_twoTs_instantiation4_to_Object(twoTs<float, double> *addr);
 int PP_twoTs_instantiation4_from_Object(PyObject *obj, void **addr);
 // ------------------------------
 

--- a/regression/reference/names/pytestnamesmodule.hpp
+++ b/regression/reference/names/pytestnamesmodule.hpp
@@ -47,7 +47,7 @@ extern PyTypeObject PY_Vvv1_Type;
 
 typedef struct {
 PyObject_HEAD
-    std::Vvv1 * myobj;
+    std::vector<int> * myobj;
     int mydtor;
     // splicer begin namespace.std.class.vector.C_object
     // splicer end namespace.std.class.vector.C_object
@@ -67,7 +67,7 @@ extern PyTypeObject PY_vector_double_Type;
 
 typedef struct {
 PyObject_HEAD
-    std::vector_double * myobj;
+    std::vector<double> * myobj;
     int mydtor;
     // splicer begin namespace.std.class.vector.C_object
     // splicer end namespace.std.class.vector.C_object
@@ -87,7 +87,7 @@ extern PyTypeObject PY_vector_instantiation5_Type;
 
 typedef struct {
 PyObject_HEAD
-    std::vector_instantiation5 * myobj;
+    std::vector<long> * myobj;
     int mydtor;
     // splicer begin namespace.std.class.vector.C_object
     // splicer end namespace.std.class.vector.C_object
@@ -107,7 +107,7 @@ extern PyTypeObject PY_vector_instantiation3_Type;
 
 typedef struct {
 PyObject_HEAD
-    std::vector_instantiation3 * myobj;
+    std::vector<internal::ImplWorker1> * myobj;
     int mydtor;
     // splicer begin namespace.std.class.vector.C_object
     // splicer end namespace.std.class.vector.C_object
@@ -143,7 +143,7 @@ extern PyTypeObject PY_twoTs_0_Type;
 
 typedef struct {
 PyObject_HEAD
-    twoTs_0 * myobj;
+    twoTs<int, long> * myobj;
     int mydtor;
     // splicer begin class.twoTs.C_object
     // splicer end class.twoTs.C_object
@@ -161,7 +161,7 @@ extern PyTypeObject PY_twoTs_instantiation4_Type;
 
 typedef struct {
 PyObject_HEAD
-    twoTs_instantiation4 * myobj;
+    twoTs<float, double> * myobj;
     int mydtor;
     // splicer begin class.twoTs.C_object
     // splicer end class.twoTs.C_object

--- a/regression/reference/names/pytestnamesmodule.hpp
+++ b/regression/reference/names/pytestnamesmodule.hpp
@@ -9,6 +9,7 @@
 #ifndef PYTESTNAMESMODULE_HPP
 #define PYTESTNAMESMODULE_HPP
 #include <Python.h>
+#include <vector>
 // splicer begin header.include
 // splicer end header.include
 
@@ -18,9 +19,6 @@ extern void *PY_SHROUD_fetch_context(int icontext);
 extern void PY_SHROUD_capsule_destructor(PyObject *cap);
 
 // ------------------------------
-namespace ns0 {
-    class Names;  // forward declare
-}
 extern PyTypeObject PY_Names_Type;
 // splicer begin namespace.ns0.class.Names.C_declaration
 // splicer end namespace.ns0.class.Names.C_declaration
@@ -38,9 +36,6 @@ PyObject *PP_Names_to_Object(ns0::Names *addr);
 int PP_Names_from_Object(PyObject *obj, void **addr);
 
 // ------------------------------
-namespace std {
-    class vector;  // forward declare
-}
 extern PyTypeObject PY_Vvv1_Type;
 // splicer begin namespace.std.class.vector.C_declaration
 // splicer end namespace.std.class.vector.C_declaration
@@ -58,9 +53,6 @@ PyObject *PP_Vvv1_to_Object(std::vector<int> *addr);
 int PP_Vvv1_from_Object(PyObject *obj, void **addr);
 
 // ------------------------------
-namespace std {
-    class vector;  // forward declare
-}
 extern PyTypeObject PY_vector_double_Type;
 // splicer begin namespace.std.class.vector.C_declaration
 // splicer end namespace.std.class.vector.C_declaration
@@ -78,9 +70,6 @@ PyObject *PP_vector_double_to_Object(std::vector<double> *addr);
 int PP_vector_double_from_Object(PyObject *obj, void **addr);
 
 // ------------------------------
-namespace std {
-    class vector;  // forward declare
-}
 extern PyTypeObject PY_vector_instantiation5_Type;
 // splicer begin namespace.std.class.vector.C_declaration
 // splicer end namespace.std.class.vector.C_declaration
@@ -98,9 +87,6 @@ PyObject *PP_vector_instantiation5_to_Object(std::vector<long> *addr);
 int PP_vector_instantiation5_from_Object(PyObject *obj, void **addr);
 
 // ------------------------------
-namespace std {
-    class vector;  // forward declare
-}
 extern PyTypeObject PY_vector_instantiation3_Type;
 // splicer begin namespace.std.class.vector.C_declaration
 // splicer end namespace.std.class.vector.C_declaration
@@ -118,7 +104,6 @@ PyObject *PP_vector_instantiation3_to_Object(std::vector<internal::ImplWorker1> 
 int PP_vector_instantiation3_from_Object(PyObject *obj, void **addr);
 
 // ------------------------------
-class Names2;  // forward declare
 extern PyTypeObject PY_Names2_Type;
 // splicer begin class.Names2.C_declaration
 // splicer end class.Names2.C_declaration
@@ -136,7 +121,6 @@ PyObject *PP_Names2_to_Object(Names2 *addr);
 int PP_Names2_from_Object(PyObject *obj, void **addr);
 
 // ------------------------------
-class twoTs;  // forward declare
 extern PyTypeObject PY_twoTs_0_Type;
 // splicer begin class.twoTs.C_declaration
 // splicer end class.twoTs.C_declaration
@@ -154,7 +138,6 @@ PyObject *PP_twoTs_0_to_Object(twoTs<int, long> *addr);
 int PP_twoTs_0_from_Object(PyObject *obj, void **addr);
 
 // ------------------------------
-class twoTs;  // forward declare
 extern PyTypeObject PY_twoTs_instantiation4_Type;
 // splicer begin class.twoTs.C_declaration
 // splicer end class.twoTs.C_declaration

--- a/regression/reference/names/pytestnamesutil.cpp
+++ b/regression/reference/names/pytestnamesutil.cpp
@@ -46,7 +46,7 @@ int PP_Names_from_Object(PyObject *obj, void **addr)
     // splicer end namespace.ns0.class.Names.utility.from_object
 }
 
-PyObject *PP_Vvv1_to_Object(std::Vvv1 *addr)
+PyObject *PP_Vvv1_to_Object(std::vector<int> *addr)
 {
     // splicer begin namespace.std.class.vector.utility.to_object
     PyObject *voidobj;
@@ -75,7 +75,7 @@ int PP_Vvv1_from_Object(PyObject *obj, void **addr)
     // splicer end namespace.std.class.vector.utility.from_object
 }
 
-PyObject *PP_vector_double_to_Object(std::vector_double *addr)
+PyObject *PP_vector_double_to_Object(std::vector<double> *addr)
 {
     // splicer begin namespace.std.class.vector.utility.to_object
     PyObject *voidobj;
@@ -104,7 +104,7 @@ int PP_vector_double_from_Object(PyObject *obj, void **addr)
     // splicer end namespace.std.class.vector.utility.from_object
 }
 
-PyObject *PP_vector_instantiation5_to_Object(std::vector_instantiation5 *addr)
+PyObject *PP_vector_instantiation5_to_Object(std::vector<long> *addr)
 {
     // splicer begin namespace.std.class.vector.utility.to_object
     PyObject *voidobj;
@@ -133,7 +133,7 @@ int PP_vector_instantiation5_from_Object(PyObject *obj, void **addr)
     // splicer end namespace.std.class.vector.utility.from_object
 }
 
-PyObject *PP_vector_instantiation3_to_Object(std::vector_instantiation3 *addr)
+PyObject *PP_vector_instantiation3_to_Object(std::vector<internal::ImplWorker1> *addr)
 {
     // splicer begin namespace.std.class.vector.utility.to_object
     PyObject *voidobj;
@@ -191,7 +191,7 @@ int PP_Names2_from_Object(PyObject *obj, void **addr)
     // splicer end class.Names2.utility.from_object
 }
 
-PyObject *PP_twoTs_0_to_Object(twoTs_0 *addr)
+PyObject *PP_twoTs_0_to_Object(twoTs<int, long> *addr)
 {
     // splicer begin class.twoTs.utility.to_object
     PyObject *voidobj;
@@ -220,7 +220,7 @@ int PP_twoTs_0_from_Object(PyObject *obj, void **addr)
     // splicer end class.twoTs.utility.from_object
 }
 
-PyObject *PP_twoTs_instantiation4_to_Object(twoTs_instantiation4 *addr)
+PyObject *PP_twoTs_instantiation4_to_Object(twoTs<float, double> *addr)
 {
     // splicer begin class.twoTs.utility.to_object
     PyObject *voidobj;

--- a/regression/reference/names2/names2.json
+++ b/regression/reference/names2/names2.json
@@ -65,6 +65,7 @@
             "LUA_result": "rv",
             "LUA_state_var": "L",
             "LUA_this_call": "",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_NAMES_ARRAY_API",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",
             "PY_dtor_context_typedef": "PY_SHROUD_dtor_context",

--- a/regression/reference/names2/names2.json
+++ b/regression/reference/names2/names2.json
@@ -195,6 +195,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "numpy",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/namespace/namespace.json
+++ b/regression/reference/namespace/namespace.json
@@ -808,6 +808,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "numpy",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/namespace/namespace.json
+++ b/regression/reference/namespace/namespace.json
@@ -68,6 +68,7 @@
             "LUA_result": "rv",
             "LUA_state_var": "L",
             "LUA_this_call": "",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_NS_ARRAY_API",
             "PY_PyObject": "PyObject",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",

--- a/regression/reference/namespace/pyns_nsworkmodule.cpp
+++ b/regression/reference/namespace/pyns_nsworkmodule.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pynsmodule.hpp"
-#include "namespace.hpp"
 
 // splicer begin namespace.nswork.include
 // splicer end namespace.nswork.include

--- a/regression/reference/namespace/pyns_outermodule.cpp
+++ b/regression/reference/namespace/pyns_outermodule.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pynsmodule.hpp"
-#include "namespace.hpp"
 
 // splicer begin namespace.outer.include
 // splicer end namespace.outer.include

--- a/regression/reference/namespace/pynsmodule.cpp
+++ b/regression/reference/namespace/pynsmodule.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pynsmodule.hpp"
-#include "namespace.hpp"
 
 // splicer begin include
 // splicer end include

--- a/regression/reference/namespace/pynsmodule.hpp
+++ b/regression/reference/namespace/pynsmodule.hpp
@@ -9,6 +9,7 @@
 #ifndef PYNSMODULE_HPP
 #define PYNSMODULE_HPP
 #include <Python.h>
+#include "namespace.hpp"
 // splicer begin header.include
 // splicer end header.include
 
@@ -18,9 +19,6 @@ extern void *PY_SHROUD_fetch_context(int icontext);
 extern void PY_SHROUD_capsule_destructor(PyObject *cap);
 
 // ------------------------------
-namespace outer {
-    class Cstruct1;  // forward declare
-}
 extern PyTypeObject PY_Cstruct1_Type;
 // splicer begin namespace.outer.class.Cstruct1.C_declaration
 // splicer end namespace.outer.class.Cstruct1.C_declaration
@@ -38,9 +36,6 @@ PyObject *PP_Cstruct1_to_Object(outer::Cstruct1 *addr);
 int PP_Cstruct1_from_Object(PyObject *obj, void **addr);
 
 // ------------------------------
-namespace nswork {
-    class ClassWork;  // forward declare
-}
 extern PyTypeObject PY_ClassWork_Type;
 // splicer begin namespace.nswork.class.ClassWork.C_declaration
 // splicer end namespace.nswork.class.ClassWork.C_declaration

--- a/regression/reference/namespace/pynsutil.cpp
+++ b/regression/reference/namespace/pynsutil.cpp
@@ -7,8 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pynsmodule.hpp"
-#include "namespace.hpp"
-
 const char *PY_Cstruct1_capsule_name = "Cstruct1";
 const char *PY_ClassWork_capsule_name = "ClassWork";
 

--- a/regression/reference/namespace/pynswork_ClassWorktype.cpp
+++ b/regression/reference/namespace/pynswork_ClassWorktype.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pynsmodule.hpp"
-#include "namespace.hpp"
 // splicer begin namespace.nswork.class.ClassWork.impl.include
 // splicer end namespace.nswork.class.ClassWork.impl.include
 

--- a/regression/reference/namespace/pyouter_Cstruct1type.cpp
+++ b/regression/reference/namespace/pyouter_Cstruct1type.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pynsmodule.hpp"
-#include "namespace.hpp"
 // splicer begin namespace.outer.class.Cstruct1.impl.include
 // splicer end namespace.outer.class.Cstruct1.impl.include
 

--- a/regression/reference/namespacedoc/namespacedoc.json
+++ b/regression/reference/namespacedoc/namespacedoc.json
@@ -455,6 +455,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "numpy",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/namespacedoc/namespacedoc.json
+++ b/regression/reference/namespacedoc/namespacedoc.json
@@ -65,6 +65,7 @@
             "LUA_result": "rv",
             "LUA_state_var": "L",
             "LUA_this_call": "",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_WRAPPED_ARRAY_API",
             "PY_PyObject": "PyObject",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",

--- a/regression/reference/none/none.json
+++ b/regression/reference/none/none.json
@@ -65,6 +65,7 @@
             "LUA_result": "rv",
             "LUA_state_var": "L",
             "LUA_this_call": "",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_LIBRARY_ARRAY_API",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",
             "PY_dtor_context_typedef": "PY_SHROUD_dtor_context",

--- a/regression/reference/none/none.json
+++ b/regression/reference/none/none.json
@@ -157,6 +157,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "numpy",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/ownership/ownership.json
+++ b/regression/reference/ownership/ownership.json
@@ -2731,6 +2731,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "numpy",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/ownership/ownership.json
+++ b/regression/reference/ownership/ownership.json
@@ -256,6 +256,7 @@
             "LUA_this_call": "",
             "LUA_used_param_state": false,
             "LUA_userdata_type": "XXLUA_userdata_type",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_OWNERSHIP_ARRAY_API",
             "PY_PyObject": "PyObject",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",

--- a/regression/reference/ownership/pyClass1type.cpp
+++ b/regression/reference/ownership/pyClass1type.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pyownershipmodule.hpp"
-#include "ownership.hpp"
 // splicer begin class.Class1.impl.include
 // splicer end class.Class1.impl.include
 

--- a/regression/reference/ownership/pyownershipmodule.cpp
+++ b/regression/reference/ownership/pyownershipmodule.cpp
@@ -9,7 +9,6 @@
 #include "pyownershipmodule.hpp"
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include "numpy/arrayobject.h"
-#include "ownership.hpp"
 
 // splicer begin include
 // splicer end include

--- a/regression/reference/ownership/pyownershipmodule.cpp
+++ b/regression/reference/ownership/pyownershipmodule.cpp
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pyownershipmodule.hpp"
+#define PY_ARRAY_UNIQUE_SYMBOL SHROUD_OWNERSHIP_ARRAY_API
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include "numpy/arrayobject.h"
 

--- a/regression/reference/ownership/pyownershipmodule.hpp
+++ b/regression/reference/ownership/pyownershipmodule.hpp
@@ -9,6 +9,7 @@
 #ifndef PYOWNERSHIPMODULE_HPP
 #define PYOWNERSHIPMODULE_HPP
 #include <Python.h>
+#include "ownership.hpp"
 // splicer begin header.include
 // splicer end header.include
 
@@ -18,7 +19,6 @@ extern void *PY_SHROUD_fetch_context(int icontext);
 extern void PY_SHROUD_capsule_destructor(PyObject *cap);
 
 // ------------------------------
-class Class1;  // forward declare
 extern PyTypeObject PY_Class1_Type;
 // splicer begin class.Class1.C_declaration
 // splicer end class.Class1.C_declaration

--- a/regression/reference/pointers-list-c/pointers.json
+++ b/regression/reference/pointers-list-c/pointers.json
@@ -64,6 +64,7 @@
             "LUA_result": "rv",
             "LUA_state_var": "L",
             "LUA_this_call": "",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_POINTERS_ARRAY_API",
             "PY_PyObject": "PyObject",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",

--- a/regression/reference/pointers-list-c/pointers.json
+++ b/regression/reference/pointers-list-c/pointers.json
@@ -1118,6 +1118,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "list",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/pointers-list-c/pypointersmodule.c
+++ b/regression/reference/pointers-list-c/pypointersmodule.c
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pypointersmodule.h"
-#include "pointers.hpp"
 #include <stdlib.h>
 
 // splicer begin include

--- a/regression/reference/pointers-list-c/pypointersmodule.h
+++ b/regression/reference/pointers-list-c/pypointersmodule.h
@@ -9,6 +9,7 @@
 #ifndef PYPOINTERSMODULE_H
 #define PYPOINTERSMODULE_H
 #include <Python.h>
+#include "pointers.hpp"
 // splicer begin header.include
 // splicer end header.include
 

--- a/regression/reference/pointers-list-cpp/pointers.json
+++ b/regression/reference/pointers-list-cpp/pointers.json
@@ -64,6 +64,7 @@
             "LUA_result": "rv",
             "LUA_state_var": "L",
             "LUA_this_call": "",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_POINTERS_ARRAY_API",
             "PY_PyObject": "PyObject",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",

--- a/regression/reference/pointers-list-cpp/pointers.json
+++ b/regression/reference/pointers-list-cpp/pointers.json
@@ -1118,6 +1118,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "list",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/pointers-list-cpp/pypointersmodule.cpp
+++ b/regression/reference/pointers-list-cpp/pypointersmodule.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pypointersmodule.hpp"
-#include "pointers.hpp"
 #include <cstdlib>
 
 // splicer begin include

--- a/regression/reference/pointers-list-cpp/pypointersmodule.hpp
+++ b/regression/reference/pointers-list-cpp/pypointersmodule.hpp
@@ -9,6 +9,7 @@
 #ifndef PYPOINTERSMODULE_HPP
 #define PYPOINTERSMODULE_HPP
 #include <Python.h>
+#include "pointers.hpp"
 // splicer begin header.include
 // splicer end header.include
 

--- a/regression/reference/pointers-numpy-c/pointers.json
+++ b/regression/reference/pointers-numpy-c/pointers.json
@@ -64,6 +64,7 @@
             "LUA_result": "rv",
             "LUA_state_var": "L",
             "LUA_this_call": "",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_POINTERS_ARRAY_API",
             "PY_PyObject": "PyObject",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",

--- a/regression/reference/pointers-numpy-c/pointers.json
+++ b/regression/reference/pointers-numpy-c/pointers.json
@@ -1118,6 +1118,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "numpy",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/pointers-numpy-c/pypointersmodule.c
+++ b/regression/reference/pointers-numpy-c/pypointersmodule.c
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pypointersmodule.h"
+#define PY_ARRAY_UNIQUE_SYMBOL SHROUD_POINTERS_ARRAY_API
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include "numpy/arrayobject.h"
 

--- a/regression/reference/pointers-numpy-c/pypointersmodule.c
+++ b/regression/reference/pointers-numpy-c/pypointersmodule.c
@@ -9,7 +9,6 @@
 #include "pypointersmodule.h"
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include "numpy/arrayobject.h"
-#include "pointers.hpp"
 
 // splicer begin include
 // splicer end include

--- a/regression/reference/pointers-numpy-c/pypointersmodule.h
+++ b/regression/reference/pointers-numpy-c/pypointersmodule.h
@@ -9,6 +9,7 @@
 #ifndef PYPOINTERSMODULE_H
 #define PYPOINTERSMODULE_H
 #include <Python.h>
+#include "pointers.hpp"
 // splicer begin header.include
 // splicer end header.include
 

--- a/regression/reference/pointers-numpy-cpp/pointers.json
+++ b/regression/reference/pointers-numpy-cpp/pointers.json
@@ -68,6 +68,7 @@
             "LUA_result": "rv",
             "LUA_state_var": "L",
             "LUA_this_call": "",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_POINTERS_ARRAY_API",
             "PY_PyObject": "PyObject",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",

--- a/regression/reference/pointers-numpy-cpp/pointers.json
+++ b/regression/reference/pointers-numpy-cpp/pointers.json
@@ -1734,6 +1734,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "numpy",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/pointers-numpy-cpp/pypointersmodule.cpp
+++ b/regression/reference/pointers-numpy-cpp/pypointersmodule.cpp
@@ -9,7 +9,6 @@
 #include "pypointersmodule.hpp"
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include "numpy/arrayobject.h"
-#include "pointers.hpp"
 
 // splicer begin include
 // splicer end include

--- a/regression/reference/pointers-numpy-cpp/pypointersmodule.cpp
+++ b/regression/reference/pointers-numpy-cpp/pypointersmodule.cpp
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pypointersmodule.hpp"
+#define PY_ARRAY_UNIQUE_SYMBOL SHROUD_POINTERS_ARRAY_API
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include "numpy/arrayobject.h"
 

--- a/regression/reference/pointers-numpy-cpp/pypointersmodule.hpp
+++ b/regression/reference/pointers-numpy-cpp/pypointersmodule.hpp
@@ -9,6 +9,7 @@
 #ifndef PYPOINTERSMODULE_HPP
 #define PYPOINTERSMODULE_HPP
 #include <Python.h>
+#include "pointers.hpp"
 // splicer begin header.include
 // splicer end header.include
 

--- a/regression/reference/preprocess/preprocess.json
+++ b/regression/reference/preprocess/preprocess.json
@@ -641,6 +641,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "numpy",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/preprocess/preprocess.json
+++ b/regression/reference/preprocess/preprocess.json
@@ -530,6 +530,7 @@
             "LUA_result": "rv",
             "LUA_state_var": "L",
             "LUA_this_call": "",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_PREPROCESS_ARRAY_API",
             "PY_PyObject": "PyObject",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",

--- a/regression/reference/preprocess/pyUser1type.cpp
+++ b/regression/reference/preprocess/pyUser1type.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pypreprocessmodule.hpp"
-#include "preprocess.hpp"
 // splicer begin class.User1.impl.include
 // splicer end class.User1.impl.include
 

--- a/regression/reference/preprocess/pyUser2type.cpp
+++ b/regression/reference/preprocess/pyUser2type.cpp
@@ -8,7 +8,6 @@
 //
 #ifdef USE_USER2
 #include "pypreprocessmodule.hpp"
-#include "User2.hpp"
 // splicer begin class.User2.impl.include
 // splicer end class.User2.impl.include
 

--- a/regression/reference/preprocess/pypreprocessmodule.cpp
+++ b/regression/reference/preprocess/pypreprocessmodule.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pypreprocessmodule.hpp"
-#include "preprocess.hpp"
 
 // splicer begin include
 // splicer end include

--- a/regression/reference/preprocess/pypreprocessmodule.hpp
+++ b/regression/reference/preprocess/pypreprocessmodule.hpp
@@ -9,6 +9,8 @@
 #ifndef PYPREPROCESSMODULE_HPP
 #define PYPREPROCESSMODULE_HPP
 #include <Python.h>
+#include "User2.hpp"
+#include "preprocess.hpp"
 // splicer begin header.include
 // splicer end header.include
 
@@ -18,7 +20,6 @@ extern void *PY_SHROUD_fetch_context(int icontext);
 extern void PY_SHROUD_capsule_destructor(PyObject *cap);
 
 // ------------------------------
-class User1;  // forward declare
 extern PyTypeObject PY_User1_Type;
 // splicer begin class.User1.C_declaration
 // splicer end class.User1.C_declaration
@@ -37,7 +38,6 @@ int PP_User1_from_Object(PyObject *obj, void **addr);
 
 // ------------------------------
 #ifdef USE_USER2
-class User2;  // forward declare
 extern PyTypeObject PY_User2_Type;
 // splicer begin class.User2.C_declaration
 // splicer end class.User2.C_declaration

--- a/regression/reference/scope/scope.json
+++ b/regression/reference/scope/scope.json
@@ -673,6 +673,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "numpy",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/scope/scope.json
+++ b/regression/reference/scope/scope.json
@@ -411,6 +411,7 @@
             "LUA_result": "rv",
             "LUA_state_var": "L",
             "LUA_this_call": "",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_SCOPE_ARRAY_API",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",
             "PY_dtor_context_typedef": "PY_SHROUD_dtor_context",

--- a/regression/reference/statement/statement.json
+++ b/regression/reference/statement/statement.json
@@ -413,6 +413,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "numpy",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/statement/statement.json
+++ b/regression/reference/statement/statement.json
@@ -68,6 +68,7 @@
             "LUA_result": "rv",
             "LUA_state_var": "L",
             "LUA_this_call": "",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_STATEMENT_ARRAY_API",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",
             "PY_dtor_context_typedef": "PY_SHROUD_dtor_context",

--- a/regression/reference/strings/pystringsmodule.cpp
+++ b/regression/reference/strings/pystringsmodule.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pystringsmodule.hpp"
-#include "strings.hpp"
 
 // splicer begin include
 // splicer end include

--- a/regression/reference/strings/pystringsmodule.hpp
+++ b/regression/reference/strings/pystringsmodule.hpp
@@ -9,6 +9,7 @@
 #ifndef PYSTRINGSMODULE_HPP
 #define PYSTRINGSMODULE_HPP
 #include <Python.h>
+#include "strings.hpp"
 // splicer begin header.include
 // splicer end header.include
 

--- a/regression/reference/strings/strings.json
+++ b/regression/reference/strings/strings.json
@@ -68,6 +68,7 @@
             "LUA_result": "rv",
             "LUA_state_var": "L",
             "LUA_this_call": "",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_STRINGS_ARRAY_API",
             "PY_PyObject": "PyObject",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",

--- a/regression/reference/strings/strings.json
+++ b/regression/reference/strings/strings.json
@@ -5907,6 +5907,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "numpy",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/struct-c/pystructmodule.c
+++ b/regression/reference/struct-c/pystructmodule.c
@@ -9,7 +9,6 @@
 #include "pystructmodule.h"
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include "numpy/arrayobject.h"
-#include "struct.h"
 
 // splicer begin include
 // splicer end include

--- a/regression/reference/struct-c/pystructmodule.c
+++ b/regression/reference/struct-c/pystructmodule.c
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pystructmodule.h"
+#define PY_ARRAY_UNIQUE_SYMBOL SHROUD_STRUCT_ARRAY_API
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include "numpy/arrayobject.h"
 

--- a/regression/reference/struct-c/pystructmodule.h
+++ b/regression/reference/struct-c/pystructmodule.h
@@ -9,6 +9,7 @@
 #ifndef PYSTRUCTMODULE_H
 #define PYSTRUCTMODULE_H
 #include <Python.h>
+#include "struct.h"
 // splicer begin header.include
 // splicer end header.include
 

--- a/regression/reference/struct-c/pystructutil.c
+++ b/regression/reference/struct-c/pystructutil.c
@@ -7,8 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pystructmodule.h"
-#include "struct.h"
-
 
 
 // ----------------------------------------

--- a/regression/reference/struct-c/struct.json
+++ b/regression/reference/struct-c/struct.json
@@ -146,6 +146,7 @@
             "LUA_result": "rv",
             "LUA_state_var": "L",
             "LUA_this_call": "",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_STRUCT_ARRAY_API",
             "PY_PyObject": "PyObject",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",

--- a/regression/reference/struct-c/struct.json
+++ b/regression/reference/struct-c/struct.json
@@ -2411,6 +2411,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "numpy",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/struct-cxx/pyCstruct1type.cpp
+++ b/regression/reference/struct-cxx/pyCstruct1type.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pystructmodule.hpp"
-#include "struct.h"
 // splicer begin class.Cstruct1.impl.include
 // splicer end class.Cstruct1.impl.include
 

--- a/regression/reference/struct-cxx/pystructmodule.cpp
+++ b/regression/reference/struct-cxx/pystructmodule.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pystructmodule.hpp"
-#include "struct.h"
 
 // splicer begin include
 // splicer end include

--- a/regression/reference/struct-cxx/pystructmodule.hpp
+++ b/regression/reference/struct-cxx/pystructmodule.hpp
@@ -9,6 +9,7 @@
 #ifndef PYSTRUCTMODULE_HPP
 #define PYSTRUCTMODULE_HPP
 #include <Python.h>
+#include "struct.h"
 // splicer begin header.include
 // splicer end header.include
 
@@ -18,7 +19,6 @@ extern void *PY_SHROUD_fetch_context(int icontext);
 extern void PY_SHROUD_capsule_destructor(PyObject *cap);
 
 // ------------------------------
-class Cstruct1;  // forward declare
 extern PyTypeObject PY_Cstruct1_Type;
 // splicer begin class.Cstruct1.C_declaration
 // splicer end class.Cstruct1.C_declaration

--- a/regression/reference/struct-cxx/pystructutil.cpp
+++ b/regression/reference/struct-cxx/pystructutil.cpp
@@ -7,8 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pystructmodule.hpp"
-#include "struct.h"
-
 const char *PY_Cstruct1_capsule_name = "Cstruct1";
 
 

--- a/regression/reference/struct-cxx/struct.json
+++ b/regression/reference/struct-cxx/struct.json
@@ -271,6 +271,7 @@
             "LUA_result": "rv",
             "LUA_state_var": "L",
             "LUA_this_call": "",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_STRUCT_ARRAY_API",
             "PY_PyObject": "PyObject",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",

--- a/regression/reference/struct-cxx/struct.json
+++ b/regression/reference/struct-cxx/struct.json
@@ -2541,6 +2541,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "numpy",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/templates/pyWorkertype.cpp
+++ b/regression/reference/templates/pyWorkertype.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pytemplatesmodule.hpp"
-#include "templates.hpp"
 // splicer begin class.Worker.impl.include
 // splicer end class.Worker.impl.include
 

--- a/regression/reference/templates/pyWorkertype.cpp
+++ b/regression/reference/templates/pyWorkertype.cpp
@@ -7,6 +7,10 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pytemplatesmodule.hpp"
+#define NO_IMPORT_ARRAY
+#define PY_ARRAY_UNIQUE_SYMBOL SHROUD_TEMPLATES_ARRAY_API
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include "numpy/arrayobject.h"
 // splicer begin class.Worker.impl.include
 // splicer end class.Worker.impl.include
 

--- a/regression/reference/templates/pyinternal_ImplWorker1type.cpp
+++ b/regression/reference/templates/pyinternal_ImplWorker1type.cpp
@@ -7,6 +7,10 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pytemplatesmodule.hpp"
+#define NO_IMPORT_ARRAY
+#define PY_ARRAY_UNIQUE_SYMBOL SHROUD_TEMPLATES_ARRAY_API
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include "numpy/arrayobject.h"
 // splicer begin namespace.internal.class.ImplWorker1.impl.include
 // splicer end namespace.internal.class.ImplWorker1.impl.include
 

--- a/regression/reference/templates/pyinternal_ImplWorker1type.cpp
+++ b/regression/reference/templates/pyinternal_ImplWorker1type.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pytemplatesmodule.hpp"
-#include "implworker1.hpp"
 // splicer begin namespace.internal.class.ImplWorker1.impl.include
 // splicer end namespace.internal.class.ImplWorker1.impl.include
 

--- a/regression/reference/templates/pyinternal_ImplWorker2type.cpp
+++ b/regression/reference/templates/pyinternal_ImplWorker2type.cpp
@@ -7,6 +7,10 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pytemplatesmodule.hpp"
+#define NO_IMPORT_ARRAY
+#define PY_ARRAY_UNIQUE_SYMBOL SHROUD_TEMPLATES_ARRAY_API
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include "numpy/arrayobject.h"
 // splicer begin namespace.internal.class.ImplWorker2.impl.include
 // splicer end namespace.internal.class.ImplWorker2.impl.include
 

--- a/regression/reference/templates/pyinternal_ImplWorker2type.cpp
+++ b/regression/reference/templates/pyinternal_ImplWorker2type.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pytemplatesmodule.hpp"
-#include "implworker2.hpp"
 // splicer begin namespace.internal.class.ImplWorker2.impl.include
 // splicer end namespace.internal.class.ImplWorker2.impl.include
 

--- a/regression/reference/templates/pystd_vector_doubletype.cpp
+++ b/regression/reference/templates/pystd_vector_doubletype.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pytemplatesmodule.hpp"
-#include <vector>
 // splicer begin namespace.std.class.vector.impl.include
 // splicer end namespace.std.class.vector.impl.include
 

--- a/regression/reference/templates/pystd_vector_doubletype.cpp
+++ b/regression/reference/templates/pystd_vector_doubletype.cpp
@@ -101,7 +101,8 @@ PY_at(
         const_cast<char **>(SHT_kwlist), &n))
         return NULL;
     double & SHCXX_rv = self->obj->at(n);
-    SHTPy_rv = PyArray_SimpleNewFromData(0, NULL, NPY_DOUBLE, SHCXX_rv);
+    SHTPy_rv = PyArray_SimpleNewFromData(0, NULL, NPY_DOUBLE,
+        &SHCXX_rv);
     if (SHTPy_rv == NULL) goto fail;
     return (PyObject *) SHTPy_rv;
 

--- a/regression/reference/templates/pystd_vector_doubletype.cpp
+++ b/regression/reference/templates/pystd_vector_doubletype.cpp
@@ -7,6 +7,10 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pytemplatesmodule.hpp"
+#define NO_IMPORT_ARRAY
+#define PY_ARRAY_UNIQUE_SYMBOL SHROUD_TEMPLATES_ARRAY_API
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include "numpy/arrayobject.h"
 // splicer begin namespace.std.class.vector.impl.include
 // splicer end namespace.std.class.vector.impl.include
 

--- a/regression/reference/templates/pystd_vector_inttype.cpp
+++ b/regression/reference/templates/pystd_vector_inttype.cpp
@@ -101,7 +101,7 @@ PY_at(
         const_cast<char **>(SHT_kwlist), &n))
         return NULL;
     int & SHCXX_rv = self->obj->at(n);
-    SHTPy_rv = PyArray_SimpleNewFromData(0, NULL, NPY_INT, SHCXX_rv);
+    SHTPy_rv = PyArray_SimpleNewFromData(0, NULL, NPY_INT, &SHCXX_rv);
     if (SHTPy_rv == NULL) goto fail;
     return (PyObject *) SHTPy_rv;
 

--- a/regression/reference/templates/pystd_vector_inttype.cpp
+++ b/regression/reference/templates/pystd_vector_inttype.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pytemplatesmodule.hpp"
-#include <vector>
 // splicer begin namespace.std.class.vector.impl.include
 // splicer end namespace.std.class.vector.impl.include
 

--- a/regression/reference/templates/pystd_vector_inttype.cpp
+++ b/regression/reference/templates/pystd_vector_inttype.cpp
@@ -7,6 +7,10 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pytemplatesmodule.hpp"
+#define NO_IMPORT_ARRAY
+#define PY_ARRAY_UNIQUE_SYMBOL SHROUD_TEMPLATES_ARRAY_API
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include "numpy/arrayobject.h"
 // splicer begin namespace.std.class.vector.impl.include
 // splicer end namespace.std.class.vector.impl.include
 

--- a/regression/reference/templates/pytemplates_internalmodule.cpp
+++ b/regression/reference/templates/pytemplates_internalmodule.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pytemplatesmodule.hpp"
-#include "templates.hpp"
 
 // splicer begin namespace.internal.include
 // splicer end namespace.internal.include

--- a/regression/reference/templates/pytemplates_stdmodule.cpp
+++ b/regression/reference/templates/pytemplates_stdmodule.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pytemplatesmodule.hpp"
-#include "templates.hpp"
 
 // splicer begin namespace.std.include
 // splicer end namespace.std.include

--- a/regression/reference/templates/pytemplatesmodule.cpp
+++ b/regression/reference/templates/pytemplatesmodule.cpp
@@ -9,7 +9,6 @@
 #include "pytemplatesmodule.hpp"
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include "numpy/arrayobject.h"
-#include "templates.hpp"
 
 // splicer begin include
 // splicer end include

--- a/regression/reference/templates/pytemplatesmodule.cpp
+++ b/regression/reference/templates/pytemplatesmodule.cpp
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pytemplatesmodule.hpp"
+#define PY_ARRAY_UNIQUE_SYMBOL SHROUD_TEMPLATES_ARRAY_API
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include "numpy/arrayobject.h"
 

--- a/regression/reference/templates/pytemplatesmodule.cpp
+++ b/regression/reference/templates/pytemplatesmodule.cpp
@@ -87,6 +87,10 @@ PY_FunctionTU_1(
 // splicer end function.function_tu_1
 }
 
+static char PY_UseImplWorker_internal_ImplWorker1__doc__[] =
+"documentation"
+;
+
 /**
  * \brief Function which uses a templated T in the implemetation.
  *
@@ -105,6 +109,10 @@ PY_UseImplWorker_internal_ImplWorker1(
     return (PyObject *) SHTPy_rv;
 // splicer end function.use_impl_worker_internal_ImplWorker1
 }
+
+static char PY_UseImplWorker_internal_ImplWorker2__doc__[] =
+"documentation"
+;
 
 /**
  * \brief Function which uses a templated T in the implemetation.
@@ -162,49 +170,15 @@ PY_FunctionTU(
     return NULL;
 // splicer end function.function_tu
 }
-
-static char PY_UseImplWorker__doc__[] =
-"documentation"
-;
-
-static PyObject *
-PY_UseImplWorker(
-  PyObject *self,
-  PyObject *args,
-  PyObject *kwds)
-{
-// splicer begin function.use_impl_worker
-    Py_ssize_t SHT_nargs = 0;
-    if (args != NULL) SHT_nargs += PyTuple_Size(args);
-    if (kwds != NULL) SHT_nargs += PyDict_Size(args);
-    PyObject *rvobj;
-    if (SHT_nargs == 0) {
-        rvobj = PY_UseImplWorker_internal_ImplWorker1(self, args, kwds);
-        if (!PyErr_Occurred()) {
-            return rvobj;
-        } else if (! PyErr_ExceptionMatches(PyExc_TypeError)) {
-            return rvobj;
-        }
-        PyErr_Clear();
-    }
-    if (SHT_nargs == 0) {
-        rvobj = PY_UseImplWorker_internal_ImplWorker2(self, args, kwds);
-        if (!PyErr_Occurred()) {
-            return rvobj;
-        } else if (! PyErr_ExceptionMatches(PyExc_TypeError)) {
-            return rvobj;
-        }
-        PyErr_Clear();
-    }
-    PyErr_SetString(PyExc_TypeError, "wrong arguments multi-dispatch");
-    return NULL;
-// splicer end function.use_impl_worker
-}
 static PyMethodDef PY_methods[] = {
+{"UseImplWorker_internal_ImplWorker1",
+    (PyCFunction)PY_UseImplWorker_internal_ImplWorker1, METH_NOARGS,
+    PY_UseImplWorker_internal_ImplWorker1__doc__},
+{"UseImplWorker_internal_ImplWorker2",
+    (PyCFunction)PY_UseImplWorker_internal_ImplWorker2, METH_NOARGS,
+    PY_UseImplWorker_internal_ImplWorker2__doc__},
 {"FunctionTU", (PyCFunction)PY_FunctionTU, METH_VARARGS|METH_KEYWORDS,
     PY_FunctionTU__doc__},
-{"UseImplWorker", (PyCFunction)PY_UseImplWorker,
-    METH_VARARGS|METH_KEYWORDS, PY_UseImplWorker__doc__},
 {NULL,   (PyCFunction)NULL, 0, NULL}            /* sentinel */
 };
 

--- a/regression/reference/templates/pytemplatesmodule.cpp
+++ b/regression/reference/templates/pytemplatesmodule.cpp
@@ -55,7 +55,7 @@ PY_FunctionTU_0(
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "il:FunctionTU",
         const_cast<char **>(SHT_kwlist), &arg1, &arg2))
         return NULL;
-    FunctionTU(arg1, arg2);
+    FunctionTU<int, long>(arg1, arg2);
     Py_RETURN_NONE;
 // splicer end function.function_tu_0
 }
@@ -81,7 +81,7 @@ PY_FunctionTU_1(
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "fd:FunctionTU",
         const_cast<char **>(SHT_kwlist), &arg1, &arg2))
         return NULL;
-    FunctionTU(arg1, arg2);
+    FunctionTU<float, double>(arg1, arg2);
     Py_RETURN_NONE;
 // splicer end function.function_tu_1
 }
@@ -99,7 +99,7 @@ PY_UseImplWorker_internal_ImplWorker1(
 // splicer begin function.use_impl_worker_internal_ImplWorker1
     PyObject * SHTPy_rv = NULL;
 
-    int SHCXX_rv = UseImplWorker();
+    int SHCXX_rv = UseImplWorker<internal::ImplWorker1>();
     SHTPy_rv = PyInt_FromLong(SHCXX_rv);
     return (PyObject *) SHTPy_rv;
 // splicer end function.use_impl_worker_internal_ImplWorker1
@@ -118,7 +118,7 @@ PY_UseImplWorker_internal_ImplWorker2(
 // splicer begin function.use_impl_worker_internal_ImplWorker2
     PyObject * SHTPy_rv = NULL;
 
-    int SHCXX_rv = UseImplWorker();
+    int SHCXX_rv = UseImplWorker<internal::ImplWorker2>();
     SHTPy_rv = PyInt_FromLong(SHCXX_rv);
     return (PyObject *) SHTPy_rv;
 // splicer end function.use_impl_worker_internal_ImplWorker2

--- a/regression/reference/templates/pytemplatesmodule.hpp
+++ b/regression/reference/templates/pytemplatesmodule.hpp
@@ -9,6 +9,10 @@
 #ifndef PYTEMPLATESMODULE_HPP
 #define PYTEMPLATESMODULE_HPP
 #include <Python.h>
+#include <vector>
+#include "implworker1.hpp"
+#include "implworker2.hpp"
+#include "templates.hpp"
 // splicer begin header.include
 // splicer end header.include
 
@@ -18,9 +22,6 @@ extern void *PY_SHROUD_fetch_context(int icontext);
 extern void PY_SHROUD_capsule_destructor(PyObject *cap);
 
 // ------------------------------
-namespace std {
-    class vector;  // forward declare
-}
 extern PyTypeObject PY_vector_int_Type;
 // splicer begin namespace.std.class.vector.C_declaration
 // splicer end namespace.std.class.vector.C_declaration
@@ -38,9 +39,6 @@ PyObject *PP_vector_int_to_Object(std::vector<int> *addr);
 int PP_vector_int_from_Object(PyObject *obj, void **addr);
 
 // ------------------------------
-namespace std {
-    class vector;  // forward declare
-}
 extern PyTypeObject PY_vector_double_Type;
 // splicer begin namespace.std.class.vector.C_declaration
 // splicer end namespace.std.class.vector.C_declaration
@@ -58,9 +56,6 @@ PyObject *PP_vector_double_to_Object(std::vector<double> *addr);
 int PP_vector_double_from_Object(PyObject *obj, void **addr);
 
 // ------------------------------
-namespace internal {
-    class ImplWorker1;  // forward declare
-}
 extern PyTypeObject PY_ImplWorker1_Type;
 // splicer begin namespace.internal.class.ImplWorker1.C_declaration
 // splicer end namespace.internal.class.ImplWorker1.C_declaration
@@ -78,9 +73,6 @@ PyObject *PP_ImplWorker1_to_Object(internal::ImplWorker1 *addr);
 int PP_ImplWorker1_from_Object(PyObject *obj, void **addr);
 
 // ------------------------------
-namespace internal {
-    class ImplWorker2;  // forward declare
-}
 extern PyTypeObject PY_ImplWorker2_Type;
 // splicer begin namespace.internal.class.ImplWorker2.C_declaration
 // splicer end namespace.internal.class.ImplWorker2.C_declaration
@@ -98,7 +90,6 @@ PyObject *PP_ImplWorker2_to_Object(internal::ImplWorker2 *addr);
 int PP_ImplWorker2_from_Object(PyObject *obj, void **addr);
 
 // ------------------------------
-class Worker;  // forward declare
 extern PyTypeObject PY_Worker_Type;
 // splicer begin class.Worker.C_declaration
 // splicer end class.Worker.C_declaration
@@ -116,7 +107,6 @@ PyObject *PP_Worker_to_Object(Worker *addr);
 int PP_Worker_from_Object(PyObject *obj, void **addr);
 
 // ------------------------------
-class user;  // forward declare
 extern PyTypeObject PY_user_int_Type;
 // splicer begin class.user.C_declaration
 // splicer end class.user.C_declaration

--- a/regression/reference/templates/pytemplatesmodule.hpp
+++ b/regression/reference/templates/pytemplatesmodule.hpp
@@ -27,7 +27,7 @@ extern PyTypeObject PY_vector_int_Type;
 
 typedef struct {
 PyObject_HEAD
-    std::vector_int * obj;
+    std::vector<int> * obj;
     int idtor;
     // splicer begin namespace.std.class.vector.C_object
     // splicer end namespace.std.class.vector.C_object
@@ -47,7 +47,7 @@ extern PyTypeObject PY_vector_double_Type;
 
 typedef struct {
 PyObject_HEAD
-    std::vector_double * obj;
+    std::vector<double> * obj;
     int idtor;
     // splicer begin namespace.std.class.vector.C_object
     // splicer end namespace.std.class.vector.C_object
@@ -123,7 +123,7 @@ extern PyTypeObject PY_user_int_Type;
 
 typedef struct {
 PyObject_HEAD
-    user_int * obj;
+    user<int> * obj;
     int idtor;
     // splicer begin class.user.C_object
     // splicer end class.user.C_object

--- a/regression/reference/templates/pytemplatesmodule.hpp
+++ b/regression/reference/templates/pytemplatesmodule.hpp
@@ -34,7 +34,7 @@ PyObject_HEAD
 } PY_vector_int;
 
 extern const char *PY_vector_int_capsule_name;
-PyObject *PP_vector_int_to_Object(std::vector_int *addr);
+PyObject *PP_vector_int_to_Object(std::vector<int> *addr);
 int PP_vector_int_from_Object(PyObject *obj, void **addr);
 
 // ------------------------------
@@ -54,7 +54,7 @@ PyObject_HEAD
 } PY_vector_double;
 
 extern const char *PY_vector_double_capsule_name;
-PyObject *PP_vector_double_to_Object(std::vector_double *addr);
+PyObject *PP_vector_double_to_Object(std::vector<double> *addr);
 int PP_vector_double_from_Object(PyObject *obj, void **addr);
 
 // ------------------------------
@@ -130,7 +130,7 @@ PyObject_HEAD
 } PY_user_int;
 
 extern const char *PY_user_int_capsule_name;
-PyObject *PP_user_int_to_Object(user_int *addr);
+PyObject *PP_user_int_to_Object(user<int> *addr);
 int PP_user_int_from_Object(PyObject *obj, void **addr);
 // ------------------------------
 

--- a/regression/reference/templates/pytemplatesutil.cpp
+++ b/regression/reference/templates/pytemplatesutil.cpp
@@ -17,7 +17,7 @@ const char *PY_Worker_capsule_name = "Worker";
 const char *PY_user_int_capsule_name = "user_int";
 
 
-PyObject *PP_vector_int_to_Object(std::vector_int *addr)
+PyObject *PP_vector_int_to_Object(std::vector<int> *addr)
 {
     // splicer begin namespace.std.class.vector.utility.to_object
     PyObject *voidobj;
@@ -46,7 +46,7 @@ int PP_vector_int_from_Object(PyObject *obj, void **addr)
     // splicer end namespace.std.class.vector.utility.from_object
 }
 
-PyObject *PP_vector_double_to_Object(std::vector_double *addr)
+PyObject *PP_vector_double_to_Object(std::vector<double> *addr)
 {
     // splicer begin namespace.std.class.vector.utility.to_object
     PyObject *voidobj;
@@ -162,7 +162,7 @@ int PP_Worker_from_Object(PyObject *obj, void **addr)
     // splicer end class.Worker.utility.from_object
 }
 
-PyObject *PP_user_int_to_Object(user_int *addr)
+PyObject *PP_user_int_to_Object(user<int> *addr)
 {
     // splicer begin class.user.utility.to_object
     PyObject *voidobj;

--- a/regression/reference/templates/pytemplatesutil.cpp
+++ b/regression/reference/templates/pytemplatesutil.cpp
@@ -7,8 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pytemplatesmodule.hpp"
-#include "templates.hpp"
-
 const char *PY_vector_int_capsule_name = "vector_int";
 const char *PY_vector_double_capsule_name = "vector_double";
 const char *PY_ImplWorker1_capsule_name = "ImplWorker1";

--- a/regression/reference/templates/pyuser_inttype.cpp
+++ b/regression/reference/templates/pyuser_inttype.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pytemplatesmodule.hpp"
-#include "templates.hpp"
 // splicer begin class.user.impl.include
 // splicer end class.user.impl.include
 

--- a/regression/reference/templates/pyuser_inttype.cpp
+++ b/regression/reference/templates/pyuser_inttype.cpp
@@ -56,7 +56,7 @@ PY_nested_double(
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "id:nested",
         const_cast<char **>(SHT_kwlist), &arg1, &arg2))
         return NULL;
-    self->obj->nested(arg1, arg2);
+    self->obj->nested<double>(arg1, arg2);
     Py_RETURN_NONE;
 // splicer end class.user.method.nested_double
 }

--- a/regression/reference/templates/pyuser_inttype.cpp
+++ b/regression/reference/templates/pyuser_inttype.cpp
@@ -7,6 +7,10 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pytemplatesmodule.hpp"
+#define NO_IMPORT_ARRAY
+#define PY_ARRAY_UNIQUE_SYMBOL SHROUD_TEMPLATES_ARRAY_API
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include "numpy/arrayobject.h"
 // splicer begin class.user.impl.include
 // splicer end class.user.impl.include
 

--- a/regression/reference/templates/templates.json
+++ b/regression/reference/templates/templates.json
@@ -418,6 +418,7 @@
             "LUA_result": "rv",
             "LUA_state_var": "L",
             "LUA_this_call": "",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_TEMPLATES_ARRAY_API",
             "PY_PyObject": "PyObject",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",

--- a/regression/reference/templates/templates.json
+++ b/regression/reference/templates/templates.json
@@ -1051,6 +1051,7 @@
                 "linenumber": 107,
                 "options": {
                     "F_create_generic": false,
+                    "PY_create_generic": false,
                     "__line__": 110,
                     "wrap_c": false,
                     "wrap_fortran": false,
@@ -1166,6 +1167,7 @@
                 "linenumber": 107,
                 "options": {
                     "F_create_generic": false,
+                    "PY_create_generic": false,
                     "__line__": 110,
                     "wrap_c": true,
                     "wrap_fortran": true,
@@ -1285,6 +1287,7 @@
                 "linenumber": 107,
                 "options": {
                     "F_create_generic": false,
+                    "PY_create_generic": false,
                     "__line__": 110,
                     "wrap_c": true,
                     "wrap_fortran": true,

--- a/regression/reference/templates/templates.json
+++ b/regression/reference/templates/templates.json
@@ -2609,6 +2609,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "numpy",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/tutorial/pyTutorialmodule.cpp
+++ b/regression/reference/tutorial/pyTutorialmodule.cpp
@@ -243,7 +243,7 @@ PY_TemplateArgument_int(
         const_cast<char **>(SHT_kwlist), &arg))
         return NULL;
 
-    tutorial::TemplateArgument(arg);
+    tutorial::TemplateArgument<int>(arg);
     Py_RETURN_NONE;
 // splicer end function.template_argument_int
 }
@@ -265,7 +265,7 @@ PY_TemplateArgument_double(
         const_cast<char **>(SHT_kwlist), &arg))
         return NULL;
 
-    tutorial::TemplateArgument(arg);
+    tutorial::TemplateArgument<double>(arg);
     Py_RETURN_NONE;
 // splicer end function.template_argument_double
 }

--- a/regression/reference/tutorial/pyTutorialmodule.cpp
+++ b/regression/reference/tutorial/pyTutorialmodule.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pyTutorialmodule.hpp"
-#include "tutorial.hpp"
 
 // splicer begin include
 // splicer end include

--- a/regression/reference/tutorial/pyTutorialmodule.hpp
+++ b/regression/reference/tutorial/pyTutorialmodule.hpp
@@ -9,6 +9,7 @@
 #ifndef PYTUTORIALMODULE_HPP
 #define PYTUTORIALMODULE_HPP
 #include <Python.h>
+#include "tutorial.hpp"
 // splicer begin header.include
 // splicer end header.include
 

--- a/regression/reference/tutorial/tutorial.json
+++ b/regression/reference/tutorial/tutorial.json
@@ -5281,6 +5281,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "numpy",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/tutorial/tutorial.json
+++ b/regression/reference/tutorial/tutorial.json
@@ -133,6 +133,7 @@
             "LUA_this_call": "",
             "LUA_used_param_state": false,
             "LUA_userdata_type": "XXLUA_userdata_type",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_TUTORIAL_ARRAY_API",
             "PY_PyObject": "PyObject",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",

--- a/regression/reference/types/pytypesmodule.cpp
+++ b/regression/reference/types/pytypesmodule.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pytypesmodule.hpp"
-#include "types.hpp"
 
 // splicer begin include
 // splicer end include

--- a/regression/reference/types/pytypesmodule.hpp
+++ b/regression/reference/types/pytypesmodule.hpp
@@ -9,6 +9,7 @@
 #ifndef PYTYPESMODULE_HPP
 #define PYTYPESMODULE_HPP
 #include <Python.h>
+#include "types.hpp"
 // splicer begin header.include
 // splicer end header.include
 

--- a/regression/reference/types/types.json
+++ b/regression/reference/types/types.json
@@ -68,6 +68,7 @@
             "LUA_result": "rv",
             "LUA_state_var": "L",
             "LUA_this_call": "",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_TYPES_ARRAY_API",
             "PY_PyObject": "PyObject",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",

--- a/regression/reference/types/types.json
+++ b/regression/reference/types/types.json
@@ -3536,6 +3536,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "numpy",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/vectors-list/pyvectorsmodule.cpp
+++ b/regression/reference/vectors-list/pyvectorsmodule.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pyvectorsmodule.hpp"
-#include "vectors.hpp"
 
 // splicer begin include
 // splicer end include

--- a/regression/reference/vectors-list/pyvectorsmodule.hpp
+++ b/regression/reference/vectors-list/pyvectorsmodule.hpp
@@ -9,6 +9,7 @@
 #ifndef PYVECTORSMODULE_HPP
 #define PYVECTORSMODULE_HPP
 #include <Python.h>
+#include "vectors.hpp"
 // splicer begin header.include
 // splicer end header.include
 

--- a/regression/reference/vectors-list/vectors.json
+++ b/regression/reference/vectors-list/vectors.json
@@ -64,6 +64,7 @@
             "LUA_result": "rv",
             "LUA_state_var": "L",
             "LUA_this_call": "",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_VECTORS_ARRAY_API",
             "PY_PyObject": "PyObject",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",

--- a/regression/reference/vectors-list/vectors.json
+++ b/regression/reference/vectors-list/vectors.json
@@ -1031,6 +1031,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "list",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/vectors-numpy/pyvectorsmodule.cpp
+++ b/regression/reference/vectors-numpy/pyvectorsmodule.cpp
@@ -9,7 +9,6 @@
 #include "pyvectorsmodule.hpp"
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include "numpy/arrayobject.h"
-#include "vectors.hpp"
 
 // splicer begin include
 // splicer end include

--- a/regression/reference/vectors-numpy/pyvectorsmodule.cpp
+++ b/regression/reference/vectors-numpy/pyvectorsmodule.cpp
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pyvectorsmodule.hpp"
+#define PY_ARRAY_UNIQUE_SYMBOL SHROUD_VECTORS_ARRAY_API
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include "numpy/arrayobject.h"
 

--- a/regression/reference/vectors-numpy/pyvectorsmodule.hpp
+++ b/regression/reference/vectors-numpy/pyvectorsmodule.hpp
@@ -9,6 +9,7 @@
 #ifndef PYVECTORSMODULE_HPP
 #define PYVECTORSMODULE_HPP
 #include <Python.h>
+#include "vectors.hpp"
 // splicer begin header.include
 // splicer end header.include
 

--- a/regression/reference/vectors-numpy/pyvectorsutil.cpp
+++ b/regression/reference/vectors-numpy/pyvectorsutil.cpp
@@ -7,8 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #include "pyvectorsmodule.hpp"
-#include "vectors.hpp"
-
 
 
 // ----------------------------------------

--- a/regression/reference/vectors-numpy/vectors.json
+++ b/regression/reference/vectors-numpy/vectors.json
@@ -64,6 +64,7 @@
             "LUA_result": "rv",
             "LUA_state_var": "L",
             "LUA_this_call": "",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_VECTORS_ARRAY_API",
             "PY_PyObject": "PyObject",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",

--- a/regression/reference/vectors-numpy/vectors.json
+++ b/regression/reference/vectors-numpy/vectors.json
@@ -1040,6 +1040,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "numpy",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/reference/vectors/vectors.json
+++ b/regression/reference/vectors/vectors.json
@@ -68,6 +68,7 @@
             "LUA_result": "rv",
             "LUA_state_var": "L",
             "LUA_this_call": "",
+            "PY_ARRAY_UNIQUE_SYMBOL": "SHROUD_VECTORS_ARRAY_API",
             "PY_capsule_destructor_function": "PY_SHROUD_capsule_destructor",
             "PY_dtor_context_array": "PY_SHROUD_capsule_context",
             "PY_dtor_context_typedef": "PY_SHROUD_dtor_context",

--- a/regression/reference/vectors/vectors.json
+++ b/regression/reference/vectors/vectors.json
@@ -2213,6 +2213,7 @@
             "PY_PyTypeObject_template": "{PY_prefix}{cxx_class}_Type",
             "PY_array_arg": "numpy",
             "PY_capsule_destructor_function_template": "{PY_prefix}SHROUD_capsule_destructor",
+            "PY_create_generic": true,
             "PY_dtor_context_array_template": "{PY_prefix}SHROUD_capsule_context",
             "PY_dtor_context_typedef_template": "{PY_prefix}SHROUD_dtor_context",
             "PY_fetch_context_function_template": "{PY_prefix}SHROUD_fetch_context",

--- a/regression/run/Makefile
+++ b/regression/run/Makefile
@@ -125,11 +125,12 @@ test-python : \
   test-python-pointers-list-cpp \
   test-python-pointers-numpy-c \
   test-python-pointers-list-c \
-  test-python-vectors-numpy \
-  test-python-clibrary \
   test-python-struct-c \
   test-python-struct-cxx \
-  test-python-ownership
+  test-python-vectors-numpy \
+  test-python-clibrary \
+  test-python-ownership \
+  test-python-templates
 
 # test-python-templates
 

--- a/regression/run/namespace/namespace.hpp
+++ b/regression/run/namespace/namespace.hpp
@@ -17,3 +17,8 @@ namespace outer {
 };
 
 void One();
+
+namespace nswork {
+  class ClassWork {
+  };
+};

--- a/regression/run/templates/implworker2.hpp
+++ b/regression/run/templates/implworker2.hpp
@@ -13,7 +13,7 @@ namespace internal
     {
     public:
         static int getValue() {
-            return 1;
+            return 2;
         }
     };
 }  // namespace internal

--- a/regression/run/templates/main.f
+++ b/regression/run/templates/main.f
@@ -85,7 +85,7 @@ contains
     call assert_equals(1, rv_int)
 
     rv_int = use_impl_worker_internal_implworker2()
-    call assert_equals(1, rv_int)
+    call assert_equals(2, rv_int)
 
   end subroutine function_templates
 

--- a/regression/run/templates/python/test.py
+++ b/regression/run/templates/python/test.py
@@ -51,11 +51,11 @@ class Templates(unittest.TestCase):
         templates.FunctionTU(1.2, 2.2)
         # call function_tu(w1, w2)
 
-#        rv_int = templates.UseImplWorker_internal_implworker1()
-#        self.assertEqual(1, rv_int)
+        rv_int = templates.UseImplWorker_internal_ImplWorker1()
+        self.assertEqual(1, rv_int)
 
-#        rv_int = templates.UseImplWorker_internal_implworker2()
-#        self.assertEqual(1, rv_int)
+        rv_int = templates.UseImplWorker_internal_ImplWorker2()
+        self.assertEqual(2, rv_int)
         
 
 # creating a new test suite

--- a/regression/run/templates/python/test.py
+++ b/regression/run/templates/python/test.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2017-2020, Lawrence Livermore National Security, LLC and
+# other Shroud Project Developers.
+# See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+#
+# #######################################################################
+#
+# test the templates module
+#
+from __future__ import print_function
+
+import unittest
+import templates
+
+class Templates(unittest.TestCase):
+    """Test templates problem"""
+     
+    def XXsetUp(self):
+        """ Setting up for the test """
+        print("FooTest:setUp_:begin")
+        ## do something...
+        print("FooTest:setUp_:end")
+     
+    def XXtearDown(self):
+        """Cleaning up after the test"""
+        print("FooTest:tearDown_:begin")
+        ## do something...
+        print("FooTest:tearDown_:end")
+
+    def test_vector_int(self):
+        v1 = templates.vector_int()
+        self.assertIsInstance(v1, templates.vector_int)
+
+        v1.push_back(1)
+
+        ivalue = v1.at(0)
+        self.assertEqual(ivalue, 1)
+
+    def test_vector_double(self):
+        v1 = templates.vector_double()
+        self.assertIsInstance(v1, templates.vector_double)
+
+        v1.push_back(1.5)
+
+        ivalue = v1.at(0)
+        self.assertEqual(ivalue, 1.5)
+
+    def test_function_templates(self):
+        templates.FunctionTU(1, 2)
+        templates.FunctionTU(1.2, 2.2)
+        # call function_tu(w1, w2)
+
+#        rv_int = templates.UseImplWorker_internal_implworker1()
+#        self.assertEqual(1, rv_int)
+
+#        rv_int = templates.UseImplWorker_internal_implworker2()
+#        self.assertEqual(1, rv_int)
+        
+
+# creating a new test suite
+newSuite = unittest.TestSuite()
+ 
+# adding a test case
+newSuite.addTest(unittest.makeSuite(Templates))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/regression/run/templates/python/testpython.c
+++ b/regression/run/templates/python/testpython.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2017-2020, Lawrence Livermore National Security, LLC and
+ * other Shroud Project Developers.
+ * See the top-level COPYRIGHT file for details.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ * #######################################################################
+ */
+#include "Python.h"
+//#include <pytemplatesmodule.hpp>
+#include <stdio.h>
+
+#if PY_MAJOR_VERSION >= 3
+#define MODINIT  PyInit_templates
+#else
+#define MODINIT  inittemplates
+#endif
+PyMODINIT_FUNC MODINIT(void);
+
+int main(int argc, char** argv)  
+{
+    char filename[] = "test.py";
+    FILE* fp;
+
+    Py_Initialize();
+    MODINIT();
+    
+    fp = fopen(filename, "r");
+    PyRun_SimpleFile(fp, filename);
+    fclose(fp);
+    Py_Exit(0);  
+    return 0;
+}

--- a/regression/templates.yaml
+++ b/regression/templates.yaml
@@ -109,6 +109,7 @@ declarations:
      brief: Function which uses a templated T in the implemetation.
   options:
     F_create_generic: False
+    PY_create_generic: False
   cxx_template:
   - instantiation: <internal::ImplWorker1>
   - instantiation: <internal::ImplWorker2>

--- a/shroud/ast.py
+++ b/shroud/ast.py
@@ -496,6 +496,7 @@ class LibraryNode(AstNode, NamespaceMixin):
             LUA_name_template="{function_name}",
             LUA_name_impl_template="{LUA_prefix}{C_name_scope}{underscore_name}",
 
+            PY_create_generic=True,
             PY_module_filename_template=(
                 "py{file_scope}module.{PY_impl_filename_suffix}"
             ),

--- a/shroud/ast.py
+++ b/shroud/ast.py
@@ -605,6 +605,8 @@ class LibraryNode(AstNode, NamespaceMixin):
             LUA_state_var="L",
             LUA_this_call="",
 
+            PY_ARRAY_UNIQUE_SYMBOL="SHROUD_{}_ARRAY_API".format(
+                self.library.upper()),
             PY_prefix="PY_",
             PY_module_name=self.library.lower(),
             PY_result="SHTPy_rv",  # Create PyObject for result

--- a/shroud/util.py
+++ b/shroud/util.py
@@ -288,6 +288,14 @@ class WrapperMixin(object):
         elif node.parent is not None:
             self.find_header(node.parent)
 
+    def find_header2(self, node, dct):
+        """Add cxx_header for node or its parent to header_impl_include."""
+        if node.cxx_header:
+            for hdr in node.cxx_header:
+                dct[hdr] = True
+        elif node.parent is not None:
+            self.find_header2(node.parent, dct)
+
     def add_statements_headers(self, intent_blk):
         """Add headers required by intent_blk to self.header_impl_include.
 

--- a/shroud/util.py
+++ b/shroud/util.py
@@ -280,21 +280,13 @@ class WrapperMixin(object):
                 else:
                     output.append("}")
 
-    def find_header(self, node):
-        """Add cxx_header for node or its parent to header_impl_include."""
-        if node.cxx_header:
-            for hdr in node.cxx_header:
-                self.header_impl_include[hdr] = True
-        elif node.parent is not None:
-            self.find_header(node.parent)
-
-    def find_header2(self, node, dct):
+    def find_header(self, node, dct):
         """Add cxx_header for node or its parent to header_impl_include."""
         if node.cxx_header:
             for hdr in node.cxx_header:
                 dct[hdr] = True
         elif node.parent is not None:
-            self.find_header2(node.parent, dct)
+            self.find_header(node.parent, dct)
 
     def add_statements_headers(self, intent_blk):
         """Add headers required by intent_blk to self.header_impl_include.

--- a/shroud/wrapc.py
+++ b/shroud/wrapc.py
@@ -401,7 +401,7 @@ class Wrapc(util.WrapperMixin):
             output.append('#include "%s"' % hname)
 
         # Use headers from implementation
-        self.find_header(node)
+        self.find_header(node, self.header_impl_include)
         self.header_impl_include.update(self.helper_header["file"])
 
         # headers required by implementation

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -861,6 +861,8 @@ return 1;""",
             flist = overloaded_methods.setdefault(function.ast.name, [])
             if not function.options.wrap_python:
                 continue
+            if not function.options.PY_create_generic:
+                continue
             flist.append(function)
         self.overloaded_methods = overloaded_methods
 

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -1958,9 +1958,13 @@ return 1;""",
             output.append("#" + node.cpp_if)
 
         append_format(output, '#include "{PY_header_filename}"', fmt)
-        #        if self.need_numpy:
-        #            output.append('#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION')
-        #            output.append('#include "numpy/arrayobject.h"')
+        if self.need_numpy:
+            output.append('#define NO_IMPORT_ARRAY')
+            append_format(output,
+                          '#define PY_ARRAY_UNIQUE_SYMBOL {PY_ARRAY_UNIQUE_SYMBOL}',
+                          fmt)
+            output.append('#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION')
+            output.append('#include "numpy/arrayobject.h"')
         self._push_splicer("impl")
 
         # Use headers from implementation
@@ -2207,6 +2211,9 @@ extern PyObject *{PY_prefix}error_obj;
 
         append_format(output, '#include "{PY_header_filename}"', fmt)
         if top and self.need_numpy:
+            append_format(output,
+                          '#define PY_ARRAY_UNIQUE_SYMBOL {PY_ARRAY_UNIQUE_SYMBOL}',
+                          fmt)
             output.append("#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION")
             output.append('#include "numpy/arrayobject.h"')
 

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -3171,7 +3171,7 @@ py_statements = dict(
             "{npy_intp}"
             "{py_var} = "
             "PyArray_SimpleNewFromData({npy_ndims},\t {npy_dims},"
-            "\t {numpy_type},\t {cxx_var});",
+            "\t {numpy_type},\t {cxx_addr}{cxx_var});",
             "if ({py_var} == NULL) goto fail;",
         ],
         object_created=True,

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -361,7 +361,7 @@ PyModule_AddObject(m, "{cxx_class}", (PyObject *)&{PY_PyTypeObject});""",
         if node.cpp_if:
             output.append("#endif // " + node.cpp_if)
 
-        self.find_header2(node, self.header_type_include)
+        self.find_header(node, self.header_type_include)
             
         # header declarations
         output = self.py_class_decl
@@ -2141,7 +2141,7 @@ return 1;""",
         """
         fmt = node.fmtdict
         fname = fmt.PY_header_filename
-        self.find_header2(node, self.header_type_include)
+        self.find_header(node, self.header_type_include)
 
         output = []
 

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -1341,14 +1341,16 @@ return 1;""",
             elif CXX_subprogram == "subroutine":
                 append_format(
                     PY_code,
-                    "{PY_this_call}{function_name}({PY_call_list});",
+                    "{PY_this_call}{function_name}"
+                    "{CXX_template}({PY_call_list});",
                     fmt,
                 )
             else:
                 need_rv = True
                 append_format(
                     PY_code,
-                    "{PY_rv_asgn}{PY_this_call}{function_name}({PY_call_list});",
+                    "{PY_rv_asgn}{PY_this_call}{function_name}"
+                    "{CXX_template}({PY_call_list});",
                     fmt,
                 )
 

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -380,7 +380,7 @@ PyModule_AddObject(m, "{cxx_class}", (PyObject *)&{PY_PyTypeObject});""",
             output,
             "typedef struct {{\n"
             "PyObject_HEAD\n"
-            "+{namespace_scope}{cxx_class} * {PY_type_obj};\n"
+            "+{namespace_scope}{cxx_type} * {PY_type_obj};\n"
             "int {PY_type_dtor};",
             fmt_class,
         )

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -452,7 +452,7 @@ return rv;""",
         to_object = to_object.split("\n")
 
         proto = wformat(
-            "PyObject *{PY_to_object_func}({namespace_scope}{cxx_class} *addr)",
+            "PyObject *{PY_to_object_func}({namespace_scope}{cxx_type} *addr)",
             fmt,
         )
         self.py_class_decl.append(proto + ";")


### PR DESCRIPTION
Improve support for templates in Python wrapper
* Use templates in PyObject : was `vector_int`, now `vector<int>`
* Remove explicit forward declare of classes in header file. Now include files associate with the type. The forward declares did not include templates.  For types such as `vector`, it would be necessary to include all template arguments such as the Allocator.
* Add define `PY_ARRAY_UNIQUE_SYMBOL`.  Only the module file calls `import_array`. Extension types share the array of function pointers created by Numpy.
* Add `PY_create_generic` to avoid creating multi-dispatch function. Useful when the template is part of the implementation and not the interface.