### PR TITLE
Ctor name

### DIFF
--- a/regression/input/classes.yaml
+++ b/regression/input/classes.yaml
@@ -23,10 +23,10 @@ declarations:
   declarations:
   - decl: int m_flag +readonly;
   - decl: int m_test +name(test);
-  - decl: Class1()         +name(new)
+  - decl: Class1()
     format:
       function_suffix: _default
-  - decl: Class1(int flag) +name(new)
+  - decl: Class1(int flag)
     format:
       function_suffix: _flag
   - decl: ~Class1()        +name(delete)

--- a/regression/input/clibrary.yaml
+++ b/regression/input/clibrary.yaml
@@ -405,7 +405,7 @@ declarations:
 ##-
 ##-- class: Class1
 ##-  declarations:
-##-  - decl: Class1()  +name(new)
+##-  - decl: Class1()
 ##-  - decl: ~Class1() +name(delete)
 ##-  - decl: void Method1()
 

--- a/regression/input/names.yaml
+++ b/regression/input/names.yaml
@@ -70,6 +70,7 @@ declarations:
       F_derived_name: FNames
   
     declarations:
+    - decl: Names()         +name(defaultctor)
     - decl: void method1()
       format:
         F_name_function: type_method1
@@ -211,7 +212,7 @@ declarations:
       template_suffix: _instantiation4
 
 ########################################
-# Teset option C_API_case
+# Test option C_API_case
 #
 - decl: namespace CAPI
   options:

--- a/regression/reference/classes/classes.json
+++ b/regression/reference/classes/classes.json
@@ -152,8 +152,7 @@
                         "ast": {
                             "attrs": {
                                 "_constructor": true,
-                                "_name": "ctor",
-                                "name": "new"
+                                "_name": "ctor"
                             },
                             "params": [],
                             "specifier": [
@@ -161,28 +160,28 @@
                             ],
                             "typemap_name": "classes::Class1"
                         },
-                        "decl": "Class1()         +name(new)",
-                        "declgen": "Class1() +name(new)",
+                        "decl": "Class1()",
+                        "declgen": "Class1()",
                         "fmtdict": {
-                            "C_name": "CLA_Class1_new_default",
+                            "C_name": "CLA_Class1_ctor_default",
                             "C_prototype": "CLA_Class1 * SHC_rv",
                             "C_return_type": "CLA_Class1 *",
-                            "F_C_call": "c_class1_new_default",
-                            "F_C_name": "c_class1_new_default",
+                            "F_C_call": "c_class1_ctor_default",
+                            "F_C_name": "c_class1_ctor_default",
                             "F_arg_c_call": "SHT_rv%cxxmem",
                             "F_arguments": "",
-                            "F_name_function": "new_default",
+                            "F_name_function": "ctor_default",
                             "F_name_generic": "class1",
-                            "F_name_impl": "class1_new_default",
+                            "F_name_impl": "class1_ctor_default",
                             "F_result_clause": "\fresult(SHT_rv)",
                             "F_subprogram": "function",
                             "PY_name_impl": "PY_Class1_tp_init_default",
                             "PY_type_impl": "PY_Class1_tp_init_default",
                             "PY_type_method": "tp_init",
                             "cxx_rv_decl": "classes::Class1 SHCXX_rv",
-                            "function_name": "new",
+                            "function_name": "ctor",
                             "function_suffix": "_default",
-                            "underscore_name": "new"
+                            "underscore_name": "ctor"
                         },
                         "options": {
                             "F_create_generic": true
@@ -289,8 +288,7 @@
                         "ast": {
                             "attrs": {
                                 "_constructor": true,
-                                "_name": "ctor",
-                                "name": "new"
+                                "_name": "ctor"
                             },
                             "params": [
                                 {
@@ -313,29 +311,29 @@
                             ],
                             "typemap_name": "classes::Class1"
                         },
-                        "decl": "Class1(int flag) +name(new)",
-                        "declgen": "Class1(int flag +intent(in)+value) +name(new)",
+                        "decl": "Class1(int flag)",
+                        "declgen": "Class1(int flag +intent(in)+value)",
                         "fmtdict": {
                             "C_call_list": "flag",
-                            "C_name": "CLA_Class1_new_flag",
+                            "C_name": "CLA_Class1_ctor_flag",
                             "C_prototype": "int flag,\t CLA_Class1 * SHC_rv",
                             "C_return_type": "CLA_Class1 *",
-                            "F_C_call": "c_class1_new_flag",
-                            "F_C_name": "c_class1_new_flag",
+                            "F_C_call": "c_class1_ctor_flag",
+                            "F_C_name": "c_class1_ctor_flag",
                             "F_arg_c_call": "flag,\t SHT_rv%cxxmem",
                             "F_arguments": "flag",
-                            "F_name_function": "new_flag",
+                            "F_name_function": "ctor_flag",
                             "F_name_generic": "class1",
-                            "F_name_impl": "class1_new_flag",
+                            "F_name_impl": "class1_ctor_flag",
                             "F_result_clause": "\fresult(SHT_rv)",
                             "F_subprogram": "function",
                             "PY_name_impl": "PY_Class1_tp_init_flag",
                             "PY_type_impl": "PY_Class1_tp_init_flag",
                             "PY_type_method": "tp_init",
                             "cxx_rv_decl": "classes::Class1 SHCXX_rv",
-                            "function_name": "new",
+                            "function_name": "ctor",
                             "function_suffix": "_flag",
-                            "underscore_name": "new"
+                            "underscore_name": "ctor"
                         },
                         "options": {
                             "F_create_generic": true

--- a/regression/reference/classes/classes.log
+++ b/regression/reference/classes/classes.log
@@ -1,8 +1,8 @@
 Read yaml classes.yaml
 Close classes_types.yaml
 class Class1
-C method Class1() +name(new)
-C method Class1(int flag +intent(in)+value) +name(new)
+C method Class1()
+C method Class1(int flag +intent(in)+value)
 C method ~Class1() +name(delete)
 C method int Method1()
 C method bool equivalent(const Class1 & obj2 +intent(in)) const
@@ -43,8 +43,8 @@ Close wrapclasses.h
 Close wrapclasses.cpp
 Close typesclasses.h
 class Class1
-C-interface, Fortran method Class1() +name(new)
-C-interface, Fortran method Class1(int flag +intent(in)+value) +name(new)
+C-interface, Fortran method Class1()
+C-interface, Fortran method Class1(int flag +intent(in)+value)
 C-interface, Fortran method ~Class1() +name(delete)
 C-interface, Fortran method int Method1()
 C-interface, Fortran method bool equivalent(const Class1 & obj2 +intent(in)) const
@@ -78,8 +78,8 @@ C-interface function void LastFunctionCalled(std::string & SHF_rv +intent(out)+l
 Close wrapfclasses.f
 Close utilclasses.cpp
 class Class1
-Python method Class1() +name(new)
-Python method Class1(int flag +intent(in)+value) +name(new)
+Python method Class1()
+Python method Class1(int flag +intent(in)+value)
 Python method ~Class1() +name(delete)
 Python method int Method1()
 Python method bool equivalent(const Class1 & obj2 +intent(in)) const

--- a/regression/reference/classes/pyClass1type.cpp
+++ b/regression/reference/classes/pyClass1type.cpp
@@ -37,7 +37,7 @@ PY_Class1_tp_del (PY_Class1 *self)
 }
 
 // ----------------------------------------
-// Function:  Class1 +name(new)
+// Function:  Class1
 // Exact:     py_default
 static int
 PY_Class1_tp_init_default(
@@ -45,7 +45,7 @@ PY_Class1_tp_init_default(
   PyObject *SHROUD_UNUSED(args),
   PyObject *SHROUD_UNUSED(kwds))
 {
-// splicer begin class.Class1.method.new_default
+// splicer begin class.Class1.method.ctor_default
     self->obj = new classes::Class1();
     if (self->obj == nullptr) {
         PyErr_NoMemory();
@@ -53,11 +53,11 @@ PY_Class1_tp_init_default(
     }
     self->idtor = 1;
     return 0;
-// splicer end class.Class1.method.new_default
+// splicer end class.Class1.method.ctor_default
 }
 
 // ----------------------------------------
-// Function:  Class1 +name(new)
+// Function:  Class1
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  int flag +intent(in)+value
@@ -69,13 +69,13 @@ PY_Class1_tp_init_flag(
   PyObject *args,
   PyObject *kwds)
 {
-// splicer begin class.Class1.method.new_flag
+// splicer begin class.Class1.method.ctor_flag
     int flag;
     const char *SHT_kwlist[] = {
         "flag",
         nullptr };
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "i:new",
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "i:ctor",
         const_cast<char **>(SHT_kwlist), &flag))
         return -1;
 
@@ -86,7 +86,7 @@ PY_Class1_tp_init_flag(
     }
     self->idtor = 1;
     return 0;
-// splicer end class.Class1.method.new_flag
+// splicer end class.Class1.method.ctor_flag
 }
 
 // ----------------------------------------
@@ -274,7 +274,7 @@ PY_Class1_tp_init(
   PyObject *args,
   PyObject *kwds)
 {
-// splicer begin class.Class1.method.new
+// splicer begin class.Class1.method.ctor
     Py_ssize_t SHT_nargs = 0;
     if (args != nullptr) SHT_nargs += PyTuple_Size(args);
     if (kwds != nullptr) SHT_nargs += PyDict_Size(args);
@@ -299,7 +299,7 @@ PY_Class1_tp_init(
     }
     PyErr_SetString(PyExc_TypeError, "wrong arguments multi-dispatch");
     return -1;
-// splicer end class.Class1.method.new
+// splicer end class.Class1.method.ctor
 }
 // splicer begin class.Class1.impl.after_methods
 // splicer end class.Class1.impl.after_methods

--- a/regression/reference/classes/wrapClass1.cpp
+++ b/regression/reference/classes/wrapClass1.cpp
@@ -41,38 +41,38 @@ static void ShroudStrToArray(CLA_SHROUD_array *array, const std::string * src, i
 // splicer end class.Class1.C_definitions
 
 // ----------------------------------------
-// Function:  Class1 +name(new)
+// Function:  Class1
 // Exact:     c_shadow_scalar_ctor
-// start CLA_Class1_new_default
-CLA_Class1 * CLA_Class1_new_default(CLA_Class1 * SHC_rv)
+// start CLA_Class1_ctor_default
+CLA_Class1 * CLA_Class1_ctor_default(CLA_Class1 * SHC_rv)
 {
-    // splicer begin class.Class1.method.new_default
+    // splicer begin class.Class1.method.ctor_default
     classes::Class1 *SHCXX_rv = new classes::Class1();
     SHC_rv->addr = static_cast<void *>(SHCXX_rv);
     SHC_rv->idtor = 0;
     return SHC_rv;
-    // splicer end class.Class1.method.new_default
+    // splicer end class.Class1.method.ctor_default
 }
-// end CLA_Class1_new_default
+// end CLA_Class1_ctor_default
 
 // ----------------------------------------
-// Function:  Class1 +name(new)
+// Function:  Class1
 // Exact:     c_shadow_scalar_ctor
 // ----------------------------------------
 // Argument:  int flag +intent(in)+value
 // Requested: c_native_scalar_in
 // Match:     c_default
-// start CLA_Class1_new_flag
-CLA_Class1 * CLA_Class1_new_flag(int flag, CLA_Class1 * SHC_rv)
+// start CLA_Class1_ctor_flag
+CLA_Class1 * CLA_Class1_ctor_flag(int flag, CLA_Class1 * SHC_rv)
 {
-    // splicer begin class.Class1.method.new_flag
+    // splicer begin class.Class1.method.ctor_flag
     classes::Class1 *SHCXX_rv = new classes::Class1(flag);
     SHC_rv->addr = static_cast<void *>(SHCXX_rv);
     SHC_rv->idtor = 0;
     return SHC_rv;
-    // splicer end class.Class1.method.new_flag
+    // splicer end class.Class1.method.ctor_flag
 }
-// end CLA_Class1_new_flag
+// end CLA_Class1_ctor_flag
 
 // ----------------------------------------
 // Function:  ~Class1 +name(delete)

--- a/regression/reference/classes/wrapClass1.h
+++ b/regression/reference/classes/wrapClass1.h
@@ -38,9 +38,9 @@ enum CLA_Class1_DIRECTION {
 // splicer begin class.Class1.C_declarations
 // splicer end class.Class1.C_declarations
 
-CLA_Class1 * CLA_Class1_new_default(CLA_Class1 * SHC_rv);
+CLA_Class1 * CLA_Class1_ctor_default(CLA_Class1 * SHC_rv);
 
-CLA_Class1 * CLA_Class1_new_flag(int flag, CLA_Class1 * SHC_rv);
+CLA_Class1 * CLA_Class1_ctor_flag(int flag, CLA_Class1 * SHC_rv);
 
 void CLA_Class1_delete(CLA_Class1 * self);
 

--- a/regression/reference/classes/wrapfclasses.f
+++ b/regression/reference/classes/wrapfclasses.f
@@ -131,43 +131,43 @@ module classes_mod
     end interface
 
     ! ----------------------------------------
-    ! Function:  Class1 +name(new)
+    ! Function:  Class1
     ! Exact:     c_shadow_scalar_result
-    ! start c_class1_new_default
+    ! start c_class1_ctor_default
     interface
-        function c_class1_new_default(SHT_crv) &
+        function c_class1_ctor_default(SHT_crv) &
                 result(SHT_rv) &
-                bind(C, name="CLA_Class1_new_default")
+                bind(C, name="CLA_Class1_ctor_default")
             use iso_c_binding, only : C_PTR
             import :: SHROUD_class1_capsule
             implicit none
             type(SHROUD_class1_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
-        end function c_class1_new_default
+        end function c_class1_ctor_default
     end interface
-    ! end c_class1_new_default
+    ! end c_class1_ctor_default
 
     ! ----------------------------------------
-    ! Function:  Class1 +name(new)
+    ! Function:  Class1
     ! Exact:     c_shadow_scalar_result
     ! ----------------------------------------
     ! Argument:  int flag +intent(in)+value
     ! Requested: c_native_scalar_in
     ! Match:     c_default
-    ! start c_class1_new_flag
+    ! start c_class1_ctor_flag
     interface
-        function c_class1_new_flag(flag, SHT_crv) &
+        function c_class1_ctor_flag(flag, SHT_crv) &
                 result(SHT_rv) &
-                bind(C, name="CLA_Class1_new_flag")
+                bind(C, name="CLA_Class1_ctor_flag")
             use iso_c_binding, only : C_INT, C_PTR
             import :: SHROUD_class1_capsule
             implicit none
             integer(C_INT), value, intent(IN) :: flag
             type(SHROUD_class1_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
-        end function c_class1_new_flag
+        end function c_class1_ctor_flag
     end interface
-    ! end c_class1_new_flag
+    ! end c_class1_ctor_flag
 
     ! ----------------------------------------
     ! Function:  ~Class1 +name(delete)
@@ -705,8 +705,8 @@ module classes_mod
 
     ! start interface class1
     interface class1
-        module procedure class1_new_default
-        module procedure class1_new_flag
+        module procedure class1_ctor_default
+        module procedure class1_ctor_flag
     end interface class1
     ! end interface class1
 
@@ -726,25 +726,25 @@ module classes_mod
 contains
 
     ! ----------------------------------------
-    ! Function:  Class1 +name(new)
-    ! Class1 +name(new)
+    ! Function:  Class1
+    ! Class1
     ! Exact:     f_shadow_ctor
     ! Exact:     c_shadow_ctor
-    ! start class1_new_default
-    function class1_new_default() &
+    ! start class1_ctor_default
+    function class1_ctor_default() &
             result(SHT_rv)
         use iso_c_binding, only : C_PTR
         type(class1) :: SHT_rv
-        ! splicer begin class.Class1.method.new_default
+        ! splicer begin class.Class1.method.ctor_default
         type(C_PTR) :: SHT_prv
-        SHT_prv = c_class1_new_default(SHT_rv%cxxmem)
-        ! splicer end class.Class1.method.new_default
-    end function class1_new_default
-    ! end class1_new_default
+        SHT_prv = c_class1_ctor_default(SHT_rv%cxxmem)
+        ! splicer end class.Class1.method.ctor_default
+    end function class1_ctor_default
+    ! end class1_ctor_default
 
     ! ----------------------------------------
-    ! Function:  Class1 +name(new)
-    ! Class1 +name(new)
+    ! Function:  Class1
+    ! Class1
     ! Exact:     f_shadow_ctor
     ! Exact:     c_shadow_ctor
     ! ----------------------------------------
@@ -753,18 +753,18 @@ contains
     ! Match:     f_default
     ! Requested: c_native_scalar_in
     ! Match:     c_default
-    ! start class1_new_flag
-    function class1_new_flag(flag) &
+    ! start class1_ctor_flag
+    function class1_ctor_flag(flag) &
             result(SHT_rv)
         use iso_c_binding, only : C_INT, C_PTR
         integer(C_INT), value, intent(IN) :: flag
         type(class1) :: SHT_rv
-        ! splicer begin class.Class1.method.new_flag
+        ! splicer begin class.Class1.method.ctor_flag
         type(C_PTR) :: SHT_prv
-        SHT_prv = c_class1_new_flag(flag, SHT_rv%cxxmem)
-        ! splicer end class.Class1.method.new_flag
-    end function class1_new_flag
-    ! end class1_new_flag
+        SHT_prv = c_class1_ctor_flag(flag, SHT_rv%cxxmem)
+        ! splicer end class.Class1.method.ctor_flag
+    end function class1_ctor_flag
+    ! end class1_ctor_flag
 
     ! ----------------------------------------
     ! Function:  ~Class1 +name(delete)

--- a/regression/reference/names/foo.cpp
+++ b/regression/reference/names/foo.cpp
@@ -18,6 +18,19 @@ extern "C" {
 // splicer end namespace.ns0.class.Names.C_definitions
 
 // ----------------------------------------
+// Function:  Names +name(defaultctor)
+// Exact:     c_shadow_scalar_ctor
+TES_ns0_Names * XXX_TES_ns0_Names_defaultctor(TES_ns0_Names * SHC_rv)
+{
+    // splicer begin namespace.ns0.class.Names.method.defaultctor
+    ns0::Names *ARG_rv = new ns0::Names();
+    SHC_rv->addr = static_cast<void *>(ARG_rv);
+    SHC_rv->idtor = 0;
+    return SHC_rv;
+    // splicer end namespace.ns0.class.Names.method.defaultctor
+}
+
+// ----------------------------------------
 // Function:  void method1
 // Requested: c
 // Match:     c_default

--- a/regression/reference/names/foo.f
+++ b/regression/reference/names/foo.f
@@ -51,6 +51,19 @@ module name_module
     interface
 
         ! ----------------------------------------
+        ! Function:  Names +name(defaultctor)
+        ! Exact:     c_shadow_scalar_result
+        function xxx_tes_names_defaultctor(SHT_crv) &
+                result(SHT_rv) &
+                bind(C, name="XXX_TES_ns0_Names_defaultctor")
+            use iso_c_binding, only : C_PTR
+            import :: SHROUD_names_capsule
+            implicit none
+            type(SHROUD_names_capsule), intent(OUT) :: SHT_crv
+            type(C_PTR) SHT_rv
+        end function xxx_tes_names_defaultctor
+
+        ! ----------------------------------------
         ! Function:  void method1
         ! Requested: c_void_scalar_result
         ! Match:     c_default
@@ -79,7 +92,26 @@ module name_module
         ! splicer end namespace.ns0.additional_interfaces
     end interface
 
+    interface FNames
+        module procedure names_defaultctor
+    end interface FNames
+
 contains
+
+    ! ----------------------------------------
+    ! Function:  Names +name(defaultctor)
+    ! Names +name(defaultctor)
+    ! Exact:     f_shadow_ctor
+    ! Exact:     c_shadow_ctor
+    function names_defaultctor() &
+            result(SHT_rv)
+        use iso_c_binding, only : C_PTR
+        type(FNames) :: SHT_rv
+        ! splicer begin namespace.ns0.class.Names.method.defaultctor
+        type(C_PTR) :: SHT_prv
+        SHT_prv = xxx_tes_names_defaultctor(SHT_rv%cxxmem)
+        ! splicer end namespace.ns0.class.Names.method.defaultctor
+    end function names_defaultctor
 
     ! ----------------------------------------
     ! Function:  void method1

--- a/regression/reference/names/foo.h
+++ b/regression/reference/names/foo.h
@@ -27,6 +27,8 @@ extern "C" {
 // splicer begin namespace.ns0.class.Names.C_declarations
 // splicer end namespace.ns0.class.Names.C_declarations
 
+TES_ns0_Names * XXX_TES_ns0_Names_defaultctor(TES_ns0_Names * SHC_rv);
+
 void XXX_TES_ns0_Names_method1(TES_ns0_Names * self);
 
 void XXX_TES_ns0_Names_method2(TES_ns0_Names * self2);

--- a/regression/reference/names/names.json
+++ b/regression/reference/names/names.json
@@ -2077,6 +2077,92 @@
                         },
                         "functions": [
                             {
+                                "_fmtresult": {
+                                    "fmtc": {
+                                        "c_const": "",
+                                        "c_type": "TES_ns0_Names",
+                                        "c_var": "SHC_rv",
+                                        "cxx_addr": "",
+                                        "cxx_member": "->",
+                                        "cxx_type": "ns0::Names",
+                                        "cxx_var": "ARG_rv",
+                                        "idtor": "0",
+                                        "sh_type": "SH_TYPE_OTHER",
+                                        "stmt0": "c_shadow_scalar_ctor",
+                                        "stmt1": "c_shadow_scalar_ctor"
+                                    },
+                                    "fmtf": {
+                                        "cxx_type": "ns0::Names",
+                                        "f_type": "type(FNames)",
+                                        "f_var": "SHT_rv",
+                                        "sh_type": "SH_TYPE_OTHER",
+                                        "stmt0": "f_shadow_ctor",
+                                        "stmt1": "f_shadow_ctor",
+                                        "stmtc0": "c_shadow_ctor",
+                                        "stmtc1": "c_shadow_ctor"
+                                    },
+                                    "fmtpy": {
+                                        "PY_build_format": "O",
+                                        "PY_to_object_idtor_func": "PP_Names_to_Object_idtor",
+                                        "PyObject": "PY_Names",
+                                        "PyTypeObject": "PY_Names_Type",
+                                        "c_deref": "",
+                                        "c_var": "ARG_rv",
+                                        "ctor_expr": "ARG_rv",
+                                        "cxx_addr": "&",
+                                        "cxx_member": ".",
+                                        "cxx_nonconst_ptr": "&ARG_rv",
+                                        "cxx_type": "ns0::Names",
+                                        "cxx_var": "ARG_rv",
+                                        "data_var": "SHData_rv",
+                                        "numpy_type": null,
+                                        "py_var": "SHTPy_rv",
+                                        "size_var": "SHSize_rv",
+                                        "stmt0": "py_default",
+                                        "stmt1": "py_default",
+                                        "vargs": "ARG_rv"
+                                    }
+                                },
+                                "_overloaded": true,
+                                "ast": {
+                                    "attrs": {
+                                        "_constructor": true,
+                                        "_name": "ctor",
+                                        "name": "defaultctor"
+                                    },
+                                    "params": [],
+                                    "specifier": [
+                                        "Names"
+                                    ],
+                                    "typemap_name": "ns0::Names"
+                                },
+                                "decl": "Names()         +name(defaultctor)",
+                                "declgen": "Names() +name(defaultctor)",
+                                "fmtdict": {
+                                    "C_name": "XXX_TES_ns0_Names_defaultctor",
+                                    "C_prototype": "TES_ns0_Names * SHC_rv",
+                                    "C_return_type": "TES_ns0_Names *",
+                                    "F_C_call": "xxx_tes_names_defaultctor",
+                                    "F_C_name": "xxx_tes_names_defaultctor",
+                                    "F_arg_c_call": "SHT_rv%cxxmem",
+                                    "F_arguments": "",
+                                    "F_name_function": "defaultctor",
+                                    "F_name_generic": "FNames",
+                                    "F_name_impl": "names_defaultctor",
+                                    "F_result_clause": "\fresult(SHT_rv)",
+                                    "F_subprogram": "function",
+                                    "PY_name_impl": "PY_Names_tp_init",
+                                    "PY_type_impl": "PY_Names_tp_init",
+                                    "PY_type_method": "tp_init",
+                                    "cxx_rv_decl": "ns0::Names ARG_rv",
+                                    "function_name": "defaultctor",
+                                    "underscore_name": "defaultctor"
+                                },
+                                "options": {
+                                    "F_create_generic": true
+                                }
+                            },
+                            {
                                 "ast": {
                                     "declarator": {
                                         "name": "method1",

--- a/regression/reference/names/names.log
+++ b/regression/reference/names/names.log
@@ -2,6 +2,7 @@ Read yaml names.yaml
 Close testnames_types.yaml
 Close wraptestnames_ns0_inner.cc
 class Names
+C method Names() +name(defaultctor)
 C method void method1()
 C method void method2()
 Close foo.h
@@ -61,6 +62,7 @@ C-interface, Fortran function void FunctionTU(int arg1 +intent(in)+value, long a
 C-interface, Fortran function void FunctionTU(float arg1 +intent(in)+value, double arg2 +intent(in)+value)
 C-interface, Fortran function int UseImplWorker()
 class Names
+C-interface, Fortran method Names() +name(defaultctor)
 C-interface, Fortran method void method1()
 C-interface, Fortran method void method2()
 Close wrapftestnames_ns0_inner.F
@@ -80,6 +82,7 @@ Close wrapftestnames_CAPI.F
 Close top.f
 Close pytestnames_ns0_innermodule.cpp
 class Names
+Python method Names() +name(defaultctor)
 Python method void method1()
 Python method void method2()
 Close pyns0_Namestype.cpp

--- a/regression/reference/names/pyns0_Namestype.cpp
+++ b/regression/reference/names/pyns0_Namestype.cpp
@@ -37,6 +37,26 @@ PY_Names_tp_del (PY_Names *self)
 }
 
 // ----------------------------------------
+// Function:  Names +name(defaultctor)
+// Exact:     py_default
+static int
+PY_Names_tp_init(
+  PY_Names *self,
+  PyObject *SHROUD_UNUSED(args),
+  PyObject *SHROUD_UNUSED(kwds))
+{
+// splicer begin namespace.ns0.class.Names.method.defaultctor
+    self->myobj = new ns0::Names();
+    if (self->myobj == nullptr) {
+        PyErr_NoMemory();
+        return -1;
+    }
+    self->mydtor = 1;
+    return 0;
+// splicer end namespace.ns0.class.Names.method.defaultctor
+}
+
+// ----------------------------------------
 // Function:  void method1
 // Exact:     py_default
 static char PY_method1__doc__[] =
@@ -144,7 +164,7 @@ PyTypeObject PY_Names_Type = {
     (descrgetfunc)nullptr,                /* tp_descr_get */
     (descrsetfunc)nullptr,                /* tp_descr_set */
     0,                              /* tp_dictoffset */
-    (initproc)0,                   /* tp_init */
+    (initproc)PY_Names_tp_init,                   /* tp_init */
     (allocfunc)nullptr,                  /* tp_alloc */
     (newfunc)nullptr,                    /* tp_new */
     (freefunc)nullptr,                   /* tp_free */

--- a/regression/reference/names/pytestnamesutil.cpp
+++ b/regression/reference/names/pytestnamesutil.cpp
@@ -390,11 +390,19 @@ static void PY_SHROUD_capsule_destructor_0(void *ptr)
     // Do not release
 }
 
+// 1 - cxx ns0::Names *
+static void PY_SHROUD_capsule_destructor_1(void *ptr)
+{
+    ns0::Names * cxx_ptr = static_cast<ns0::Names *>(ptr);
+    delete cxx_ptr;
+}
+
 // Code used to release arrays for NumPy objects
 // via a Capsule base object with a destructor.
 // Context strings
 static PY_SHROUD_dtor_context PY_SHROUD_capsule_context[] = {
     {"--none--", PY_SHROUD_capsule_destructor_0},
+    {"cxx ns0::Names *", PY_SHROUD_capsule_destructor_1},
     {nullptr, nullptr},
 };
 

--- a/regression/run/classes/testc.c
+++ b/regression/run/classes/testc.c
@@ -18,7 +18,7 @@ void test_class(void)
   int flag;
   CLA_Class1 c1_buf, *c1;
 
-  c1 = CLA_Class1_new_default(&c1_buf);
+  c1 = CLA_Class1_ctor_default(&c1_buf);
   assert(c1 == &c1_buf && "CLA_class1_new_default");
 
   flag = CLA_Class1_method1(c1);


### PR DESCRIPTION
Remove ctor +name from classes.yaml
A generic interface is created for constructors now so name is not needed.


