### PR TITLE
Use spointers in pystatements

### DIFF
--- a/regression/reference/example/example.json
+++ b/regression/reference/example/example.json
@@ -9095,8 +9095,8 @@
                                             "py_var": "SHPy_in",
                                             "pytmp_var": "SHTPy_in",
                                             "size_var": "SHSize_in",
-                                            "stmt0": "py_native_in_dimension_numpy",
-                                            "stmt1": "py_native_in_dimension_numpy"
+                                            "stmt0": "py_native_*_in_pointer_numpy",
+                                            "stmt1": "py_native_*_in_pointer_numpy"
                                         }
                                     },
                                     "out": {
@@ -9162,8 +9162,8 @@
                                             "py_var": "SHPy_out",
                                             "rank": "1",
                                             "size_var": "SHSize_out",
-                                            "stmt0": "py_native_out_dimension_numpy",
-                                            "stmt1": "py_native_out_dimension_numpy"
+                                            "stmt0": "py_native_*_out_allocatable_numpy",
+                                            "stmt1": "py_native_*_out_allocatable_numpy"
                                         }
                                     },
                                     "sizein": {

--- a/regression/reference/example/pyUserLibrary_example_nestedmodule.cpp
+++ b/regression/reference/example/pyUserLibrary_example_nestedmodule.cpp
@@ -672,10 +672,10 @@ PP_verylongfunctionname2(
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  double * in +intent(in)+rank(2)
-// Exact:     py_native_in_dimension_numpy
+// Exact:     py_native_*_in_pointer_numpy
 // ----------------------------------------
 // Argument:  double * out +deref(allocatable)+dimension(shape(in))+intent(out)
-// Exact:     py_native_out_dimension_numpy
+// Exact:     py_native_*_out_allocatable_numpy
 static char PP_cos_doubles__doc__[] =
 "documentation"
 ;

--- a/regression/reference/ownership/ownership.json
+++ b/regression/reference/ownership/ownership.json
@@ -376,8 +376,8 @@
                         "numpy_type": "NPY_INT",
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_native_result_dimension_numpy",
-                        "stmt1": "py_native_result_dimension_numpy"
+                        "stmt0": "py_native_*_result_pointer_numpy",
+                        "stmt1": "py_native_*_result_pointer_numpy"
                     }
                 },
                 "ast": {
@@ -606,8 +606,8 @@
                         "py_var": "SHTPy_rv",
                         "rank": "1",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_native_result_dimension_numpy",
-                        "stmt1": "py_native_result_dimension_numpy"
+                        "stmt0": "py_native_*_result_pointer_numpy",
+                        "stmt1": "py_native_*_result_pointer_numpy"
                     }
                 },
                 "ast": {
@@ -895,8 +895,8 @@
                         "py_var": "SHTPy_rv",
                         "rank": "1",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_native_result_dimension_numpy",
-                        "stmt1": "py_native_result_dimension_numpy"
+                        "stmt0": "py_native_*_result_allocatable_numpy",
+                        "stmt1": "py_native_*_result_allocatable_numpy"
                     }
                 },
                 "ast": {
@@ -1184,8 +1184,8 @@
                         "py_var": "SHTPy_rv",
                         "rank": "1",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_native_result_dimension_numpy",
-                        "stmt1": "py_native_result_dimension_numpy"
+                        "stmt0": "py_native_*_result_pointer_numpy",
+                        "stmt1": "py_native_*_result_pointer_numpy"
                     }
                 },
                 "ast": {
@@ -1574,8 +1574,8 @@
                         "py_var": "SHTPy_rv",
                         "rank": "1",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_native_result_dimension_numpy",
-                        "stmt1": "py_native_result_dimension_numpy"
+                        "stmt0": "py_native_*_result_pointer_numpy",
+                        "stmt1": "py_native_*_result_pointer_numpy"
                     }
                 },
                 "ast": {
@@ -1849,8 +1849,8 @@
                         "py_var": "SHTPy_rv",
                         "rank": "1",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_native_result_dimension_numpy",
-                        "stmt1": "py_native_result_dimension_numpy"
+                        "stmt0": "py_native_*_result_allocatable_numpy",
+                        "stmt1": "py_native_*_result_allocatable_numpy"
                     }
                 },
                 "ast": {
@@ -2009,8 +2009,8 @@
                         "py_var": "SHTPy_rv",
                         "rank": "1",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_native_result_dimension_numpy",
-                        "stmt1": "py_native_result_dimension_numpy"
+                        "stmt0": "py_native_*_result_pointer_numpy",
+                        "stmt1": "py_native_*_result_pointer_numpy"
                     }
                 },
                 "ast": {

--- a/regression/reference/ownership/pyownershipmodule.cpp
+++ b/regression/reference/ownership/pyownershipmodule.cpp
@@ -62,7 +62,7 @@ PY_ReturnIntPtrScalar(
 
 // ----------------------------------------
 // Function:  int * ReturnIntPtrPointer +deref(pointer)
-// Exact:     py_native_result_dimension_numpy
+// Exact:     py_native_*_result_pointer_numpy
 static char PY_ReturnIntPtrPointer__doc__[] =
 "documentation"
 ;
@@ -92,7 +92,7 @@ fail:
 
 // ----------------------------------------
 // Function:  int * ReturnIntPtrDimPointer +deref(pointer)+dimension(len)
-// Exact:     py_native_result_dimension_numpy
+// Exact:     py_native_*_result_pointer_numpy
 // ----------------------------------------
 // Argument:  int * len +hidden+intent(out)
 // Requested: py_native_*_out
@@ -131,7 +131,7 @@ fail:
 
 // ----------------------------------------
 // Function:  int * ReturnIntPtrDimAlloc +deref(allocatable)+dimension(len)
-// Exact:     py_native_result_dimension_numpy
+// Exact:     py_native_*_result_allocatable_numpy
 // ----------------------------------------
 // Argument:  int * len +hidden+intent(out)
 // Requested: py_native_*_out
@@ -170,7 +170,7 @@ fail:
 
 // ----------------------------------------
 // Function:  int * ReturnIntPtrDimDefault +dimension(len)
-// Exact:     py_native_result_dimension_numpy
+// Exact:     py_native_*_result_pointer_numpy
 // ----------------------------------------
 // Argument:  int * len +hidden+intent(out)
 // Requested: py_native_*_out
@@ -209,7 +209,7 @@ fail:
 
 // ----------------------------------------
 // Function:  int * ReturnIntPtrDimPointerNew +deref(pointer)+dimension(len)+owner(caller)
-// Exact:     py_native_result_dimension_numpy
+// Exact:     py_native_*_result_pointer_numpy
 // ----------------------------------------
 // Argument:  int * len +hidden+intent(out)
 // Requested: py_native_*_out
@@ -248,7 +248,7 @@ fail:
 
 // ----------------------------------------
 // Function:  int * ReturnIntPtrDimAllocNew +deref(allocatable)+dimension(len)+owner(caller)
-// Exact:     py_native_result_dimension_numpy
+// Exact:     py_native_*_result_allocatable_numpy
 // ----------------------------------------
 // Argument:  int * len +hidden+intent(out)
 // Requested: py_native_*_out
@@ -287,7 +287,7 @@ fail:
 
 // ----------------------------------------
 // Function:  int * ReturnIntPtrDimDefaultNew +dimension(len)+owner(caller)
-// Exact:     py_native_result_dimension_numpy
+// Exact:     py_native_*_result_pointer_numpy
 // ----------------------------------------
 // Argument:  int * len +hidden+intent(out)
 // Requested: py_native_*_out

--- a/regression/reference/pointers-list-c/pointers.json
+++ b/regression/reference/pointers-list-c/pointers.json
@@ -167,8 +167,8 @@
                             "py_var": "SHPy_in",
                             "pytmp_var": "SHTPy_in",
                             "size_var": "SHSize_in",
-                            "stmt0": "py_native_in_dimension_list",
-                            "stmt1": "py_native_in_dimension_list"
+                            "stmt0": "py_native_*_in_pointer_list",
+                            "stmt1": "py_native_*_in_pointer_list"
                         }
                     },
                     "out": {
@@ -192,8 +192,8 @@
                             "py_var": "SHPy_out",
                             "rank": "1",
                             "size_var": "SHSize_out",
-                            "stmt0": "py_native_out_dimension_list",
-                            "stmt1": "py_native_out_dimension_list"
+                            "stmt0": "py_native_*_out_allocatable_list",
+                            "stmt1": "py_native_*_out_allocatable_list"
                         }
                     },
                     "sizein": {
@@ -324,8 +324,8 @@
                             "py_var": "SHPy_in",
                             "pytmp_var": "SHTPy_in",
                             "size_var": "SHSize_in",
-                            "stmt0": "py_native_in_dimension_list",
-                            "stmt1": "py_native_in_dimension_list"
+                            "stmt0": "py_native_*_in_pointer_list",
+                            "stmt1": "py_native_*_in_pointer_list"
                         }
                     },
                     "out": {
@@ -349,8 +349,8 @@
                             "py_var": "SHPy_out",
                             "rank": "1",
                             "size_var": "SHSize_out",
-                            "stmt0": "py_native_out_dimension_list",
-                            "stmt1": "py_native_out_dimension_list"
+                            "stmt0": "py_native_*_out_allocatable_list",
+                            "stmt1": "py_native_*_out_allocatable_list"
                         }
                     },
                     "sizein": {
@@ -506,8 +506,8 @@
                             "py_var": "SHPy_values",
                             "rank": "1",
                             "size_var": "SHSize_values",
-                            "stmt0": "py_native_out_dimension_list",
-                            "stmt1": "py_native_out_dimension_list"
+                            "stmt0": "py_native_*_out_pointer_list",
+                            "stmt1": "py_native_*_out_pointer_list"
                         }
                     }
                 },
@@ -601,8 +601,8 @@
                             "py_var": "SHPy_arg1",
                             "rank": "1",
                             "size_var": "SHSize_arg1",
-                            "stmt0": "py_native_out_dimension_list",
-                            "stmt1": "py_native_out_dimension_list"
+                            "stmt0": "py_native_*_out_pointer_list",
+                            "stmt1": "py_native_*_out_pointer_list"
                         }
                     },
                     "arg2": {
@@ -626,8 +626,8 @@
                             "py_var": "SHPy_arg2",
                             "rank": "1",
                             "size_var": "SHSize_arg2",
-                            "stmt0": "py_native_out_dimension_list",
-                            "stmt1": "py_native_out_dimension_list"
+                            "stmt0": "py_native_*_out_pointer_list",
+                            "stmt1": "py_native_*_out_pointer_list"
                         }
                     }
                 },
@@ -749,8 +749,8 @@
                             "py_var": "SHPy_values",
                             "rank": "1",
                             "size_var": "SHSize_values",
-                            "stmt0": "py_native_out_dimension_list",
-                            "stmt1": "py_native_out_dimension_list"
+                            "stmt0": "py_native_*_out_allocatable_list",
+                            "stmt1": "py_native_*_out_allocatable_list"
                         }
                     }
                 },
@@ -858,8 +858,8 @@
                             "py_var": "SHPy_values",
                             "rank": "1",
                             "size_var": "SHSize_values",
-                            "stmt0": "py_native_out_dimension_list",
-                            "stmt1": "py_native_out_dimension_list"
+                            "stmt0": "py_native_*_out_pointer_list",
+                            "stmt1": "py_native_*_out_pointer_list"
                         }
                     }
                 },
@@ -982,8 +982,8 @@
                             "py_var": "SHPy_values",
                             "pytmp_var": "SHTPy_values",
                             "size_var": "SHSize_values",
-                            "stmt0": "py_native_in_dimension_list",
-                            "stmt1": "py_native_in_dimension_list"
+                            "stmt0": "py_native_*_in_pointer_list",
+                            "stmt1": "py_native_*_in_pointer_list"
                         }
                     }
                 },
@@ -1083,8 +1083,8 @@
                             "py_var": "SHPy_out",
                             "rank": "1",
                             "size_var": "SHSize_out",
-                            "stmt0": "py_native_out_dimension_list",
-                            "stmt1": "py_native_out_dimension_list"
+                            "stmt0": "py_native_*_out_pointer_list",
+                            "stmt1": "py_native_*_out_pointer_list"
                         }
                     }
                 },
@@ -1157,8 +1157,8 @@
                             "py_var": "SHPy_array",
                             "pytmp_var": "SHTPy_array",
                             "size_var": "SHSize_array",
-                            "stmt0": "py_native_inout_dimension_list",
-                            "stmt1": "py_native_inout_dimension_list"
+                            "stmt0": "py_native_*_inout_pointer_list",
+                            "stmt1": "py_native_*_inout_pointer_list"
                         }
                     },
                     "sizein": {

--- a/regression/reference/pointers-list-c/pointers.json
+++ b/regression/reference/pointers-list-c/pointers.json
@@ -2090,8 +2090,8 @@
                         "numpy_type": "NPY_INT",
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_native_result_dimension_list",
-                        "stmt1": "py_native_result_dimension_list"
+                        "stmt0": "py_native_*_result_pointer_list",
+                        "stmt1": "py_native_*_result_pointer_list"
                     }
                 },
                 "ast": {
@@ -2140,8 +2140,8 @@
                         "py_var": "SHTPy_rv",
                         "rank": "1",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_native_result_dimension_list",
-                        "stmt1": "py_native_result_dimension_list"
+                        "stmt0": "py_native_*_result_pointer_list",
+                        "stmt1": "py_native_*_result_pointer_list"
                     }
                 },
                 "ast": {
@@ -2195,8 +2195,8 @@
                         "numpy_type": "NPY_INT",
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_native_result_dimension_list",
-                        "stmt1": "py_native_result_dimension_list"
+                        "stmt0": "py_native_*_result_pointer_list",
+                        "stmt1": "py_native_*_result_pointer_list"
                     }
                 },
                 "ast": {
@@ -2246,8 +2246,8 @@
                         "py_var": "SHTPy_rv",
                         "rank": "1",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_native_result_dimension_list",
-                        "stmt1": "py_native_result_dimension_list"
+                        "stmt0": "py_native_*_result_pointer_list",
+                        "stmt1": "py_native_*_result_pointer_list"
                     }
                 },
                 "ast": {

--- a/regression/reference/pointers-list-c/pypointersmodule.c
+++ b/regression/reference/pointers-list-c/pypointersmodule.c
@@ -942,7 +942,7 @@ PY_returnAddress2(
 
 // ----------------------------------------
 // Function:  int * returnIntPtrToScalar
-// Exact:     py_native_result_dimension_list
+// Exact:     py_native_*_result_pointer_list
 static char PY_returnIntPtrToScalar__doc__[] =
 "documentation"
 ;
@@ -972,7 +972,7 @@ fail:
 
 // ----------------------------------------
 // Function:  int * returnIntPtrToFixedArray +dimension(10)
-// Exact:     py_native_result_dimension_list
+// Exact:     py_native_*_result_pointer_list
 static char PY_returnIntPtrToFixedArray__doc__[] =
 "documentation"
 ;
@@ -1002,7 +1002,7 @@ fail:
 
 // ----------------------------------------
 // Function:  const int * returnIntPtrToConstScalar
-// Exact:     py_native_result_dimension_list
+// Exact:     py_native_*_result_pointer_list
 static char PY_returnIntPtrToConstScalar__doc__[] =
 "documentation"
 ;
@@ -1032,7 +1032,7 @@ fail:
 
 // ----------------------------------------
 // Function:  const int * returnIntPtrToFixedConstArray +dimension(10)
-// Exact:     py_native_result_dimension_list
+// Exact:     py_native_*_result_pointer_list
 static char PY_returnIntPtrToFixedConstArray__doc__[] =
 "documentation"
 ;

--- a/regression/reference/pointers-list-c/pypointersmodule.c
+++ b/regression/reference/pointers-list-c/pypointersmodule.c
@@ -204,10 +204,10 @@ PY_intargs(
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  double * in +intent(in)+rank(1)
-// Exact:     py_native_in_dimension_list
+// Exact:     py_native_*_in_pointer_list
 // ----------------------------------------
 // Argument:  double * out +deref(allocatable)+dimension(size(in))+intent(out)
-// Exact:     py_native_out_dimension_list
+// Exact:     py_native_*_out_allocatable_list
 static char PY_cos_doubles__doc__[] =
 "documentation"
 ;
@@ -276,10 +276,10 @@ fail:
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  double * in +intent(in)+rank(1)
-// Exact:     py_native_in_dimension_list
+// Exact:     py_native_*_in_pointer_list
 // ----------------------------------------
 // Argument:  int * out +deref(allocatable)+dimension(size(in))+intent(out)
-// Exact:     py_native_out_dimension_list
+// Exact:     py_native_*_out_allocatable_list
 static char PY_truncate_to_int__doc__[] =
 "documentation"
 ;
@@ -353,7 +353,7 @@ fail:
 // Match:     py_default
 // ----------------------------------------
 // Argument:  int * values +dimension(3)+intent(out)
-// Exact:     py_native_out_dimension_list
+// Exact:     py_native_*_out_pointer_list
 static char PY_get_values__doc__[] =
 "documentation"
 ;
@@ -410,10 +410,10 @@ fail:
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  int * arg1 +dimension(3)+intent(out)
-// Exact:     py_native_out_dimension_list
+// Exact:     py_native_*_out_pointer_list
 // ----------------------------------------
 // Argument:  int * arg2 +dimension(3)+intent(out)
-// Exact:     py_native_out_dimension_list
+// Exact:     py_native_*_out_pointer_list
 static char PY_get_values2__doc__[] =
 "documentation"
 ;
@@ -484,7 +484,7 @@ fail:
 // Match:     py_default
 // ----------------------------------------
 // Argument:  int * values +deref(allocatable)+dimension(nvar)+intent(out)
-// Exact:     py_native_out_dimension_list
+// Exact:     py_native_*_out_allocatable_list
 static char PY_iota_allocatable__doc__[] =
 "documentation"
 ;
@@ -542,7 +542,7 @@ fail:
 // Match:     py_default
 // ----------------------------------------
 // Argument:  int * values +dimension(nvar)+intent(out)
-// Exact:     py_native_out_dimension_list
+// Exact:     py_native_*_out_pointer_list
 static char PY_iota_dimension__doc__[] =
 "documentation"
 ;
@@ -596,7 +596,7 @@ fail:
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  int * values +intent(in)+rank(1)
-// Exact:     py_native_in_dimension_list
+// Exact:     py_native_*_in_pointer_list
 // ----------------------------------------
 // Argument:  int * result +intent(out)
 // Requested: py_native_*_out
@@ -654,7 +654,7 @@ fail:
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  int * out +dimension(3)+intent(out)
-// Exact:     py_native_out_dimension_list
+// Exact:     py_native_*_out_pointer_list
 static char PY_fillIntArray__doc__[] =
 "documentation"
 ;
@@ -703,7 +703,7 @@ fail:
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  int * array +intent(inout)+rank(1)
-// Exact:     py_native_inout_dimension_list
+// Exact:     py_native_*_inout_pointer_list
 static char PY_incrementIntArray__doc__[] =
 "documentation"
 ;

--- a/regression/reference/pointers-list-cxx/pointers.json
+++ b/regression/reference/pointers-list-cxx/pointers.json
@@ -167,8 +167,8 @@
                             "py_var": "SHPy_in",
                             "pytmp_var": "SHTPy_in",
                             "size_var": "SHSize_in",
-                            "stmt0": "py_native_in_dimension_list",
-                            "stmt1": "py_native_in_dimension_list"
+                            "stmt0": "py_native_*_in_pointer_list",
+                            "stmt1": "py_native_*_in_pointer_list"
                         }
                     },
                     "out": {
@@ -192,8 +192,8 @@
                             "py_var": "SHPy_out",
                             "rank": "1",
                             "size_var": "SHSize_out",
-                            "stmt0": "py_native_out_dimension_list",
-                            "stmt1": "py_native_out_dimension_list"
+                            "stmt0": "py_native_*_out_allocatable_list",
+                            "stmt1": "py_native_*_out_allocatable_list"
                         }
                     },
                     "sizein": {
@@ -324,8 +324,8 @@
                             "py_var": "SHPy_in",
                             "pytmp_var": "SHTPy_in",
                             "size_var": "SHSize_in",
-                            "stmt0": "py_native_in_dimension_list",
-                            "stmt1": "py_native_in_dimension_list"
+                            "stmt0": "py_native_*_in_pointer_list",
+                            "stmt1": "py_native_*_in_pointer_list"
                         }
                     },
                     "out": {
@@ -349,8 +349,8 @@
                             "py_var": "SHPy_out",
                             "rank": "1",
                             "size_var": "SHSize_out",
-                            "stmt0": "py_native_out_dimension_list",
-                            "stmt1": "py_native_out_dimension_list"
+                            "stmt0": "py_native_*_out_allocatable_list",
+                            "stmt1": "py_native_*_out_allocatable_list"
                         }
                     },
                     "sizein": {
@@ -506,8 +506,8 @@
                             "py_var": "SHPy_values",
                             "rank": "1",
                             "size_var": "SHSize_values",
-                            "stmt0": "py_native_out_dimension_list",
-                            "stmt1": "py_native_out_dimension_list"
+                            "stmt0": "py_native_*_out_pointer_list",
+                            "stmt1": "py_native_*_out_pointer_list"
                         }
                     }
                 },
@@ -601,8 +601,8 @@
                             "py_var": "SHPy_arg1",
                             "rank": "1",
                             "size_var": "SHSize_arg1",
-                            "stmt0": "py_native_out_dimension_list",
-                            "stmt1": "py_native_out_dimension_list"
+                            "stmt0": "py_native_*_out_pointer_list",
+                            "stmt1": "py_native_*_out_pointer_list"
                         }
                     },
                     "arg2": {
@@ -626,8 +626,8 @@
                             "py_var": "SHPy_arg2",
                             "rank": "1",
                             "size_var": "SHSize_arg2",
-                            "stmt0": "py_native_out_dimension_list",
-                            "stmt1": "py_native_out_dimension_list"
+                            "stmt0": "py_native_*_out_pointer_list",
+                            "stmt1": "py_native_*_out_pointer_list"
                         }
                     }
                 },
@@ -749,8 +749,8 @@
                             "py_var": "SHPy_values",
                             "rank": "1",
                             "size_var": "SHSize_values",
-                            "stmt0": "py_native_out_dimension_list",
-                            "stmt1": "py_native_out_dimension_list"
+                            "stmt0": "py_native_*_out_allocatable_list",
+                            "stmt1": "py_native_*_out_allocatable_list"
                         }
                     }
                 },
@@ -858,8 +858,8 @@
                             "py_var": "SHPy_values",
                             "rank": "1",
                             "size_var": "SHSize_values",
-                            "stmt0": "py_native_out_dimension_list",
-                            "stmt1": "py_native_out_dimension_list"
+                            "stmt0": "py_native_*_out_pointer_list",
+                            "stmt1": "py_native_*_out_pointer_list"
                         }
                     }
                 },
@@ -982,8 +982,8 @@
                             "py_var": "SHPy_values",
                             "pytmp_var": "SHTPy_values",
                             "size_var": "SHSize_values",
-                            "stmt0": "py_native_in_dimension_list",
-                            "stmt1": "py_native_in_dimension_list"
+                            "stmt0": "py_native_*_in_pointer_list",
+                            "stmt1": "py_native_*_in_pointer_list"
                         }
                     }
                 },
@@ -1083,8 +1083,8 @@
                             "py_var": "SHPy_out",
                             "rank": "1",
                             "size_var": "SHSize_out",
-                            "stmt0": "py_native_out_dimension_list",
-                            "stmt1": "py_native_out_dimension_list"
+                            "stmt0": "py_native_*_out_pointer_list",
+                            "stmt1": "py_native_*_out_pointer_list"
                         }
                     }
                 },
@@ -1157,8 +1157,8 @@
                             "py_var": "SHPy_array",
                             "pytmp_var": "SHTPy_array",
                             "size_var": "SHSize_array",
-                            "stmt0": "py_native_inout_dimension_list",
-                            "stmt1": "py_native_inout_dimension_list"
+                            "stmt0": "py_native_*_inout_pointer_list",
+                            "stmt1": "py_native_*_inout_pointer_list"
                         }
                     },
                     "sizein": {

--- a/regression/reference/pointers-list-cxx/pointers.json
+++ b/regression/reference/pointers-list-cxx/pointers.json
@@ -2090,8 +2090,8 @@
                         "numpy_type": "NPY_INT",
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_native_result_dimension_list",
-                        "stmt1": "py_native_result_dimension_list"
+                        "stmt0": "py_native_*_result_pointer_list",
+                        "stmt1": "py_native_*_result_pointer_list"
                     }
                 },
                 "ast": {
@@ -2140,8 +2140,8 @@
                         "py_var": "SHTPy_rv",
                         "rank": "1",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_native_result_dimension_list",
-                        "stmt1": "py_native_result_dimension_list"
+                        "stmt0": "py_native_*_result_pointer_list",
+                        "stmt1": "py_native_*_result_pointer_list"
                     }
                 },
                 "ast": {
@@ -2195,8 +2195,8 @@
                         "numpy_type": "NPY_INT",
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_native_result_dimension_list",
-                        "stmt1": "py_native_result_dimension_list"
+                        "stmt0": "py_native_*_result_pointer_list",
+                        "stmt1": "py_native_*_result_pointer_list"
                     }
                 },
                 "ast": {
@@ -2246,8 +2246,8 @@
                         "py_var": "SHTPy_rv",
                         "rank": "1",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_native_result_dimension_list",
-                        "stmt1": "py_native_result_dimension_list"
+                        "stmt0": "py_native_*_result_pointer_list",
+                        "stmt1": "py_native_*_result_pointer_list"
                     }
                 },
                 "ast": {

--- a/regression/reference/pointers-list-cxx/pypointersmodule.cpp
+++ b/regression/reference/pointers-list-cxx/pypointersmodule.cpp
@@ -206,10 +206,10 @@ PY_intargs(
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  double * in +intent(in)+rank(1)
-// Exact:     py_native_in_dimension_list
+// Exact:     py_native_*_in_pointer_list
 // ----------------------------------------
 // Argument:  double * out +deref(allocatable)+dimension(size(in))+intent(out)
-// Exact:     py_native_out_dimension_list
+// Exact:     py_native_*_out_allocatable_list
 static char PY_cos_doubles__doc__[] =
 "documentation"
 ;
@@ -280,10 +280,10 @@ fail:
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  double * in +intent(in)+rank(1)
-// Exact:     py_native_in_dimension_list
+// Exact:     py_native_*_in_pointer_list
 // ----------------------------------------
 // Argument:  int * out +deref(allocatable)+dimension(size(in))+intent(out)
-// Exact:     py_native_out_dimension_list
+// Exact:     py_native_*_out_allocatable_list
 static char PY_truncate_to_int__doc__[] =
 "documentation"
 ;
@@ -359,7 +359,7 @@ fail:
 // Match:     py_default
 // ----------------------------------------
 // Argument:  int * values +dimension(3)+intent(out)
-// Exact:     py_native_out_dimension_list
+// Exact:     py_native_*_out_pointer_list
 static char PY_get_values__doc__[] =
 "documentation"
 ;
@@ -418,10 +418,10 @@ fail:
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  int * arg1 +dimension(3)+intent(out)
-// Exact:     py_native_out_dimension_list
+// Exact:     py_native_*_out_pointer_list
 // ----------------------------------------
 // Argument:  int * arg2 +dimension(3)+intent(out)
-// Exact:     py_native_out_dimension_list
+// Exact:     py_native_*_out_pointer_list
 static char PY_get_values2__doc__[] =
 "documentation"
 ;
@@ -494,7 +494,7 @@ fail:
 // Match:     py_default
 // ----------------------------------------
 // Argument:  int * values +deref(allocatable)+dimension(nvar)+intent(out)
-// Exact:     py_native_out_dimension_list
+// Exact:     py_native_*_out_allocatable_list
 static char PY_iota_allocatable__doc__[] =
 "documentation"
 ;
@@ -553,7 +553,7 @@ fail:
 // Match:     py_default
 // ----------------------------------------
 // Argument:  int * values +dimension(nvar)+intent(out)
-// Exact:     py_native_out_dimension_list
+// Exact:     py_native_*_out_pointer_list
 static char PY_iota_dimension__doc__[] =
 "documentation"
 ;
@@ -608,7 +608,7 @@ fail:
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  int * values +intent(in)+rank(1)
-// Exact:     py_native_in_dimension_list
+// Exact:     py_native_*_in_pointer_list
 // ----------------------------------------
 // Argument:  int * result +intent(out)
 // Requested: py_native_*_out
@@ -667,7 +667,7 @@ fail:
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  int * out +dimension(3)+intent(out)
-// Exact:     py_native_out_dimension_list
+// Exact:     py_native_*_out_pointer_list
 static char PY_fillIntArray__doc__[] =
 "documentation"
 ;
@@ -718,7 +718,7 @@ fail:
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  int * array +intent(inout)+rank(1)
-// Exact:     py_native_inout_dimension_list
+// Exact:     py_native_*_inout_pointer_list
 static char PY_incrementIntArray__doc__[] =
 "documentation"
 ;

--- a/regression/reference/pointers-list-cxx/pypointersmodule.cpp
+++ b/regression/reference/pointers-list-cxx/pypointersmodule.cpp
@@ -960,7 +960,7 @@ PY_returnAddress2(
 
 // ----------------------------------------
 // Function:  int * returnIntPtrToScalar
-// Exact:     py_native_result_dimension_list
+// Exact:     py_native_*_result_pointer_list
 static char PY_returnIntPtrToScalar__doc__[] =
 "documentation"
 ;
@@ -990,7 +990,7 @@ fail:
 
 // ----------------------------------------
 // Function:  int * returnIntPtrToFixedArray +dimension(10)
-// Exact:     py_native_result_dimension_list
+// Exact:     py_native_*_result_pointer_list
 static char PY_returnIntPtrToFixedArray__doc__[] =
 "documentation"
 ;
@@ -1020,7 +1020,7 @@ fail:
 
 // ----------------------------------------
 // Function:  const int * returnIntPtrToConstScalar
-// Exact:     py_native_result_dimension_list
+// Exact:     py_native_*_result_pointer_list
 static char PY_returnIntPtrToConstScalar__doc__[] =
 "documentation"
 ;
@@ -1050,7 +1050,7 @@ fail:
 
 // ----------------------------------------
 // Function:  const int * returnIntPtrToFixedConstArray +dimension(10)
-// Exact:     py_native_result_dimension_list
+// Exact:     py_native_*_result_pointer_list
 static char PY_returnIntPtrToFixedConstArray__doc__[] =
 "documentation"
 ;

--- a/regression/reference/pointers-numpy-c/pointers.json
+++ b/regression/reference/pointers-numpy-c/pointers.json
@@ -2076,8 +2076,8 @@
                         "numpy_type": "NPY_INT",
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_native_result_dimension_numpy",
-                        "stmt1": "py_native_result_dimension_numpy"
+                        "stmt0": "py_native_*_result_pointer_numpy",
+                        "stmt1": "py_native_*_result_pointer_numpy"
                     }
                 },
                 "ast": {
@@ -2125,8 +2125,8 @@
                         "py_var": "SHTPy_rv",
                         "rank": "1",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_native_result_dimension_numpy",
-                        "stmt1": "py_native_result_dimension_numpy"
+                        "stmt0": "py_native_*_result_pointer_numpy",
+                        "stmt1": "py_native_*_result_pointer_numpy"
                     }
                 },
                 "ast": {
@@ -2179,8 +2179,8 @@
                         "numpy_type": "NPY_INT",
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_native_result_dimension_numpy",
-                        "stmt1": "py_native_result_dimension_numpy"
+                        "stmt0": "py_native_*_result_pointer_numpy",
+                        "stmt1": "py_native_*_result_pointer_numpy"
                     }
                 },
                 "ast": {
@@ -2229,8 +2229,8 @@
                         "py_var": "SHTPy_rv",
                         "rank": "1",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_native_result_dimension_numpy",
-                        "stmt1": "py_native_result_dimension_numpy"
+                        "stmt0": "py_native_*_result_pointer_numpy",
+                        "stmt1": "py_native_*_result_pointer_numpy"
                     }
                 },
                 "ast": {

--- a/regression/reference/pointers-numpy-c/pointers.json
+++ b/regression/reference/pointers-numpy-c/pointers.json
@@ -166,8 +166,8 @@
                             "py_var": "SHPy_in",
                             "pytmp_var": "SHTPy_in",
                             "size_var": "SHSize_in",
-                            "stmt0": "py_native_in_dimension_numpy",
-                            "stmt1": "py_native_in_dimension_numpy"
+                            "stmt0": "py_native_*_in_pointer_numpy",
+                            "stmt1": "py_native_*_in_pointer_numpy"
                         }
                     },
                     "out": {
@@ -190,8 +190,8 @@
                             "py_var": "SHPy_out",
                             "rank": "1",
                             "size_var": "SHSize_out",
-                            "stmt0": "py_native_out_dimension_numpy",
-                            "stmt1": "py_native_out_dimension_numpy"
+                            "stmt0": "py_native_*_out_allocatable_numpy",
+                            "stmt1": "py_native_*_out_allocatable_numpy"
                         }
                     },
                     "sizein": {
@@ -321,8 +321,8 @@
                             "py_var": "SHPy_in",
                             "pytmp_var": "SHTPy_in",
                             "size_var": "SHSize_in",
-                            "stmt0": "py_native_in_dimension_numpy",
-                            "stmt1": "py_native_in_dimension_numpy"
+                            "stmt0": "py_native_*_in_pointer_numpy",
+                            "stmt1": "py_native_*_in_pointer_numpy"
                         }
                     },
                     "out": {
@@ -345,8 +345,8 @@
                             "py_var": "SHPy_out",
                             "rank": "1",
                             "size_var": "SHSize_out",
-                            "stmt0": "py_native_out_dimension_numpy",
-                            "stmt1": "py_native_out_dimension_numpy"
+                            "stmt0": "py_native_*_out_allocatable_numpy",
+                            "stmt1": "py_native_*_out_allocatable_numpy"
                         }
                     },
                     "sizein": {
@@ -501,8 +501,8 @@
                             "py_var": "SHPy_values",
                             "rank": "1",
                             "size_var": "SHSize_values",
-                            "stmt0": "py_native_out_dimension_numpy",
-                            "stmt1": "py_native_out_dimension_numpy"
+                            "stmt0": "py_native_*_out_pointer_numpy",
+                            "stmt1": "py_native_*_out_pointer_numpy"
                         }
                     }
                 },
@@ -595,8 +595,8 @@
                             "py_var": "SHPy_arg1",
                             "rank": "1",
                             "size_var": "SHSize_arg1",
-                            "stmt0": "py_native_out_dimension_numpy",
-                            "stmt1": "py_native_out_dimension_numpy"
+                            "stmt0": "py_native_*_out_pointer_numpy",
+                            "stmt1": "py_native_*_out_pointer_numpy"
                         }
                     },
                     "arg2": {
@@ -619,8 +619,8 @@
                             "py_var": "SHPy_arg2",
                             "rank": "1",
                             "size_var": "SHSize_arg2",
-                            "stmt0": "py_native_out_dimension_numpy",
-                            "stmt1": "py_native_out_dimension_numpy"
+                            "stmt0": "py_native_*_out_pointer_numpy",
+                            "stmt1": "py_native_*_out_pointer_numpy"
                         }
                     }
                 },
@@ -741,8 +741,8 @@
                             "py_var": "SHPy_values",
                             "rank": "1",
                             "size_var": "SHSize_values",
-                            "stmt0": "py_native_out_dimension_numpy",
-                            "stmt1": "py_native_out_dimension_numpy"
+                            "stmt0": "py_native_*_out_allocatable_numpy",
+                            "stmt1": "py_native_*_out_allocatable_numpy"
                         }
                     }
                 },
@@ -849,8 +849,8 @@
                             "py_var": "SHPy_values",
                             "rank": "1",
                             "size_var": "SHSize_values",
-                            "stmt0": "py_native_out_dimension_numpy",
-                            "stmt1": "py_native_out_dimension_numpy"
+                            "stmt0": "py_native_*_out_pointer_numpy",
+                            "stmt1": "py_native_*_out_pointer_numpy"
                         }
                     }
                 },
@@ -972,8 +972,8 @@
                             "py_var": "SHPy_values",
                             "pytmp_var": "SHTPy_values",
                             "size_var": "SHSize_values",
-                            "stmt0": "py_native_in_dimension_numpy",
-                            "stmt1": "py_native_in_dimension_numpy"
+                            "stmt0": "py_native_*_in_pointer_numpy",
+                            "stmt1": "py_native_*_in_pointer_numpy"
                         }
                     }
                 },
@@ -1072,8 +1072,8 @@
                             "py_var": "SHPy_out",
                             "rank": "1",
                             "size_var": "SHSize_out",
-                            "stmt0": "py_native_out_dimension_numpy",
-                            "stmt1": "py_native_out_dimension_numpy"
+                            "stmt0": "py_native_*_out_pointer_numpy",
+                            "stmt1": "py_native_*_out_pointer_numpy"
                         }
                     }
                 },
@@ -1144,8 +1144,8 @@
                             "py_var": "SHPy_array",
                             "pytmp_var": "SHTPy_array",
                             "size_var": "SHSize_array",
-                            "stmt0": "py_native_inout_dimension_numpy",
-                            "stmt1": "py_native_inout_dimension_numpy"
+                            "stmt0": "py_native_*_inout_pointer_numpy",
+                            "stmt1": "py_native_*_inout_pointer_numpy"
                         }
                     },
                     "sizein": {

--- a/regression/reference/pointers-numpy-c/pypointersmodule.c
+++ b/regression/reference/pointers-numpy-c/pypointersmodule.c
@@ -839,7 +839,7 @@ PY_returnAddress2(
 
 // ----------------------------------------
 // Function:  int * returnIntPtrToScalar
-// Exact:     py_native_result_dimension_numpy
+// Exact:     py_native_*_result_pointer_numpy
 static char PY_returnIntPtrToScalar__doc__[] =
 "documentation"
 ;
@@ -869,7 +869,7 @@ fail:
 
 // ----------------------------------------
 // Function:  int * returnIntPtrToFixedArray +dimension(10)
-// Exact:     py_native_result_dimension_numpy
+// Exact:     py_native_*_result_pointer_numpy
 static char PY_returnIntPtrToFixedArray__doc__[] =
 "documentation"
 ;
@@ -901,7 +901,7 @@ fail:
 
 // ----------------------------------------
 // Function:  const int * returnIntPtrToConstScalar
-// Exact:     py_native_result_dimension_numpy
+// Exact:     py_native_*_result_pointer_numpy
 static char PY_returnIntPtrToConstScalar__doc__[] =
 "documentation"
 ;
@@ -932,7 +932,7 @@ fail:
 
 // ----------------------------------------
 // Function:  const int * returnIntPtrToFixedConstArray +dimension(10)
-// Exact:     py_native_result_dimension_numpy
+// Exact:     py_native_*_result_pointer_numpy
 static char PY_returnIntPtrToFixedConstArray__doc__[] =
 "documentation"
 ;

--- a/regression/reference/pointers-numpy-c/pypointersmodule.c
+++ b/regression/reference/pointers-numpy-c/pypointersmodule.c
@@ -122,10 +122,10 @@ PY_intargs(
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  double * in +intent(in)+rank(1)
-// Exact:     py_native_in_dimension_numpy
+// Exact:     py_native_*_in_pointer_numpy
 // ----------------------------------------
 // Argument:  double * out +deref(allocatable)+dimension(size(in))+intent(out)
-// Exact:     py_native_out_dimension_numpy
+// Exact:     py_native_*_out_allocatable_numpy
 static char PY_cos_doubles__doc__[] =
 "documentation"
 ;
@@ -194,10 +194,10 @@ fail:
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  double * in +intent(in)+rank(1)
-// Exact:     py_native_in_dimension_numpy
+// Exact:     py_native_*_in_pointer_numpy
 // ----------------------------------------
 // Argument:  int * out +deref(allocatable)+dimension(size(in))+intent(out)
-// Exact:     py_native_out_dimension_numpy
+// Exact:     py_native_*_out_allocatable_numpy
 static char PY_truncate_to_int__doc__[] =
 "documentation"
 ;
@@ -271,7 +271,7 @@ fail:
 // Match:     py_default
 // ----------------------------------------
 // Argument:  int * values +dimension(3)+intent(out)
-// Exact:     py_native_out_dimension_numpy
+// Exact:     py_native_*_out_pointer_numpy
 static char PY_get_values__doc__[] =
 "documentation"
 ;
@@ -326,10 +326,10 @@ fail:
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  int * arg1 +dimension(3)+intent(out)
-// Exact:     py_native_out_dimension_numpy
+// Exact:     py_native_*_out_pointer_numpy
 // ----------------------------------------
 // Argument:  int * arg2 +dimension(3)+intent(out)
-// Exact:     py_native_out_dimension_numpy
+// Exact:     py_native_*_out_pointer_numpy
 static char PY_get_values2__doc__[] =
 "documentation"
 ;
@@ -396,7 +396,7 @@ fail:
 // Match:     py_default
 // ----------------------------------------
 // Argument:  int * values +deref(allocatable)+dimension(nvar)+intent(out)
-// Exact:     py_native_out_dimension_numpy
+// Exact:     py_native_*_out_allocatable_numpy
 static char PY_iota_allocatable__doc__[] =
 "documentation"
 ;
@@ -449,7 +449,7 @@ fail:
 // Match:     py_default
 // ----------------------------------------
 // Argument:  int * values +dimension(nvar)+intent(out)
-// Exact:     py_native_out_dimension_numpy
+// Exact:     py_native_*_out_pointer_numpy
 static char PY_iota_dimension__doc__[] =
 "documentation"
 ;
@@ -498,7 +498,7 @@ fail:
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  int * values +intent(in)+rank(1)
-// Exact:     py_native_in_dimension_numpy
+// Exact:     py_native_*_in_pointer_numpy
 // ----------------------------------------
 // Argument:  int * result +intent(out)
 // Requested: py_native_*_out
@@ -560,7 +560,7 @@ fail:
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  int * out +dimension(3)+intent(out)
-// Exact:     py_native_out_dimension_numpy
+// Exact:     py_native_*_out_pointer_numpy
 static char PY_fillIntArray__doc__[] =
 "documentation"
 ;
@@ -604,7 +604,7 @@ fail:
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  int * array +intent(inout)+rank(1)
-// Exact:     py_native_inout_dimension_numpy
+// Exact:     py_native_*_inout_pointer_numpy
 static char PY_incrementIntArray__doc__[] =
 "documentation"
 ;

--- a/regression/reference/pointers-numpy-cxx/pointers.json
+++ b/regression/reference/pointers-numpy-cxx/pointers.json
@@ -2076,8 +2076,8 @@
                         "numpy_type": "NPY_INT",
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_native_result_dimension_numpy",
-                        "stmt1": "py_native_result_dimension_numpy"
+                        "stmt0": "py_native_*_result_pointer_numpy",
+                        "stmt1": "py_native_*_result_pointer_numpy"
                     }
                 },
                 "ast": {
@@ -2125,8 +2125,8 @@
                         "py_var": "SHTPy_rv",
                         "rank": "1",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_native_result_dimension_numpy",
-                        "stmt1": "py_native_result_dimension_numpy"
+                        "stmt0": "py_native_*_result_pointer_numpy",
+                        "stmt1": "py_native_*_result_pointer_numpy"
                     }
                 },
                 "ast": {
@@ -2179,8 +2179,8 @@
                         "numpy_type": "NPY_INT",
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_native_result_dimension_numpy",
-                        "stmt1": "py_native_result_dimension_numpy"
+                        "stmt0": "py_native_*_result_pointer_numpy",
+                        "stmt1": "py_native_*_result_pointer_numpy"
                     }
                 },
                 "ast": {
@@ -2229,8 +2229,8 @@
                         "py_var": "SHTPy_rv",
                         "rank": "1",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_native_result_dimension_numpy",
-                        "stmt1": "py_native_result_dimension_numpy"
+                        "stmt0": "py_native_*_result_pointer_numpy",
+                        "stmt1": "py_native_*_result_pointer_numpy"
                     }
                 },
                 "ast": {

--- a/regression/reference/pointers-numpy-cxx/pointers.json
+++ b/regression/reference/pointers-numpy-cxx/pointers.json
@@ -166,8 +166,8 @@
                             "py_var": "SHPy_in",
                             "pytmp_var": "SHTPy_in",
                             "size_var": "SHSize_in",
-                            "stmt0": "py_native_in_dimension_numpy",
-                            "stmt1": "py_native_in_dimension_numpy"
+                            "stmt0": "py_native_*_in_pointer_numpy",
+                            "stmt1": "py_native_*_in_pointer_numpy"
                         }
                     },
                     "out": {
@@ -190,8 +190,8 @@
                             "py_var": "SHPy_out",
                             "rank": "1",
                             "size_var": "SHSize_out",
-                            "stmt0": "py_native_out_dimension_numpy",
-                            "stmt1": "py_native_out_dimension_numpy"
+                            "stmt0": "py_native_*_out_allocatable_numpy",
+                            "stmt1": "py_native_*_out_allocatable_numpy"
                         }
                     },
                     "sizein": {
@@ -321,8 +321,8 @@
                             "py_var": "SHPy_in",
                             "pytmp_var": "SHTPy_in",
                             "size_var": "SHSize_in",
-                            "stmt0": "py_native_in_dimension_numpy",
-                            "stmt1": "py_native_in_dimension_numpy"
+                            "stmt0": "py_native_*_in_pointer_numpy",
+                            "stmt1": "py_native_*_in_pointer_numpy"
                         }
                     },
                     "out": {
@@ -345,8 +345,8 @@
                             "py_var": "SHPy_out",
                             "rank": "1",
                             "size_var": "SHSize_out",
-                            "stmt0": "py_native_out_dimension_numpy",
-                            "stmt1": "py_native_out_dimension_numpy"
+                            "stmt0": "py_native_*_out_allocatable_numpy",
+                            "stmt1": "py_native_*_out_allocatable_numpy"
                         }
                     },
                     "sizein": {
@@ -501,8 +501,8 @@
                             "py_var": "SHPy_values",
                             "rank": "1",
                             "size_var": "SHSize_values",
-                            "stmt0": "py_native_out_dimension_numpy",
-                            "stmt1": "py_native_out_dimension_numpy"
+                            "stmt0": "py_native_*_out_pointer_numpy",
+                            "stmt1": "py_native_*_out_pointer_numpy"
                         }
                     }
                 },
@@ -595,8 +595,8 @@
                             "py_var": "SHPy_arg1",
                             "rank": "1",
                             "size_var": "SHSize_arg1",
-                            "stmt0": "py_native_out_dimension_numpy",
-                            "stmt1": "py_native_out_dimension_numpy"
+                            "stmt0": "py_native_*_out_pointer_numpy",
+                            "stmt1": "py_native_*_out_pointer_numpy"
                         }
                     },
                     "arg2": {
@@ -619,8 +619,8 @@
                             "py_var": "SHPy_arg2",
                             "rank": "1",
                             "size_var": "SHSize_arg2",
-                            "stmt0": "py_native_out_dimension_numpy",
-                            "stmt1": "py_native_out_dimension_numpy"
+                            "stmt0": "py_native_*_out_pointer_numpy",
+                            "stmt1": "py_native_*_out_pointer_numpy"
                         }
                     }
                 },
@@ -741,8 +741,8 @@
                             "py_var": "SHPy_values",
                             "rank": "1",
                             "size_var": "SHSize_values",
-                            "stmt0": "py_native_out_dimension_numpy",
-                            "stmt1": "py_native_out_dimension_numpy"
+                            "stmt0": "py_native_*_out_allocatable_numpy",
+                            "stmt1": "py_native_*_out_allocatable_numpy"
                         }
                     }
                 },
@@ -849,8 +849,8 @@
                             "py_var": "SHPy_values",
                             "rank": "1",
                             "size_var": "SHSize_values",
-                            "stmt0": "py_native_out_dimension_numpy",
-                            "stmt1": "py_native_out_dimension_numpy"
+                            "stmt0": "py_native_*_out_pointer_numpy",
+                            "stmt1": "py_native_*_out_pointer_numpy"
                         }
                     }
                 },
@@ -972,8 +972,8 @@
                             "py_var": "SHPy_values",
                             "pytmp_var": "SHTPy_values",
                             "size_var": "SHSize_values",
-                            "stmt0": "py_native_in_dimension_numpy",
-                            "stmt1": "py_native_in_dimension_numpy"
+                            "stmt0": "py_native_*_in_pointer_numpy",
+                            "stmt1": "py_native_*_in_pointer_numpy"
                         }
                     }
                 },
@@ -1072,8 +1072,8 @@
                             "py_var": "SHPy_out",
                             "rank": "1",
                             "size_var": "SHSize_out",
-                            "stmt0": "py_native_out_dimension_numpy",
-                            "stmt1": "py_native_out_dimension_numpy"
+                            "stmt0": "py_native_*_out_pointer_numpy",
+                            "stmt1": "py_native_*_out_pointer_numpy"
                         }
                     }
                 },
@@ -1144,8 +1144,8 @@
                             "py_var": "SHPy_array",
                             "pytmp_var": "SHTPy_array",
                             "size_var": "SHSize_array",
-                            "stmt0": "py_native_inout_dimension_numpy",
-                            "stmt1": "py_native_inout_dimension_numpy"
+                            "stmt0": "py_native_*_inout_pointer_numpy",
+                            "stmt1": "py_native_*_inout_pointer_numpy"
                         }
                     },
                     "sizein": {

--- a/regression/reference/pointers-numpy-cxx/pypointersmodule.cpp
+++ b/regression/reference/pointers-numpy-cxx/pypointersmodule.cpp
@@ -858,7 +858,7 @@ PY_returnAddress2(
 
 // ----------------------------------------
 // Function:  int * returnIntPtrToScalar
-// Exact:     py_native_result_dimension_numpy
+// Exact:     py_native_*_result_pointer_numpy
 static char PY_returnIntPtrToScalar__doc__[] =
 "documentation"
 ;
@@ -888,7 +888,7 @@ fail:
 
 // ----------------------------------------
 // Function:  int * returnIntPtrToFixedArray +dimension(10)
-// Exact:     py_native_result_dimension_numpy
+// Exact:     py_native_*_result_pointer_numpy
 static char PY_returnIntPtrToFixedArray__doc__[] =
 "documentation"
 ;
@@ -920,7 +920,7 @@ fail:
 
 // ----------------------------------------
 // Function:  const int * returnIntPtrToConstScalar
-// Exact:     py_native_result_dimension_numpy
+// Exact:     py_native_*_result_pointer_numpy
 static char PY_returnIntPtrToConstScalar__doc__[] =
 "documentation"
 ;
@@ -951,7 +951,7 @@ fail:
 
 // ----------------------------------------
 // Function:  const int * returnIntPtrToFixedConstArray +dimension(10)
-// Exact:     py_native_result_dimension_numpy
+// Exact:     py_native_*_result_pointer_numpy
 static char PY_returnIntPtrToFixedConstArray__doc__[] =
 "documentation"
 ;

--- a/regression/reference/pointers-numpy-cxx/pypointersmodule.cpp
+++ b/regression/reference/pointers-numpy-cxx/pypointersmodule.cpp
@@ -123,10 +123,10 @@ PY_intargs(
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  double * in +intent(in)+rank(1)
-// Exact:     py_native_in_dimension_numpy
+// Exact:     py_native_*_in_pointer_numpy
 // ----------------------------------------
 // Argument:  double * out +deref(allocatable)+dimension(size(in))+intent(out)
-// Exact:     py_native_out_dimension_numpy
+// Exact:     py_native_*_out_allocatable_numpy
 static char PY_cos_doubles__doc__[] =
 "documentation"
 ;
@@ -197,10 +197,10 @@ fail:
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  double * in +intent(in)+rank(1)
-// Exact:     py_native_in_dimension_numpy
+// Exact:     py_native_*_in_pointer_numpy
 // ----------------------------------------
 // Argument:  int * out +deref(allocatable)+dimension(size(in))+intent(out)
-// Exact:     py_native_out_dimension_numpy
+// Exact:     py_native_*_out_allocatable_numpy
 static char PY_truncate_to_int__doc__[] =
 "documentation"
 ;
@@ -276,7 +276,7 @@ fail:
 // Match:     py_default
 // ----------------------------------------
 // Argument:  int * values +dimension(3)+intent(out)
-// Exact:     py_native_out_dimension_numpy
+// Exact:     py_native_*_out_pointer_numpy
 static char PY_get_values__doc__[] =
 "documentation"
 ;
@@ -333,10 +333,10 @@ fail:
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  int * arg1 +dimension(3)+intent(out)
-// Exact:     py_native_out_dimension_numpy
+// Exact:     py_native_*_out_pointer_numpy
 // ----------------------------------------
 // Argument:  int * arg2 +dimension(3)+intent(out)
-// Exact:     py_native_out_dimension_numpy
+// Exact:     py_native_*_out_pointer_numpy
 static char PY_get_values2__doc__[] =
 "documentation"
 ;
@@ -406,7 +406,7 @@ fail:
 // Match:     py_default
 // ----------------------------------------
 // Argument:  int * values +deref(allocatable)+dimension(nvar)+intent(out)
-// Exact:     py_native_out_dimension_numpy
+// Exact:     py_native_*_out_allocatable_numpy
 static char PY_iota_allocatable__doc__[] =
 "documentation"
 ;
@@ -461,7 +461,7 @@ fail:
 // Match:     py_default
 // ----------------------------------------
 // Argument:  int * values +dimension(nvar)+intent(out)
-// Exact:     py_native_out_dimension_numpy
+// Exact:     py_native_*_out_pointer_numpy
 static char PY_iota_dimension__doc__[] =
 "documentation"
 ;
@@ -512,7 +512,7 @@ fail:
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  int * values +intent(in)+rank(1)
-// Exact:     py_native_in_dimension_numpy
+// Exact:     py_native_*_in_pointer_numpy
 // ----------------------------------------
 // Argument:  int * result +intent(out)
 // Requested: py_native_*_out
@@ -575,7 +575,7 @@ fail:
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  int * out +dimension(3)+intent(out)
-// Exact:     py_native_out_dimension_numpy
+// Exact:     py_native_*_out_pointer_numpy
 static char PY_fillIntArray__doc__[] =
 "documentation"
 ;
@@ -621,7 +621,7 @@ fail:
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  int * array +intent(inout)+rank(1)
-// Exact:     py_native_inout_dimension_numpy
+// Exact:     py_native_*_inout_pointer_numpy
 static char PY_incrementIntArray__doc__[] =
 "documentation"
 ;

--- a/regression/reference/references/pyArrayWrappertype.cpp
+++ b/regression/reference/references/pyArrayWrappertype.cpp
@@ -139,7 +139,7 @@ PY_allocate(
 
 // ----------------------------------------
 // Function:  double * getArray +dimension(getSize())
-// Exact:     py_native_result_dimension_numpy
+// Exact:     py_native_*_result_pointer_numpy
 static char PY_getArray__doc__[] =
 "documentation"
 ;
@@ -172,7 +172,7 @@ fail:
 
 // ----------------------------------------
 // Function:  double * getArrayConst +dimension(getSize())
-// Exact:     py_native_result_dimension_numpy
+// Exact:     py_native_*_result_pointer_numpy
 static char PY_getArrayConst__doc__[] =
 "documentation"
 ;
@@ -205,7 +205,7 @@ fail:
 
 // ----------------------------------------
 // Function:  const double * getArrayC +dimension(getSize())
-// Exact:     py_native_result_dimension_numpy
+// Exact:     py_native_*_result_pointer_numpy
 static char PY_getArrayC__doc__[] =
 "documentation"
 ;
@@ -238,7 +238,7 @@ fail:
 
 // ----------------------------------------
 // Function:  const double * getArrayConstC +dimension(getSize())
-// Exact:     py_native_result_dimension_numpy
+// Exact:     py_native_*_result_pointer_numpy
 static char PY_getArrayConstC__doc__[] =
 "documentation"
 ;

--- a/regression/reference/references/references.json
+++ b/regression/reference/references/references.json
@@ -387,8 +387,8 @@
                                 "py_var": "SHTPy_rv",
                                 "rank": "1",
                                 "size_var": "SHSize_rv",
-                                "stmt0": "py_native_result_dimension_numpy",
-                                "stmt1": "py_native_result_dimension_numpy"
+                                "stmt0": "py_native_*_result_pointer_numpy",
+                                "stmt1": "py_native_*_result_pointer_numpy"
                             }
                         },
                         "ast": {
@@ -570,8 +570,8 @@
                                 "py_var": "SHTPy_rv",
                                 "rank": "1",
                                 "size_var": "SHSize_rv",
-                                "stmt0": "py_native_result_dimension_numpy",
-                                "stmt1": "py_native_result_dimension_numpy"
+                                "stmt0": "py_native_*_result_pointer_numpy",
+                                "stmt1": "py_native_*_result_pointer_numpy"
                             }
                         },
                         "ast": {
@@ -755,8 +755,8 @@
                                 "py_var": "SHTPy_rv",
                                 "rank": "1",
                                 "size_var": "SHSize_rv",
-                                "stmt0": "py_native_result_dimension_numpy",
-                                "stmt1": "py_native_result_dimension_numpy"
+                                "stmt0": "py_native_*_result_pointer_numpy",
+                                "stmt1": "py_native_*_result_pointer_numpy"
                             }
                         },
                         "ast": {
@@ -940,8 +940,8 @@
                                 "py_var": "SHTPy_rv",
                                 "rank": "1",
                                 "size_var": "SHSize_rv",
-                                "stmt0": "py_native_result_dimension_numpy",
-                                "stmt1": "py_native_result_dimension_numpy"
+                                "stmt0": "py_native_*_result_pointer_numpy",
+                                "stmt1": "py_native_*_result_pointer_numpy"
                             }
                         },
                         "ast": {

--- a/regression/reference/templates/pystd_vector_doubletype.cpp
+++ b/regression/reference/templates/pystd_vector_doubletype.cpp
@@ -94,7 +94,7 @@ PY_push_back(
 
 // ----------------------------------------
 // Function:  double & at
-// Exact:     py_native_result_dimension_numpy
+// Exact:     py_native_&_result_pointer_numpy
 // ----------------------------------------
 // Argument:  size_type n +intent(in)+value
 // Requested: py_native_scalar_in

--- a/regression/reference/templates/pystd_vector_inttype.cpp
+++ b/regression/reference/templates/pystd_vector_inttype.cpp
@@ -94,7 +94,7 @@ PY_push_back(
 
 // ----------------------------------------
 // Function:  int & at
-// Exact:     py_native_result_dimension_numpy
+// Exact:     py_native_&_result_pointer_numpy
 // ----------------------------------------
 // Argument:  size_type n +intent(in)+value
 // Requested: py_native_scalar_in

--- a/regression/reference/templates/templates.json
+++ b/regression/reference/templates/templates.json
@@ -1662,8 +1662,8 @@
                                         "numpy_type": "NPY_INT",
                                         "py_var": "SHTPy_rv",
                                         "size_var": "SHSize_rv",
-                                        "stmt0": "py_native_result_dimension_numpy",
-                                        "stmt1": "py_native_result_dimension_numpy"
+                                        "stmt0": "py_native_&_result_pointer_numpy",
+                                        "stmt1": "py_native_&_result_pointer_numpy"
                                     }
                                 },
                                 "_generated": "cxx_template",
@@ -2220,8 +2220,8 @@
                                         "numpy_type": "NPY_DOUBLE",
                                         "py_var": "SHTPy_rv",
                                         "size_var": "SHSize_rv",
-                                        "stmt0": "py_native_result_dimension_numpy",
-                                        "stmt1": "py_native_result_dimension_numpy"
+                                        "stmt0": "py_native_&_result_pointer_numpy",
+                                        "stmt1": "py_native_&_result_pointer_numpy"
                                     }
                                 },
                                 "_generated": "cxx_template",

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -1255,9 +1255,12 @@ return 1;""",
             elif arg_typemap.base == "vector":
                 stmts = ["py", sgroup, intent, options.PY_array_arg]
             elif rank or dimension:
+                deref = attrs["deref"] or "pointer"
                 # ex. (int * arg1 +intent(in) +rank(1))
-                stmts = ["py", sgroup, intent, "dimension", options.PY_array_arg]
+                stmts = ["py", sgroup, spointer, intent, deref, options.PY_array_arg]
             else:
+                # Scalar argument
+                # ex. (int * arg1 +intent(in))
                 stmts = ["py", sgroup, spointer, intent]
             if stmts is not None:
                 if intent_blk is None:
@@ -3622,7 +3625,7 @@ py_statements = [
 ####################
 ## numpy
     dict(
-        name="py_native_in_dimension_numpy",
+        name="py_native_*_in_pointer_numpy",
         need_numpy=True,
         parse_format="O",
         parse_args=["&{pytmp_var}"],
@@ -3651,7 +3654,7 @@ py_statements = [
     ),
 
     dict(
-        name="py_native_inout_dimension_numpy",
+        name="py_native_*_inout_pointer_numpy",
         need_numpy=True,
         parse_format="O",
         parse_args=["&{pytmp_var}"],
@@ -3678,7 +3681,7 @@ py_statements = [
     ),
 
     dict(
-        name="py_native_out_dimension_numpy",
+        name="py_native_*_out_pointer_numpy",
         need_numpy=True,
         c_local_var="pointer",
         declare=[
@@ -3747,7 +3750,7 @@ py_statements = [
 ########################################
 ## list
     dict(
-        name="py_native_in_dimension_list",
+        name="py_native_*_in_pointer_list",
         c_helper="create_from_PyObject_{cxx_type}",
         parse_format="O",
         parse_args=["&{pytmp_var}"],
@@ -3772,7 +3775,7 @@ py_statements = [
     ),
 
     dict(
-        name="py_native_inout_dimension_list",
+        name="py_native_*_inout_pointer_list",
 #        c_helper="update_PyList_{cxx_type}",
         c_helper="create_from_PyObject_{cxx_type} to_PyList_{cxx_type}",
         parse_format="O",
@@ -3804,7 +3807,7 @@ py_statements = [
     ),
 
     dict(
-        name="py_native_out_dimension_list",
+        name="py_native_*_out_pointer_list",
         c_helper="to_PyList_{cxx_type}",
         c_header=["<stdlib.h>"],  # malloc/free
         cxx_header=["<cstdlib>"],  # malloc/free
@@ -3814,11 +3817,9 @@ py_statements = [
             "{cxx_type} * {cxx_var} = {nullptr};",
         ],
         c_pre_call=[
-#            "{cxx_decl}[{array_size}];",
             "{c_var} = malloc(\tsizeof({c_type}) * ({array_size}));",
         ] + malloc_error,
         cxx_pre_call=[
-#            "{cxx_decl}[{array_size}];",
             "{cxx_var} = static_cast<{cxx_type} *>\t(std::malloc(\tsizeof({cxx_type}) * ({array_size})));",
         ] + malloc_error,
         post_call=[
@@ -3840,32 +3841,12 @@ py_statements = [
 ########################################
 ## allocatable
     dict(
-        name="py_native_out_allocatable_list",
-        c_helper="to_PyList_{cxx_type}",
-        c_header=["<stdlib.h>"],  # malloc/free
-        cxx_header=["<cstdlib>"],  # malloc/free
-        c_local_var="pointer",
-        declare=[
-            "{cxx_type} * {cxx_var} = {nullptr};",
-        ],
-        c_pre_call=[
-            "{c_var} = malloc(sizeof({c_type}) * {size_var});",
-        ] + malloc_error,
-        cxx_pre_call=[
-            "{cxx_var} = static_cast<{cxx_type} *>\t(std::malloc(sizeof({cxx_type}) * {size_var}));",
-        ] + malloc_error,
-        post_call=[
-            "PyObject *{py_var} = {hnamefunc0}\t({cxx_var},\t {size_var});",
-            "if ({py_var} == {nullptr}) goto fail;",
-        ],
-        object_created=True,
-        cleanup=[
-            "{stdlib}free({cxx_var});",
-        ],
-        fail=[
-            "if ({cxx_var} != {nullptr})\t {stdlib}free({cxx_var});",
-        ],
-        goto_fail=True,
+        name="py_native_*_out_allocatable_list",
+        base="py_native_*_out_pointer_list",
+    ),
+    dict(
+        name="py_native_*_out_allocatable_numpy",
+        base="py_native_*_out_pointer_numpy",
     ),
 
 ########################################

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -1852,6 +1852,7 @@ return 1;""",
         """
         options = node.options
         ast = node.ast
+        attrs = ast.attrs
         is_ctor = ast.is_ctor()
         CXX_subprogram = node.CXX_subprogram
         result_typemap = node.CXX_result_typemap
@@ -1909,7 +1910,10 @@ return 1;""",
                     result_return_pointer_as in ["pointer", "allocatable"]
                     and result_typemap.base != "string"
             ):
-                stmts = ["py", sgroup, "result", "dimension", options.PY_array_arg]
+                spointer = ast.get_indirect_stmt()
+                deref = attrs["deref"] or "pointer"
+                stmts = ["py", sgroup, spointer, "result",
+                         deref, options.PY_array_arg]
             else:
                 stmts = ["py", sgroup, "result"]
             if stmts is not None:
@@ -3707,7 +3711,7 @@ py_statements = [
     ),
 
     dict(
-        name="py_native_result_dimension_list",
+        name="py_native_*_result_pointer_list",
         c_helper="to_PyList_{cxx_type}",
         declare=[
             "PyObject *{py_var} = {nullptr};",
@@ -3724,7 +3728,7 @@ py_statements = [
         goto_fail=True,
     ),
     dict(
-        name="py_native_result_dimension_numpy",
+        name="py_native_*_result_pointer_numpy",
         need_numpy=True,
         declare=[
             "{npy_intp_decl}"
@@ -3745,6 +3749,14 @@ py_statements = [
         declare_capsule=declare_capsule,
         post_call_capsule=post_call_capsule,
         fail_capsule=fail_capsule,
+    ),
+    dict(
+        name="py_native_&_result_pointer_numpy",
+        base="py_native_*_result_pointer_numpy",
+    ),
+    dict(
+        name="py_native_*_result_allocatable_numpy",
+        base="py_native_*_result_pointer_numpy",
     ),
 
 ########################################


### PR DESCRIPTION
##  Generalize how py_statements are found for pointers
    
* Was: ["py", sgroup, intent, "dimension", options.PY_array_arg]
* Now: ["py", sgroup, spointer, intent, deref, options.PY_array_arg]
    
Adds spointer (`*`, `**`, `[]`) and deref (*pointer*, *allocatable*, *raw*)
This will put it on par with wrapf.py and make it easer to add py_statements for other cases.