### PR TITLE
Add test on dimension attribute

### DIFF
--- a/shroud/generate.py
+++ b/shroud/generate.py
@@ -187,6 +187,10 @@ class VerifyAttrs(object):
                     "used on pointer and references"
                 )
         if dimension:
+            if dimension is True:
+                raise RuntimeError(
+                    "dimension attribute must have a value."
+                )
             if attrs["value"]:
                 raise RuntimeError(
                     "argument may not have 'value' and 'dimension' attribute."

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -11,6 +11,10 @@ from shroud import generate
 
 import unittest
 
+class Config(object):
+    def __init__(self):
+        pass
+
 
 class CheckImplied(unittest.TestCase):
     def setUp(self):
@@ -23,6 +27,34 @@ class CheckImplied(unittest.TestCase):
             ")"
         )
         self.func1 = node
+
+    def test_dimension_1(self):
+        # Check missing dimension value
+        # (:) used to be accepted as assumed shape -- now rank(1).
+        library = ast.LibraryNode()
+        node = self.library.add_function(
+            "void func1(const int *array  +dimension)"
+        )
+        config = Config()
+        vfy = generate.VerifyAttrs(library, config)
+
+        with self.assertRaises(RuntimeError) as context:
+            vfy.check_fcn_attrs(node)
+        self.assertTrue("dimension attribute must have a value" in str(context.exception))
+
+    def test_dimension_2(self):
+        # Check bad dimension
+        # (:) used to be accepted as assumed shape -- now rank(1).
+        library = ast.LibraryNode()
+        node = self.library.add_function(
+            "void func1(const int *array  +dimension(:))"
+        )
+        config = Config()
+        vfy = generate.VerifyAttrs(library, config)
+
+        with self.assertRaises(RuntimeError) as context:
+            vfy.check_fcn_attrs(node)
+        self.assertTrue("Unable to parse dimension" in str(context.exception))
 
     def test_implied_attrs(self):
         func = self.func1


### PR DESCRIPTION
It must have a value i.e. +dimension is an error.  Before this implied
assumed-size.  Files should now use +rank(1) to define assumed-shape.