### PR TITLE
Dump helpers

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -50,6 +50,14 @@ sitedir
        Return the installation directory of shroud and exit.
        This path can be used to find cmake/SetupShroud.cmake.
 
+write-helpers BASE
+       Write files which contain the available helper functions
+       into the files BASE.c and BASE.f.
+
+yaml-types FILE
+       Write a YAML file with the default types.
+
+
 Global Fields
 -------------
 

--- a/regression/do-test.py
+++ b/regression/do-test.py
@@ -317,7 +317,10 @@ if __name__ == "__main__":
 
     availTests = [
         TestDesc("none",
-                 cmdline=["--yaml-types", "def_types.yaml"]),
+                 cmdline=[
+                     "--write-helpers", "helpers",
+                     "--yaml-types", "def_types.yaml",
+                 ]),
         TestDesc("tutorial"),
         TestDesc("types"),
         TestDesc("classes"),

--- a/regression/reference/classes/typesclasses.h
+++ b/regression/reference/classes/typesclasses.h
@@ -16,8 +16,8 @@
 extern "C" {
 #endif
 
-// helper capsule_CLA_Class1
 // start struct CLA_Class1
+// helper capsule_CLA_Class1
 struct s_CLA_Class1 {
     void *addr;     /* address of C++ memory */
     int idtor;      /* index of destructor */

--- a/regression/reference/memdoc/typesmemdoc.h
+++ b/regression/reference/memdoc/typesmemdoc.h
@@ -66,8 +66,8 @@ typedef struct s_STR_SHROUD_capsule_data STR_SHROUD_capsule_data;
 #define SH_TYPE_STRUCT     31
 #define SH_TYPE_OTHER      32
 
-// helper array_context
 // start array_context
+// helper array_context
 struct s_STR_SHROUD_array {
     STR_SHROUD_capsule_data cxx;      /* address of C++ memory */
     union {

--- a/regression/reference/memdoc/wrapfmemdoc.f
+++ b/regression/reference/memdoc/wrapfmemdoc.f
@@ -27,8 +27,8 @@ module memdoc_mod
         integer(C_INT) :: idtor = 0       ! index of destructor
     end type SHROUD_capsule_data
 
-    ! helper array_context
     ! start array_context
+    ! helper array_context
     type, bind(C) :: SHROUD_array
         ! address of C++ memory
         type(SHROUD_capsule_data) :: cxx

--- a/regression/reference/memdoc/wrapmemdoc.cpp
+++ b/regression/reference/memdoc/wrapmemdoc.cpp
@@ -19,8 +19,8 @@
 extern "C" {
 
 
-// helper ShroudStrToArray
 // start helper ShroudStrToArray
+// helper ShroudStrToArray
 // Save str metadata into array to allow Fortran to access values.
 static void ShroudStrToArray(STR_SHROUD_array *array, const std::string * src, int idtor)
 {
@@ -38,8 +38,8 @@ static void ShroudStrToArray(STR_SHROUD_array *array, const std::string * src, i
 }
 // end helper ShroudStrToArray
 
-// helper copy_string
 // start helper copy_string
+// helper copy_string
 // Copy the char* or std::string in context into c_var.
 // Called by Fortran to deal with allocatable character.
 void STR_ShroudCopyStringAndFree(STR_SHROUD_array *data, char *c_var, size_t c_var_len) {

--- a/regression/reference/none/helpers.c
+++ b/regression/reference/none/helpers.c
@@ -366,6 +366,1159 @@ static int SHROUD_from_PyObject_char(PyObject *obj, const char *name,
 }
 ##### end from_PyObject_char source
 
+##### start from_PyObject_double source
+
+// helper from_PyObject_double
+// Convert obj into an array of type double
+// Return -1 on error.
+static int SHROUD_from_PyObject_double(PyObject *obj, const char *name,
+    double **pin, Py_ssize_t *psize)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    double *in = static_cast<double *>
+        (std::malloc(size * sizeof(double)));
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in[i] = PyFloat_AsDouble(item);
+        if (PyErr_Occurred()) {
+            std::free(in);
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be double", name,
+                (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    *pin = in;
+    *psize = size;
+    return 0;
+}
+##### end from_PyObject_double source
+
+##### start from_PyObject_float source
+
+// helper from_PyObject_float
+// Convert obj into an array of type float
+// Return -1 on error.
+static int SHROUD_from_PyObject_float(PyObject *obj, const char *name,
+    float **pin, Py_ssize_t *psize)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    float *in = static_cast<float *>(std::malloc(size * sizeof(float)));
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in[i] = PyFloat_AsDouble(item);
+        if (PyErr_Occurred()) {
+            std::free(in);
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be float", name, (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    *pin = in;
+    *psize = size;
+    return 0;
+}
+##### end from_PyObject_float source
+
+##### start from_PyObject_int source
+
+// helper from_PyObject_int
+// Convert obj into an array of type int
+// Return -1 on error.
+static int SHROUD_from_PyObject_int(PyObject *obj, const char *name,
+    int **pin, Py_ssize_t *psize)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    int *in = static_cast<int *>(std::malloc(size * sizeof(int)));
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in[i] = PyInt_AsLong(item);
+        if (PyErr_Occurred()) {
+            std::free(in);
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be int", name, (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    *pin = in;
+    *psize = size;
+    return 0;
+}
+##### end from_PyObject_int source
+
+##### start from_PyObject_int16_t source
+
+// helper from_PyObject_int16_t
+// Convert obj into an array of type int16_t
+// Return -1 on error.
+static int SHROUD_from_PyObject_int16_t(PyObject *obj, const char *name,
+    int16_t **pin, Py_ssize_t *psize)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    int16_t *in = static_cast<int16_t *>
+        (std::malloc(size * sizeof(int16_t)));
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in[i] = PyInt_AsLong(item);
+        if (PyErr_Occurred()) {
+            std::free(in);
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be int16_t", name,
+                (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    *pin = in;
+    *psize = size;
+    return 0;
+}
+##### end from_PyObject_int16_t source
+
+##### start from_PyObject_int32_t source
+
+// helper from_PyObject_int32_t
+// Convert obj into an array of type int32_t
+// Return -1 on error.
+static int SHROUD_from_PyObject_int32_t(PyObject *obj, const char *name,
+    int32_t **pin, Py_ssize_t *psize)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    int32_t *in = static_cast<int32_t *>
+        (std::malloc(size * sizeof(int32_t)));
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in[i] = PyInt_AsLong(item);
+        if (PyErr_Occurred()) {
+            std::free(in);
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be int32_t", name,
+                (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    *pin = in;
+    *psize = size;
+    return 0;
+}
+##### end from_PyObject_int32_t source
+
+##### start from_PyObject_int64_t source
+
+// helper from_PyObject_int64_t
+// Convert obj into an array of type int64_t
+// Return -1 on error.
+static int SHROUD_from_PyObject_int64_t(PyObject *obj, const char *name,
+    int64_t **pin, Py_ssize_t *psize)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    int64_t *in = static_cast<int64_t *>
+        (std::malloc(size * sizeof(int64_t)));
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in[i] = PyInt_AsLong(item);
+        if (PyErr_Occurred()) {
+            std::free(in);
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be int64_t", name,
+                (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    *pin = in;
+    *psize = size;
+    return 0;
+}
+##### end from_PyObject_int64_t source
+
+##### start from_PyObject_int8_t source
+
+// helper from_PyObject_int8_t
+// Convert obj into an array of type int8_t
+// Return -1 on error.
+static int SHROUD_from_PyObject_int8_t(PyObject *obj, const char *name,
+    int8_t **pin, Py_ssize_t *psize)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    int8_t *in = static_cast<int8_t *>
+        (std::malloc(size * sizeof(int8_t)));
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in[i] = PyInt_AsLong(item);
+        if (PyErr_Occurred()) {
+            std::free(in);
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be int8_t", name,
+                (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    *pin = in;
+    *psize = size;
+    return 0;
+}
+##### end from_PyObject_int8_t source
+
+##### start from_PyObject_long source
+
+// helper from_PyObject_long
+// Convert obj into an array of type long
+// Return -1 on error.
+static int SHROUD_from_PyObject_long(PyObject *obj, const char *name,
+    long **pin, Py_ssize_t *psize)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    long *in = static_cast<long *>(std::malloc(size * sizeof(long)));
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in[i] = PyInt_AsLong(item);
+        if (PyErr_Occurred()) {
+            std::free(in);
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be long", name, (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    *pin = in;
+    *psize = size;
+    return 0;
+}
+##### end from_PyObject_long source
+
+##### start from_PyObject_short source
+
+// helper from_PyObject_short
+// Convert obj into an array of type short
+// Return -1 on error.
+static int SHROUD_from_PyObject_short(PyObject *obj, const char *name,
+    short **pin, Py_ssize_t *psize)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    short *in = static_cast<short *>(std::malloc(size * sizeof(short)));
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in[i] = PyInt_AsLong(item);
+        if (PyErr_Occurred()) {
+            std::free(in);
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be short", name, (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    *pin = in;
+    *psize = size;
+    return 0;
+}
+##### end from_PyObject_short source
+
+##### start from_PyObject_uint16_t source
+
+// helper from_PyObject_uint16_t
+// Convert obj into an array of type uint16_t
+// Return -1 on error.
+static int SHROUD_from_PyObject_uint16_t(PyObject *obj,
+    const char *name, uint16_t **pin, Py_ssize_t *psize)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    uint16_t *in = static_cast<uint16_t *>
+        (std::malloc(size * sizeof(uint16_t)));
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in[i] = PyInt_AsLong(item);
+        if (PyErr_Occurred()) {
+            std::free(in);
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be uint16_t", name,
+                (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    *pin = in;
+    *psize = size;
+    return 0;
+}
+##### end from_PyObject_uint16_t source
+
+##### start from_PyObject_uint32_t source
+
+// helper from_PyObject_uint32_t
+// Convert obj into an array of type uint32_t
+// Return -1 on error.
+static int SHROUD_from_PyObject_uint32_t(PyObject *obj,
+    const char *name, uint32_t **pin, Py_ssize_t *psize)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    uint32_t *in = static_cast<uint32_t *>
+        (std::malloc(size * sizeof(uint32_t)));
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in[i] = PyInt_AsLong(item);
+        if (PyErr_Occurred()) {
+            std::free(in);
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be uint32_t", name,
+                (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    *pin = in;
+    *psize = size;
+    return 0;
+}
+##### end from_PyObject_uint32_t source
+
+##### start from_PyObject_uint64_t source
+
+// helper from_PyObject_uint64_t
+// Convert obj into an array of type uint64_t
+// Return -1 on error.
+static int SHROUD_from_PyObject_uint64_t(PyObject *obj,
+    const char *name, uint64_t **pin, Py_ssize_t *psize)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    uint64_t *in = static_cast<uint64_t *>
+        (std::malloc(size * sizeof(uint64_t)));
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in[i] = PyInt_AsLong(item);
+        if (PyErr_Occurred()) {
+            std::free(in);
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be uint64_t", name,
+                (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    *pin = in;
+    *psize = size;
+    return 0;
+}
+##### end from_PyObject_uint64_t source
+
+##### start from_PyObject_uint8_t source
+
+// helper from_PyObject_uint8_t
+// Convert obj into an array of type uint8_t
+// Return -1 on error.
+static int SHROUD_from_PyObject_uint8_t(PyObject *obj, const char *name,
+    uint8_t **pin, Py_ssize_t *psize)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    uint8_t *in = static_cast<uint8_t *>
+        (std::malloc(size * sizeof(uint8_t)));
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in[i] = PyInt_AsLong(item);
+        if (PyErr_Occurred()) {
+            std::free(in);
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be uint8_t", name,
+                (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    *pin = in;
+    *psize = size;
+    return 0;
+}
+##### end from_PyObject_uint8_t source
+
+##### start from_PyObject_unsigned int source
+
+// helper from_PyObject_unsigned int
+// Convert obj into an array of type unsigned int
+// Return -1 on error.
+static int SHROUD_from_PyObject_unsigned int(PyObject *obj,
+    const char *name, unsigned int **pin, Py_ssize_t *psize)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    unsigned int *in = static_cast<unsigned int *>
+        (std::malloc(size * sizeof(unsigned int)));
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in[i] = PyInt_AsLong(item);
+        if (PyErr_Occurred()) {
+            std::free(in);
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be unsigned int", name,
+                (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    *pin = in;
+    *psize = size;
+    return 0;
+}
+##### end from_PyObject_unsigned int source
+
+##### start from_PyObject_unsigned long source
+
+// helper from_PyObject_unsigned long
+// Convert obj into an array of type unsigned long
+// Return -1 on error.
+static int SHROUD_from_PyObject_unsigned long(PyObject *obj,
+    const char *name, unsigned long **pin, Py_ssize_t *psize)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    unsigned long *in = static_cast<unsigned long *>
+        (std::malloc(size * sizeof(unsigned long)));
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in[i] = PyInt_AsLong(item);
+        if (PyErr_Occurred()) {
+            std::free(in);
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be unsigned long", name,
+                (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    *pin = in;
+    *psize = size;
+    return 0;
+}
+##### end from_PyObject_unsigned long source
+
+##### start from_PyObject_unsigned short source
+
+// helper from_PyObject_unsigned short
+// Convert obj into an array of type unsigned short
+// Return -1 on error.
+static int SHROUD_from_PyObject_unsigned short(PyObject *obj,
+    const char *name, unsigned short **pin, Py_ssize_t *psize)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    unsigned short *in = static_cast<unsigned short *>
+        (std::malloc(size * sizeof(unsigned short)));
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in[i] = PyInt_AsLong(item);
+        if (PyErr_Occurred()) {
+            std::free(in);
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be unsigned short", name,
+                (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    *pin = in;
+    *psize = size;
+    return 0;
+}
+##### end from_PyObject_unsigned short source
+
+##### start from_PyObject_vector_double cxx_source
+
+// helper from_PyObject_vector_double
+// Convert obj into an array of type double
+// Return -1 on error.
+static int SHROUD_from_PyObject_vector_double(PyObject *obj,
+    const char *name, std::vector<double> & in)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in.push_back(PyFloat_AsDouble(item));
+        if (PyErr_Occurred()) {
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be double", name,
+                (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    return 0;
+}
+##### end from_PyObject_vector_double cxx_source
+
+##### start from_PyObject_vector_float cxx_source
+
+// helper from_PyObject_vector_float
+// Convert obj into an array of type float
+// Return -1 on error.
+static int SHROUD_from_PyObject_vector_float(PyObject *obj,
+    const char *name, std::vector<float> & in)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in.push_back(PyFloat_AsDouble(item));
+        if (PyErr_Occurred()) {
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be float", name, (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    return 0;
+}
+##### end from_PyObject_vector_float cxx_source
+
+##### start from_PyObject_vector_int cxx_source
+
+// helper from_PyObject_vector_int
+// Convert obj into an array of type int
+// Return -1 on error.
+static int SHROUD_from_PyObject_vector_int(PyObject *obj,
+    const char *name, std::vector<int> & in)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in.push_back(PyInt_AsLong(item));
+        if (PyErr_Occurred()) {
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be int", name, (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    return 0;
+}
+##### end from_PyObject_vector_int cxx_source
+
+##### start from_PyObject_vector_int16_t cxx_source
+
+// helper from_PyObject_vector_int16_t
+// Convert obj into an array of type int16_t
+// Return -1 on error.
+static int SHROUD_from_PyObject_vector_int16_t(PyObject *obj,
+    const char *name, std::vector<int16_t> & in)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in.push_back(PyInt_AsLong(item));
+        if (PyErr_Occurred()) {
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be int16_t", name,
+                (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    return 0;
+}
+##### end from_PyObject_vector_int16_t cxx_source
+
+##### start from_PyObject_vector_int32_t cxx_source
+
+// helper from_PyObject_vector_int32_t
+// Convert obj into an array of type int32_t
+// Return -1 on error.
+static int SHROUD_from_PyObject_vector_int32_t(PyObject *obj,
+    const char *name, std::vector<int32_t> & in)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in.push_back(PyInt_AsLong(item));
+        if (PyErr_Occurred()) {
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be int32_t", name,
+                (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    return 0;
+}
+##### end from_PyObject_vector_int32_t cxx_source
+
+##### start from_PyObject_vector_int64_t cxx_source
+
+// helper from_PyObject_vector_int64_t
+// Convert obj into an array of type int64_t
+// Return -1 on error.
+static int SHROUD_from_PyObject_vector_int64_t(PyObject *obj,
+    const char *name, std::vector<int64_t> & in)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in.push_back(PyInt_AsLong(item));
+        if (PyErr_Occurred()) {
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be int64_t", name,
+                (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    return 0;
+}
+##### end from_PyObject_vector_int64_t cxx_source
+
+##### start from_PyObject_vector_int8_t cxx_source
+
+// helper from_PyObject_vector_int8_t
+// Convert obj into an array of type int8_t
+// Return -1 on error.
+static int SHROUD_from_PyObject_vector_int8_t(PyObject *obj,
+    const char *name, std::vector<int8_t> & in)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in.push_back(PyInt_AsLong(item));
+        if (PyErr_Occurred()) {
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be int8_t", name,
+                (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    return 0;
+}
+##### end from_PyObject_vector_int8_t cxx_source
+
+##### start from_PyObject_vector_long cxx_source
+
+// helper from_PyObject_vector_long
+// Convert obj into an array of type long
+// Return -1 on error.
+static int SHROUD_from_PyObject_vector_long(PyObject *obj,
+    const char *name, std::vector<long> & in)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in.push_back(PyInt_AsLong(item));
+        if (PyErr_Occurred()) {
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be long", name, (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    return 0;
+}
+##### end from_PyObject_vector_long cxx_source
+
+##### start from_PyObject_vector_long long cxx_source
+
+// helper from_PyObject_vector_long long
+// Convert obj into an array of type long long
+// Return -1 on error.
+static int SHROUD_from_PyObject_vector_long long(PyObject *obj,
+    const char *name, std::vector<long long> & in)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in.push_back(XXXPy_get);
+        if (PyErr_Occurred()) {
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be long long", name,
+                (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    return 0;
+}
+##### end from_PyObject_vector_long long cxx_source
+
+##### start from_PyObject_vector_short cxx_source
+
+// helper from_PyObject_vector_short
+// Convert obj into an array of type short
+// Return -1 on error.
+static int SHROUD_from_PyObject_vector_short(PyObject *obj,
+    const char *name, std::vector<short> & in)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in.push_back(PyInt_AsLong(item));
+        if (PyErr_Occurred()) {
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be short", name, (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    return 0;
+}
+##### end from_PyObject_vector_short cxx_source
+
+##### start from_PyObject_vector_size_t cxx_source
+
+// helper from_PyObject_vector_size_t
+// Convert obj into an array of type size_t
+// Return -1 on error.
+static int SHROUD_from_PyObject_vector_size_t(PyObject *obj,
+    const char *name, std::vector<size_t> & in)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in.push_back(XXXPy_get);
+        if (PyErr_Occurred()) {
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be size_t", name,
+                (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    return 0;
+}
+##### end from_PyObject_vector_size_t cxx_source
+
+##### start from_PyObject_vector_uint16_t cxx_source
+
+// helper from_PyObject_vector_uint16_t
+// Convert obj into an array of type uint16_t
+// Return -1 on error.
+static int SHROUD_from_PyObject_vector_uint16_t(PyObject *obj,
+    const char *name, std::vector<uint16_t> & in)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in.push_back(PyInt_AsLong(item));
+        if (PyErr_Occurred()) {
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be uint16_t", name,
+                (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    return 0;
+}
+##### end from_PyObject_vector_uint16_t cxx_source
+
+##### start from_PyObject_vector_uint32_t cxx_source
+
+// helper from_PyObject_vector_uint32_t
+// Convert obj into an array of type uint32_t
+// Return -1 on error.
+static int SHROUD_from_PyObject_vector_uint32_t(PyObject *obj,
+    const char *name, std::vector<uint32_t> & in)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in.push_back(PyInt_AsLong(item));
+        if (PyErr_Occurred()) {
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be uint32_t", name,
+                (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    return 0;
+}
+##### end from_PyObject_vector_uint32_t cxx_source
+
+##### start from_PyObject_vector_uint64_t cxx_source
+
+// helper from_PyObject_vector_uint64_t
+// Convert obj into an array of type uint64_t
+// Return -1 on error.
+static int SHROUD_from_PyObject_vector_uint64_t(PyObject *obj,
+    const char *name, std::vector<uint64_t> & in)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in.push_back(PyInt_AsLong(item));
+        if (PyErr_Occurred()) {
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be uint64_t", name,
+                (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    return 0;
+}
+##### end from_PyObject_vector_uint64_t cxx_source
+
+##### start from_PyObject_vector_uint8_t cxx_source
+
+// helper from_PyObject_vector_uint8_t
+// Convert obj into an array of type uint8_t
+// Return -1 on error.
+static int SHROUD_from_PyObject_vector_uint8_t(PyObject *obj,
+    const char *name, std::vector<uint8_t> & in)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in.push_back(PyInt_AsLong(item));
+        if (PyErr_Occurred()) {
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be uint8_t", name,
+                (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    return 0;
+}
+##### end from_PyObject_vector_uint8_t cxx_source
+
+##### start from_PyObject_vector_unsigned int cxx_source
+
+// helper from_PyObject_vector_unsigned int
+// Convert obj into an array of type unsigned int
+// Return -1 on error.
+static int SHROUD_from_PyObject_vector_unsigned int(PyObject *obj,
+    const char *name, std::vector<unsigned int> & in)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in.push_back(PyInt_AsLong(item));
+        if (PyErr_Occurred()) {
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be unsigned int", name,
+                (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    return 0;
+}
+##### end from_PyObject_vector_unsigned int cxx_source
+
+##### start from_PyObject_vector_unsigned long cxx_source
+
+// helper from_PyObject_vector_unsigned long
+// Convert obj into an array of type unsigned long
+// Return -1 on error.
+static int SHROUD_from_PyObject_vector_unsigned long(PyObject *obj,
+    const char *name, std::vector<unsigned long> & in)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in.push_back(PyInt_AsLong(item));
+        if (PyErr_Occurred()) {
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be unsigned long", name,
+                (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    return 0;
+}
+##### end from_PyObject_vector_unsigned long cxx_source
+
+##### start from_PyObject_vector_unsigned long long cxx_source
+
+// helper from_PyObject_vector_unsigned long long
+// Convert obj into an array of type unsigned long long
+// Return -1 on error.
+static int SHROUD_from_PyObject_vector_unsigned long long(PyObject *obj,
+    const char *name, std::vector<unsigned long long> & in)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in.push_back(XXXPy_get);
+        if (PyErr_Occurred()) {
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be unsigned long long",
+                name, (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    return 0;
+}
+##### end from_PyObject_vector_unsigned long long cxx_source
+
+##### start from_PyObject_vector_unsigned short cxx_source
+
+// helper from_PyObject_vector_unsigned short
+// Convert obj into an array of type unsigned short
+// Return -1 on error.
+static int SHROUD_from_PyObject_vector_unsigned short(PyObject *obj,
+    const char *name, std::vector<unsigned short> & in)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in.push_back(PyInt_AsLong(item));
+        if (PyErr_Occurred()) {
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be unsigned short", name,
+                (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    return 0;
+}
+##### end from_PyObject_vector_unsigned short cxx_source
+
 ##### start get_from_object_char source
 
 // helper get_from_object_char
@@ -434,6 +1587,806 @@ static int SHROUD_get_from_object_charptr(PyObject *obj,
 }
 ##### end get_from_object_charptr source
 
+##### start get_from_object_double_list source
+
+// helper get_from_object_double_list
+// Convert PyObject to double pointer.
+static int SHROUD_get_from_object_double_list(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    double *in;
+    Py_ssize_t size;
+    if (SHROUD_from_PyObject_double(obj, "in", &in,  &size) == -1) {
+        return 0;
+    }
+    value->obj = nullptr;
+    value->data = static_cast<double *>(in);
+    value->size = size;
+    return 1;
+}
+##### end get_from_object_double_list source
+
+##### start get_from_object_double_numpy source
+
+// helper get_from_object_double_numpy
+// Convert PyObject to double pointer.
+static int SHROUD_get_from_object_double_numpy(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    PyObject *array = PyArray_FROM_OTF(obj, NPY_DOUBLE,
+        NPY_ARRAY_IN_ARRAY);
+    if (array == nullptr) {
+        PyErr_SetString(PyExc_ValueError,
+            "must be a 1-D array of double");
+        return 0;
+    }
+    value->obj = array;
+    value->data = PyArray_DATA(reinterpret_cast<PyArrayObject *>
+        (array));
+    value->size = PyArray_SIZE(reinterpret_cast<PyArrayObject *>
+        (array));
+    return 1;
+}
+##### end get_from_object_double_numpy source
+
+##### start get_from_object_float_list source
+
+// helper get_from_object_float_list
+// Convert PyObject to float pointer.
+static int SHROUD_get_from_object_float_list(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    float *in;
+    Py_ssize_t size;
+    if (SHROUD_from_PyObject_float(obj, "in", &in,  &size) == -1) {
+        return 0;
+    }
+    value->obj = nullptr;
+    value->data = static_cast<float *>(in);
+    value->size = size;
+    return 1;
+}
+##### end get_from_object_float_list source
+
+##### start get_from_object_float_numpy source
+
+// helper get_from_object_float_numpy
+// Convert PyObject to float pointer.
+static int SHROUD_get_from_object_float_numpy(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    PyObject *array = PyArray_FROM_OTF(obj, NPY_FLOAT,
+        NPY_ARRAY_IN_ARRAY);
+    if (array == nullptr) {
+        PyErr_SetString(PyExc_ValueError,
+            "must be a 1-D array of float");
+        return 0;
+    }
+    value->obj = array;
+    value->data = PyArray_DATA(reinterpret_cast<PyArrayObject *>
+        (array));
+    value->size = PyArray_SIZE(reinterpret_cast<PyArrayObject *>
+        (array));
+    return 1;
+}
+##### end get_from_object_float_numpy source
+
+##### start get_from_object_int16_t_list source
+
+// helper get_from_object_int16_t_list
+// Convert PyObject to int16_t pointer.
+static int SHROUD_get_from_object_int16_t_list(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    int16_t *in;
+    Py_ssize_t size;
+    if (SHROUD_from_PyObject_int16_t(obj, "in", &in,  &size) == -1) {
+        return 0;
+    }
+    value->obj = nullptr;
+    value->data = static_cast<int16_t *>(in);
+    value->size = size;
+    return 1;
+}
+##### end get_from_object_int16_t_list source
+
+##### start get_from_object_int16_t_numpy source
+
+// helper get_from_object_int16_t_numpy
+// Convert PyObject to int16_t pointer.
+static int SHROUD_get_from_object_int16_t_numpy(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    PyObject *array = PyArray_FROM_OTF(obj, NPY_INT16,
+        NPY_ARRAY_IN_ARRAY);
+    if (array == nullptr) {
+        PyErr_SetString(PyExc_ValueError,
+            "must be a 1-D array of int16_t");
+        return 0;
+    }
+    value->obj = array;
+    value->data = PyArray_DATA(reinterpret_cast<PyArrayObject *>
+        (array));
+    value->size = PyArray_SIZE(reinterpret_cast<PyArrayObject *>
+        (array));
+    return 1;
+}
+##### end get_from_object_int16_t_numpy source
+
+##### start get_from_object_int32_t_list source
+
+// helper get_from_object_int32_t_list
+// Convert PyObject to int32_t pointer.
+static int SHROUD_get_from_object_int32_t_list(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    int32_t *in;
+    Py_ssize_t size;
+    if (SHROUD_from_PyObject_int32_t(obj, "in", &in,  &size) == -1) {
+        return 0;
+    }
+    value->obj = nullptr;
+    value->data = static_cast<int32_t *>(in);
+    value->size = size;
+    return 1;
+}
+##### end get_from_object_int32_t_list source
+
+##### start get_from_object_int32_t_numpy source
+
+// helper get_from_object_int32_t_numpy
+// Convert PyObject to int32_t pointer.
+static int SHROUD_get_from_object_int32_t_numpy(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    PyObject *array = PyArray_FROM_OTF(obj, NPY_INT32,
+        NPY_ARRAY_IN_ARRAY);
+    if (array == nullptr) {
+        PyErr_SetString(PyExc_ValueError,
+            "must be a 1-D array of int32_t");
+        return 0;
+    }
+    value->obj = array;
+    value->data = PyArray_DATA(reinterpret_cast<PyArrayObject *>
+        (array));
+    value->size = PyArray_SIZE(reinterpret_cast<PyArrayObject *>
+        (array));
+    return 1;
+}
+##### end get_from_object_int32_t_numpy source
+
+##### start get_from_object_int64_t_list source
+
+// helper get_from_object_int64_t_list
+// Convert PyObject to int64_t pointer.
+static int SHROUD_get_from_object_int64_t_list(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    int64_t *in;
+    Py_ssize_t size;
+    if (SHROUD_from_PyObject_int64_t(obj, "in", &in,  &size) == -1) {
+        return 0;
+    }
+    value->obj = nullptr;
+    value->data = static_cast<int64_t *>(in);
+    value->size = size;
+    return 1;
+}
+##### end get_from_object_int64_t_list source
+
+##### start get_from_object_int64_t_numpy source
+
+// helper get_from_object_int64_t_numpy
+// Convert PyObject to int64_t pointer.
+static int SHROUD_get_from_object_int64_t_numpy(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    PyObject *array = PyArray_FROM_OTF(obj, NPY_INT64,
+        NPY_ARRAY_IN_ARRAY);
+    if (array == nullptr) {
+        PyErr_SetString(PyExc_ValueError,
+            "must be a 1-D array of int64_t");
+        return 0;
+    }
+    value->obj = array;
+    value->data = PyArray_DATA(reinterpret_cast<PyArrayObject *>
+        (array));
+    value->size = PyArray_SIZE(reinterpret_cast<PyArrayObject *>
+        (array));
+    return 1;
+}
+##### end get_from_object_int64_t_numpy source
+
+##### start get_from_object_int8_t_list source
+
+// helper get_from_object_int8_t_list
+// Convert PyObject to int8_t pointer.
+static int SHROUD_get_from_object_int8_t_list(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    int8_t *in;
+    Py_ssize_t size;
+    if (SHROUD_from_PyObject_int8_t(obj, "in", &in,  &size) == -1) {
+        return 0;
+    }
+    value->obj = nullptr;
+    value->data = static_cast<int8_t *>(in);
+    value->size = size;
+    return 1;
+}
+##### end get_from_object_int8_t_list source
+
+##### start get_from_object_int8_t_numpy source
+
+// helper get_from_object_int8_t_numpy
+// Convert PyObject to int8_t pointer.
+static int SHROUD_get_from_object_int8_t_numpy(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    PyObject *array = PyArray_FROM_OTF(obj, NPY_INT8,
+        NPY_ARRAY_IN_ARRAY);
+    if (array == nullptr) {
+        PyErr_SetString(PyExc_ValueError,
+            "must be a 1-D array of int8_t");
+        return 0;
+    }
+    value->obj = array;
+    value->data = PyArray_DATA(reinterpret_cast<PyArrayObject *>
+        (array));
+    value->size = PyArray_SIZE(reinterpret_cast<PyArrayObject *>
+        (array));
+    return 1;
+}
+##### end get_from_object_int8_t_numpy source
+
+##### start get_from_object_int_list source
+
+// helper get_from_object_int_list
+// Convert PyObject to int pointer.
+static int SHROUD_get_from_object_int_list(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    int *in;
+    Py_ssize_t size;
+    if (SHROUD_from_PyObject_int(obj, "in", &in,  &size) == -1) {
+        return 0;
+    }
+    value->obj = nullptr;
+    value->data = static_cast<int *>(in);
+    value->size = size;
+    return 1;
+}
+##### end get_from_object_int_list source
+
+##### start get_from_object_int_numpy source
+
+// helper get_from_object_int_numpy
+// Convert PyObject to int pointer.
+static int SHROUD_get_from_object_int_numpy(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    PyObject *array = PyArray_FROM_OTF(obj, NPY_INT,
+        NPY_ARRAY_IN_ARRAY);
+    if (array == nullptr) {
+        PyErr_SetString(PyExc_ValueError, "must be a 1-D array of int");
+        return 0;
+    }
+    value->obj = array;
+    value->data = PyArray_DATA(reinterpret_cast<PyArrayObject *>
+        (array));
+    value->size = PyArray_SIZE(reinterpret_cast<PyArrayObject *>
+        (array));
+    return 1;
+}
+##### end get_from_object_int_numpy source
+
+##### start get_from_object_long long_list source
+
+// helper get_from_object_long long_list
+// Convert PyObject to long long pointer.
+static int SHROUD_get_from_object_long long_list(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    long long *in;
+    Py_ssize_t size;
+    if (SHROUD_from_PyObject_long long(obj, "in", &in,  &size) == -1) {
+        return 0;
+    }
+    value->obj = nullptr;
+    value->data = static_cast<long long *>(in);
+    value->size = size;
+    return 1;
+}
+##### end get_from_object_long long_list source
+
+##### start get_from_object_long long_numpy source
+
+// helper get_from_object_long long_numpy
+// Convert PyObject to long long pointer.
+static int SHROUD_get_from_object_long long_numpy(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    PyObject *array = PyArray_FROM_OTF(obj, NPY_LONGLONG,
+        NPY_ARRAY_IN_ARRAY);
+    if (array == nullptr) {
+        PyErr_SetString(PyExc_ValueError,
+            "must be a 1-D array of long long");
+        return 0;
+    }
+    value->obj = array;
+    value->data = PyArray_DATA(reinterpret_cast<PyArrayObject *>
+        (array));
+    value->size = PyArray_SIZE(reinterpret_cast<PyArrayObject *>
+        (array));
+    return 1;
+}
+##### end get_from_object_long long_numpy source
+
+##### start get_from_object_long_list source
+
+// helper get_from_object_long_list
+// Convert PyObject to long pointer.
+static int SHROUD_get_from_object_long_list(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    long *in;
+    Py_ssize_t size;
+    if (SHROUD_from_PyObject_long(obj, "in", &in,  &size) == -1) {
+        return 0;
+    }
+    value->obj = nullptr;
+    value->data = static_cast<long *>(in);
+    value->size = size;
+    return 1;
+}
+##### end get_from_object_long_list source
+
+##### start get_from_object_long_numpy source
+
+// helper get_from_object_long_numpy
+// Convert PyObject to long pointer.
+static int SHROUD_get_from_object_long_numpy(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    PyObject *array = PyArray_FROM_OTF(obj, NPY_LONG,
+        NPY_ARRAY_IN_ARRAY);
+    if (array == nullptr) {
+        PyErr_SetString(PyExc_ValueError,
+            "must be a 1-D array of long");
+        return 0;
+    }
+    value->obj = array;
+    value->data = PyArray_DATA(reinterpret_cast<PyArrayObject *>
+        (array));
+    value->size = PyArray_SIZE(reinterpret_cast<PyArrayObject *>
+        (array));
+    return 1;
+}
+##### end get_from_object_long_numpy source
+
+##### start get_from_object_short_list source
+
+// helper get_from_object_short_list
+// Convert PyObject to short pointer.
+static int SHROUD_get_from_object_short_list(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    short *in;
+    Py_ssize_t size;
+    if (SHROUD_from_PyObject_short(obj, "in", &in,  &size) == -1) {
+        return 0;
+    }
+    value->obj = nullptr;
+    value->data = static_cast<short *>(in);
+    value->size = size;
+    return 1;
+}
+##### end get_from_object_short_list source
+
+##### start get_from_object_short_numpy source
+
+// helper get_from_object_short_numpy
+// Convert PyObject to short pointer.
+static int SHROUD_get_from_object_short_numpy(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    PyObject *array = PyArray_FROM_OTF(obj, NPY_SHORT,
+        NPY_ARRAY_IN_ARRAY);
+    if (array == nullptr) {
+        PyErr_SetString(PyExc_ValueError,
+            "must be a 1-D array of short");
+        return 0;
+    }
+    value->obj = array;
+    value->data = PyArray_DATA(reinterpret_cast<PyArrayObject *>
+        (array));
+    value->size = PyArray_SIZE(reinterpret_cast<PyArrayObject *>
+        (array));
+    return 1;
+}
+##### end get_from_object_short_numpy source
+
+##### start get_from_object_size_t_list source
+
+// helper get_from_object_size_t_list
+// Convert PyObject to size_t pointer.
+static int SHROUD_get_from_object_size_t_list(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    size_t *in;
+    Py_ssize_t size;
+    if (SHROUD_from_PyObject_size_t(obj, "in", &in,  &size) == -1) {
+        return 0;
+    }
+    value->obj = nullptr;
+    value->data = static_cast<size_t *>(in);
+    value->size = size;
+    return 1;
+}
+##### end get_from_object_size_t_list source
+
+##### start get_from_object_size_t_numpy source
+
+// helper get_from_object_size_t_numpy
+// Convert PyObject to size_t pointer.
+static int SHROUD_get_from_object_size_t_numpy(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    PyObject *array = PyArray_FROM_OTF(obj, None, NPY_ARRAY_IN_ARRAY);
+    if (array == nullptr) {
+        PyErr_SetString(PyExc_ValueError,
+            "must be a 1-D array of size_t");
+        return 0;
+    }
+    value->obj = array;
+    value->data = PyArray_DATA(reinterpret_cast<PyArrayObject *>
+        (array));
+    value->size = PyArray_SIZE(reinterpret_cast<PyArrayObject *>
+        (array));
+    return 1;
+}
+##### end get_from_object_size_t_numpy source
+
+##### start get_from_object_uint16_t_list source
+
+// helper get_from_object_uint16_t_list
+// Convert PyObject to uint16_t pointer.
+static int SHROUD_get_from_object_uint16_t_list(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    uint16_t *in;
+    Py_ssize_t size;
+    if (SHROUD_from_PyObject_uint16_t(obj, "in", &in,  &size) == -1) {
+        return 0;
+    }
+    value->obj = nullptr;
+    value->data = static_cast<uint16_t *>(in);
+    value->size = size;
+    return 1;
+}
+##### end get_from_object_uint16_t_list source
+
+##### start get_from_object_uint16_t_numpy source
+
+// helper get_from_object_uint16_t_numpy
+// Convert PyObject to uint16_t pointer.
+static int SHROUD_get_from_object_uint16_t_numpy(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    PyObject *array = PyArray_FROM_OTF(obj, NPY_UINT16,
+        NPY_ARRAY_IN_ARRAY);
+    if (array == nullptr) {
+        PyErr_SetString(PyExc_ValueError,
+            "must be a 1-D array of uint16_t");
+        return 0;
+    }
+    value->obj = array;
+    value->data = PyArray_DATA(reinterpret_cast<PyArrayObject *>
+        (array));
+    value->size = PyArray_SIZE(reinterpret_cast<PyArrayObject *>
+        (array));
+    return 1;
+}
+##### end get_from_object_uint16_t_numpy source
+
+##### start get_from_object_uint32_t_list source
+
+// helper get_from_object_uint32_t_list
+// Convert PyObject to uint32_t pointer.
+static int SHROUD_get_from_object_uint32_t_list(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    uint32_t *in;
+    Py_ssize_t size;
+    if (SHROUD_from_PyObject_uint32_t(obj, "in", &in,  &size) == -1) {
+        return 0;
+    }
+    value->obj = nullptr;
+    value->data = static_cast<uint32_t *>(in);
+    value->size = size;
+    return 1;
+}
+##### end get_from_object_uint32_t_list source
+
+##### start get_from_object_uint32_t_numpy source
+
+// helper get_from_object_uint32_t_numpy
+// Convert PyObject to uint32_t pointer.
+static int SHROUD_get_from_object_uint32_t_numpy(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    PyObject *array = PyArray_FROM_OTF(obj, NPY_UINT32,
+        NPY_ARRAY_IN_ARRAY);
+    if (array == nullptr) {
+        PyErr_SetString(PyExc_ValueError,
+            "must be a 1-D array of uint32_t");
+        return 0;
+    }
+    value->obj = array;
+    value->data = PyArray_DATA(reinterpret_cast<PyArrayObject *>
+        (array));
+    value->size = PyArray_SIZE(reinterpret_cast<PyArrayObject *>
+        (array));
+    return 1;
+}
+##### end get_from_object_uint32_t_numpy source
+
+##### start get_from_object_uint64_t_list source
+
+// helper get_from_object_uint64_t_list
+// Convert PyObject to uint64_t pointer.
+static int SHROUD_get_from_object_uint64_t_list(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    uint64_t *in;
+    Py_ssize_t size;
+    if (SHROUD_from_PyObject_uint64_t(obj, "in", &in,  &size) == -1) {
+        return 0;
+    }
+    value->obj = nullptr;
+    value->data = static_cast<uint64_t *>(in);
+    value->size = size;
+    return 1;
+}
+##### end get_from_object_uint64_t_list source
+
+##### start get_from_object_uint64_t_numpy source
+
+// helper get_from_object_uint64_t_numpy
+// Convert PyObject to uint64_t pointer.
+static int SHROUD_get_from_object_uint64_t_numpy(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    PyObject *array = PyArray_FROM_OTF(obj, NPY_UINT64,
+        NPY_ARRAY_IN_ARRAY);
+    if (array == nullptr) {
+        PyErr_SetString(PyExc_ValueError,
+            "must be a 1-D array of uint64_t");
+        return 0;
+    }
+    value->obj = array;
+    value->data = PyArray_DATA(reinterpret_cast<PyArrayObject *>
+        (array));
+    value->size = PyArray_SIZE(reinterpret_cast<PyArrayObject *>
+        (array));
+    return 1;
+}
+##### end get_from_object_uint64_t_numpy source
+
+##### start get_from_object_uint8_t_list source
+
+// helper get_from_object_uint8_t_list
+// Convert PyObject to uint8_t pointer.
+static int SHROUD_get_from_object_uint8_t_list(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    uint8_t *in;
+    Py_ssize_t size;
+    if (SHROUD_from_PyObject_uint8_t(obj, "in", &in,  &size) == -1) {
+        return 0;
+    }
+    value->obj = nullptr;
+    value->data = static_cast<uint8_t *>(in);
+    value->size = size;
+    return 1;
+}
+##### end get_from_object_uint8_t_list source
+
+##### start get_from_object_uint8_t_numpy source
+
+// helper get_from_object_uint8_t_numpy
+// Convert PyObject to uint8_t pointer.
+static int SHROUD_get_from_object_uint8_t_numpy(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    PyObject *array = PyArray_FROM_OTF(obj, NPY_UINT8,
+        NPY_ARRAY_IN_ARRAY);
+    if (array == nullptr) {
+        PyErr_SetString(PyExc_ValueError,
+            "must be a 1-D array of uint8_t");
+        return 0;
+    }
+    value->obj = array;
+    value->data = PyArray_DATA(reinterpret_cast<PyArrayObject *>
+        (array));
+    value->size = PyArray_SIZE(reinterpret_cast<PyArrayObject *>
+        (array));
+    return 1;
+}
+##### end get_from_object_uint8_t_numpy source
+
+##### start get_from_object_unsigned int_list source
+
+// helper get_from_object_unsigned int_list
+// Convert PyObject to unsigned int pointer.
+static int SHROUD_get_from_object_unsigned int_list(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    unsigned int *in;
+    Py_ssize_t size;
+    if (SHROUD_from_PyObject_unsigned int(obj, "in", &in, 
+        &size) == -1) {
+        return 0;
+    }
+    value->obj = nullptr;
+    value->data = static_cast<unsigned int *>(in);
+    value->size = size;
+    return 1;
+}
+##### end get_from_object_unsigned int_list source
+
+##### start get_from_object_unsigned int_numpy source
+
+// helper get_from_object_unsigned int_numpy
+// Convert PyObject to unsigned int pointer.
+static int SHROUD_get_from_object_unsigned int_numpy(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    PyObject *array = PyArray_FROM_OTF(obj, NPY_INT,
+        NPY_ARRAY_IN_ARRAY);
+    if (array == nullptr) {
+        PyErr_SetString(PyExc_ValueError,
+            "must be a 1-D array of unsigned int");
+        return 0;
+    }
+    value->obj = array;
+    value->data = PyArray_DATA(reinterpret_cast<PyArrayObject *>
+        (array));
+    value->size = PyArray_SIZE(reinterpret_cast<PyArrayObject *>
+        (array));
+    return 1;
+}
+##### end get_from_object_unsigned int_numpy source
+
+##### start get_from_object_unsigned long long_list source
+
+// helper get_from_object_unsigned long long_list
+// Convert PyObject to unsigned long long pointer.
+static int SHROUD_get_from_object_unsigned long long_list(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    unsigned long long *in;
+    Py_ssize_t size;
+    if (SHROUD_from_PyObject_unsigned long long(obj, "in", &in, 
+        &size) == -1) {
+        return 0;
+    }
+    value->obj = nullptr;
+    value->data = static_cast<unsigned long long *>(in);
+    value->size = size;
+    return 1;
+}
+##### end get_from_object_unsigned long long_list source
+
+##### start get_from_object_unsigned long long_numpy source
+
+// helper get_from_object_unsigned long long_numpy
+// Convert PyObject to unsigned long long pointer.
+static int SHROUD_get_from_object_unsigned long long_numpy
+    (PyObject *obj, LIB_SHROUD_converter_value *value)
+{
+    PyObject *array = PyArray_FROM_OTF(obj, NPY_LONGLONG,
+        NPY_ARRAY_IN_ARRAY);
+    if (array == nullptr) {
+        PyErr_SetString(PyExc_ValueError,
+            "must be a 1-D array of unsigned long long");
+        return 0;
+    }
+    value->obj = array;
+    value->data = PyArray_DATA(reinterpret_cast<PyArrayObject *>
+        (array));
+    value->size = PyArray_SIZE(reinterpret_cast<PyArrayObject *>
+        (array));
+    return 1;
+}
+##### end get_from_object_unsigned long long_numpy source
+
+##### start get_from_object_unsigned long_list source
+
+// helper get_from_object_unsigned long_list
+// Convert PyObject to unsigned long pointer.
+static int SHROUD_get_from_object_unsigned long_list(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    unsigned long *in;
+    Py_ssize_t size;
+    if (SHROUD_from_PyObject_unsigned long(obj, "in", &in, 
+        &size) == -1) {
+        return 0;
+    }
+    value->obj = nullptr;
+    value->data = static_cast<unsigned long *>(in);
+    value->size = size;
+    return 1;
+}
+##### end get_from_object_unsigned long_list source
+
+##### start get_from_object_unsigned long_numpy source
+
+// helper get_from_object_unsigned long_numpy
+// Convert PyObject to unsigned long pointer.
+static int SHROUD_get_from_object_unsigned long_numpy(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    PyObject *array = PyArray_FROM_OTF(obj, NPY_LONG,
+        NPY_ARRAY_IN_ARRAY);
+    if (array == nullptr) {
+        PyErr_SetString(PyExc_ValueError,
+            "must be a 1-D array of unsigned long");
+        return 0;
+    }
+    value->obj = array;
+    value->data = PyArray_DATA(reinterpret_cast<PyArrayObject *>
+        (array));
+    value->size = PyArray_SIZE(reinterpret_cast<PyArrayObject *>
+        (array));
+    return 1;
+}
+##### end get_from_object_unsigned long_numpy source
+
+##### start get_from_object_unsigned short_list source
+
+// helper get_from_object_unsigned short_list
+// Convert PyObject to unsigned short pointer.
+static int SHROUD_get_from_object_unsigned short_list(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    unsigned short *in;
+    Py_ssize_t size;
+    if (SHROUD_from_PyObject_unsigned short(obj, "in", &in, 
+        &size) == -1) {
+        return 0;
+    }
+    value->obj = nullptr;
+    value->data = static_cast<unsigned short *>(in);
+    value->size = size;
+    return 1;
+}
+##### end get_from_object_unsigned short_list source
+
+##### start get_from_object_unsigned short_numpy source
+
+// helper get_from_object_unsigned short_numpy
+// Convert PyObject to unsigned short pointer.
+static int SHROUD_get_from_object_unsigned short_numpy(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    PyObject *array = PyArray_FROM_OTF(obj, NPY_SHORT,
+        NPY_ARRAY_IN_ARRAY);
+    if (array == nullptr) {
+        PyErr_SetString(PyExc_ValueError,
+            "must be a 1-D array of unsigned short");
+        return 0;
+    }
+    value->obj = array;
+    value->data = PyArray_DATA(reinterpret_cast<PyArrayObject *>
+        (array));
+    value->size = PyArray_SIZE(reinterpret_cast<PyArrayObject *>
+        (array));
+    return 1;
+}
+##### end get_from_object_unsigned short_numpy source
+
 ##### start to_PyList_char source
 
 // helper to_PyList_char
@@ -447,3 +2400,1101 @@ static PyObject *SHROUD_to_PyList_char(char * *in, size_t size)
     return out;
 }
 ##### end to_PyList_char source
+
+##### start to_PyList_double source
+
+// helper to_PyList_double
+// Convert double pointer to PyList of PyObjects.
+static PyObject *SHROUD_to_PyList_double(double *in, size_t size)
+{
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyFloat_FromDouble(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_double source
+
+##### start to_PyList_float source
+
+// helper to_PyList_float
+// Convert float pointer to PyList of PyObjects.
+static PyObject *SHROUD_to_PyList_float(float *in, size_t size)
+{
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyFloat_FromDouble(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_float source
+
+##### start to_PyList_int source
+
+// helper to_PyList_int
+// Convert int pointer to PyList of PyObjects.
+static PyObject *SHROUD_to_PyList_int(int *in, size_t size)
+{
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_int source
+
+##### start to_PyList_int16_t source
+
+// helper to_PyList_int16_t
+// Convert int16_t pointer to PyList of PyObjects.
+static PyObject *SHROUD_to_PyList_int16_t(int16_t *in, size_t size)
+{
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_int16_t source
+
+##### start to_PyList_int32_t source
+
+// helper to_PyList_int32_t
+// Convert int32_t pointer to PyList of PyObjects.
+static PyObject *SHROUD_to_PyList_int32_t(int32_t *in, size_t size)
+{
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_int32_t source
+
+##### start to_PyList_int64_t source
+
+// helper to_PyList_int64_t
+// Convert int64_t pointer to PyList of PyObjects.
+static PyObject *SHROUD_to_PyList_int64_t(int64_t *in, size_t size)
+{
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_int64_t source
+
+##### start to_PyList_int8_t source
+
+// helper to_PyList_int8_t
+// Convert int8_t pointer to PyList of PyObjects.
+static PyObject *SHROUD_to_PyList_int8_t(int8_t *in, size_t size)
+{
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_int8_t source
+
+##### start to_PyList_long source
+
+// helper to_PyList_long
+// Convert long pointer to PyList of PyObjects.
+static PyObject *SHROUD_to_PyList_long(long *in, size_t size)
+{
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_long source
+
+##### start to_PyList_short source
+
+// helper to_PyList_short
+// Convert short pointer to PyList of PyObjects.
+static PyObject *SHROUD_to_PyList_short(short *in, size_t size)
+{
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_short source
+
+##### start to_PyList_size_t source
+
+// helper to_PyList_size_t
+// Convert size_t pointer to PyList of PyObjects.
+static PyObject *SHROUD_to_PyList_size_t(size_t *in, size_t size)
+{
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyInt_FromSize_t(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_size_t source
+
+##### start to_PyList_uint16_t source
+
+// helper to_PyList_uint16_t
+// Convert uint16_t pointer to PyList of PyObjects.
+static PyObject *SHROUD_to_PyList_uint16_t(uint16_t *in, size_t size)
+{
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_uint16_t source
+
+##### start to_PyList_uint32_t source
+
+// helper to_PyList_uint32_t
+// Convert uint32_t pointer to PyList of PyObjects.
+static PyObject *SHROUD_to_PyList_uint32_t(uint32_t *in, size_t size)
+{
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_uint32_t source
+
+##### start to_PyList_uint64_t source
+
+// helper to_PyList_uint64_t
+// Convert uint64_t pointer to PyList of PyObjects.
+static PyObject *SHROUD_to_PyList_uint64_t(uint64_t *in, size_t size)
+{
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_uint64_t source
+
+##### start to_PyList_uint8_t source
+
+// helper to_PyList_uint8_t
+// Convert uint8_t pointer to PyList of PyObjects.
+static PyObject *SHROUD_to_PyList_uint8_t(uint8_t *in, size_t size)
+{
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_uint8_t source
+
+##### start to_PyList_unsigned int source
+
+// helper to_PyList_unsigned int
+// Convert unsigned int pointer to PyList of PyObjects.
+static PyObject *SHROUD_to_PyList_unsigned int
+    (unsigned int *in, size_t size)
+{
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_unsigned int source
+
+##### start to_PyList_unsigned long source
+
+// helper to_PyList_unsigned long
+// Convert unsigned long pointer to PyList of PyObjects.
+static PyObject *SHROUD_to_PyList_unsigned long
+    (unsigned long *in, size_t size)
+{
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_unsigned long source
+
+##### start to_PyList_unsigned short source
+
+// helper to_PyList_unsigned short
+// Convert unsigned short pointer to PyList of PyObjects.
+static PyObject *SHROUD_to_PyList_unsigned short
+    (unsigned short *in, size_t size)
+{
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_unsigned short source
+
+##### start to_PyList_vector_double source
+
+// helper to_PyList_vector_double
+static PyObject *SHROUD_to_PyList_vector_double
+    (std::vector<double> & in)
+{
+    size_t size = in.size();
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyFloat_FromDouble(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_vector_double source
+
+##### start to_PyList_vector_float source
+
+// helper to_PyList_vector_float
+static PyObject *SHROUD_to_PyList_vector_float(std::vector<float> & in)
+{
+    size_t size = in.size();
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyFloat_FromDouble(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_vector_float source
+
+##### start to_PyList_vector_int source
+
+// helper to_PyList_vector_int
+static PyObject *SHROUD_to_PyList_vector_int(std::vector<int> & in)
+{
+    size_t size = in.size();
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_vector_int source
+
+##### start to_PyList_vector_int16_t source
+
+// helper to_PyList_vector_int16_t
+static PyObject *SHROUD_to_PyList_vector_int16_t
+    (std::vector<int16_t> & in)
+{
+    size_t size = in.size();
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_vector_int16_t source
+
+##### start to_PyList_vector_int32_t source
+
+// helper to_PyList_vector_int32_t
+static PyObject *SHROUD_to_PyList_vector_int32_t
+    (std::vector<int32_t> & in)
+{
+    size_t size = in.size();
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_vector_int32_t source
+
+##### start to_PyList_vector_int64_t source
+
+// helper to_PyList_vector_int64_t
+static PyObject *SHROUD_to_PyList_vector_int64_t
+    (std::vector<int64_t> & in)
+{
+    size_t size = in.size();
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_vector_int64_t source
+
+##### start to_PyList_vector_int8_t source
+
+// helper to_PyList_vector_int8_t
+static PyObject *SHROUD_to_PyList_vector_int8_t
+    (std::vector<int8_t> & in)
+{
+    size_t size = in.size();
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_vector_int8_t source
+
+##### start to_PyList_vector_long source
+
+// helper to_PyList_vector_long
+static PyObject *SHROUD_to_PyList_vector_long(std::vector<long> & in)
+{
+    size_t size = in.size();
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_vector_long source
+
+##### start to_PyList_vector_long long source
+
+// helper to_PyList_vector_long long
+static PyObject *SHROUD_to_PyList_vector_long long
+    (std::vector<long long> & in)
+{
+    size_t size = in.size();
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, XXXPy_ctor);
+    }
+    return out;
+}
+##### end to_PyList_vector_long long source
+
+##### start to_PyList_vector_short source
+
+// helper to_PyList_vector_short
+static PyObject *SHROUD_to_PyList_vector_short(std::vector<short> & in)
+{
+    size_t size = in.size();
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_vector_short source
+
+##### start to_PyList_vector_size_t source
+
+// helper to_PyList_vector_size_t
+static PyObject *SHROUD_to_PyList_vector_size_t
+    (std::vector<size_t> & in)
+{
+    size_t size = in.size();
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyInt_FromSize_t(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_vector_size_t source
+
+##### start to_PyList_vector_uint16_t source
+
+// helper to_PyList_vector_uint16_t
+static PyObject *SHROUD_to_PyList_vector_uint16_t
+    (std::vector<uint16_t> & in)
+{
+    size_t size = in.size();
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_vector_uint16_t source
+
+##### start to_PyList_vector_uint32_t source
+
+// helper to_PyList_vector_uint32_t
+static PyObject *SHROUD_to_PyList_vector_uint32_t
+    (std::vector<uint32_t> & in)
+{
+    size_t size = in.size();
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_vector_uint32_t source
+
+##### start to_PyList_vector_uint64_t source
+
+// helper to_PyList_vector_uint64_t
+static PyObject *SHROUD_to_PyList_vector_uint64_t
+    (std::vector<uint64_t> & in)
+{
+    size_t size = in.size();
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_vector_uint64_t source
+
+##### start to_PyList_vector_uint8_t source
+
+// helper to_PyList_vector_uint8_t
+static PyObject *SHROUD_to_PyList_vector_uint8_t
+    (std::vector<uint8_t> & in)
+{
+    size_t size = in.size();
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_vector_uint8_t source
+
+##### start to_PyList_vector_unsigned int source
+
+// helper to_PyList_vector_unsigned int
+static PyObject *SHROUD_to_PyList_vector_unsigned int
+    (std::vector<unsigned int> & in)
+{
+    size_t size = in.size();
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_vector_unsigned int source
+
+##### start to_PyList_vector_unsigned long source
+
+// helper to_PyList_vector_unsigned long
+static PyObject *SHROUD_to_PyList_vector_unsigned long
+    (std::vector<unsigned long> & in)
+{
+    size_t size = in.size();
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_vector_unsigned long source
+
+##### start to_PyList_vector_unsigned long long source
+
+// helper to_PyList_vector_unsigned long long
+static PyObject *SHROUD_to_PyList_vector_unsigned long long
+    (std::vector<unsigned long long> & in)
+{
+    size_t size = in.size();
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, XXXPy_ctor);
+    }
+    return out;
+}
+##### end to_PyList_vector_unsigned long long source
+
+##### start to_PyList_vector_unsigned short source
+
+// helper to_PyList_vector_unsigned short
+static PyObject *SHROUD_to_PyList_vector_unsigned short
+    (std::vector<unsigned short> & in)
+{
+    size_t size = in.size();
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_vector_unsigned short source
+
+##### start update_PyList_double source
+
+// helper update_PyList_double
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_double
+    (PyObject *out, double *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyFloat_FromDouble(in[i]));
+    }
+}
+##### end update_PyList_double source
+
+##### start update_PyList_float source
+
+// helper update_PyList_float
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_float
+    (PyObject *out, float *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyFloat_FromDouble(in[i]));
+    }
+}
+##### end update_PyList_float source
+
+##### start update_PyList_int source
+
+// helper update_PyList_int
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_int
+    (PyObject *out, int *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+}
+##### end update_PyList_int source
+
+##### start update_PyList_int16_t source
+
+// helper update_PyList_int16_t
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_int16_t
+    (PyObject *out, int16_t *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+}
+##### end update_PyList_int16_t source
+
+##### start update_PyList_int32_t source
+
+// helper update_PyList_int32_t
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_int32_t
+    (PyObject *out, int32_t *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+}
+##### end update_PyList_int32_t source
+
+##### start update_PyList_int64_t source
+
+// helper update_PyList_int64_t
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_int64_t
+    (PyObject *out, int64_t *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+}
+##### end update_PyList_int64_t source
+
+##### start update_PyList_int8_t source
+
+// helper update_PyList_int8_t
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_int8_t
+    (PyObject *out, int8_t *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+}
+##### end update_PyList_int8_t source
+
+##### start update_PyList_long source
+
+// helper update_PyList_long
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_long
+    (PyObject *out, long *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+}
+##### end update_PyList_long source
+
+##### start update_PyList_short source
+
+// helper update_PyList_short
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_short
+    (PyObject *out, short *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+}
+##### end update_PyList_short source
+
+##### start update_PyList_size_t source
+
+// helper update_PyList_size_t
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_size_t
+    (PyObject *out, size_t *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyInt_FromSize_t(in[i]));
+    }
+}
+##### end update_PyList_size_t source
+
+##### start update_PyList_uint16_t source
+
+// helper update_PyList_uint16_t
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_uint16_t
+    (PyObject *out, uint16_t *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+}
+##### end update_PyList_uint16_t source
+
+##### start update_PyList_uint32_t source
+
+// helper update_PyList_uint32_t
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_uint32_t
+    (PyObject *out, uint32_t *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+}
+##### end update_PyList_uint32_t source
+
+##### start update_PyList_uint64_t source
+
+// helper update_PyList_uint64_t
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_uint64_t
+    (PyObject *out, uint64_t *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+}
+##### end update_PyList_uint64_t source
+
+##### start update_PyList_uint8_t source
+
+// helper update_PyList_uint8_t
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_uint8_t
+    (PyObject *out, uint8_t *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+}
+##### end update_PyList_uint8_t source
+
+##### start update_PyList_unsigned int source
+
+// helper update_PyList_unsigned int
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_unsigned int
+    (PyObject *out, unsigned int *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+}
+##### end update_PyList_unsigned int source
+
+##### start update_PyList_unsigned long source
+
+// helper update_PyList_unsigned long
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_unsigned long
+    (PyObject *out, unsigned long *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+}
+##### end update_PyList_unsigned long source
+
+##### start update_PyList_unsigned short source
+
+// helper update_PyList_unsigned short
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_unsigned short
+    (PyObject *out, unsigned short *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+}
+##### end update_PyList_unsigned short source
+
+##### start update_PyList_vector_double source
+
+// helper update_PyList_vector_double
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_double
+    (PyObject *out, double *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyFloat_FromDouble(in[i]));
+    }
+}
+##### end update_PyList_vector_double source
+
+##### start update_PyList_vector_float source
+
+// helper update_PyList_vector_float
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_float
+    (PyObject *out, float *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyFloat_FromDouble(in[i]));
+    }
+}
+##### end update_PyList_vector_float source
+
+##### start update_PyList_vector_int source
+
+// helper update_PyList_vector_int
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_int
+    (PyObject *out, int *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+}
+##### end update_PyList_vector_int source
+
+##### start update_PyList_vector_int16_t source
+
+// helper update_PyList_vector_int16_t
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_int16_t
+    (PyObject *out, int16_t *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+}
+##### end update_PyList_vector_int16_t source
+
+##### start update_PyList_vector_int32_t source
+
+// helper update_PyList_vector_int32_t
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_int32_t
+    (PyObject *out, int32_t *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+}
+##### end update_PyList_vector_int32_t source
+
+##### start update_PyList_vector_int64_t source
+
+// helper update_PyList_vector_int64_t
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_int64_t
+    (PyObject *out, int64_t *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+}
+##### end update_PyList_vector_int64_t source
+
+##### start update_PyList_vector_int8_t source
+
+// helper update_PyList_vector_int8_t
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_int8_t
+    (PyObject *out, int8_t *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+}
+##### end update_PyList_vector_int8_t source
+
+##### start update_PyList_vector_long source
+
+// helper update_PyList_vector_long
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_long
+    (PyObject *out, long *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+}
+##### end update_PyList_vector_long source
+
+##### start update_PyList_vector_long long source
+
+// helper update_PyList_vector_long long
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_long long
+    (PyObject *out, long long *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, XXXPy_ctor);
+    }
+}
+##### end update_PyList_vector_long long source
+
+##### start update_PyList_vector_short source
+
+// helper update_PyList_vector_short
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_short
+    (PyObject *out, short *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+}
+##### end update_PyList_vector_short source
+
+##### start update_PyList_vector_size_t source
+
+// helper update_PyList_vector_size_t
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_size_t
+    (PyObject *out, size_t *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyInt_FromSize_t(in[i]));
+    }
+}
+##### end update_PyList_vector_size_t source
+
+##### start update_PyList_vector_uint16_t source
+
+// helper update_PyList_vector_uint16_t
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_uint16_t
+    (PyObject *out, uint16_t *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+}
+##### end update_PyList_vector_uint16_t source
+
+##### start update_PyList_vector_uint32_t source
+
+// helper update_PyList_vector_uint32_t
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_uint32_t
+    (PyObject *out, uint32_t *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+}
+##### end update_PyList_vector_uint32_t source
+
+##### start update_PyList_vector_uint64_t source
+
+// helper update_PyList_vector_uint64_t
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_uint64_t
+    (PyObject *out, uint64_t *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+}
+##### end update_PyList_vector_uint64_t source
+
+##### start update_PyList_vector_uint8_t source
+
+// helper update_PyList_vector_uint8_t
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_uint8_t
+    (PyObject *out, uint8_t *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+}
+##### end update_PyList_vector_uint8_t source
+
+##### start update_PyList_vector_unsigned int source
+
+// helper update_PyList_vector_unsigned int
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_unsigned int
+    (PyObject *out, unsigned int *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+}
+##### end update_PyList_vector_unsigned int source
+
+##### start update_PyList_vector_unsigned long source
+
+// helper update_PyList_vector_unsigned long
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_unsigned long
+    (PyObject *out, unsigned long *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+}
+##### end update_PyList_vector_unsigned long source
+
+##### start update_PyList_vector_unsigned long long source
+
+// helper update_PyList_vector_unsigned long long
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_unsigned long long
+    (PyObject *out, unsigned long long *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, XXXPy_ctor);
+    }
+}
+##### end update_PyList_vector_unsigned long long source
+
+##### start update_PyList_vector_unsigned short source
+
+// helper update_PyList_vector_unsigned short
+// Replace members of existing list with new values.
+// out is known to be a PyList of the correct length.
+static void SHROUD_update_PyList_unsigned short
+    (PyObject *out, unsigned short *in, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) {
+        PyObject *item = PyList_GET_ITEM(out, i);
+        Py_DECREF(item);
+        PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
+    }
+}
+##### end update_PyList_vector_unsigned short source

--- a/regression/reference/none/helpers.c
+++ b/regression/reference/none/helpers.c
@@ -826,12 +826,12 @@ static int SHROUD_from_PyObject_uint8_t(PyObject *obj, const char *name,
 }
 ##### end from_PyObject_uint8_t source
 
-##### start from_PyObject_unsigned int source
+##### start from_PyObject_unsigned_int source
 
-// helper from_PyObject_unsigned int
+// helper from_PyObject_unsigned_int
 // Convert obj into an array of type unsigned int
 // Return -1 on error.
-static int SHROUD_from_PyObject_unsigned int(PyObject *obj,
+static int SHROUD_from_PyObject_unsigned_int(PyObject *obj,
     const char *name, unsigned int **pin, Py_ssize_t *psize)
 {
     PyObject *seq = PySequence_Fast(obj, "holder");
@@ -860,14 +860,14 @@ static int SHROUD_from_PyObject_unsigned int(PyObject *obj,
     *psize = size;
     return 0;
 }
-##### end from_PyObject_unsigned int source
+##### end from_PyObject_unsigned_int source
 
-##### start from_PyObject_unsigned long source
+##### start from_PyObject_unsigned_long source
 
-// helper from_PyObject_unsigned long
+// helper from_PyObject_unsigned_long
 // Convert obj into an array of type unsigned long
 // Return -1 on error.
-static int SHROUD_from_PyObject_unsigned long(PyObject *obj,
+static int SHROUD_from_PyObject_unsigned_long(PyObject *obj,
     const char *name, unsigned long **pin, Py_ssize_t *psize)
 {
     PyObject *seq = PySequence_Fast(obj, "holder");
@@ -896,14 +896,14 @@ static int SHROUD_from_PyObject_unsigned long(PyObject *obj,
     *psize = size;
     return 0;
 }
-##### end from_PyObject_unsigned long source
+##### end from_PyObject_unsigned_long source
 
-##### start from_PyObject_unsigned short source
+##### start from_PyObject_unsigned_short source
 
-// helper from_PyObject_unsigned short
+// helper from_PyObject_unsigned_short
 // Convert obj into an array of type unsigned short
 // Return -1 on error.
-static int SHROUD_from_PyObject_unsigned short(PyObject *obj,
+static int SHROUD_from_PyObject_unsigned_short(PyObject *obj,
     const char *name, unsigned short **pin, Py_ssize_t *psize)
 {
     PyObject *seq = PySequence_Fast(obj, "holder");
@@ -932,7 +932,7 @@ static int SHROUD_from_PyObject_unsigned short(PyObject *obj,
     *psize = size;
     return 0;
 }
-##### end from_PyObject_unsigned short source
+##### end from_PyObject_unsigned_short source
 
 ##### start from_PyObject_vector_double cxx_source
 
@@ -1179,12 +1179,12 @@ static int SHROUD_from_PyObject_vector_long(PyObject *obj,
 }
 ##### end from_PyObject_vector_long cxx_source
 
-##### start from_PyObject_vector_long long cxx_source
+##### start from_PyObject_vector_long_long cxx_source
 
-// helper from_PyObject_vector_long long
+// helper from_PyObject_vector_long_long
 // Convert obj into an array of type long long
 // Return -1 on error.
-static int SHROUD_from_PyObject_vector_long long(PyObject *obj,
+static int SHROUD_from_PyObject_vector_long_long(PyObject *obj,
     const char *name, std::vector<long long> & in)
 {
     PyObject *seq = PySequence_Fast(obj, "holder");
@@ -1208,7 +1208,7 @@ static int SHROUD_from_PyObject_vector_long long(PyObject *obj,
     Py_DECREF(seq);
     return 0;
 }
-##### end from_PyObject_vector_long long cxx_source
+##### end from_PyObject_vector_long_long cxx_source
 
 ##### start from_PyObject_vector_short cxx_source
 
@@ -1395,12 +1395,12 @@ static int SHROUD_from_PyObject_vector_uint8_t(PyObject *obj,
 }
 ##### end from_PyObject_vector_uint8_t cxx_source
 
-##### start from_PyObject_vector_unsigned int cxx_source
+##### start from_PyObject_vector_unsigned_int cxx_source
 
-// helper from_PyObject_vector_unsigned int
+// helper from_PyObject_vector_unsigned_int
 // Convert obj into an array of type unsigned int
 // Return -1 on error.
-static int SHROUD_from_PyObject_vector_unsigned int(PyObject *obj,
+static int SHROUD_from_PyObject_vector_unsigned_int(PyObject *obj,
     const char *name, std::vector<unsigned int> & in)
 {
     PyObject *seq = PySequence_Fast(obj, "holder");
@@ -1424,14 +1424,14 @@ static int SHROUD_from_PyObject_vector_unsigned int(PyObject *obj,
     Py_DECREF(seq);
     return 0;
 }
-##### end from_PyObject_vector_unsigned int cxx_source
+##### end from_PyObject_vector_unsigned_int cxx_source
 
-##### start from_PyObject_vector_unsigned long cxx_source
+##### start from_PyObject_vector_unsigned_long cxx_source
 
-// helper from_PyObject_vector_unsigned long
+// helper from_PyObject_vector_unsigned_long
 // Convert obj into an array of type unsigned long
 // Return -1 on error.
-static int SHROUD_from_PyObject_vector_unsigned long(PyObject *obj,
+static int SHROUD_from_PyObject_vector_unsigned_long(PyObject *obj,
     const char *name, std::vector<unsigned long> & in)
 {
     PyObject *seq = PySequence_Fast(obj, "holder");
@@ -1455,14 +1455,14 @@ static int SHROUD_from_PyObject_vector_unsigned long(PyObject *obj,
     Py_DECREF(seq);
     return 0;
 }
-##### end from_PyObject_vector_unsigned long cxx_source
+##### end from_PyObject_vector_unsigned_long cxx_source
 
-##### start from_PyObject_vector_unsigned long long cxx_source
+##### start from_PyObject_vector_unsigned_long_long cxx_source
 
-// helper from_PyObject_vector_unsigned long long
+// helper from_PyObject_vector_unsigned_long_long
 // Convert obj into an array of type unsigned long long
 // Return -1 on error.
-static int SHROUD_from_PyObject_vector_unsigned long long(PyObject *obj,
+static int SHROUD_from_PyObject_vector_unsigned_long_long(PyObject *obj,
     const char *name, std::vector<unsigned long long> & in)
 {
     PyObject *seq = PySequence_Fast(obj, "holder");
@@ -1486,14 +1486,14 @@ static int SHROUD_from_PyObject_vector_unsigned long long(PyObject *obj,
     Py_DECREF(seq);
     return 0;
 }
-##### end from_PyObject_vector_unsigned long long cxx_source
+##### end from_PyObject_vector_unsigned_long_long cxx_source
 
-##### start from_PyObject_vector_unsigned short cxx_source
+##### start from_PyObject_vector_unsigned_short cxx_source
 
-// helper from_PyObject_vector_unsigned short
+// helper from_PyObject_vector_unsigned_short
 // Convert obj into an array of type unsigned short
 // Return -1 on error.
-static int SHROUD_from_PyObject_vector_unsigned short(PyObject *obj,
+static int SHROUD_from_PyObject_vector_unsigned_short(PyObject *obj,
     const char *name, std::vector<unsigned short> & in)
 {
     PyObject *seq = PySequence_Fast(obj, "holder");
@@ -1517,7 +1517,7 @@ static int SHROUD_from_PyObject_vector_unsigned short(PyObject *obj,
     Py_DECREF(seq);
     return 0;
 }
-##### end from_PyObject_vector_unsigned short cxx_source
+##### end from_PyObject_vector_unsigned_short cxx_source
 
 ##### start get_from_object_char source
 
@@ -1880,48 +1880,6 @@ static int SHROUD_get_from_object_int_numpy(PyObject *obj,
 }
 ##### end get_from_object_int_numpy source
 
-##### start get_from_object_long long_list source
-
-// helper get_from_object_long long_list
-// Convert PyObject to long long pointer.
-static int SHROUD_get_from_object_long long_list(PyObject *obj,
-    LIB_SHROUD_converter_value *value)
-{
-    long long *in;
-    Py_ssize_t size;
-    if (SHROUD_from_PyObject_long long(obj, "in", &in,  &size) == -1) {
-        return 0;
-    }
-    value->obj = nullptr;
-    value->data = static_cast<long long *>(in);
-    value->size = size;
-    return 1;
-}
-##### end get_from_object_long long_list source
-
-##### start get_from_object_long long_numpy source
-
-// helper get_from_object_long long_numpy
-// Convert PyObject to long long pointer.
-static int SHROUD_get_from_object_long long_numpy(PyObject *obj,
-    LIB_SHROUD_converter_value *value)
-{
-    PyObject *array = PyArray_FROM_OTF(obj, NPY_LONGLONG,
-        NPY_ARRAY_IN_ARRAY);
-    if (array == nullptr) {
-        PyErr_SetString(PyExc_ValueError,
-            "must be a 1-D array of long long");
-        return 0;
-    }
-    value->obj = array;
-    value->data = PyArray_DATA(reinterpret_cast<PyArrayObject *>
-        (array));
-    value->size = PyArray_SIZE(reinterpret_cast<PyArrayObject *>
-        (array));
-    return 1;
-}
-##### end get_from_object_long long_numpy source
-
 ##### start get_from_object_long_list source
 
 // helper get_from_object_long_list
@@ -1940,6 +1898,48 @@ static int SHROUD_get_from_object_long_list(PyObject *obj,
     return 1;
 }
 ##### end get_from_object_long_list source
+
+##### start get_from_object_long_long_list source
+
+// helper get_from_object_long_long_list
+// Convert PyObject to long long pointer.
+static int SHROUD_get_from_object_long_long_list(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    long long *in;
+    Py_ssize_t size;
+    if (SHROUD_from_PyObject_long_long(obj, "in", &in,  &size) == -1) {
+        return 0;
+    }
+    value->obj = nullptr;
+    value->data = static_cast<long long *>(in);
+    value->size = size;
+    return 1;
+}
+##### end get_from_object_long_long_list source
+
+##### start get_from_object_long_long_numpy source
+
+// helper get_from_object_long_long_numpy
+// Convert PyObject to long long pointer.
+static int SHROUD_get_from_object_long_long_numpy(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    PyObject *array = PyArray_FROM_OTF(obj, NPY_LONGLONG,
+        NPY_ARRAY_IN_ARRAY);
+    if (array == nullptr) {
+        PyErr_SetString(PyExc_ValueError,
+            "must be a 1-D array of long long");
+        return 0;
+    }
+    value->obj = array;
+    value->data = PyArray_DATA(reinterpret_cast<PyArrayObject *>
+        (array));
+    value->size = PyArray_SIZE(reinterpret_cast<PyArrayObject *>
+        (array));
+    return 1;
+}
+##### end get_from_object_long_long_numpy source
 
 ##### start get_from_object_long_numpy source
 
@@ -2215,16 +2215,16 @@ static int SHROUD_get_from_object_uint8_t_numpy(PyObject *obj,
 }
 ##### end get_from_object_uint8_t_numpy source
 
-##### start get_from_object_unsigned int_list source
+##### start get_from_object_unsigned_int_list source
 
-// helper get_from_object_unsigned int_list
+// helper get_from_object_unsigned_int_list
 // Convert PyObject to unsigned int pointer.
-static int SHROUD_get_from_object_unsigned int_list(PyObject *obj,
+static int SHROUD_get_from_object_unsigned_int_list(PyObject *obj,
     LIB_SHROUD_converter_value *value)
 {
     unsigned int *in;
     Py_ssize_t size;
-    if (SHROUD_from_PyObject_unsigned int(obj, "in", &in, 
+    if (SHROUD_from_PyObject_unsigned_int(obj, "in", &in, 
         &size) == -1) {
         return 0;
     }
@@ -2233,13 +2233,13 @@ static int SHROUD_get_from_object_unsigned int_list(PyObject *obj,
     value->size = size;
     return 1;
 }
-##### end get_from_object_unsigned int_list source
+##### end get_from_object_unsigned_int_list source
 
-##### start get_from_object_unsigned int_numpy source
+##### start get_from_object_unsigned_int_numpy source
 
-// helper get_from_object_unsigned int_numpy
+// helper get_from_object_unsigned_int_numpy
 // Convert PyObject to unsigned int pointer.
-static int SHROUD_get_from_object_unsigned int_numpy(PyObject *obj,
+static int SHROUD_get_from_object_unsigned_int_numpy(PyObject *obj,
     LIB_SHROUD_converter_value *value)
 {
     PyObject *array = PyArray_FROM_OTF(obj, NPY_INT,
@@ -2256,18 +2256,38 @@ static int SHROUD_get_from_object_unsigned int_numpy(PyObject *obj,
         (array));
     return 1;
 }
-##### end get_from_object_unsigned int_numpy source
+##### end get_from_object_unsigned_int_numpy source
 
-##### start get_from_object_unsigned long long_list source
+##### start get_from_object_unsigned_long_list source
 
-// helper get_from_object_unsigned long long_list
+// helper get_from_object_unsigned_long_list
+// Convert PyObject to unsigned long pointer.
+static int SHROUD_get_from_object_unsigned_long_list(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    unsigned long *in;
+    Py_ssize_t size;
+    if (SHROUD_from_PyObject_unsigned_long(obj, "in", &in, 
+        &size) == -1) {
+        return 0;
+    }
+    value->obj = nullptr;
+    value->data = static_cast<unsigned long *>(in);
+    value->size = size;
+    return 1;
+}
+##### end get_from_object_unsigned_long_list source
+
+##### start get_from_object_unsigned_long_long_list source
+
+// helper get_from_object_unsigned_long_long_list
 // Convert PyObject to unsigned long long pointer.
-static int SHROUD_get_from_object_unsigned long long_list(PyObject *obj,
+static int SHROUD_get_from_object_unsigned_long_long_list(PyObject *obj,
     LIB_SHROUD_converter_value *value)
 {
     unsigned long long *in;
     Py_ssize_t size;
-    if (SHROUD_from_PyObject_unsigned long long(obj, "in", &in, 
+    if (SHROUD_from_PyObject_unsigned_long_long(obj, "in", &in, 
         &size) == -1) {
         return 0;
     }
@@ -2276,13 +2296,13 @@ static int SHROUD_get_from_object_unsigned long long_list(PyObject *obj,
     value->size = size;
     return 1;
 }
-##### end get_from_object_unsigned long long_list source
+##### end get_from_object_unsigned_long_long_list source
 
-##### start get_from_object_unsigned long long_numpy source
+##### start get_from_object_unsigned_long_long_numpy source
 
-// helper get_from_object_unsigned long long_numpy
+// helper get_from_object_unsigned_long_long_numpy
 // Convert PyObject to unsigned long long pointer.
-static int SHROUD_get_from_object_unsigned long long_numpy
+static int SHROUD_get_from_object_unsigned_long_long_numpy
     (PyObject *obj, LIB_SHROUD_converter_value *value)
 {
     PyObject *array = PyArray_FROM_OTF(obj, NPY_LONGLONG,
@@ -2299,33 +2319,13 @@ static int SHROUD_get_from_object_unsigned long long_numpy
         (array));
     return 1;
 }
-##### end get_from_object_unsigned long long_numpy source
+##### end get_from_object_unsigned_long_long_numpy source
 
-##### start get_from_object_unsigned long_list source
+##### start get_from_object_unsigned_long_numpy source
 
-// helper get_from_object_unsigned long_list
+// helper get_from_object_unsigned_long_numpy
 // Convert PyObject to unsigned long pointer.
-static int SHROUD_get_from_object_unsigned long_list(PyObject *obj,
-    LIB_SHROUD_converter_value *value)
-{
-    unsigned long *in;
-    Py_ssize_t size;
-    if (SHROUD_from_PyObject_unsigned long(obj, "in", &in, 
-        &size) == -1) {
-        return 0;
-    }
-    value->obj = nullptr;
-    value->data = static_cast<unsigned long *>(in);
-    value->size = size;
-    return 1;
-}
-##### end get_from_object_unsigned long_list source
-
-##### start get_from_object_unsigned long_numpy source
-
-// helper get_from_object_unsigned long_numpy
-// Convert PyObject to unsigned long pointer.
-static int SHROUD_get_from_object_unsigned long_numpy(PyObject *obj,
+static int SHROUD_get_from_object_unsigned_long_numpy(PyObject *obj,
     LIB_SHROUD_converter_value *value)
 {
     PyObject *array = PyArray_FROM_OTF(obj, NPY_LONG,
@@ -2342,18 +2342,18 @@ static int SHROUD_get_from_object_unsigned long_numpy(PyObject *obj,
         (array));
     return 1;
 }
-##### end get_from_object_unsigned long_numpy source
+##### end get_from_object_unsigned_long_numpy source
 
-##### start get_from_object_unsigned short_list source
+##### start get_from_object_unsigned_short_list source
 
-// helper get_from_object_unsigned short_list
+// helper get_from_object_unsigned_short_list
 // Convert PyObject to unsigned short pointer.
-static int SHROUD_get_from_object_unsigned short_list(PyObject *obj,
+static int SHROUD_get_from_object_unsigned_short_list(PyObject *obj,
     LIB_SHROUD_converter_value *value)
 {
     unsigned short *in;
     Py_ssize_t size;
-    if (SHROUD_from_PyObject_unsigned short(obj, "in", &in, 
+    if (SHROUD_from_PyObject_unsigned_short(obj, "in", &in, 
         &size) == -1) {
         return 0;
     }
@@ -2362,13 +2362,13 @@ static int SHROUD_get_from_object_unsigned short_list(PyObject *obj,
     value->size = size;
     return 1;
 }
-##### end get_from_object_unsigned short_list source
+##### end get_from_object_unsigned_short_list source
 
-##### start get_from_object_unsigned short_numpy source
+##### start get_from_object_unsigned_short_numpy source
 
-// helper get_from_object_unsigned short_numpy
+// helper get_from_object_unsigned_short_numpy
 // Convert PyObject to unsigned short pointer.
-static int SHROUD_get_from_object_unsigned short_numpy(PyObject *obj,
+static int SHROUD_get_from_object_unsigned_short_numpy(PyObject *obj,
     LIB_SHROUD_converter_value *value)
 {
     PyObject *array = PyArray_FROM_OTF(obj, NPY_SHORT,
@@ -2385,7 +2385,7 @@ static int SHROUD_get_from_object_unsigned short_numpy(PyObject *obj,
         (array));
     return 1;
 }
-##### end get_from_object_unsigned short_numpy source
+##### end get_from_object_unsigned_short_numpy source
 
 ##### start to_PyList_char source
 
@@ -2597,11 +2597,11 @@ static PyObject *SHROUD_to_PyList_uint8_t(uint8_t *in, size_t size)
 }
 ##### end to_PyList_uint8_t source
 
-##### start to_PyList_unsigned int source
+##### start to_PyList_unsigned_int source
 
-// helper to_PyList_unsigned int
+// helper to_PyList_unsigned_int
 // Convert unsigned int pointer to PyList of PyObjects.
-static PyObject *SHROUD_to_PyList_unsigned int
+static PyObject *SHROUD_to_PyList_unsigned_int
     (unsigned int *in, size_t size)
 {
     PyObject *out = PyList_New(size);
@@ -2610,13 +2610,13 @@ static PyObject *SHROUD_to_PyList_unsigned int
     }
     return out;
 }
-##### end to_PyList_unsigned int source
+##### end to_PyList_unsigned_int source
 
-##### start to_PyList_unsigned long source
+##### start to_PyList_unsigned_long source
 
-// helper to_PyList_unsigned long
+// helper to_PyList_unsigned_long
 // Convert unsigned long pointer to PyList of PyObjects.
-static PyObject *SHROUD_to_PyList_unsigned long
+static PyObject *SHROUD_to_PyList_unsigned_long
     (unsigned long *in, size_t size)
 {
     PyObject *out = PyList_New(size);
@@ -2625,13 +2625,13 @@ static PyObject *SHROUD_to_PyList_unsigned long
     }
     return out;
 }
-##### end to_PyList_unsigned long source
+##### end to_PyList_unsigned_long source
 
-##### start to_PyList_unsigned short source
+##### start to_PyList_unsigned_short source
 
-// helper to_PyList_unsigned short
+// helper to_PyList_unsigned_short
 // Convert unsigned short pointer to PyList of PyObjects.
-static PyObject *SHROUD_to_PyList_unsigned short
+static PyObject *SHROUD_to_PyList_unsigned_short
     (unsigned short *in, size_t size)
 {
     PyObject *out = PyList_New(size);
@@ -2640,7 +2640,7 @@ static PyObject *SHROUD_to_PyList_unsigned short
     }
     return out;
 }
-##### end to_PyList_unsigned short source
+##### end to_PyList_unsigned_short source
 
 ##### start to_PyList_vector_double source
 
@@ -2759,10 +2759,10 @@ static PyObject *SHROUD_to_PyList_vector_long(std::vector<long> & in)
 }
 ##### end to_PyList_vector_long source
 
-##### start to_PyList_vector_long long source
+##### start to_PyList_vector_long_long source
 
-// helper to_PyList_vector_long long
-static PyObject *SHROUD_to_PyList_vector_long long
+// helper to_PyList_vector_long_long
+static PyObject *SHROUD_to_PyList_vector_long_long
     (std::vector<long long> & in)
 {
     size_t size = in.size();
@@ -2772,7 +2772,7 @@ static PyObject *SHROUD_to_PyList_vector_long long
     }
     return out;
 }
-##### end to_PyList_vector_long long source
+##### end to_PyList_vector_long_long source
 
 ##### start to_PyList_vector_short source
 
@@ -2863,10 +2863,10 @@ static PyObject *SHROUD_to_PyList_vector_uint8_t
 }
 ##### end to_PyList_vector_uint8_t source
 
-##### start to_PyList_vector_unsigned int source
+##### start to_PyList_vector_unsigned_int source
 
-// helper to_PyList_vector_unsigned int
-static PyObject *SHROUD_to_PyList_vector_unsigned int
+// helper to_PyList_vector_unsigned_int
+static PyObject *SHROUD_to_PyList_vector_unsigned_int
     (std::vector<unsigned int> & in)
 {
     size_t size = in.size();
@@ -2876,12 +2876,12 @@ static PyObject *SHROUD_to_PyList_vector_unsigned int
     }
     return out;
 }
-##### end to_PyList_vector_unsigned int source
+##### end to_PyList_vector_unsigned_int source
 
-##### start to_PyList_vector_unsigned long source
+##### start to_PyList_vector_unsigned_long source
 
-// helper to_PyList_vector_unsigned long
-static PyObject *SHROUD_to_PyList_vector_unsigned long
+// helper to_PyList_vector_unsigned_long
+static PyObject *SHROUD_to_PyList_vector_unsigned_long
     (std::vector<unsigned long> & in)
 {
     size_t size = in.size();
@@ -2891,12 +2891,12 @@ static PyObject *SHROUD_to_PyList_vector_unsigned long
     }
     return out;
 }
-##### end to_PyList_vector_unsigned long source
+##### end to_PyList_vector_unsigned_long source
 
-##### start to_PyList_vector_unsigned long long source
+##### start to_PyList_vector_unsigned_long_long source
 
-// helper to_PyList_vector_unsigned long long
-static PyObject *SHROUD_to_PyList_vector_unsigned long long
+// helper to_PyList_vector_unsigned_long_long
+static PyObject *SHROUD_to_PyList_vector_unsigned_long_long
     (std::vector<unsigned long long> & in)
 {
     size_t size = in.size();
@@ -2906,12 +2906,12 @@ static PyObject *SHROUD_to_PyList_vector_unsigned long long
     }
     return out;
 }
-##### end to_PyList_vector_unsigned long long source
+##### end to_PyList_vector_unsigned_long_long source
 
-##### start to_PyList_vector_unsigned short source
+##### start to_PyList_vector_unsigned_short source
 
-// helper to_PyList_vector_unsigned short
-static PyObject *SHROUD_to_PyList_vector_unsigned short
+// helper to_PyList_vector_unsigned_short
+static PyObject *SHROUD_to_PyList_vector_unsigned_short
     (std::vector<unsigned short> & in)
 {
     size_t size = in.size();
@@ -2921,7 +2921,7 @@ static PyObject *SHROUD_to_PyList_vector_unsigned short
     }
     return out;
 }
-##### end to_PyList_vector_unsigned short source
+##### end to_PyList_vector_unsigned_short source
 
 ##### start update_PyList_double source
 
@@ -3147,12 +3147,12 @@ static void SHROUD_update_PyList_uint8_t
 }
 ##### end update_PyList_uint8_t source
 
-##### start update_PyList_unsigned int source
+##### start update_PyList_unsigned_int source
 
-// helper update_PyList_unsigned int
+// helper update_PyList_unsigned_int
 // Replace members of existing list with new values.
 // out is known to be a PyList of the correct length.
-static void SHROUD_update_PyList_unsigned int
+static void SHROUD_update_PyList_unsigned_int
     (PyObject *out, unsigned int *in, size_t size)
 {
     for (size_t i = 0; i < size; ++i) {
@@ -3161,14 +3161,14 @@ static void SHROUD_update_PyList_unsigned int
         PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
     }
 }
-##### end update_PyList_unsigned int source
+##### end update_PyList_unsigned_int source
 
-##### start update_PyList_unsigned long source
+##### start update_PyList_unsigned_long source
 
-// helper update_PyList_unsigned long
+// helper update_PyList_unsigned_long
 // Replace members of existing list with new values.
 // out is known to be a PyList of the correct length.
-static void SHROUD_update_PyList_unsigned long
+static void SHROUD_update_PyList_unsigned_long
     (PyObject *out, unsigned long *in, size_t size)
 {
     for (size_t i = 0; i < size; ++i) {
@@ -3177,14 +3177,14 @@ static void SHROUD_update_PyList_unsigned long
         PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
     }
 }
-##### end update_PyList_unsigned long source
+##### end update_PyList_unsigned_long source
 
-##### start update_PyList_unsigned short source
+##### start update_PyList_unsigned_short source
 
-// helper update_PyList_unsigned short
+// helper update_PyList_unsigned_short
 // Replace members of existing list with new values.
 // out is known to be a PyList of the correct length.
-static void SHROUD_update_PyList_unsigned short
+static void SHROUD_update_PyList_unsigned_short
     (PyObject *out, unsigned short *in, size_t size)
 {
     for (size_t i = 0; i < size; ++i) {
@@ -3193,14 +3193,14 @@ static void SHROUD_update_PyList_unsigned short
         PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
     }
 }
-##### end update_PyList_unsigned short source
+##### end update_PyList_unsigned_short source
 
 ##### start update_PyList_vector_double source
 
 // helper update_PyList_vector_double
 // Replace members of existing list with new values.
 // out is known to be a PyList of the correct length.
-static void SHROUD_update_PyList_double
+static void SHROUD_update_PyList_vector_double
     (PyObject *out, double *in, size_t size)
 {
     for (size_t i = 0; i < size; ++i) {
@@ -3216,7 +3216,7 @@ static void SHROUD_update_PyList_double
 // helper update_PyList_vector_float
 // Replace members of existing list with new values.
 // out is known to be a PyList of the correct length.
-static void SHROUD_update_PyList_float
+static void SHROUD_update_PyList_vector_float
     (PyObject *out, float *in, size_t size)
 {
     for (size_t i = 0; i < size; ++i) {
@@ -3232,7 +3232,7 @@ static void SHROUD_update_PyList_float
 // helper update_PyList_vector_int
 // Replace members of existing list with new values.
 // out is known to be a PyList of the correct length.
-static void SHROUD_update_PyList_int
+static void SHROUD_update_PyList_vector_int
     (PyObject *out, int *in, size_t size)
 {
     for (size_t i = 0; i < size; ++i) {
@@ -3248,7 +3248,7 @@ static void SHROUD_update_PyList_int
 // helper update_PyList_vector_int16_t
 // Replace members of existing list with new values.
 // out is known to be a PyList of the correct length.
-static void SHROUD_update_PyList_int16_t
+static void SHROUD_update_PyList_vector_int16_t
     (PyObject *out, int16_t *in, size_t size)
 {
     for (size_t i = 0; i < size; ++i) {
@@ -3264,7 +3264,7 @@ static void SHROUD_update_PyList_int16_t
 // helper update_PyList_vector_int32_t
 // Replace members of existing list with new values.
 // out is known to be a PyList of the correct length.
-static void SHROUD_update_PyList_int32_t
+static void SHROUD_update_PyList_vector_int32_t
     (PyObject *out, int32_t *in, size_t size)
 {
     for (size_t i = 0; i < size; ++i) {
@@ -3280,7 +3280,7 @@ static void SHROUD_update_PyList_int32_t
 // helper update_PyList_vector_int64_t
 // Replace members of existing list with new values.
 // out is known to be a PyList of the correct length.
-static void SHROUD_update_PyList_int64_t
+static void SHROUD_update_PyList_vector_int64_t
     (PyObject *out, int64_t *in, size_t size)
 {
     for (size_t i = 0; i < size; ++i) {
@@ -3296,7 +3296,7 @@ static void SHROUD_update_PyList_int64_t
 // helper update_PyList_vector_int8_t
 // Replace members of existing list with new values.
 // out is known to be a PyList of the correct length.
-static void SHROUD_update_PyList_int8_t
+static void SHROUD_update_PyList_vector_int8_t
     (PyObject *out, int8_t *in, size_t size)
 {
     for (size_t i = 0; i < size; ++i) {
@@ -3312,7 +3312,7 @@ static void SHROUD_update_PyList_int8_t
 // helper update_PyList_vector_long
 // Replace members of existing list with new values.
 // out is known to be a PyList of the correct length.
-static void SHROUD_update_PyList_long
+static void SHROUD_update_PyList_vector_long
     (PyObject *out, long *in, size_t size)
 {
     for (size_t i = 0; i < size; ++i) {
@@ -3323,12 +3323,12 @@ static void SHROUD_update_PyList_long
 }
 ##### end update_PyList_vector_long source
 
-##### start update_PyList_vector_long long source
+##### start update_PyList_vector_long_long source
 
-// helper update_PyList_vector_long long
+// helper update_PyList_vector_long_long
 // Replace members of existing list with new values.
 // out is known to be a PyList of the correct length.
-static void SHROUD_update_PyList_long long
+static void SHROUD_update_PyList_vector_long_long
     (PyObject *out, long long *in, size_t size)
 {
     for (size_t i = 0; i < size; ++i) {
@@ -3337,14 +3337,14 @@ static void SHROUD_update_PyList_long long
         PyList_SET_ITEM(out, i, XXXPy_ctor);
     }
 }
-##### end update_PyList_vector_long long source
+##### end update_PyList_vector_long_long source
 
 ##### start update_PyList_vector_short source
 
 // helper update_PyList_vector_short
 // Replace members of existing list with new values.
 // out is known to be a PyList of the correct length.
-static void SHROUD_update_PyList_short
+static void SHROUD_update_PyList_vector_short
     (PyObject *out, short *in, size_t size)
 {
     for (size_t i = 0; i < size; ++i) {
@@ -3360,7 +3360,7 @@ static void SHROUD_update_PyList_short
 // helper update_PyList_vector_size_t
 // Replace members of existing list with new values.
 // out is known to be a PyList of the correct length.
-static void SHROUD_update_PyList_size_t
+static void SHROUD_update_PyList_vector_size_t
     (PyObject *out, size_t *in, size_t size)
 {
     for (size_t i = 0; i < size; ++i) {
@@ -3376,7 +3376,7 @@ static void SHROUD_update_PyList_size_t
 // helper update_PyList_vector_uint16_t
 // Replace members of existing list with new values.
 // out is known to be a PyList of the correct length.
-static void SHROUD_update_PyList_uint16_t
+static void SHROUD_update_PyList_vector_uint16_t
     (PyObject *out, uint16_t *in, size_t size)
 {
     for (size_t i = 0; i < size; ++i) {
@@ -3392,7 +3392,7 @@ static void SHROUD_update_PyList_uint16_t
 // helper update_PyList_vector_uint32_t
 // Replace members of existing list with new values.
 // out is known to be a PyList of the correct length.
-static void SHROUD_update_PyList_uint32_t
+static void SHROUD_update_PyList_vector_uint32_t
     (PyObject *out, uint32_t *in, size_t size)
 {
     for (size_t i = 0; i < size; ++i) {
@@ -3408,7 +3408,7 @@ static void SHROUD_update_PyList_uint32_t
 // helper update_PyList_vector_uint64_t
 // Replace members of existing list with new values.
 // out is known to be a PyList of the correct length.
-static void SHROUD_update_PyList_uint64_t
+static void SHROUD_update_PyList_vector_uint64_t
     (PyObject *out, uint64_t *in, size_t size)
 {
     for (size_t i = 0; i < size; ++i) {
@@ -3424,7 +3424,7 @@ static void SHROUD_update_PyList_uint64_t
 // helper update_PyList_vector_uint8_t
 // Replace members of existing list with new values.
 // out is known to be a PyList of the correct length.
-static void SHROUD_update_PyList_uint8_t
+static void SHROUD_update_PyList_vector_uint8_t
     (PyObject *out, uint8_t *in, size_t size)
 {
     for (size_t i = 0; i < size; ++i) {
@@ -3435,12 +3435,12 @@ static void SHROUD_update_PyList_uint8_t
 }
 ##### end update_PyList_vector_uint8_t source
 
-##### start update_PyList_vector_unsigned int source
+##### start update_PyList_vector_unsigned_int source
 
-// helper update_PyList_vector_unsigned int
+// helper update_PyList_vector_unsigned_int
 // Replace members of existing list with new values.
 // out is known to be a PyList of the correct length.
-static void SHROUD_update_PyList_unsigned int
+static void SHROUD_update_PyList_vector_unsigned_int
     (PyObject *out, unsigned int *in, size_t size)
 {
     for (size_t i = 0; i < size; ++i) {
@@ -3449,14 +3449,14 @@ static void SHROUD_update_PyList_unsigned int
         PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
     }
 }
-##### end update_PyList_vector_unsigned int source
+##### end update_PyList_vector_unsigned_int source
 
-##### start update_PyList_vector_unsigned long source
+##### start update_PyList_vector_unsigned_long source
 
-// helper update_PyList_vector_unsigned long
+// helper update_PyList_vector_unsigned_long
 // Replace members of existing list with new values.
 // out is known to be a PyList of the correct length.
-static void SHROUD_update_PyList_unsigned long
+static void SHROUD_update_PyList_vector_unsigned_long
     (PyObject *out, unsigned long *in, size_t size)
 {
     for (size_t i = 0; i < size; ++i) {
@@ -3465,14 +3465,14 @@ static void SHROUD_update_PyList_unsigned long
         PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
     }
 }
-##### end update_PyList_vector_unsigned long source
+##### end update_PyList_vector_unsigned_long source
 
-##### start update_PyList_vector_unsigned long long source
+##### start update_PyList_vector_unsigned_long_long source
 
-// helper update_PyList_vector_unsigned long long
+// helper update_PyList_vector_unsigned_long_long
 // Replace members of existing list with new values.
 // out is known to be a PyList of the correct length.
-static void SHROUD_update_PyList_unsigned long long
+static void SHROUD_update_PyList_vector_unsigned_long_long
     (PyObject *out, unsigned long long *in, size_t size)
 {
     for (size_t i = 0; i < size; ++i) {
@@ -3481,14 +3481,14 @@ static void SHROUD_update_PyList_unsigned long long
         PyList_SET_ITEM(out, i, XXXPy_ctor);
     }
 }
-##### end update_PyList_vector_unsigned long long source
+##### end update_PyList_vector_unsigned_long_long source
 
-##### start update_PyList_vector_unsigned short source
+##### start update_PyList_vector_unsigned_short source
 
-// helper update_PyList_vector_unsigned short
+// helper update_PyList_vector_unsigned_short
 // Replace members of existing list with new values.
 // out is known to be a PyList of the correct length.
-static void SHROUD_update_PyList_unsigned short
+static void SHROUD_update_PyList_vector_unsigned_short
     (PyObject *out, unsigned short *in, size_t size)
 {
     for (size_t i = 0; i < size; ++i) {
@@ -3497,4 +3497,4 @@ static void SHROUD_update_PyList_unsigned short
         PyList_SET_ITEM(out, i, PyInt_FromLong(in[i]));
     }
 }
-##### end update_PyList_vector_unsigned short source
+##### end update_PyList_vector_unsigned_short source

--- a/regression/reference/none/helpers.c
+++ b/regression/reference/none/helpers.c
@@ -1,0 +1,449 @@
+
+##### start PY_converter_type source
+
+// helper PY_converter_type
+// Store PyObject and pointer to the data it contains.
+typedef struct {
+    PyObject *obj;
+    void *data;   // points into obj.
+    size_t size;
+} LIB_SHROUD_converter_value;
+##### end PY_converter_type source
+
+##### start ShroudLenTrim source
+
+// helper ShroudLenTrim
+// Returns the length of character string src with length nsrc,
+// ignoring any trailing blanks.
+int ShroudLenTrim(const char *src, int nsrc) {
+    int i;
+
+    for (i = nsrc - 1; i >= 0; i--) {
+        if (src[i] != ' ') {
+            break;
+        }
+    }
+
+    return i + 1;
+}
+
+##### end ShroudLenTrim source
+
+##### start ShroudStrAlloc c_source
+
+// helper ShroudStrAlloc
+// Copy src into new memory and null terminate.
+static char *ShroudStrAlloc(const char *src, int nsrc, int ntrim)
+{
+   char *rv = malloc(nsrc + 1);
+   if (ntrim > 0) {
+     memcpy(rv, src, ntrim);
+   }
+   rv[ntrim] = '\0';
+   return rv;
+}
+##### end ShroudStrAlloc c_source
+
+##### start ShroudStrAlloc cxx_source
+
+// helper ShroudStrAlloc
+// Copy src into new memory and null terminate.
+static char *ShroudStrAlloc(const char *src, int nsrc, int ntrim)
+{
+   char *rv = (char *) std::malloc(nsrc + 1);
+   if (ntrim > 0) {
+     std::memcpy(rv, src, ntrim);
+   }
+   rv[ntrim] = '\0';
+   return rv;
+}
+##### end ShroudStrAlloc cxx_source
+
+##### start ShroudStrArrayAlloc c_source
+
+// helper ShroudStrArrayAlloc
+// Copy src into new memory and null terminate.
+static char **ShroudStrArrayAlloc(const char *src, int nsrc, int len)
+{
+   char **rv = malloc(sizeof(char *) * nsrc);
+   const char *src0 = src;
+   for(int i=0; i < nsrc; ++i) {
+      int ntrim = ShroudLenTrim(src0, len);
+      char *tgt = malloc(ntrim+1);
+      memcpy(tgt, src0, ntrim);
+      tgt[ntrim] = '\0';
+      rv[i] = tgt;
+      src0 += len;
+   }
+   return rv;
+}
+##### end ShroudStrArrayAlloc c_source
+
+##### start ShroudStrArrayAlloc cxx_source
+
+// helper ShroudStrArrayAlloc
+// Copy src into new memory and null terminate.
+// char **src +size(nsrc) +len(len)
+// CHARACTER(len) src(nsrc)
+static char **ShroudStrArrayAlloc(const char *src, int nsrc, int len)
+{
+   char **rv = static_cast<char **>(std::malloc(sizeof(char *) * nsrc));
+   const char *src0 = src;
+   for(int i=0; i < nsrc; ++i) {
+      int ntrim = ShroudLenTrim(src0, len);
+      char *tgt = static_cast<char *>(std::malloc(ntrim+1));
+      std::memcpy(tgt, src0, ntrim);
+      tgt[ntrim] = '\0';
+      rv[i] = tgt;
+      src0 += len;
+   }
+   return rv;
+}
+##### end ShroudStrArrayAlloc cxx_source
+
+##### start ShroudStrArrayFree c_source
+
+// helper ShroudStrArrayFree
+// Release memory allocated by ShroudStrArrayAlloc
+static void ShroudStrArrayFree(char **src, int nsrc)
+{
+   for(int i=0; i < nsrc; ++i) {
+       free(src[i]);
+   }
+   free(src);
+}
+##### end ShroudStrArrayFree c_source
+
+##### start ShroudStrArrayFree cxx_source
+
+// helper ShroudStrArrayFree
+// Release memory allocated by ShroudStrArrayAlloc
+static void ShroudStrArrayFree(char **src, int nsrc)
+{
+   for(int i=0; i < nsrc; ++i) {
+       std::free(src[i]);
+   }
+   std::free(src);
+}
+##### end ShroudStrArrayFree cxx_source
+
+##### start ShroudStrBlankFill c_source
+
+// helper ShroudStrBlankFill
+// blank fill dest starting at trailing NULL.
+static void ShroudStrBlankFill(char *dest, int ndest)
+{
+   int nm = strlen(dest);
+   if(ndest > nm) memset(dest+nm,' ',ndest-nm);
+}
+##### end ShroudStrBlankFill c_source
+
+##### start ShroudStrBlankFill cxx_source
+
+// helper ShroudStrBlankFill
+// blank fill dest starting at trailing NULL.
+static void ShroudStrBlankFill(char *dest, int ndest)
+{
+   int nm = std::strlen(dest);
+   if(ndest > nm) std::memset(dest+nm,' ',ndest-nm);
+}
+##### end ShroudStrBlankFill cxx_source
+
+##### start ShroudStrCopy c_source
+
+// helper ShroudStrCopy
+// Copy src into dest, blank fill to ndest characters
+// Truncate if dest is too short.
+// dest will not be NULL terminated.
+static void ShroudStrCopy(char *dest, int ndest, const char *src, int nsrc)
+{
+   if (src == NULL) {
+     memset(dest,' ',ndest); // convert NULL pointer to blank filled string
+   } else {
+     if (nsrc < 0) nsrc = strlen(src);
+     int nm = nsrc < ndest ? nsrc : ndest;
+     memcpy(dest,src,nm);
+     if(ndest > nm) memset(dest+nm,' ',ndest-nm); // blank fill
+   }
+}
+##### end ShroudStrCopy c_source
+
+##### start ShroudStrCopy cxx_source
+
+// helper ShroudStrCopy
+// Copy src into dest, blank fill to ndest characters
+// Truncate if dest is too short.
+// dest will not be NULL terminated.
+static void ShroudStrCopy(char *dest, int ndest, const char *src, int nsrc)
+{
+   if (src == NULL) {
+     std::memset(dest,' ',ndest); // convert NULL pointer to blank filled string
+   } else {
+     if (nsrc < 0) nsrc = std::strlen(src);
+     int nm = nsrc < ndest ? nsrc : ndest;
+     std::memcpy(dest,src,nm);
+     if(ndest > nm) std::memset(dest+nm,' ',ndest-nm); // blank fill
+   }
+}
+##### end ShroudStrCopy cxx_source
+
+##### start ShroudStrFree c_source
+
+// helper ShroudStrFree
+// Release memory allocated by ShroudStrAlloc
+static void ShroudStrFree(char *src)
+{
+   free(src);
+}
+##### end ShroudStrFree c_source
+
+##### start ShroudStrFree cxx_source
+
+// helper ShroudStrFree
+// Release memory allocated by ShroudStrAlloc
+static void ShroudStrFree(char *src)
+{
+   free(src);
+}
+##### end ShroudStrFree cxx_source
+
+##### start ShroudStrToArray source
+
+// helper ShroudStrToArray
+// Save str metadata into array to allow Fortran to access values.
+static void ShroudStrToArray(LIB_SHROUD_array *array, const std::string * src, int idtor)
+{
+    array->cxx.addr = static_cast<void *>(const_cast<std::string *>(src));
+    array->cxx.idtor = idtor;
+    if (src->empty()) {
+        array->addr.ccharp = NULL;
+        array->elem_len = 0;
+    } else {
+        array->addr.ccharp = src->data();
+        array->elem_len = src->length();
+    }
+    array->size = 1;
+    array->rank = 1;
+}
+##### end ShroudStrToArray source
+
+##### start ShroudTypeDefines source
+
+/* helper ShroudTypeDefines */
+/* Shroud type defines */
+#define SH_TYPE_SIGNED_CHAR 1
+#define SH_TYPE_SHORT       2
+#define SH_TYPE_INT         3
+#define SH_TYPE_LONG        4
+#define SH_TYPE_LONG_LONG   5
+#define SH_TYPE_SIZE_T      6
+
+#define SH_TYPE_UNSIGNED_SHORT       SH_TYPE_SHORT + 100
+#define SH_TYPE_UNSIGNED_INT         SH_TYPE_INT + 100
+#define SH_TYPE_UNSIGNED_LONG        SH_TYPE_LONG + 100
+#define SH_TYPE_UNSIGNED_LONG_LONG   SH_TYPE_LONG_LONG + 100
+
+#define SH_TYPE_INT8_T      7
+#define SH_TYPE_INT16_T     8
+#define SH_TYPE_INT32_T     9
+#define SH_TYPE_INT64_T    10
+
+#define SH_TYPE_UINT8_T    SH_TYPE_INT8_T + 100
+#define SH_TYPE_UINT16_T   SH_TYPE_INT16_T + 100
+#define SH_TYPE_UINT32_T   SH_TYPE_INT32_T + 100
+#define SH_TYPE_UINT64_T   SH_TYPE_INT64_T + 100
+
+/* least8 least16 least32 least64 */
+/* fast8 fast16 fast32 fast64 */
+/* intmax_t intptr_t ptrdiff_t */
+
+#define SH_TYPE_FLOAT        22
+#define SH_TYPE_DOUBLE       23
+#define SH_TYPE_LONG_DOUBLE  24
+#define SH_TYPE_FLOAT_COMPLEX       25
+#define SH_TYPE_DOUBLE_COMPLEX      26
+#define SH_TYPE_LONG_DOUBLE_COMPLEX 27
+
+#define SH_TYPE_BOOL       28
+#define SH_TYPE_CHAR       29
+#define SH_TYPE_CPTR       30
+#define SH_TYPE_STRUCT     31
+#define SH_TYPE_OTHER      32
+##### end ShroudTypeDefines source
+
+##### start array_context source
+
+// helper array_context
+struct s_LIB_SHROUD_array {
+    LIB_SHROUD_capsule_data cxx;      /* address of C++ memory */
+    union {
+        const void * base;
+        const char * ccharp;
+    } addr;
+    int type;        /* type of element */
+    size_t elem_len; /* bytes-per-item or character len in c++ */
+    size_t size;     /* size of data in c++ */
+    int rank;        /* number of dimensions */
+};
+typedef struct s_LIB_SHROUD_array LIB_SHROUD_array;
+##### end array_context source
+
+##### start capsule_data_helper source
+
+// helper capsule_data_helper
+struct s_LIB_SHROUD_capsule_data {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_LIB_SHROUD_capsule_data LIB_SHROUD_capsule_data;
+##### end capsule_data_helper source
+
+##### start copy_array cxx_source
+
+// helper copy_array
+// Copy std::vector into array c_var(c_var_size).
+// Then release std::vector.
+// Called from Fortran.
+void LIB_ShroudCopyArray(LIB_SHROUD_array *data, void *c_var, 
+    size_t c_var_size)
+{
+    const void *cxx_var = data->addr.base;
+    int n = c_var_size < data->size ? c_var_size : data->size;
+    n *= data->elem_len;
+    std::memcpy(c_var, cxx_var, n);
+    LIB_SHROUD_memory_destructor(&data->cxx); // delete data->cxx.addr
+}
+##### end copy_array cxx_source
+
+##### start copy_string source
+
+// helper copy_string
+// Copy the char* or std::string in context into c_var.
+// Called by Fortran to deal with allocatable character.
+void LIB_ShroudCopyStringAndFree(LIB_SHROUD_array *data, char *c_var, size_t c_var_len) {
+    const char *cxx_var = data->addr.ccharp;
+    size_t n = c_var_len;
+    if (data->elem_len < n) n = data->elem_len;
+    std::strncpy(c_var, cxx_var, n);
+    LIB_SHROUD_memory_destructor(&data->cxx); // delete data->cxx.addr
+}
+
+##### end copy_string source
+
+##### start from_PyObject_char source
+
+// helper from_PyObject_char
+// Convert obj into an array of type char *
+// Return -1 on error.
+static int SHROUD_from_PyObject_char(PyObject *obj, const char *name,
+    char * **pin, Py_ssize_t *psize)
+{
+    PyObject *seq = PySequence_Fast(obj, "holder");
+    if (seq == NULL) {
+        PyErr_Format(PyExc_TypeError, "argument '%s' must be iterable",
+            name);
+        return -1;
+    }
+    Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
+    char * *in = static_cast<char * *>
+        (std::malloc(size * sizeof(char *)));
+    for (Py_ssize_t i = 0; i < size; i++) {
+        PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
+        in[i] = PyString_AsString(item);
+        if (PyErr_Occurred()) {
+            std::free(in);
+            Py_DECREF(seq);
+            PyErr_Format(PyExc_ValueError,
+                "argument '%s', index %d must be string", name,
+                (int) i);
+            return -1;
+        }
+    }
+    Py_DECREF(seq);
+    *pin = in;
+    *psize = size;
+    return 0;
+}
+##### end from_PyObject_char source
+
+##### start get_from_object_char source
+
+// helper get_from_object_char
+// Converter to PyObject to char *.
+static int SHROUD_get_from_object_char(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    size_t size = 0;
+    char *out;
+    if (PyUnicode_Check(obj)) {
+#if PY_MAJOR_VERSION >= 3
+        PyObject *strobj = PyUnicode_AsUTF8String(obj);
+        out = PyBytes_AS_STRING(strobj);
+        size = PyString_Size(obj);
+        value->obj = strobj;  // steal reference
+#else
+        PyObject *strobj = PyUnicode_AsUTF8String(obj);
+        out = PyString_AsString(strobj);
+        size = PyString_Size(obj);
+        value->obj = strobj;  // steal reference
+#endif
+#if PY_MAJOR_VERSION >= 3
+    } else if (PyByteArray_Check(obj)) {
+        out = PyBytes_AS_STRING(obj);
+        size = PyBytes_GET_SIZE(obj);
+        value->obj = obj;
+        Py_INCREF(obj);
+#else
+    } else if (PyString_Check(obj)) {
+        out = PyString_AsString(obj);
+        size = PyString_Size(obj);
+        value->obj = obj;
+        Py_INCREF(obj);
+#endif
+    } else if (obj == Py_None) {
+        out = NULL;
+        size = 0;
+        value->obj = NULL;
+    } else {
+        PyErr_SetString(PyExc_ValueError, "argument must be a string");
+        return 0;
+    }
+    value->data = out;
+    value->size = size;
+    return 1;
+}
+
+##### end get_from_object_char source
+
+##### start get_from_object_charptr source
+
+// helper get_from_object_charptr
+// Convert PyObject to char * pointer.
+static int SHROUD_get_from_object_charptr(PyObject *obj,
+    LIB_SHROUD_converter_value *value)
+{
+    char * *in;
+    Py_ssize_t size;
+    if (SHROUD_from_PyObject_char(obj, "in", &in,  &size) == -1) {
+        return 0;
+    }
+    value->obj = nullptr;
+    value->data = static_cast<char * *>(in);
+    value->size = size;
+    return 1;
+}
+##### end get_from_object_charptr source
+
+##### start to_PyList_char source
+
+// helper to_PyList_char
+// Convert char * pointer to PyList of PyObjects.
+static PyObject *SHROUD_to_PyList_char(char * *in, size_t size)
+{
+    PyObject *out = PyList_New(size);
+    for (size_t i = 0; i < size; ++i) {
+        PyList_SET_ITEM(out, i, PyString_FromString(in[i]));
+    }
+    return out;
+}
+##### end to_PyList_char source

--- a/regression/reference/none/helpers.f
+++ b/regression/reference/none/helpers.f
@@ -21,6 +21,310 @@ end subroutine SHROUD_capsule_final
             
 ##### end capsule_helper source
 
+##### start copy_array_double interface
+
+interface
+    ! helper copy_array_double
+    ! Copy contents of context into c_var.
+    subroutine SHROUD_copy_array_double(context, c_var, c_var_size) &
+        bind(C, name="LIB_ShroudCopyArray")
+        use iso_c_binding, only : C_DOUBLE, C_SIZE_T
+        import SHROUD_array
+        type(SHROUD_array), intent(IN) :: context
+        real(C_DOUBLE), intent(OUT) :: c_var(*)
+        integer(C_SIZE_T), value :: c_var_size
+    end subroutine SHROUD_copy_array_double
+end interface
+##### end copy_array_double interface
+
+##### start copy_array_float interface
+
+interface
+    ! helper copy_array_float
+    ! Copy contents of context into c_var.
+    subroutine SHROUD_copy_array_float(context, c_var, c_var_size) &
+        bind(C, name="LIB_ShroudCopyArray")
+        use iso_c_binding, only : C_FLOAT, C_SIZE_T
+        import SHROUD_array
+        type(SHROUD_array), intent(IN) :: context
+        real(C_FLOAT), intent(OUT) :: c_var(*)
+        integer(C_SIZE_T), value :: c_var_size
+    end subroutine SHROUD_copy_array_float
+end interface
+##### end copy_array_float interface
+
+##### start copy_array_int interface
+
+interface
+    ! helper copy_array_int
+    ! Copy contents of context into c_var.
+    subroutine SHROUD_copy_array_int(context, c_var, c_var_size) &
+        bind(C, name="LIB_ShroudCopyArray")
+        use iso_c_binding, only : C_INT, C_SIZE_T
+        import SHROUD_array
+        type(SHROUD_array), intent(IN) :: context
+        integer(C_INT), intent(OUT) :: c_var(*)
+        integer(C_SIZE_T), value :: c_var_size
+    end subroutine SHROUD_copy_array_int
+end interface
+##### end copy_array_int interface
+
+##### start copy_array_int16_t interface
+
+interface
+    ! helper copy_array_int16_t
+    ! Copy contents of context into c_var.
+    subroutine SHROUD_copy_array_int16_t(context, c_var, c_var_size) &
+        bind(C, name="LIB_ShroudCopyArray")
+        use iso_c_binding, only : C_INT16_T, C_SIZE_T
+        import SHROUD_array
+        type(SHROUD_array), intent(IN) :: context
+        integer(C_INT16_T), intent(OUT) :: c_var(*)
+        integer(C_SIZE_T), value :: c_var_size
+    end subroutine SHROUD_copy_array_int16_t
+end interface
+##### end copy_array_int16_t interface
+
+##### start copy_array_int32_t interface
+
+interface
+    ! helper copy_array_int32_t
+    ! Copy contents of context into c_var.
+    subroutine SHROUD_copy_array_int32_t(context, c_var, c_var_size) &
+        bind(C, name="LIB_ShroudCopyArray")
+        use iso_c_binding, only : C_INT32_T, C_SIZE_T
+        import SHROUD_array
+        type(SHROUD_array), intent(IN) :: context
+        integer(C_INT32_T), intent(OUT) :: c_var(*)
+        integer(C_SIZE_T), value :: c_var_size
+    end subroutine SHROUD_copy_array_int32_t
+end interface
+##### end copy_array_int32_t interface
+
+##### start copy_array_int64_t interface
+
+interface
+    ! helper copy_array_int64_t
+    ! Copy contents of context into c_var.
+    subroutine SHROUD_copy_array_int64_t(context, c_var, c_var_size) &
+        bind(C, name="LIB_ShroudCopyArray")
+        use iso_c_binding, only : C_INT64_T, C_SIZE_T
+        import SHROUD_array
+        type(SHROUD_array), intent(IN) :: context
+        integer(C_INT64_T), intent(OUT) :: c_var(*)
+        integer(C_SIZE_T), value :: c_var_size
+    end subroutine SHROUD_copy_array_int64_t
+end interface
+##### end copy_array_int64_t interface
+
+##### start copy_array_int8_t interface
+
+interface
+    ! helper copy_array_int8_t
+    ! Copy contents of context into c_var.
+    subroutine SHROUD_copy_array_int8_t(context, c_var, c_var_size) &
+        bind(C, name="LIB_ShroudCopyArray")
+        use iso_c_binding, only : C_INT8_T, C_SIZE_T
+        import SHROUD_array
+        type(SHROUD_array), intent(IN) :: context
+        integer(C_INT8_T), intent(OUT) :: c_var(*)
+        integer(C_SIZE_T), value :: c_var_size
+    end subroutine SHROUD_copy_array_int8_t
+end interface
+##### end copy_array_int8_t interface
+
+##### start copy_array_long interface
+
+interface
+    ! helper copy_array_long
+    ! Copy contents of context into c_var.
+    subroutine SHROUD_copy_array_long(context, c_var, c_var_size) &
+        bind(C, name="LIB_ShroudCopyArray")
+        use iso_c_binding, only : C_LONG, C_SIZE_T
+        import SHROUD_array
+        type(SHROUD_array), intent(IN) :: context
+        integer(C_LONG), intent(OUT) :: c_var(*)
+        integer(C_SIZE_T), value :: c_var_size
+    end subroutine SHROUD_copy_array_long
+end interface
+##### end copy_array_long interface
+
+##### start copy_array_long long interface
+
+interface
+    ! helper copy_array_long long
+    ! Copy contents of context into c_var.
+    subroutine SHROUD_copy_array_long long(context, c_var, c_var_size) &
+        bind(C, name="LIB_ShroudCopyArray")
+        use iso_c_binding, only : C_LONG_LONG, C_SIZE_T
+        import SHROUD_array
+        type(SHROUD_array), intent(IN) :: context
+        integer(C_LONG_LONG), intent(OUT) :: c_var(*)
+        integer(C_SIZE_T), value :: c_var_size
+    end subroutine SHROUD_copy_array_long long
+end interface
+##### end copy_array_long long interface
+
+##### start copy_array_short interface
+
+interface
+    ! helper copy_array_short
+    ! Copy contents of context into c_var.
+    subroutine SHROUD_copy_array_short(context, c_var, c_var_size) &
+        bind(C, name="LIB_ShroudCopyArray")
+        use iso_c_binding, only : C_SHORT, C_SIZE_T
+        import SHROUD_array
+        type(SHROUD_array), intent(IN) :: context
+        integer(C_SHORT), intent(OUT) :: c_var(*)
+        integer(C_SIZE_T), value :: c_var_size
+    end subroutine SHROUD_copy_array_short
+end interface
+##### end copy_array_short interface
+
+##### start copy_array_size_t interface
+
+interface
+    ! helper copy_array_size_t
+    ! Copy contents of context into c_var.
+    subroutine SHROUD_copy_array_size_t(context, c_var, c_var_size) &
+        bind(C, name="LIB_ShroudCopyArray")
+        use iso_c_binding, only : C_SIZE_T, C_SIZE_T
+        import SHROUD_array
+        type(SHROUD_array), intent(IN) :: context
+        integer(C_SIZE_T), intent(OUT) :: c_var(*)
+        integer(C_SIZE_T), value :: c_var_size
+    end subroutine SHROUD_copy_array_size_t
+end interface
+##### end copy_array_size_t interface
+
+##### start copy_array_uint16_t interface
+
+interface
+    ! helper copy_array_uint16_t
+    ! Copy contents of context into c_var.
+    subroutine SHROUD_copy_array_uint16_t(context, c_var, c_var_size) &
+        bind(C, name="LIB_ShroudCopyArray")
+        use iso_c_binding, only : C_INT16_T, C_SIZE_T
+        import SHROUD_array
+        type(SHROUD_array), intent(IN) :: context
+        integer(C_INT16_T), intent(OUT) :: c_var(*)
+        integer(C_SIZE_T), value :: c_var_size
+    end subroutine SHROUD_copy_array_uint16_t
+end interface
+##### end copy_array_uint16_t interface
+
+##### start copy_array_uint32_t interface
+
+interface
+    ! helper copy_array_uint32_t
+    ! Copy contents of context into c_var.
+    subroutine SHROUD_copy_array_uint32_t(context, c_var, c_var_size) &
+        bind(C, name="LIB_ShroudCopyArray")
+        use iso_c_binding, only : C_INT32_T, C_SIZE_T
+        import SHROUD_array
+        type(SHROUD_array), intent(IN) :: context
+        integer(C_INT32_T), intent(OUT) :: c_var(*)
+        integer(C_SIZE_T), value :: c_var_size
+    end subroutine SHROUD_copy_array_uint32_t
+end interface
+##### end copy_array_uint32_t interface
+
+##### start copy_array_uint64_t interface
+
+interface
+    ! helper copy_array_uint64_t
+    ! Copy contents of context into c_var.
+    subroutine SHROUD_copy_array_uint64_t(context, c_var, c_var_size) &
+        bind(C, name="LIB_ShroudCopyArray")
+        use iso_c_binding, only : C_INT64_T, C_SIZE_T
+        import SHROUD_array
+        type(SHROUD_array), intent(IN) :: context
+        integer(C_INT64_T), intent(OUT) :: c_var(*)
+        integer(C_SIZE_T), value :: c_var_size
+    end subroutine SHROUD_copy_array_uint64_t
+end interface
+##### end copy_array_uint64_t interface
+
+##### start copy_array_uint8_t interface
+
+interface
+    ! helper copy_array_uint8_t
+    ! Copy contents of context into c_var.
+    subroutine SHROUD_copy_array_uint8_t(context, c_var, c_var_size) &
+        bind(C, name="LIB_ShroudCopyArray")
+        use iso_c_binding, only : C_INT8_T, C_SIZE_T
+        import SHROUD_array
+        type(SHROUD_array), intent(IN) :: context
+        integer(C_INT8_T), intent(OUT) :: c_var(*)
+        integer(C_SIZE_T), value :: c_var_size
+    end subroutine SHROUD_copy_array_uint8_t
+end interface
+##### end copy_array_uint8_t interface
+
+##### start copy_array_unsigned int interface
+
+interface
+    ! helper copy_array_unsigned int
+    ! Copy contents of context into c_var.
+    subroutine SHROUD_copy_array_unsigned int(context, c_var, c_var_size) &
+        bind(C, name="LIB_ShroudCopyArray")
+        use iso_c_binding, only : C_INT, C_SIZE_T
+        import SHROUD_array
+        type(SHROUD_array), intent(IN) :: context
+        integer(C_INT), intent(OUT) :: c_var(*)
+        integer(C_SIZE_T), value :: c_var_size
+    end subroutine SHROUD_copy_array_unsigned int
+end interface
+##### end copy_array_unsigned int interface
+
+##### start copy_array_unsigned long interface
+
+interface
+    ! helper copy_array_unsigned long
+    ! Copy contents of context into c_var.
+    subroutine SHROUD_copy_array_unsigned long(context, c_var, c_var_size) &
+        bind(C, name="LIB_ShroudCopyArray")
+        use iso_c_binding, only : C_LONG, C_SIZE_T
+        import SHROUD_array
+        type(SHROUD_array), intent(IN) :: context
+        integer(C_LONG), intent(OUT) :: c_var(*)
+        integer(C_SIZE_T), value :: c_var_size
+    end subroutine SHROUD_copy_array_unsigned long
+end interface
+##### end copy_array_unsigned long interface
+
+##### start copy_array_unsigned long long interface
+
+interface
+    ! helper copy_array_unsigned long long
+    ! Copy contents of context into c_var.
+    subroutine SHROUD_copy_array_unsigned long long(context, c_var, c_var_size) &
+        bind(C, name="LIB_ShroudCopyArray")
+        use iso_c_binding, only : C_LONG_LONG, C_SIZE_T
+        import SHROUD_array
+        type(SHROUD_array), intent(IN) :: context
+        integer(C_LONG_LONG), intent(OUT) :: c_var(*)
+        integer(C_SIZE_T), value :: c_var_size
+    end subroutine SHROUD_copy_array_unsigned long long
+end interface
+##### end copy_array_unsigned long long interface
+
+##### start copy_array_unsigned short interface
+
+interface
+    ! helper copy_array_unsigned short
+    ! Copy contents of context into c_var.
+    subroutine SHROUD_copy_array_unsigned short(context, c_var, c_var_size) &
+        bind(C, name="LIB_ShroudCopyArray")
+        use iso_c_binding, only : C_SHORT, C_SIZE_T
+        import SHROUD_array
+        type(SHROUD_array), intent(IN) :: context
+        integer(C_SHORT), intent(OUT) :: c_var(*)
+        integer(C_SIZE_T), value :: c_var_size
+    end subroutine SHROUD_copy_array_unsigned short
+end interface
+##### end copy_array_unsigned short interface
+
 ##### start copy_string interface
 
 interface

--- a/regression/reference/none/helpers.f
+++ b/regression/reference/none/helpers.f
@@ -149,21 +149,21 @@ interface
 end interface
 ##### end copy_array_long interface
 
-##### start copy_array_long long interface
+##### start copy_array_long_long interface
 
 interface
-    ! helper copy_array_long long
+    ! helper copy_array_long_long
     ! Copy contents of context into c_var.
-    subroutine SHROUD_copy_array_long long(context, c_var, c_var_size) &
+    subroutine SHROUD_copy_array_long_long(context, c_var, c_var_size) &
         bind(C, name="LIB_ShroudCopyArray")
         use iso_c_binding, only : C_LONG_LONG, C_SIZE_T
         import SHROUD_array
         type(SHROUD_array), intent(IN) :: context
         integer(C_LONG_LONG), intent(OUT) :: c_var(*)
         integer(C_SIZE_T), value :: c_var_size
-    end subroutine SHROUD_copy_array_long long
+    end subroutine SHROUD_copy_array_long_long
 end interface
-##### end copy_array_long long interface
+##### end copy_array_long_long interface
 
 ##### start copy_array_short interface
 
@@ -261,69 +261,69 @@ interface
 end interface
 ##### end copy_array_uint8_t interface
 
-##### start copy_array_unsigned int interface
+##### start copy_array_unsigned_int interface
 
 interface
-    ! helper copy_array_unsigned int
+    ! helper copy_array_unsigned_int
     ! Copy contents of context into c_var.
-    subroutine SHROUD_copy_array_unsigned int(context, c_var, c_var_size) &
+    subroutine SHROUD_copy_array_unsigned_int(context, c_var, c_var_size) &
         bind(C, name="LIB_ShroudCopyArray")
         use iso_c_binding, only : C_INT, C_SIZE_T
         import SHROUD_array
         type(SHROUD_array), intent(IN) :: context
         integer(C_INT), intent(OUT) :: c_var(*)
         integer(C_SIZE_T), value :: c_var_size
-    end subroutine SHROUD_copy_array_unsigned int
+    end subroutine SHROUD_copy_array_unsigned_int
 end interface
-##### end copy_array_unsigned int interface
+##### end copy_array_unsigned_int interface
 
-##### start copy_array_unsigned long interface
+##### start copy_array_unsigned_long interface
 
 interface
-    ! helper copy_array_unsigned long
+    ! helper copy_array_unsigned_long
     ! Copy contents of context into c_var.
-    subroutine SHROUD_copy_array_unsigned long(context, c_var, c_var_size) &
+    subroutine SHROUD_copy_array_unsigned_long(context, c_var, c_var_size) &
         bind(C, name="LIB_ShroudCopyArray")
         use iso_c_binding, only : C_LONG, C_SIZE_T
         import SHROUD_array
         type(SHROUD_array), intent(IN) :: context
         integer(C_LONG), intent(OUT) :: c_var(*)
         integer(C_SIZE_T), value :: c_var_size
-    end subroutine SHROUD_copy_array_unsigned long
+    end subroutine SHROUD_copy_array_unsigned_long
 end interface
-##### end copy_array_unsigned long interface
+##### end copy_array_unsigned_long interface
 
-##### start copy_array_unsigned long long interface
+##### start copy_array_unsigned_long_long interface
 
 interface
-    ! helper copy_array_unsigned long long
+    ! helper copy_array_unsigned_long_long
     ! Copy contents of context into c_var.
-    subroutine SHROUD_copy_array_unsigned long long(context, c_var, c_var_size) &
+    subroutine SHROUD_copy_array_unsigned_long_long(context, c_var, c_var_size) &
         bind(C, name="LIB_ShroudCopyArray")
         use iso_c_binding, only : C_LONG_LONG, C_SIZE_T
         import SHROUD_array
         type(SHROUD_array), intent(IN) :: context
         integer(C_LONG_LONG), intent(OUT) :: c_var(*)
         integer(C_SIZE_T), value :: c_var_size
-    end subroutine SHROUD_copy_array_unsigned long long
+    end subroutine SHROUD_copy_array_unsigned_long_long
 end interface
-##### end copy_array_unsigned long long interface
+##### end copy_array_unsigned_long_long interface
 
-##### start copy_array_unsigned short interface
+##### start copy_array_unsigned_short interface
 
 interface
-    ! helper copy_array_unsigned short
+    ! helper copy_array_unsigned_short
     ! Copy contents of context into c_var.
-    subroutine SHROUD_copy_array_unsigned short(context, c_var, c_var_size) &
+    subroutine SHROUD_copy_array_unsigned_short(context, c_var, c_var_size) &
         bind(C, name="LIB_ShroudCopyArray")
         use iso_c_binding, only : C_SHORT, C_SIZE_T
         import SHROUD_array
         type(SHROUD_array), intent(IN) :: context
         integer(C_SHORT), intent(OUT) :: c_var(*)
         integer(C_SIZE_T), value :: c_var_size
-    end subroutine SHROUD_copy_array_unsigned short
+    end subroutine SHROUD_copy_array_unsigned_short
 end interface
-##### end copy_array_unsigned short interface
+##### end copy_array_unsigned_short interface
 
 ##### start copy_string interface
 

--- a/regression/reference/none/helpers.f
+++ b/regression/reference/none/helpers.f
@@ -1,4 +1,79 @@
 
+##### start ShroudTypeDefines derived_type
+
+! helper ShroudTypeDefines
+! Shroud type defines from helper ShroudTypeDefines
+integer, parameter, private :: &
+    SH_TYPE_SIGNED_CHAR= 1, &
+    SH_TYPE_SHORT      = 2, &
+    SH_TYPE_INT        = 3, &
+    SH_TYPE_LONG       = 4, &
+    SH_TYPE_LONG_LONG  = 5, &
+    SH_TYPE_SIZE_T     = 6, &
+    SH_TYPE_UNSIGNED_SHORT      = SH_TYPE_SHORT + 100, &
+    SH_TYPE_UNSIGNED_INT        = SH_TYPE_INT + 100, &
+    SH_TYPE_UNSIGNED_LONG       = SH_TYPE_LONG + 100, &
+    SH_TYPE_UNSIGNED_LONG_LONG  = SH_TYPE_LONG_LONG + 100, &
+    SH_TYPE_INT8_T    =  7, &
+    SH_TYPE_INT16_T   =  8, &
+    SH_TYPE_INT32_T   =  9, &
+    SH_TYPE_INT64_T   = 10, &
+    SH_TYPE_UINT8_T  =  SH_TYPE_INT8_T + 100, &
+    SH_TYPE_UINT16_T =  SH_TYPE_INT16_T + 100, &
+    SH_TYPE_UINT32_T =  SH_TYPE_INT32_T + 100, &
+    SH_TYPE_UINT64_T =  SH_TYPE_INT64_T + 100, &
+    SH_TYPE_FLOAT       = 22, &
+    SH_TYPE_DOUBLE      = 23, &
+    SH_TYPE_LONG_DOUBLE = 24, &
+    SH_TYPE_FLOAT_COMPLEX      = 25, &
+    SH_TYPE_DOUBLE_COMPLEX     = 26, &
+    SH_TYPE_LONG_DOUBLE_COMPLEX= 27, &
+    SH_TYPE_BOOL      = 28, &
+    SH_TYPE_CHAR      = 29, &
+    SH_TYPE_CPTR      = 30, &
+    SH_TYPE_STRUCT    = 31, &
+    SH_TYPE_OTHER     = 32
+##### end ShroudTypeDefines derived_type
+
+##### start array_context derived_type
+
+! helper array_context
+type, bind(C) :: SHROUD_array
+    ! address of C++ memory
+    type(SHROUD_capsule_data) :: cxx
+    ! address of data in cxx
+    type(C_PTR) :: base_addr = C_NULL_PTR
+    ! type of element
+    integer(C_INT) :: type
+    ! bytes-per-item or character len of data in cxx
+    integer(C_SIZE_T) :: elem_len = 0_C_SIZE_T
+    ! size of data in cxx
+    integer(C_SIZE_T) :: size = 0_C_SIZE_T
+    ! number of dimensions
+    integer(C_INT) :: rank = -1
+end type SHROUD_array
+##### end array_context derived_type
+
+##### start capsule_data_helper derived_type
+
+! helper capsule_data_helper
+type, bind(C) :: SHROUD_capsule_data
+    type(C_PTR) :: addr = C_NULL_PTR  ! address of C++ memory
+    integer(C_INT) :: idtor = 0       ! index of destructor
+end type SHROUD_capsule_data
+##### end capsule_data_helper derived_type
+
+##### start capsule_helper derived_type
+
+! helper capsule_helper
+type SHROUD_capsule
+    private
+    type(SHROUD_capsule_data) :: mem
+contains
+    final :: SHROUD_capsule_final
+end type SHROUD_capsule
+##### end capsule_helper derived_type
+
 ##### start capsule_helper source
 
 ! helper capsule_helper

--- a/regression/reference/none/helpers.f
+++ b/regression/reference/none/helpers.f
@@ -1,0 +1,38 @@
+
+##### start capsule_helper source
+
+! helper capsule_helper
+! finalize a static SHROUD_capsule_data
+subroutine SHROUD_capsule_final(cap)
+    use iso_c_binding, only : C_BOOL
+    type(SHROUD_capsule), intent(INOUT) :: cap
+    interface
+        subroutine array_destructor(ptr, gc)&
+            bind(C, name="LIB_SHROUD_memory_destructor")
+            use iso_c_binding, only : C_BOOL
+            import SHROUD_capsule_data
+            implicit none
+            type(SHROUD_capsule_data), intent(INOUT) :: ptr
+            logical(C_BOOL), value, intent(IN) :: gc
+        end subroutine array_destructor
+    end interface
+    call array_destructor(cap%mem, .false._C_BOOL)
+end subroutine SHROUD_capsule_final
+            
+##### end capsule_helper source
+
+##### start copy_string interface
+
+interface
+    ! helper copy_string
+    ! Copy the char* or std::string in context into c_var.
+    subroutine SHROUD_copy_string_and_free(context, c_var, c_var_size) &
+         bind(c,name="LIB_ShroudCopyStringAndFree")
+        use, intrinsic :: iso_c_binding, only : C_CHAR, C_SIZE_T
+        import SHROUD_array
+        type(SHROUD_array), intent(IN) :: context
+        character(kind=C_CHAR), intent(OUT) :: c_var(*)
+        integer(C_SIZE_T), value :: c_var_size
+    end subroutine SHROUD_copy_string_and_free
+end interface
+##### end copy_string interface

--- a/regression/reference/strings/typesstrings.h
+++ b/regression/reference/strings/typesstrings.h
@@ -66,8 +66,8 @@ typedef struct s_STR_SHROUD_capsule_data STR_SHROUD_capsule_data;
 #define SH_TYPE_STRUCT     31
 #define SH_TYPE_OTHER      32
 
-// helper array_context
 // start array_context
+// helper array_context
 struct s_STR_SHROUD_array {
     STR_SHROUD_capsule_data cxx;      /* address of C++ memory */
     union {

--- a/regression/reference/strings/wrapfstrings.f
+++ b/regression/reference/strings/wrapfstrings.f
@@ -27,8 +27,8 @@ module strings_mod
         integer(C_INT) :: idtor = 0       ! index of destructor
     end type SHROUD_capsule_data
 
-    ! helper array_context
     ! start array_context
+    ! helper array_context
     type, bind(C) :: SHROUD_array
         ! address of C++ memory
         type(SHROUD_capsule_data) :: cxx

--- a/regression/reference/strings/wrapstrings.cpp
+++ b/regression/reference/strings/wrapstrings.cpp
@@ -63,8 +63,8 @@ static void ShroudStrFree(char *src)
    free(src);
 }
 
-// helper ShroudStrToArray
 // start helper ShroudStrToArray
+// helper ShroudStrToArray
 // Save str metadata into array to allow Fortran to access values.
 static void ShroudStrToArray(STR_SHROUD_array *array, const std::string * src, int idtor)
 {
@@ -82,8 +82,8 @@ static void ShroudStrToArray(STR_SHROUD_array *array, const std::string * src, i
 }
 // end helper ShroudStrToArray
 
-// helper copy_string
 // start helper copy_string
+// helper copy_string
 // Copy the char* or std::string in context into c_var.
 // Called by Fortran to deal with allocatable character.
 void STR_ShroudCopyStringAndFree(STR_SHROUD_array *data, char *c_var, size_t c_var_len) {

--- a/regression/reference/tutorial/typesTutorial.h
+++ b/regression/reference/tutorial/typesTutorial.h
@@ -66,8 +66,8 @@ typedef struct s_TUT_SHROUD_capsule_data TUT_SHROUD_capsule_data;
 #define SH_TYPE_STRUCT     31
 #define SH_TYPE_OTHER      32
 
-// helper array_context
 // start array_context
+// helper array_context
 struct s_TUT_SHROUD_array {
     TUT_SHROUD_capsule_data cxx;      /* address of C++ memory */
     union {

--- a/regression/reference/tutorial/wrapTutorial.cpp
+++ b/regression/reference/tutorial/wrapTutorial.cpp
@@ -36,8 +36,8 @@ static void ShroudStrCopy(char *dest, int ndest, const char *src, int nsrc)
    }
 }
 
-// helper ShroudStrToArray
 // start helper ShroudStrToArray
+// helper ShroudStrToArray
 // Save str metadata into array to allow Fortran to access values.
 static void ShroudStrToArray(TUT_SHROUD_array *array, const std::string * src, int idtor)
 {
@@ -55,8 +55,8 @@ static void ShroudStrToArray(TUT_SHROUD_array *array, const std::string * src, i
 }
 // end helper ShroudStrToArray
 
-// helper copy_string
 // start helper copy_string
+// helper copy_string
 // Copy the char* or std::string in context into c_var.
 // Called by Fortran to deal with allocatable character.
 void TUT_ShroudCopyStringAndFree(TUT_SHROUD_array *data, char *c_var, size_t c_var_len) {

--- a/regression/reference/tutorial/wrapftutorial.f
+++ b/regression/reference/tutorial/wrapftutorial.f
@@ -27,8 +27,8 @@ module tutorial_mod
         integer(C_INT) :: idtor = 0       ! index of destructor
     end type SHROUD_capsule_data
 
-    ! helper array_context
     ! start array_context
+    ! helper array_context
     type, bind(C) :: SHROUD_array
         ! address of C++ memory
         type(SHROUD_capsule_data) :: cxx

--- a/regression/reference/vectors/typesvectors.h
+++ b/regression/reference/vectors/typesvectors.h
@@ -66,8 +66,8 @@ struct s_VEC_SHROUD_capsule_data {
 };
 typedef struct s_VEC_SHROUD_capsule_data VEC_SHROUD_capsule_data;
 
-// helper array_context
 // start array_context
+// helper array_context
 struct s_VEC_SHROUD_array {
     VEC_SHROUD_capsule_data cxx;      /* address of C++ memory */
     union {

--- a/regression/reference/vectors/wrapfvectors.f
+++ b/regression/reference/vectors/wrapfvectors.f
@@ -27,8 +27,8 @@ module vectors_mod
         integer(C_INT) :: idtor = 0       ! index of destructor
     end type SHROUD_capsule_data
 
-    ! helper array_context
     ! start array_context
+    ! helper array_context
     type, bind(C) :: SHROUD_array
         ! address of C++ memory
         type(SHROUD_capsule_data) :: cxx

--- a/regression/reference/vectors/wrapvectors.cpp
+++ b/regression/reference/vectors/wrapvectors.cpp
@@ -34,8 +34,8 @@ int ShroudLenTrim(const char *src, int nsrc) {
 }
 
 
-// helper copy_array
 // start helper copy_array
+// helper copy_array
 // Copy std::vector into array c_var(c_var_size).
 // Then release std::vector.
 // Called from Fortran.

--- a/shroud/generate.py
+++ b/shroud/generate.py
@@ -434,6 +434,7 @@ class GenFunctions(object):
         literalinclude2 = newlibrary.options.literalinclude2
         whelpers.add_external_helpers()
         whelpers.add_capsule_helper()
+        whelpers.add_all_copy_array_helpers()
 
         self.function_index = newlibrary.function_index
 
@@ -1157,8 +1158,6 @@ class GenFunctions(object):
                     arg.set_type(typemap.lookup_type("char_scalar"))
             elif arg_typemap.base == "vector":
                 has_buf_arg = True
-                # Create helpers for vector template.
-                whelpers.add_copy_array_helper(fmt, arg)
 
         # Function Result.
         has_string_result = False
@@ -1177,8 +1176,6 @@ class GenFunctions(object):
             result_name = result_as_arg or fmt.C_string_result_as_arg
         elif result_typemap.base == "vector":
             has_vector_result = True
-            # Create helpers for vector template.
-            whelpers.add_copy_array_helper(fmt, ast)
         elif result_is_ptr and attrs["deref"] == "allocatable":
             has_allocatable_result = True
 

--- a/shroud/generate.py
+++ b/shroud/generate.py
@@ -432,8 +432,8 @@ class GenFunctions(object):
         """
         newlibrary = self.newlibrary
         literalinclude2 = newlibrary.options.literalinclude2
-        whelpers.add_external_helpers(newlibrary.fmtdict, literalinclude2)
-        whelpers.add_capsule_helper(newlibrary.fmtdict, literalinclude2)
+        whelpers.add_external_helpers()
+        whelpers.add_capsule_helper()
 
         self.function_index = newlibrary.function_index
 

--- a/shroud/generate.py
+++ b/shroud/generate.py
@@ -1590,6 +1590,7 @@ class Preprocess(object):
 
 
 def generate_functions(library, config):
+    whelpers.set_library(library)
     VerifyAttrs(library, config).verify_attrs()
     GenFunctions(library, config).gen_library()
     Namify(library, config).name_library()

--- a/shroud/generate.py
+++ b/shroud/generate.py
@@ -431,10 +431,7 @@ class GenFunctions(object):
         """Entry routine to generate functions for a library.
         """
         newlibrary = self.newlibrary
-        literalinclude2 = newlibrary.options.literalinclude2
-        whelpers.add_external_helpers()
-        whelpers.add_capsule_helper()
-        whelpers.add_all_copy_array_helpers()
+        whelpers.add_all_helpers()
 
         self.function_index = newlibrary.function_index
 

--- a/shroud/main.py
+++ b/shroud/main.py
@@ -260,7 +260,10 @@ def main():
         "--cmake", default="", help="Create a file with CMake macro"
     )
     parser.add_argument(
-        "--yaml-types", default="", help="Write a YAML file with default types"
+        "--write-helpers", default="", help="Write a file with helper functions."
+    )
+    parser.add_argument(
+        "--yaml-types", default="", help="Write a YAML file with default types."
     )
     parser.add_argument("filename", nargs="*", help="Input file to process.")
 
@@ -297,6 +300,7 @@ def create_wrapper(filename, outdir="", path=None):
         args.path = []
     else:
         args.path = path
+    args.write_helpers = ""
     args.yaml_types = ""
 
     config = main_with_args(args)
@@ -360,6 +364,7 @@ def main_with_args(args):
     config.python_dir = args.outdir_python or args.outdir
     config.lua_dir = args.outdir_lua or args.outdir
     config.yaml_dir = args.outdir_yaml or args.outdir
+    config.write_helpers = args.write_helpers
     config.yaml_types = args.yaml_types
     config.log = log
     #    config.cfiles = []  # list of C/C++ files created
@@ -501,6 +506,14 @@ def main_with_args(args):
                 fp.write(" ".join(config.ffiles))
             fp.write("\n")
 
+    if args.write_helpers:
+        hfile = os.path.join(args.logdir, args.write_helpers + ".c")
+        with open(hfile, "w") as fp:
+            whelpers.write_c_helpers(fp)
+        hfile = os.path.join(args.logdir, args.write_helpers + ".f")
+        with open(hfile, "w") as fp:
+            whelpers.write_f_helpers(fp)
+            
     log.close()
 
     # This helps when running with a pipe, like CMake's execute_process

--- a/shroud/main.py
+++ b/shroud/main.py
@@ -441,6 +441,7 @@ def main_with_args(args):
         TypeOut(None, config).write_all_types(def_types, config.yaml_types)
 
     newlibrary = ast.create_library_from_dictionary(allinput)
+    whelpers.set_library(newlibrary)
 
     try:
         generate.generate_functions(newlibrary, config)
@@ -477,7 +478,6 @@ def main_with_args(args):
     TypeOut(newlibrary, config).write_class_types()
 
     try:
-        whelpers.set_library(newlibrary)
         options = newlibrary.options
         if options.wrap_c:
             wrapc.Wrapc(newlibrary, config, splicers["c"]).wrap_library()

--- a/shroud/main.py
+++ b/shroud/main.py
@@ -441,7 +441,6 @@ def main_with_args(args):
         TypeOut(None, config).write_all_types(def_types, config.yaml_types)
 
     newlibrary = ast.create_library_from_dictionary(allinput)
-    whelpers.set_library(newlibrary)
 
     try:
         generate.generate_functions(newlibrary, config)

--- a/shroud/util.py
+++ b/shroud/util.py
@@ -540,6 +540,10 @@ class WrapperMixin(object):
         ^  start line in column 1
         +  indent line
         -  deindent line
+
+        Args:
+             fp
+             lines - list of lines
         """
         for line in lines:
             if isinstance(line, int):

--- a/shroud/whelpers.py
+++ b/shroud/whelpers.py
@@ -1264,6 +1264,37 @@ integer, parameter, private :: &
 )  # end FHelpers
 
 
+# Routines to dump helper routines to a file.
+
+def gather_helpers(helpers, keys):
+    output = []
+    for name in sorted(helpers.keys()):
+        helper = helpers[name]
+        for key in keys:
+            if key in helper:
+                output.append("")
+                output.append("##### start {} {}".format(name, key))
+                output.append(helper[key])
+                output.append("##### end {} {}".format(name, key))
+    return output
+
+def write_c_helpers(fp):
+    output = gather_helpers(CHelpers, ["source", "c_source", "cxx_source"])
+    wrapper = util.WrapperMixin()
+    wrapper.linelen = 72
+    wrapper.indent = 0
+    wrapper.cont = ""
+    wrapper.write_lines(fp, output)
+
+def write_f_helpers(fp):
+    output = gather_helpers(FHelpers, ["interface", "source"])
+    wrapper = util.WrapperMixin()
+    wrapper.linelen = 72
+    wrapper.indent = 0
+    wrapper.cont = "&"
+    wrapper.write_lines(fp, output)
+
+
 cmake = """
 # Setup Shroud
 # This file defines:

--- a/shroud/whelpers.py
+++ b/shroud/whelpers.py
@@ -122,7 +122,7 @@ extern "C" {
 /* *INDENT-ON* */"""
 
 
-def add_external_helpers(fmtin, literalinclude):
+def add_external_helpers():
     """Create helper which have generated names.
     For example, code uses format entries
     C_prefix, C_memory_dtor_function,
@@ -136,6 +136,9 @@ def add_external_helpers(fmtin, literalinclude):
         fmtin - format dictionary from the library.
         literalinclude - value of top level option.literalinclude2
     """
+    fmtin = _newlibrary.fmtdict
+    literalinclude = _newlibrary.options.literalinclude2
+    
     fmt = util.Scope(fmtin)
     fmt.lstart = ""
     fmt.lend = ""
@@ -379,7 +382,7 @@ typedef struct s_{C_type_name} {C_type_name};{cpp_endif}{lend}""".format(
     return name
 
 
-def add_capsule_helper(fmtin, literalinclude):
+def add_capsule_helper():
     """Share info with C++ to allow Fortran to release memory.
 
     Used with shadow classes and std::vector.
@@ -388,6 +391,8 @@ def add_capsule_helper(fmtin, literalinclude):
         fmt - format dictionary from the library.
         literalinclude -
     """
+    fmtin = _newlibrary.fmtdict
+    literalinclude = _newlibrary.options.literalinclude2
     # Add some format strings
     fmt = util.Scope(fmtin)
     fmt.lstart = ""

--- a/shroud/whelpers.py
+++ b/shroud/whelpers.py
@@ -117,6 +117,19 @@ extern "C" {
 /* *INDENT-ON* */"""
 
 
+def add_all_helpers():
+    """Create helper functions.
+    Create helpers for all types.
+    """
+    fmt = util.Scope(_newlibrary.fmtdict)
+    add_external_helpers()
+    add_capsule_helper()
+    for ntypemap in typemap.get_global_types().values():
+        if ntypemap.sgroup == "native":
+            add_copy_array_helper(fmt, ntypemap)
+            add_to_PyList_helper(fmt, ntypemap)
+            add_to_PyList_helper_vector(fmt, ntypemap)
+
 def add_external_helpers():
     """Create helper which have generated names.
     For example, code uses format entries
@@ -197,7 +210,6 @@ if (data->elem_len < n) n = data->elem_len;
             fmt,
         ),
     )
-    ##########
 
     # Deal with allocatable character
     FHelpers[name] = dict(
@@ -415,10 +427,6 @@ def add_capsule_helper():
     """Share info with C++ to allow Fortran to release memory.
 
     Used with shadow classes and std::vector.
-
-    Args:
-        fmt - format dictionary from the library.
-        literalinclude -
     """
     fmtin = _newlibrary.fmtdict
     literalinclude = _newlibrary.options.literalinclude2
@@ -567,16 +575,6 @@ integer(C_INT) :: rank = -1
         )
         FHelpers[name] = helper
 
-
-def add_all_copy_array_helpers():
-    """Create helpers which are type based.
-    """
-    fmt = util.Scope(_newlibrary.fmtdict)
-    for ntypemap in typemap.get_global_types().values():
-        if ntypemap.sgroup == "native":
-            add_copy_array_helper(fmt, ntypemap)
-            add_to_PyList_helper(fmt, ntypemap)
-            add_to_PyList_helper_vector(fmt, ntypemap)
 
 def add_copy_array_helper(fmt, ntypemap):
     """Create Fortran interface to helper function
@@ -1285,7 +1283,7 @@ def write_c_helpers(fp):
     wrapper.write_lines(fp, output)
 
 def write_f_helpers(fp):
-    output = gather_helpers(FHelpers, ["interface", "source"])
+    output = gather_helpers(FHelpers, ["derived_type", "interface", "source"])
     wrapper = util.WrapperMixin()
     wrapper.linelen = 72
     wrapper.indent = 0

--- a/shroud/whelpers.py
+++ b/shroud/whelpers.py
@@ -583,8 +583,15 @@ n *= data->elem_len;
         )
         CHelpers[name] = helper
 
+def add_all_copy_array_helpers():
+    """Create helpers which are type based.
+    """
+    fmt = util.Scope(_newlibrary.fmtdict)
+    for ntypemap in typemap.get_global_types().values():
+        if ntypemap.sgroup == "native":
+            add_copy_array_helper_from_typemap(fmt, ntypemap)
 
-def add_copy_array_helper(fmtin, ast):
+def add_copy_array_helper_from_typemap(fmt, ntypemap):
     """Create Fortran interface to helper function
     which copies an array based on c_type.
     Each interface calls the same C helper.
@@ -593,14 +600,9 @@ def add_copy_array_helper(fmtin, ast):
     This allows multiple wrapped libraries to coexist.
 
     Args:
-        fmtin -
-        ast -
+        fmt      - util.Scope
+        ntypemap - typemap.Typemap
     """
-    fmt = util.Scope(fmtin)
-    ntypemap = ast.typemap
-    if ntypemap.base == "vector":
-        ntypemap = ast.template_arguments[0].typemap
-
     fmt.c_type = ntypemap.c_type
     fmt.f_kind = ntypemap.f_kind
     fmt.f_type = ntypemap.f_type

--- a/shroud/whelpers.py
+++ b/shroud/whelpers.py
@@ -153,8 +153,8 @@ def add_external_helpers():
             # via an interface for each cxx_type.
             cxx_source=wformat(
                 """
-// helper {hname}
-{lstart}// Copy std::vector into array c_var(c_var_size).
+{lstart}// helper {hname}
+// Copy std::vector into array c_var(c_var_size).
 // Then release std::vector.
 // Called from Fortran.
 void {C_prefix}ShroudCopyArray({C_array_type} *data, \tvoid *c_var, \tsize_t c_var_size)
@@ -183,8 +183,8 @@ n *= data->elem_len;
         # XXX - mangle name
         source=wformat(
             """
-// helper {hname}
-{lstart}// Copy the char* or std::string in context into c_var.
+{lstart}// helper {hname}
+// Copy the char* or std::string in context into c_var.
 // Called by Fortran to deal with allocatable character.
 void {C_prefix}ShroudCopyStringAndFree({C_array_type} *data, char *c_var, size_t c_var_len) {{+
 const char *cxx_var = data->addr.ccharp;
@@ -231,8 +231,8 @@ integer(C_SIZE_T), value :: c_var_size
         cxx_include="<cstring> <cstddef>",
         source=wformat(
             """
-// helper {hname}
-{lstart}// Save str metadata into array to allow Fortran to access values.
+{lstart}// helper {hname}
+// Save str metadata into array to allow Fortran to access values.
 static void ShroudStrToArray({C_array_type} *array, const std::string * src, int idtor)
 {{+
 array->cxx.addr = static_cast<void *>(const_cast<std::string *>(src));
@@ -396,8 +396,8 @@ def add_shadow_helper(node):
             scope="utility",
             # h_shared_code
             source="""
-// helper {hname}
-{lstart}{cpp_if}struct s_{C_type_name} {{+
+{lstart}// helper {hname}
+{cpp_if}struct s_{C_type_name} {{+
 void *addr;     /* address of C++ memory */
 int idtor;      /* index of destructor */
 -}};
@@ -517,8 +517,8 @@ call array_destructor(cap%mem, .false._C_BOOL)
             # And help with debugging since ccharp will display contents.
             source=wformat(
                 """
-// helper {hname}
-{lstart}struct s_{C_array_type} {{+
+{lstart}// helper {hname}
+struct s_{C_array_type} {{+
 {C_capsule_data_type} cxx;      /* address of C++ memory */
 union {{+
 const void * base;
@@ -545,8 +545,8 @@ typedef struct s_{C_array_type} {C_array_type};{lend}""",
         helper = dict(
             derived_type=wformat(
                 """
-! helper {hname}
-{lstart}type, bind(C) :: {F_array_type}+
+{lstart}! helper {hname}
+type, bind(C) :: {F_array_type}+
 ! address of C++ memory
 type({F_capsule_data_type}) :: cxx
 ! address of data in cxx

--- a/shroud/wrapc.py
+++ b/shroud/wrapc.py
@@ -80,8 +80,6 @@ class Wrapc(util.WrapperMixin):
         fmt_library = newlibrary.fmtdict
         # reserved the 0 slot of capsule_order
         self.add_capsule_code("--none--", None, ["// Nothing to delete"])
-        whelpers.set_literalinclude(newlibrary.options.literalinclude2)
-        whelpers.add_copy_array_helper_c(fmt_library)
         self.wrap_namespace(newlibrary.wrap_namespace, True)
         self.write_header_utility()
 

--- a/shroud/wrapf.py
+++ b/shroud/wrapf.py
@@ -1436,7 +1436,6 @@ rv = .false.
                 )
 
         # Function result.
-        whelpers.add_copy_array_helper(fmt_result, ast)
         need_wrapper = self.build_arg_list_impl(
             fmt_result,
             C_node.ast,

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -737,7 +737,6 @@ return 1;""",
         stmt0 = typemap.compute_name(stmts)
         intent_blk = lookup_stmts(stmts)
         output = fileinfo.GetSetBody
-        whelpers.add_to_PyList_helper(ast)
         ########################################
         # getter
         output.append("")
@@ -1171,7 +1170,6 @@ return 1;""",
             spointer = arg.get_indirect_stmt()
             stmts = None
 
-            whelpers.add_to_PyList_helper(arg)
             intent_blk = None
             if node._generated == "struct_as_class_ctor":
                 stmts = ["py", "ctor", sgroup, spointer]
@@ -1210,7 +1208,6 @@ return 1;""",
                 stmts = ["py", sgroup, intent, arg_typemap.PY_struct_as]
             elif arg_typemap.base == "vector":
                 stmts = ["py", sgroup, intent, options.PY_array_arg]
-                whelpers.add_to_PyList_helper_vector(arg)
             elif dimension:
                 # ex. (int * arg1 +intent(in) +dimension(:))
                 self.check_dimension_blk(arg)
@@ -1863,7 +1860,6 @@ return 1;""",
                 stmts = ["py", sgroup, "result", options.PY_struct_arg]
             elif result_typemap.base == "vector":
                 stmts = ["py", sgroup, "result", options.PY_array_arg]
-                whelpers.add_to_PyList_helper_vector(ast)
             elif (
                     result_return_pointer_as in ["pointer", "allocatable"]
                     and result_typemap.base != "string"


### PR DESCRIPTION
* Create all helpers before creating wrappers. Before they were created on a as-needed basis as a sort of optimization.  However, the savings are minimal and added complication to wrappers.  Some helpers are created internally for each native type, many of which will never be used. However, they are still only added to the wrappers on a as-needed basis.  The final wrappers are the same after this change.
* Added --write-helpers option used to test helpers.
* Fixed some naming problems in wrappers by using flat_name instead of c_type.  For example the helper functions should be named using "long_long" and not "long long".