### PR TITLE
Python 3 fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ do-test :
 do-test-replace :
 	@export TEST_OUTPUT_DIR=$(top)/$(tempdir)/regression; \
 	export TEST_INPUT_DIR=$(top)/regression; \
-	export EXECUTABLE_DIR=$(python.dir); \
+	export EXECUTABLE_DIR=$(python.dir)/shroud; \
 	$(PYTHON) regression/do-test.py -r $(do-test-args)
 
 ########################################################################

--- a/regression/do-test.py
+++ b/regression/do-test.py
@@ -232,20 +232,20 @@ class Tester:
         if mismatch:
             status = False
             for file in mismatch:
-                logging.warn("Does not compare: " + file)
+                logging.warning("Does not compare: " + file)
         if errors:
             status = False
             for file in errors:
-                logging.warn("Unable to compare: " + file)
+                logging.warning("Unable to compare: " + file)
 
         if cmp.left_only:
             status = False
             for file in cmp.left_only:
-                logging.warn("Only in reference: " + file)
+                logging.warning("Only in reference: " + file)
         if cmp.right_only:
             status = False
             for file in cmp.right_only:
-                logging.warn("Only in result: " + file)
+                logging.warning("Only in result: " + file)
 
         if status:
             logging.info("Test {} pass".format(self.testname))

--- a/regression/input/enum.yaml
+++ b/regression/input/enum.yaml
@@ -16,6 +16,10 @@ options:
   wrap_python: True
   wrap_lua: False
 
+format:
+  # Avoid conflict with builtin module
+  PY_module_name: cenum
+
 declarations:
 
 - decl: |

--- a/regression/reference/enum-c/pyenummodule.c
+++ b/regression/reference/enum-c/pyenummodule.c
@@ -85,9 +85,9 @@ static struct PyModuleDef moduledef = {
 
 PyMODINIT_FUNC
 #if PY_MAJOR_VERSION >= 3
-PyInit_enum(void)
+PyInit_cenum(void)
 #else
-initenum(void)
+initcenum(void)
 #endif
 {
     PyObject *m = NULL;
@@ -101,7 +101,7 @@ initenum(void)
 #if PY_MAJOR_VERSION >= 3
     m = PyModule_Create(&moduledef);
 #else
-    m = Py_InitModule4("enum", PY_methods,
+    m = Py_InitModule4("cenum", PY_methods,
         PY__doc__,
         (PyObject*)NULL,PYTHON_API_VERSION);
 #endif
@@ -135,7 +135,7 @@ initenum(void)
 
     /* Check for errors */
     if (PyErr_Occurred())
-        Py_FatalError("can't initialize module enum");
+        Py_FatalError("can't initialize module cenum");
     return RETVAL;
 }
 

--- a/regression/reference/enum-c/pyenummodule.h
+++ b/regression/reference/enum-c/pyenummodule.h
@@ -19,9 +19,9 @@
 extern PyObject *PY_error_obj;
 
 #if PY_MAJOR_VERSION >= 3
-PyMODINIT_FUNC PyInit_enum(void);
+PyMODINIT_FUNC PyInit_cenum(void);
 #else
-PyMODINIT_FUNC initenum(void);
+PyMODINIT_FUNC initcenum(void);
 #endif
 
 #endif  /* PYENUMMODULE_H */

--- a/regression/reference/enum-cxx/pyenummodule.cpp
+++ b/regression/reference/enum-cxx/pyenummodule.cpp
@@ -85,9 +85,9 @@ static struct PyModuleDef moduledef = {
 
 extern "C" PyMODINIT_FUNC
 #if PY_MAJOR_VERSION >= 3
-PyInit_enum(void)
+PyInit_cenum(void)
 #else
-initenum(void)
+initcenum(void)
 #endif
 {
     PyObject *m = nullptr;
@@ -101,7 +101,7 @@ initenum(void)
 #if PY_MAJOR_VERSION >= 3
     m = PyModule_Create(&moduledef);
 #else
-    m = Py_InitModule4("enum", PY_methods,
+    m = Py_InitModule4("cenum", PY_methods,
         PY__doc__,
         (PyObject*)nullptr,PYTHON_API_VERSION);
 #endif
@@ -135,7 +135,7 @@ initenum(void)
 
     /* Check for errors */
     if (PyErr_Occurred())
-        Py_FatalError("can't initialize module enum");
+        Py_FatalError("can't initialize module cenum");
     return RETVAL;
 }
 

--- a/regression/reference/enum-cxx/pyenummodule.hpp
+++ b/regression/reference/enum-cxx/pyenummodule.hpp
@@ -19,9 +19,9 @@
 extern PyObject *PY_error_obj;
 
 #if PY_MAJOR_VERSION >= 3
-extern "C" PyMODINIT_FUNC PyInit_enum(void);
+extern "C" PyMODINIT_FUNC PyInit_cenum(void);
 #else
-extern "C" PyMODINIT_FUNC initenum(void);
+extern "C" PyMODINIT_FUNC initcenum(void);
 #endif
 
 #endif  /* PYENUMMODULE_HPP */

--- a/regression/reference/example/pyUserLibrary_example_nestedmodule.cpp
+++ b/regression/reference/example/pyUserLibrary_example_nestedmodule.cpp
@@ -843,6 +843,14 @@ static PyMethodDef PP_methods[] = {
 };
 
 #if PY_MAJOR_VERSION >= 3
+static char PP__doc__[] =
+"XXX submodule doc"  //"library documentation"
+;
+
+struct module_state {
+    PyObject *error;
+};
+
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "userlibrary.example.nested", /* m_name */
@@ -865,7 +873,7 @@ PyObject *PP_init_userlibrary_example_nested(void)
 #if PY_MAJOR_VERSION >= 3
     m = PyModule_Create(&moduledef);
 #else
-    m = Py_InitModule3((char *) "userlibrary.example.nested", PP_methods, nullptr);
+    m = Py_InitModule3((char *) "nested", PP_methods, nullptr);
 #endif
     if (m == nullptr)
         return nullptr;

--- a/regression/reference/example/pyUserLibrary_examplemodule.cpp
+++ b/regression/reference/example/pyUserLibrary_examplemodule.cpp
@@ -38,6 +38,14 @@ static PyMethodDef PP_methods[] = {
 };
 
 #if PY_MAJOR_VERSION >= 3
+static char PP__doc__[] =
+"XXX submodule doc"  //"library documentation"
+;
+
+struct module_state {
+    PyObject *error;
+};
+
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "userlibrary.example", /* m_name */
@@ -60,7 +68,7 @@ PyObject *PP_init_userlibrary_example(void)
 #if PY_MAJOR_VERSION >= 3
     m = PyModule_Create(&moduledef);
 #else
-    m = Py_InitModule3((char *) "userlibrary.example", PP_methods, nullptr);
+    m = Py_InitModule3((char *) "example", PP_methods, nullptr);
 #endif
     if (m == nullptr)
         return nullptr;

--- a/regression/reference/names/pytestnames_internalmodule.cpp
+++ b/regression/reference/names/pytestnames_internalmodule.cpp
@@ -34,6 +34,14 @@ static PyMethodDef PY_methods[] = {
 };
 
 #if PY_MAJOR_VERSION >= 3
+static char PY__doc__[] =
+"XXX submodule doc"  //"library documentation"
+;
+
+struct module_state {
+    PyObject *error;
+};
+
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "testnames.internal", /* m_name */
@@ -56,7 +64,7 @@ PyObject *PY_init_testnames_internal(void)
 #if PY_MAJOR_VERSION >= 3
     m = PyModule_Create(&moduledef);
 #else
-    m = Py_InitModule3((char *) "testnames.internal", PY_methods, nullptr);
+    m = Py_InitModule3((char *) "internal", PY_methods, nullptr);
 #endif
     if (m == nullptr)
         return nullptr;

--- a/regression/reference/names/pytestnames_ns0_innermodule.cpp
+++ b/regression/reference/names/pytestnames_ns0_innermodule.cpp
@@ -34,6 +34,14 @@ static PyMethodDef PY_methods[] = {
 };
 
 #if PY_MAJOR_VERSION >= 3
+static char PY__doc__[] =
+"XXX submodule doc"  //"library documentation"
+;
+
+struct module_state {
+    PyObject *error;
+};
+
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "testnames.ns0.inner", /* m_name */
@@ -56,7 +64,7 @@ PyObject *PY_init_testnames_ns0_inner(void)
 #if PY_MAJOR_VERSION >= 3
     m = PyModule_Create(&moduledef);
 #else
-    m = Py_InitModule3((char *) "testnames.ns0.inner", PY_methods, nullptr);
+    m = Py_InitModule3((char *) "inner", PY_methods, nullptr);
 #endif
     if (m == nullptr)
         return nullptr;

--- a/regression/reference/names/pytestnames_ns0module.cpp
+++ b/regression/reference/names/pytestnames_ns0module.cpp
@@ -34,6 +34,14 @@ static PyMethodDef PY_methods[] = {
 };
 
 #if PY_MAJOR_VERSION >= 3
+static char PY__doc__[] =
+"XXX submodule doc"  //"library documentation"
+;
+
+struct module_state {
+    PyObject *error;
+};
+
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "testnames.ns0", /* m_name */
@@ -56,7 +64,7 @@ PyObject *PY_init_testnames_ns0(void)
 #if PY_MAJOR_VERSION >= 3
     m = PyModule_Create(&moduledef);
 #else
-    m = Py_InitModule3((char *) "testnames.ns0", PY_methods, nullptr);
+    m = Py_InitModule3((char *) "ns0", PY_methods, nullptr);
 #endif
     if (m == nullptr)
         return nullptr;

--- a/regression/reference/names/pytestnames_ns1module.cpp
+++ b/regression/reference/names/pytestnames_ns1module.cpp
@@ -54,6 +54,14 @@ static PyMethodDef PY_methods[] = {
 };
 
 #if PY_MAJOR_VERSION >= 3
+static char PY__doc__[] =
+"XXX submodule doc"  //"library documentation"
+;
+
+struct module_state {
+    PyObject *error;
+};
+
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "testnames.ns1", /* m_name */
@@ -76,7 +84,7 @@ PyObject *PY_init_testnames_ns1(void)
 #if PY_MAJOR_VERSION >= 3
     m = PyModule_Create(&moduledef);
 #else
-    m = Py_InitModule3((char *) "testnames.ns1", PY_methods, nullptr);
+    m = Py_InitModule3((char *) "ns1", PY_methods, nullptr);
 #endif
     if (m == nullptr)
         return nullptr;

--- a/regression/reference/names/pytestnames_stdmodule.cpp
+++ b/regression/reference/names/pytestnames_stdmodule.cpp
@@ -34,6 +34,14 @@ static PyMethodDef PY_methods[] = {
 };
 
 #if PY_MAJOR_VERSION >= 3
+static char PY__doc__[] =
+"XXX submodule doc"  //"library documentation"
+;
+
+struct module_state {
+    PyObject *error;
+};
+
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "testnames.std", /* m_name */
@@ -56,7 +64,7 @@ PyObject *PY_init_testnames_std(void)
 #if PY_MAJOR_VERSION >= 3
     m = PyModule_Create(&moduledef);
 #else
-    m = Py_InitModule3((char *) "testnames.std", PY_methods, nullptr);
+    m = Py_InitModule3((char *) "std", PY_methods, nullptr);
 #endif
     if (m == nullptr)
         return nullptr;

--- a/regression/reference/namespace/pyns_nsworkmodule.cpp
+++ b/regression/reference/namespace/pyns_nsworkmodule.cpp
@@ -34,6 +34,14 @@ static PyMethodDef PY_methods[] = {
 };
 
 #if PY_MAJOR_VERSION >= 3
+static char PY__doc__[] =
+"XXX submodule doc"  //"library documentation"
+;
+
+struct module_state {
+    PyObject *error;
+};
+
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "ns.nswork", /* m_name */
@@ -56,7 +64,7 @@ PyObject *PY_init_ns_nswork(void)
 #if PY_MAJOR_VERSION >= 3
     m = PyModule_Create(&moduledef);
 #else
-    m = Py_InitModule3((char *) "ns.nswork", PY_methods, nullptr);
+    m = Py_InitModule3((char *) "nswork", PY_methods, nullptr);
 #endif
     if (m == nullptr)
         return nullptr;

--- a/regression/reference/namespace/pyns_outermodule.cpp
+++ b/regression/reference/namespace/pyns_outermodule.cpp
@@ -54,6 +54,14 @@ static PyMethodDef PY_methods[] = {
 };
 
 #if PY_MAJOR_VERSION >= 3
+static char PY__doc__[] =
+"XXX submodule doc"  //"library documentation"
+;
+
+struct module_state {
+    PyObject *error;
+};
+
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "ns.outer", /* m_name */
@@ -76,7 +84,7 @@ PyObject *PY_init_ns_outer(void)
 #if PY_MAJOR_VERSION >= 3
     m = PyModule_Create(&moduledef);
 #else
-    m = Py_InitModule3((char *) "ns.outer", PY_methods, nullptr);
+    m = Py_InitModule3((char *) "outer", PY_methods, nullptr);
 #endif
     if (m == nullptr)
         return nullptr;

--- a/regression/reference/namespacedoc/pywrapped_inner1module.cpp
+++ b/regression/reference/namespacedoc/pywrapped_inner1module.cpp
@@ -54,6 +54,14 @@ static PyMethodDef PY_methods[] = {
 };
 
 #if PY_MAJOR_VERSION >= 3
+static char PY__doc__[] =
+"XXX submodule doc"  //"library documentation"
+;
+
+struct module_state {
+    PyObject *error;
+};
+
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "wrapped.inner1", /* m_name */
@@ -76,7 +84,7 @@ PyObject *PY_init_wrapped_inner1(void)
 #if PY_MAJOR_VERSION >= 3
     m = PyModule_Create(&moduledef);
 #else
-    m = Py_InitModule3((char *) "wrapped.inner1", PY_methods, nullptr);
+    m = Py_InitModule3((char *) "inner1", PY_methods, nullptr);
 #endif
     if (m == nullptr)
         return nullptr;

--- a/regression/reference/namespacedoc/pywrapped_inner2module.cpp
+++ b/regression/reference/namespacedoc/pywrapped_inner2module.cpp
@@ -54,6 +54,14 @@ static PyMethodDef PY_methods[] = {
 };
 
 #if PY_MAJOR_VERSION >= 3
+static char PY__doc__[] =
+"XXX submodule doc"  //"library documentation"
+;
+
+struct module_state {
+    PyObject *error;
+};
+
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "wrapped.inner2", /* m_name */
@@ -76,7 +84,7 @@ PyObject *PY_init_wrapped_inner2(void)
 #if PY_MAJOR_VERSION >= 3
     m = PyModule_Create(&moduledef);
 #else
-    m = Py_InitModule3((char *) "wrapped.inner2", PY_methods, nullptr);
+    m = Py_InitModule3((char *) "inner2", PY_methods, nullptr);
 #endif
     if (m == nullptr)
         return nullptr;

--- a/regression/reference/namespacedoc/pywrapped_inner4module.cpp
+++ b/regression/reference/namespacedoc/pywrapped_inner4module.cpp
@@ -54,6 +54,14 @@ static PyMethodDef PY_methods[] = {
 };
 
 #if PY_MAJOR_VERSION >= 3
+static char PY__doc__[] =
+"XXX submodule doc"  //"library documentation"
+;
+
+struct module_state {
+    PyObject *error;
+};
+
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "wrapped.inner4", /* m_name */
@@ -76,7 +84,7 @@ PyObject *PY_init_wrapped_inner4(void)
 #if PY_MAJOR_VERSION >= 3
     m = PyModule_Create(&moduledef);
 #else
-    m = Py_InitModule3((char *) "wrapped.inner4", PY_methods, nullptr);
+    m = Py_InitModule3((char *) "inner4", PY_methods, nullptr);
 #endif
     if (m == nullptr)
         return nullptr;

--- a/regression/reference/templates/pytemplates_internalmodule.cpp
+++ b/regression/reference/templates/pytemplates_internalmodule.cpp
@@ -38,6 +38,14 @@ static PyMethodDef PY_methods[] = {
 };
 
 #if PY_MAJOR_VERSION >= 3
+static char PY__doc__[] =
+"XXX submodule doc"  //"library documentation"
+;
+
+struct module_state {
+    PyObject *error;
+};
+
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "templates", /* m_name */
@@ -60,7 +68,7 @@ PyObject *PY_init_templates_internal(void)
 #if PY_MAJOR_VERSION >= 3
     m = PyModule_Create(&moduledef);
 #else
-    m = Py_InitModule3((char *) "templates", PY_methods, nullptr);
+    m = Py_InitModule3((char *) "internal", PY_methods, nullptr);
 #endif
     if (m == nullptr)
         return nullptr;

--- a/regression/reference/templates/pytemplates_stdmodule.cpp
+++ b/regression/reference/templates/pytemplates_stdmodule.cpp
@@ -38,6 +38,14 @@ static PyMethodDef PY_methods[] = {
 };
 
 #if PY_MAJOR_VERSION >= 3
+static char PY__doc__[] =
+"XXX submodule doc"  //"library documentation"
+;
+
+struct module_state {
+    PyObject *error;
+};
+
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "templates", /* m_name */
@@ -60,7 +68,7 @@ PyObject *PY_init_templates_std(void)
 #if PY_MAJOR_VERSION >= 3
     m = PyModule_Create(&moduledef);
 #else
-    m = Py_InitModule3((char *) "templates", PY_methods, nullptr);
+    m = Py_InitModule3((char *) "std", PY_methods, nullptr);
 #endif
     if (m == nullptr)
         return nullptr;

--- a/regression/run/enum-c/python/Makefile
+++ b/regression/run/enum-c/python/Makefile
@@ -24,9 +24,9 @@ OBJS = \
 
 CFLAGS += $(SHARED)
 
-all : enum.so
+all : cenum.so
 
-enum.so : $(OBJS)
+cenum.so : $(OBJS)
 	$(CXX) $(LD_SHARED) -o $@ $^ $(LIBS)
 
 simple : testpython.o $(OBJS)

--- a/regression/run/enum-c/python/test.py
+++ b/regression/run/enum-c/python/test.py
@@ -11,7 +11,7 @@
 from __future__ import print_function
 
 import unittest
-import enum
+import cenum
 
 class NotTrue:
     """Test bool arguments errors"""
@@ -34,19 +34,19 @@ class Enum(unittest.TestCase):
         print("FooTest:tearDown_:end")
 
     def test_enum_Color(self):
-        self.assertEqual(10, enum.RED)
-        self.assertEqual(11, enum.BLUE)
-        self.assertEqual(12, enum.WHITE)
+        self.assertEqual(10, cenum.RED)
+        self.assertEqual(11, cenum.BLUE)
+        self.assertEqual(12, cenum.WHITE)
 
     def test_enum_val(self):
-        self.assertEqual(0, enum.a1)
-        self.assertEqual(3, enum.b1)
-        self.assertEqual(4, enum.c1)
-        self.assertEqual(3, enum.d1)
-        self.assertEqual(3, enum.e1)
-        self.assertEqual(4, enum.f1)
-        self.assertEqual(5, enum.g1)
-        self.assertEqual(100, enum.h1)
+        self.assertEqual(0, cenum.a1)
+        self.assertEqual(3, cenum.b1)
+        self.assertEqual(4, cenum.c1)
+        self.assertEqual(3, cenum.d1)
+        self.assertEqual(3, cenum.e1)
+        self.assertEqual(4, cenum.f1)
+        self.assertEqual(5, cenum.g1)
+        self.assertEqual(100, cenum.h1)
 
 
 # creating a new test suite

--- a/regression/run/templates/python/test.py
+++ b/regression/run/templates/python/test.py
@@ -29,8 +29,8 @@ class Templates(unittest.TestCase):
         print("FooTest:tearDown_:end")
 
     def test_vector_int(self):
-        v1 = templates.vector_int()
-        self.assertIsInstance(v1, templates.vector_int)
+        v1 = templates.std.vector_int()
+        self.assertIsInstance(v1, templates.std.vector_int)
 
         v1.push_back(1)
 
@@ -38,8 +38,8 @@ class Templates(unittest.TestCase):
         self.assertEqual(ivalue, 1)
 
     def test_vector_double(self):
-        v1 = templates.vector_double()
-        self.assertIsInstance(v1, templates.vector_double)
+        v1 = templates.std.vector_double()
+        self.assertIsInstance(v1, templates.std.vector_double)
 
         v1.push_back(1.5)
 

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -3144,6 +3144,14 @@ return RETVAL;
 # A submodule always returns a PyObject.
 submodule_begin = """
 #if PY_MAJOR_VERSION >= 3
+static char {PY_prefix}_doc__[] =
+"XXX submodule doc"  //"{PY_library_doc}"
+;
+
+struct module_state {{
+    PyObject *error;
+}};
+
 static struct PyModuleDef moduledef = {{
     PyModuleDef_HEAD_INIT,
     "{PY_module_scope}", /* m_name */
@@ -3166,7 +3174,7 @@ PyObject *m;
 #if PY_MAJOR_VERSION >= 3
 m = PyModule_Create(&moduledef);
 #else
-m = Py_InitModule3((char *) "{PY_module_scope}", {PY_prefix}methods, {nullptr});
+m = Py_InitModule3((char *) "{PY_module_name}", {PY_prefix}methods, {nullptr});
 #endif
 if (m == {nullptr})
 +return {nullptr};-


### PR DESCRIPTION
* Rename enum module to cenum to avoid conflict with builtin enum
* Fixes for nested modules.  Also fixes Python 2 submodules.
* Remove DeprecationWarnings