### PR TITLE
Char scalar

### DIFF
--- a/regression/reference/arrayclass/arrayclass.json
+++ b/regression/reference/arrayclass/arrayclass.json
@@ -2845,7 +2845,7 @@
                                 "numpy_type": "NPY_BOOL",
                                 "py_var": "SHTPy_rv",
                                 "size_var": "SHSize_rv",
-                                "stmt0": "py_bool_result",
+                                "stmt0": "py_bool_scalar_result",
                                 "stmt1": "py_bool_result"
                             }
                         },

--- a/regression/reference/arrayclass/pyArrayWrappertype.cpp
+++ b/regression/reference/arrayclass/pyArrayWrappertype.cpp
@@ -522,7 +522,8 @@ PY_fetchVoidRef(
 
 // ----------------------------------------
 // Function:  bool checkPtr
-// Exact:     py_bool_result
+// Requested: py_bool_scalar_result
+// Match:     py_bool_result
 // ----------------------------------------
 // Argument:  void * array +intent(in)+value
 // Exact:     py_void_*_in

--- a/regression/reference/arrayclass/pyarrayclassutil.cpp
+++ b/regression/reference/arrayclass/pyarrayclassutil.cpp
@@ -8,6 +8,20 @@
 //
 #include "pyarrayclassmodule.hpp"
 
+#ifdef __cplusplus
+#define SHROUD_UNUSED(param)
+#else
+#define SHROUD_UNUSED(param) param
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+#define PyInt_AsLong PyLong_AsLong
+#define PyInt_FromLong PyLong_FromLong
+#define PyInt_FromSize_t PyLong_FromSize_t
+#define PyString_FromString PyUnicode_FromString
+#define PyString_FromStringAndSize PyUnicode_FromStringAndSize
+#endif
+
 const char *PY_ArrayWrapper_capsule_name = "ArrayWrapper";
 
 

--- a/regression/reference/classes/classes.json
+++ b/regression/reference/classes/classes.json
@@ -559,7 +559,7 @@
                                 "numpy_type": "NPY_BOOL",
                                 "py_var": "SHTPy_rv",
                                 "size_var": "SHSize_rv",
-                                "stmt0": "py_bool_result",
+                                "stmt0": "py_bool_scalar_result",
                                 "stmt1": "py_bool_result"
                             }
                         },
@@ -1022,8 +1022,8 @@
                                 "numpy_type": null,
                                 "py_var": "SHTPy_rv",
                                 "size_var": "SHSize_rv",
-                                "stmt0": "py_shadow_result",
-                                "stmt1": "py_shadow_result"
+                                "stmt0": "py_shadow_*_result",
+                                "stmt1": "py_shadow_*_result"
                             }
                         },
                         "ast": {
@@ -1115,8 +1115,8 @@
                                 "numpy_type": null,
                                 "py_var": "SHTPy_rv",
                                 "size_var": "SHSize_rv",
-                                "stmt0": "py_string_result",
-                                "stmt1": "py_string_result"
+                                "stmt0": "py_string_&_result",
+                                "stmt1": "py_string_&_result"
                             }
                         },
                         "ast": {
@@ -1803,8 +1803,8 @@
                                 "numpy_type": null,
                                 "py_var": "SHTPy_rv",
                                 "size_var": "SHSize_rv",
-                                "stmt0": "py_string_result",
-                                "stmt1": "py_string_result"
+                                "stmt0": "py_string_&_result",
+                                "stmt1": "py_string_&_result"
                             }
                         },
                         "ast": {
@@ -2039,8 +2039,8 @@
                                 "numpy_type": null,
                                 "py_var": "SHTPy_rv",
                                 "size_var": "SHSize_rv",
-                                "stmt0": "py_shadow_result",
-                                "stmt1": "py_shadow_result"
+                                "stmt0": "py_shadow_&_result",
+                                "stmt1": "py_shadow_&_result"
                             }
                         },
                         "ast": {
@@ -2422,7 +2422,7 @@
                             "py_var": "SHPy_arg",
                             "size_var": "SHSize_arg",
                             "stmt0": "py_shadow_*_in",
-                            "stmt1": "py_shadow_in"
+                            "stmt1": "py_shadow_*_in"
                         }
                     }
                 },
@@ -2634,8 +2634,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_shadow_result",
-                        "stmt1": "py_shadow_result"
+                        "stmt0": "py_shadow_*_result",
+                        "stmt1": "py_shadow_*_result"
                     }
                 },
                 "ast": {
@@ -2787,8 +2787,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_shadow_result",
-                        "stmt1": "py_shadow_result"
+                        "stmt0": "py_shadow_&_result",
+                        "stmt1": "py_shadow_&_result"
                     }
                 },
                 "ast": {
@@ -3165,8 +3165,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_string_result",
-                        "stmt1": "py_string_result"
+                        "stmt0": "py_string_&_result",
+                        "stmt1": "py_string_&_result"
                     }
                 },
                 "ast": {

--- a/regression/reference/classes/pyClass1type.cpp
+++ b/regression/reference/classes/pyClass1type.cpp
@@ -121,7 +121,8 @@ PY_Method1(
 
 // ----------------------------------------
 // Function:  bool equivalent
-// Exact:     py_bool_result
+// Requested: py_bool_scalar_result
+// Match:     py_bool_result
 // ----------------------------------------
 // Argument:  const Class1 & obj2 +intent(in)
 // Exact:     py_shadow_&_in
@@ -169,7 +170,7 @@ fail:
 
 // ----------------------------------------
 // Function:  Class1 * getclass3
-// Exact:     py_shadow_result
+// Exact:     py_shadow_*_result
 static char PY_getclass3__doc__[] =
 "documentation"
 ;
@@ -197,7 +198,7 @@ PY_getclass3(
 
 // ----------------------------------------
 // Function:  const std::string & getName +deref(allocatable)
-// Exact:     py_string_result
+// Exact:     py_string_&_result
 static char PY_getName__doc__[] =
 "documentation"
 ;

--- a/regression/reference/classes/pyClass2type.cpp
+++ b/regression/reference/classes/pyClass2type.cpp
@@ -38,7 +38,7 @@ PY_Class2_tp_del (PY_Class2 *self)
 
 // ----------------------------------------
 // Function:  const std::string & getName +deref(allocatable)
-// Exact:     py_string_result
+// Exact:     py_string_&_result
 static char PY_getName__doc__[] =
 "documentation"
 ;

--- a/regression/reference/classes/pySingletontype.cpp
+++ b/regression/reference/classes/pySingletontype.cpp
@@ -38,7 +38,7 @@ PY_Singleton_tp_del (PY_Singleton *self)
 
 // ----------------------------------------
 // Function:  static Singleton & getReference
-// Exact:     py_shadow_result
+// Exact:     py_shadow_&_result
 static char PY_getReference__doc__[] =
 "documentation"
 ;

--- a/regression/reference/classes/pyclassesmodule.cpp
+++ b/regression/reference/classes/pyclassesmodule.cpp
@@ -118,8 +118,7 @@ PY_passClassByValue(
 // Match:     py_default
 // ----------------------------------------
 // Argument:  const Class1 * arg +intent(in)
-// Requested: py_shadow_*_in
-// Match:     py_shadow_in
+// Exact:     py_shadow_*_in
 static char PY_useclass__doc__[] =
 "documentation"
 ;
@@ -155,7 +154,7 @@ PY_useclass(
 
 // ----------------------------------------
 // Function:  Class1 * getclass3
-// Exact:     py_shadow_result
+// Exact:     py_shadow_*_result
 static char PY_getclass3__doc__[] =
 "documentation"
 ;
@@ -179,7 +178,7 @@ PY_getclass3(
 
 // ----------------------------------------
 // Function:  Class1 & getClassReference
-// Exact:     py_shadow_result
+// Exact:     py_shadow_&_result
 static char PY_getClassReference__doc__[] =
 "documentation"
 ;
@@ -261,7 +260,7 @@ PY_get_global_flag(
 
 // ----------------------------------------
 // Function:  const std::string & LastFunctionCalled +deref(result-as-arg)+len(30)
-// Exact:     py_string_result
+// Exact:     py_string_&_result
 static char PY_LastFunctionCalled__doc__[] =
 "documentation"
 ;

--- a/regression/reference/classes/pyclassesutil.cpp
+++ b/regression/reference/classes/pyclassesutil.cpp
@@ -8,6 +8,20 @@
 //
 #include "pyclassesmodule.hpp"
 
+#ifdef __cplusplus
+#define SHROUD_UNUSED(param)
+#else
+#define SHROUD_UNUSED(param) param
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+#define PyInt_AsLong PyLong_AsLong
+#define PyInt_FromLong PyLong_FromLong
+#define PyInt_FromSize_t PyLong_FromSize_t
+#define PyString_FromString PyUnicode_FromString
+#define PyString_FromStringAndSize PyUnicode_FromStringAndSize
+#endif
+
 const char *PY_Class1_capsule_name = "Class1";
 const char *PY_Class2_capsule_name = "Class2";
 const char *PY_Singleton_capsule_name = "Singleton";

--- a/regression/reference/clibrary/clibrary.json
+++ b/regression/reference/clibrary/clibrary.json
@@ -980,7 +980,7 @@
                         "stmt0": "f_char_scalar_result_result-as-arg",
                         "stmt1": "f_default",
                         "stmtc0": "c_char_scalar_result_buf",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_char_scalar_result_buf"
                     },
                     "fmtpy": {
                         "array_size": "1",

--- a/regression/reference/clibrary/clibrary.json
+++ b/regression/reference/clibrary/clibrary.json
@@ -996,8 +996,8 @@
                         "numpy_type": "NPY_INTP",
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_char_result",
-                        "stmt1": "py_char_result"
+                        "stmt0": "py_char_*_result",
+                        "stmt1": "py_char_*_result"
                     }
                 },
                 "ast": {
@@ -2988,7 +2988,7 @@
                         "numpy_type": "NPY_BOOL",
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_bool_result",
+                        "stmt0": "py_bool_scalar_result",
                         "stmt1": "py_bool_result"
                     }
                 },
@@ -3133,7 +3133,7 @@
                         "numpy_type": "NPY_BOOL",
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_bool_result",
+                        "stmt0": "py_bool_scalar_result",
                         "stmt1": "py_bool_result"
                     }
                 },

--- a/regression/reference/clibrary/clibrary.json
+++ b/regression/reference/clibrary/clibrary.json
@@ -969,7 +969,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "c_char_*_result",
-                        "stmt1": "c_char_result"
+                        "stmt1": "c_char_*_result"
                     },
                     "fmtf": {
                         "c_var_len": "30",
@@ -980,7 +980,7 @@
                         "stmt0": "f_char_scalar_result_result-as-arg",
                         "stmt1": "f_default",
                         "stmtc0": "c_char_scalar_result_buf",
-                        "stmtc1": "c_char_result_buf"
+                        "stmtc1": "c_default"
                     },
                     "fmtpy": {
                         "array_size": "1",
@@ -1099,7 +1099,7 @@
                             "idtor": "0",
                             "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_*_result_buf",
-                            "stmt1": "c_char_result_buf"
+                            "stmt1": "c_char_*_result_buf"
                         },
                         "fmtf": {
                             "F_pointer": "SHPTR_SHF_rv",
@@ -1112,7 +1112,7 @@
                             "stmt0": "f_char_*_result",
                             "stmt1": "f_default",
                             "stmtc0": "c_char_*_result_buf",
-                            "stmtc1": "c_char_result_buf"
+                            "stmtc1": "c_char_*_result_buf"
                         }
                     },
                     "arg1": {
@@ -1500,7 +1500,7 @@
                             "idtor": "0",
                             "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_*_inout_buf",
-                            "stmt1": "c_char_inout_buf"
+                            "stmt1": "c_char_*_inout_buf"
                         },
                         "fmtf": {
                             "F_pointer": "SHPTR_s",
@@ -1514,7 +1514,7 @@
                             "stmt0": "f_char_*_inout",
                             "stmt1": "f_default",
                             "stmtc0": "c_char_*_inout_buf",
-                            "stmtc1": "c_char_inout_buf"
+                            "stmtc1": "c_char_*_inout_buf"
                         }
                     }
                 },
@@ -1696,7 +1696,7 @@
                             "idtor": "0",
                             "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_*_out_buf",
-                            "stmt1": "c_char_out_buf"
+                            "stmt1": "c_char_*_out_buf"
                         },
                         "fmtf": {
                             "F_pointer": "SHPTR_name1",
@@ -1709,7 +1709,7 @@
                             "stmt0": "f_char_*_out",
                             "stmt1": "f_default",
                             "stmtc0": "c_char_*_out_buf",
-                            "stmtc1": "c_char_out_buf"
+                            "stmtc1": "c_char_*_out_buf"
                         }
                     }
                 },
@@ -1946,7 +1946,7 @@
                             "idtor": "0",
                             "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_*_out_buf",
-                            "stmt1": "c_char_out_buf"
+                            "stmt1": "c_char_*_out_buf"
                         },
                         "fmtf": {
                             "F_pointer": "SHPTR_name1",
@@ -1959,7 +1959,7 @@
                             "stmt0": "f_char_*_out",
                             "stmt1": "f_default",
                             "stmtc0": "c_char_*_out_buf",
-                            "stmtc1": "c_char_out_buf"
+                            "stmtc1": "c_char_*_out_buf"
                         }
                     },
                     "name2": {
@@ -1978,7 +1978,7 @@
                             "idtor": "0",
                             "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_*_out_buf",
-                            "stmt1": "c_char_out_buf"
+                            "stmt1": "c_char_*_out_buf"
                         },
                         "fmtf": {
                             "F_pointer": "SHPTR_name2",
@@ -1991,7 +1991,7 @@
                             "stmt0": "f_char_*_out",
                             "stmt1": "f_default",
                             "stmtc0": "c_char_*_out_buf",
-                            "stmtc1": "c_char_out_buf"
+                            "stmtc1": "c_char_*_out_buf"
                         }
                     }
                 },
@@ -2269,7 +2269,7 @@
                             "idtor": "0",
                             "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_*_out_buf",
-                            "stmt1": "c_char_out_buf"
+                            "stmt1": "c_char_*_out_buf"
                         },
                         "fmtf": {
                             "F_pointer": "SHPTR_text",
@@ -2282,7 +2282,7 @@
                             "stmt0": "f_char_*_out",
                             "stmt1": "f_default",
                             "stmtc0": "c_char_*_out_buf",
-                            "stmtc1": "c_char_out_buf"
+                            "stmtc1": "c_char_*_out_buf"
                         }
                     }
                 },
@@ -3328,7 +3328,7 @@
                             "idtor": "0",
                             "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_*_out_buf",
-                            "stmt1": "c_char_out_buf"
+                            "stmt1": "c_char_*_out_buf"
                         },
                         "fmtf": {
                             "F_pointer": "SHPTR_outbuf",
@@ -3341,7 +3341,7 @@
                             "stmt0": "f_char_*_out",
                             "stmt1": "f_default",
                             "stmtc0": "c_char_*_out_buf",
-                            "stmtc1": "c_char_out_buf"
+                            "stmtc1": "c_char_*_out_buf"
                         }
                     }
                 },
@@ -3940,7 +3940,7 @@
                             "idtor": "0",
                             "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_*_out_buf",
-                            "stmt1": "c_char_out_buf"
+                            "stmt1": "c_char_*_out_buf"
                         },
                         "fmtf": {
                             "F_pointer": "SHPTR_outbuf",
@@ -3953,7 +3953,7 @@
                             "stmt0": "f_char_*_out",
                             "stmt1": "f_default",
                             "stmtc0": "c_char_*_out_buf",
-                            "stmtc1": "c_char_out_buf"
+                            "stmtc1": "c_char_*_out_buf"
                         }
                     }
                 },
@@ -4688,7 +4688,7 @@
                             "idtor": "0",
                             "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_*_out_buf",
-                            "stmt1": "c_char_out_buf"
+                            "stmt1": "c_char_*_out_buf"
                         },
                         "fmtf": {
                             "F_pointer": "SHPTR_outbuf",
@@ -4701,7 +4701,7 @@
                             "stmt0": "f_char_*_out",
                             "stmt1": "f_default",
                             "stmtc0": "c_char_*_out_buf",
-                            "stmtc1": "c_char_out_buf"
+                            "stmtc1": "c_char_*_out_buf"
                         }
                     },
                     "type": {

--- a/regression/reference/clibrary/pyClibrarymodule.c
+++ b/regression/reference/clibrary/pyClibrarymodule.c
@@ -244,7 +244,7 @@ fail:
 
 // ----------------------------------------
 // Function:  char * Function4a +deref(result-as-arg)+len(30)
-// Exact:     py_char_result
+// Exact:     py_char_*_result
 // ----------------------------------------
 // Argument:  const char * arg1 +intent(in)
 // Exact:     py_char_*_in
@@ -584,7 +584,8 @@ PY_ImpliedLenTrim(
 
 // ----------------------------------------
 // Function:  bool ImpliedBoolTrue
-// Exact:     py_bool_result
+// Requested: py_bool_scalar_result
+// Match:     py_bool_result
 // ----------------------------------------
 // Argument:  bool flag +implied(true)+intent(in)+value
 // Exact:     py_default
@@ -625,7 +626,8 @@ fail:
 
 // ----------------------------------------
 // Function:  bool ImpliedBoolFalse
-// Exact:     py_bool_result
+// Requested: py_bool_scalar_result
+// Match:     py_bool_result
 // ----------------------------------------
 // Argument:  bool flag +implied(false)+intent(in)+value
 // Exact:     py_default

--- a/regression/reference/clibrary/wrapClibrary.c
+++ b/regression/reference/clibrary/wrapClibrary.c
@@ -92,8 +92,7 @@ double CLI_pass_by_value_macro(int arg2)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  char * SHF_rv +intent(out)+len(NSHF_rv)
-// Requested: c_char_*_result_buf
-// Match:     c_char_result_buf
+// Exact:     c_char_*_result_buf
 void CLI_function4a_bufferify(const char * arg1, const char * arg2,
     char * SHF_rv, int NSHF_rv)
 {
@@ -115,8 +114,7 @@ void CLI_function4a_bufferify(const char * arg1, const char * arg2,
 // Match:     c_default
 // ----------------------------------------
 // Argument:  char * s +intent(inout)+len(Ns)+len_trim(Ls)
-// Requested: c_char_*_inout_buf
-// Match:     c_char_inout_buf
+// Exact:     c_char_*_inout_buf
 void CLI_pass_char_ptr_in_out_bufferify(char * s, int Ls, int Ns)
 {
     // splicer begin function.pass_char_ptr_in_out_bufferify
@@ -140,8 +138,7 @@ void CLI_pass_char_ptr_in_out_bufferify(char * s, int Ls, int Ns)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  char * name1 +charlen(MAXNAME)+intent(out)+len(Nname1)
-// Requested: c_char_*_out_buf
-// Match:     c_char_out_buf
+// Exact:     c_char_*_out_buf
 // start CLI_return_one_name_bufferify
 void CLI_return_one_name_bufferify(char * name1, int Nname1)
 {
@@ -165,12 +162,10 @@ void CLI_return_one_name_bufferify(char * name1, int Nname1)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  char * name1 +charlen(MAXNAME)+intent(out)+len(Nname1)
-// Requested: c_char_*_out_buf
-// Match:     c_char_out_buf
+// Exact:     c_char_*_out_buf
 // ----------------------------------------
 // Argument:  char * name2 +charlen(MAXNAME)+intent(out)+len(Nname2)
-// Requested: c_char_*_out_buf
-// Match:     c_char_out_buf
+// Exact:     c_char_*_out_buf
 void CLI_return_two_names_bufferify(char * name1, int Nname1,
     char * name2, int Nname2)
 {
@@ -191,8 +186,7 @@ void CLI_return_two_names_bufferify(char * name1, int Nname1,
 // Match:     c_default
 // ----------------------------------------
 // Argument:  char * text +charlen(MAXNAME)+intent(out)+len(Ntext)
-// Requested: c_char_*_out_buf
-// Match:     c_char_out_buf
+// Exact:     c_char_*_out_buf
 // ----------------------------------------
 // Argument:  int ltext +implied(len(text))+intent(in)+value
 // Requested: c_native_scalar_in_buf
@@ -218,8 +212,7 @@ void CLI_implied_text_len_bufferify(char * text, int Ntext, int ltext)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  char * outbuf +intent(out)+len(Noutbuf)
-// Requested: c_char_*_out_buf
-// Match:     c_char_out_buf
+// Exact:     c_char_*_out_buf
 void CLI_bind_c2_bufferify(char * outbuf, int Noutbuf)
 {
     // splicer begin function.bind_c2_bufferify
@@ -245,8 +238,7 @@ void CLI_bind_c2_bufferify(char * outbuf, int Noutbuf)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  char * outbuf +intent(out)+len(Noutbuf)
-// Requested: c_char_*_out_buf
-// Match:     c_char_out_buf
+// Exact:     c_char_*_out_buf
 int CLI_pass_assumed_type_buf_bufferify(void * arg, char * outbuf,
     int Noutbuf)
 {
@@ -280,8 +272,7 @@ int CLI_pass_assumed_type_buf_bufferify(void * arg, char * outbuf,
 // Match:     c_default
 // ----------------------------------------
 // Argument:  char * outbuf +intent(out)+len(Noutbuf)
-// Requested: c_char_*_out_buf
-// Match:     c_char_out_buf
+// Exact:     c_char_*_out_buf
 void CLI_callback3_bufferify(const char * type, void * in,
     void ( * incr)(int *), char * outbuf, int Noutbuf)
 {

--- a/regression/reference/clibrary/wrapfclibrary.f
+++ b/regression/reference/clibrary/wrapfclibrary.f
@@ -174,8 +174,7 @@ module clibrary_mod
 
     ! ----------------------------------------
     ! Function:  char * Function4a +deref(result-as-arg)+len(30)
-    ! Requested: c_char_*_result
-    ! Match:     c_char_result
+    ! Exact:     c_char_*_result
     ! ----------------------------------------
     ! Argument:  const char * arg1 +intent(in)
     ! Requested: c_char_*_in
@@ -210,8 +209,7 @@ module clibrary_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  char * SHF_rv +intent(out)+len(NSHF_rv)
-    ! Requested: c_char_*_result_buf
-    ! Match:     c_char_result_buf
+    ! Exact:     c_char_*_result_buf
     interface
         subroutine c_function4a_bufferify(arg1, arg2, SHF_rv, NSHF_rv) &
                 bind(C, name="CLI_function4a_bufferify")
@@ -266,8 +264,7 @@ module clibrary_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  char * s +intent(inout)+len(Ns)+len_trim(Ls)
-    ! Requested: c_char_*_inout_buf
-    ! Match:     c_char_inout_buf
+    ! Exact:     c_char_*_inout_buf
     interface
         subroutine c_pass_char_ptr_in_out_bufferify(s, Ls, Ns) &
                 bind(C, name="CLI_pass_char_ptr_in_out_bufferify")
@@ -304,8 +301,7 @@ module clibrary_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  char * name1 +charlen(MAXNAME)+intent(out)+len(Nname1)
-    ! Requested: c_char_*_out_buf
-    ! Match:     c_char_out_buf
+    ! Exact:     c_char_*_out_buf
     ! start c_return_one_name_bufferify
     interface
         subroutine c_return_one_name_bufferify(name1, Nname1) &
@@ -346,12 +342,10 @@ module clibrary_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  char * name1 +charlen(MAXNAME)+intent(out)+len(Nname1)
-    ! Requested: c_char_*_out_buf
-    ! Match:     c_char_out_buf
+    ! Exact:     c_char_*_out_buf
     ! ----------------------------------------
     ! Argument:  char * name2 +charlen(MAXNAME)+intent(out)+len(Nname2)
-    ! Requested: c_char_*_out_buf
-    ! Match:     c_char_out_buf
+    ! Exact:     c_char_*_out_buf
     interface
         subroutine c_return_two_names_bufferify(name1, Nname1, name2, &
                 Nname2) &
@@ -395,8 +389,7 @@ module clibrary_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  char * text +charlen(MAXNAME)+intent(out)+len(Ntext)
-    ! Requested: c_char_*_out_buf
-    ! Match:     c_char_out_buf
+    ! Exact:     c_char_*_out_buf
     ! ----------------------------------------
     ! Argument:  int ltext +implied(len(text))+intent(in)+value
     ! Requested: c_native_scalar_in_buf
@@ -544,8 +537,7 @@ module clibrary_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  char * outbuf +intent(out)+len(Noutbuf)
-    ! Requested: c_char_*_out_buf
-    ! Match:     c_char_out_buf
+    ! Exact:     c_char_*_out_buf
     interface
         subroutine c_bind_c2_bufferify(outbuf, Noutbuf) &
                 bind(C, name="CLI_bind_c2_bufferify")
@@ -653,8 +645,7 @@ module clibrary_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  char * outbuf +intent(out)+len(Noutbuf)
-    ! Requested: c_char_*_out_buf
-    ! Match:     c_char_out_buf
+    ! Exact:     c_char_*_out_buf
     interface
         function c_pass_assumed_type_buf_bufferify(arg, outbuf, Noutbuf) &
                 result(SHT_rv) &
@@ -774,8 +765,7 @@ module clibrary_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  char * outbuf +intent(out)+len(Noutbuf)
-    ! Requested: c_char_*_out_buf
-    ! Match:     c_char_out_buf
+    ! Exact:     c_char_*_out_buf
     interface
         subroutine c_callback3_bufferify(type, in, incr, outbuf, &
                 Noutbuf) &
@@ -882,13 +872,12 @@ contains
     ! Match:     f_default
     ! Function:  void Function4a +len(30)
     ! Requested: c_char_scalar_result_buf
-    ! Match:     c_char_result_buf
+    ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  char * SHF_rv +intent(out)+len(NSHF_rv)
     ! Requested: f_char_*_result
     ! Match:     f_default
-    ! Requested: c_char_*_result_buf
-    ! Match:     c_char_result_buf
+    ! Exact:     c_char_*_result_buf
     function function4a(arg1, arg2) &
             result(SHT_rv)
         use iso_c_binding, only : C_INT, C_NULL_CHAR
@@ -931,8 +920,7 @@ contains
     ! Requested: f_char_*_inout
     ! Match:     f_default
     ! Argument:  char * s +intent(inout)+len(Ns)+len_trim(Ls)
-    ! Requested: c_char_*_inout_buf
-    ! Match:     c_char_inout_buf
+    ! Exact:     c_char_*_inout_buf
     !>
     !! \brief toupper
     !!
@@ -961,8 +949,7 @@ contains
     ! Requested: f_char_*_out
     ! Match:     f_default
     ! Argument:  char * name1 +charlen(MAXNAME)+intent(out)+len(Nname1)
-    ! Requested: c_char_*_out_buf
-    ! Match:     c_char_out_buf
+    ! Exact:     c_char_*_out_buf
     !>
     !! \brief Test charlen attribute
     !!
@@ -993,15 +980,13 @@ contains
     ! Requested: f_char_*_out
     ! Match:     f_default
     ! Argument:  char * name1 +charlen(MAXNAME)+intent(out)+len(Nname1)
-    ! Requested: c_char_*_out_buf
-    ! Match:     c_char_out_buf
+    ! Exact:     c_char_*_out_buf
     ! ----------------------------------------
     ! Argument:  char * name2 +charlen(MAXNAME)+intent(out)
     ! Requested: f_char_*_out
     ! Match:     f_default
     ! Argument:  char * name2 +charlen(MAXNAME)+intent(out)+len(Nname2)
-    ! Requested: c_char_*_out_buf
-    ! Match:     c_char_out_buf
+    ! Exact:     c_char_*_out_buf
     !>
     !! \brief Test charlen attribute
     !!
@@ -1032,8 +1017,7 @@ contains
     ! Requested: f_char_*_out
     ! Match:     f_default
     ! Argument:  char * text +charlen(MAXNAME)+intent(out)+len(Ntext)
-    ! Requested: c_char_*_out_buf
-    ! Match:     c_char_out_buf
+    ! Exact:     c_char_*_out_buf
     !>
     !! \brief Fill text, at most ltext characters.
     !!
@@ -1164,8 +1148,7 @@ contains
     ! Requested: f_char_*_out
     ! Match:     f_default
     ! Argument:  char * outbuf +intent(out)+len(Noutbuf)
-    ! Requested: c_char_*_out_buf
-    ! Match:     c_char_out_buf
+    ! Exact:     c_char_*_out_buf
     !>
     !! \brief Rename Fortran name for interface only function
     !!
@@ -1192,8 +1175,7 @@ contains
     ! Requested: f_char_*_out
     ! Match:     f_default
     ! Argument:  char * outbuf +intent(out)+len(Noutbuf)
-    ! Requested: c_char_*_out_buf
-    ! Match:     c_char_out_buf
+    ! Exact:     c_char_*_out_buf
     !>
     !! \brief Test assumed-type
     !!
@@ -1283,8 +1265,7 @@ contains
     ! Requested: f_char_*_out
     ! Match:     f_default
     ! Argument:  char * outbuf +intent(out)+len(Noutbuf)
-    ! Requested: c_char_*_out_buf
-    ! Match:     c_char_out_buf
+    ! Exact:     c_char_*_out_buf
     !>
     !! \brief Test function pointer
     !!

--- a/regression/reference/clibrary/wrapfclibrary.f
+++ b/regression/reference/clibrary/wrapfclibrary.f
@@ -871,8 +871,7 @@ contains
     ! Requested: f_char_scalar_result_result-as-arg
     ! Match:     f_default
     ! Function:  void Function4a +len(30)
-    ! Requested: c_char_scalar_result_buf
-    ! Match:     c_default
+    ! Exact:     c_char_scalar_result_buf
     ! ----------------------------------------
     ! Argument:  char * SHF_rv +intent(out)+len(NSHF_rv)
     ! Requested: f_char_*_result

--- a/regression/reference/cxxlibrary/cxxlibrary.json
+++ b/regression/reference/cxxlibrary/cxxlibrary.json
@@ -1316,7 +1316,7 @@
                         "numpy_type": "NPY_BOOL",
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_bool_result",
+                        "stmt0": "py_bool_scalar_result",
                         "stmt1": "py_bool_result"
                     }
                 },

--- a/regression/reference/cxxlibrary/pycxxlibrarymodule.cpp
+++ b/regression/reference/cxxlibrary/pycxxlibrarymodule.cpp
@@ -418,7 +418,8 @@ fail:
 
 // ----------------------------------------
 // Function:  bool defaultPtrIsNULL
-// Exact:     py_bool_result
+// Requested: py_bool_scalar_result
+// Match:     py_bool_result
 // ----------------------------------------
 // Argument:  double * data=nullptr +intent(in)+rank(1)
 // Exact:     py_native_*_in_pointer_numpy

--- a/regression/reference/cxxlibrary/pycxxlibraryutil.cpp
+++ b/regression/reference/cxxlibrary/pycxxlibraryutil.cpp
@@ -8,6 +8,20 @@
 //
 #include "pycxxlibrarymodule.hpp"
 
+#ifdef __cplusplus
+#define SHROUD_UNUSED(param)
+#else
+#define SHROUD_UNUSED(param) param
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+#define PyInt_AsLong PyLong_AsLong
+#define PyInt_FromLong PyLong_FromLong
+#define PyInt_FromSize_t PyLong_FromSize_t
+#define PyString_FromString PyUnicode_FromString
+#define PyString_FromStringAndSize PyUnicode_FromStringAndSize
+#endif
+
 const char *PY_Cstruct1_cls_capsule_name = "Cstruct1_cls";
 
 

--- a/regression/reference/debugfalse/tutorial.json
+++ b/regression/reference/debugfalse/tutorial.json
@@ -374,7 +374,7 @@
                             "py_var": "SHPy_arg1",
                             "size_var": "SHSize_arg1",
                             "stmt0": "py_string_&_in",
-                            "stmt1": "py_string_in"
+                            "stmt1": "py_string_&_in"
                         }
                     },
                     "arg2": {
@@ -406,7 +406,7 @@
                             "py_var": "SHPy_arg2",
                             "size_var": "SHSize_arg2",
                             "stmt0": "py_string_&_in",
-                            "stmt1": "py_string_in"
+                            "stmt1": "py_string_&_in"
                         }
                     }
                 },
@@ -440,8 +440,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_string_result",
-                        "stmt1": "py_string_result"
+                        "stmt0": "py_string_scalar_result",
+                        "stmt1": "py_string_scalar_result"
                     }
                 },
                 "ast": {
@@ -1232,7 +1232,7 @@
                             "py_var": "SHPy_name",
                             "size_var": "SHSize_name",
                             "stmt0": "py_string_&_in",
-                            "stmt1": "py_string_in"
+                            "stmt1": "py_string_&_in"
                         }
                     }
                 },
@@ -2272,7 +2272,7 @@
                             "py_var": "SHPy_name",
                             "size_var": "SHSize_name",
                             "stmt0": "py_string_&_in",
-                            "stmt1": "py_string_in"
+                            "stmt1": "py_string_&_in"
                         }
                     }
                 },
@@ -5050,8 +5050,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_string_result",
-                        "stmt1": "py_string_result"
+                        "stmt0": "py_string_&_result",
+                        "stmt1": "py_string_&_result"
                     }
                 },
                 "ast": {

--- a/regression/reference/example/example.json
+++ b/regression/reference/example/example.json
@@ -698,8 +698,8 @@
                                                 "numpy_type": null,
                                                 "py_var": "SHTPy_rv",
                                                 "size_var": "SHSize_rv",
-                                                "stmt0": "py_string_result",
-                                                "stmt1": "py_string_result"
+                                                "stmt0": "py_string_&_result",
+                                                "stmt1": "py_string_&_result"
                                             }
                                         },
                                         "ast": {
@@ -896,8 +896,8 @@
                                                 "numpy_type": null,
                                                 "py_var": "SHTPy_rv",
                                                 "size_var": "SHSize_rv",
-                                                "stmt0": "py_string_result",
-                                                "stmt1": "py_string_result"
+                                                "stmt0": "py_string_&_result",
+                                                "stmt1": "py_string_&_result"
                                             }
                                         },
                                         "ast": {
@@ -1554,7 +1554,7 @@
                                                 "numpy_type": "NPY_BOOL",
                                                 "py_var": "SHTPy_rv",
                                                 "size_var": "SHSize_rv",
-                                                "stmt0": "py_bool_result",
+                                                "stmt0": "py_bool_scalar_result",
                                                 "stmt1": "py_bool_result"
                                             }
                                         },
@@ -2073,8 +2073,8 @@
                                                 "numpy_type": null,
                                                 "py_var": "SHTPy_rv",
                                                 "size_var": "SHSize_rv",
-                                                "stmt0": "py_string_result",
-                                                "stmt1": "py_string_result"
+                                                "stmt0": "py_string_&_result",
+                                                "stmt1": "py_string_&_result"
                                             }
                                         },
                                         "ast": {
@@ -2284,8 +2284,8 @@
                                                 "numpy_type": null,
                                                 "py_var": "SHTPy_rv",
                                                 "size_var": "SHSize_rv",
-                                                "stmt0": "py_string_result",
-                                                "stmt1": "py_string_result"
+                                                "stmt0": "py_string_&_result",
+                                                "stmt1": "py_string_&_result"
                                             }
                                         },
                                         "ast": {
@@ -2490,8 +2490,8 @@
                                                 "numpy_type": null,
                                                 "py_var": "SHTPy_rv",
                                                 "size_var": "SHSize_rv",
-                                                "stmt0": "py_string_result",
-                                                "stmt1": "py_string_result"
+                                                "stmt0": "py_string_&_result",
+                                                "stmt1": "py_string_&_result"
                                             }
                                         },
                                         "ast": {
@@ -2696,8 +2696,8 @@
                                                 "numpy_type": null,
                                                 "py_var": "SHTPy_rv",
                                                 "size_var": "SHSize_rv",
-                                                "stmt0": "py_string_result",
-                                                "stmt1": "py_string_result"
+                                                "stmt0": "py_string_&_result",
+                                                "stmt1": "py_string_&_result"
                                             }
                                         },
                                         "ast": {
@@ -3013,7 +3013,7 @@
                                                     "py_var": "SHPy_in",
                                                     "size_var": "SHSize_in",
                                                     "stmt0": "py_shadow_*_in",
-                                                    "stmt1": "py_shadow_in"
+                                                    "stmt1": "py_shadow_*_in"
                                                 }
                                             }
                                         },
@@ -3065,8 +3065,8 @@
                                                 "numpy_type": null,
                                                 "py_var": "SHTPy_rv",
                                                 "size_var": "SHSize_rv",
-                                                "stmt0": "py_shadow_result",
-                                                "stmt1": "py_shadow_result"
+                                                "stmt0": "py_shadow_*_result",
+                                                "stmt1": "py_shadow_*_result"
                                             }
                                         },
                                         "ast": {
@@ -5277,7 +5277,7 @@
                                             "py_var": "SHPy_name",
                                             "size_var": "SHSize_name",
                                             "stmt0": "py_string_&_in",
-                                            "stmt1": "py_string_in"
+                                            "stmt1": "py_string_&_in"
                                         }
                                     }
                                 },
@@ -5327,7 +5327,7 @@
                                         "numpy_type": "NPY_BOOL",
                                         "py_var": "SHTPy_rv",
                                         "size_var": "SHSize_rv",
-                                        "stmt0": "py_bool_result",
+                                        "stmt0": "py_bool_scalar_result",
                                         "stmt1": "py_bool_result"
                                     }
                                 },
@@ -5560,7 +5560,7 @@
                                         "numpy_type": "NPY_BOOL",
                                         "py_var": "SHTPy_rv",
                                         "size_var": "SHSize_rv",
-                                        "stmt0": "py_bool_result",
+                                        "stmt0": "py_bool_scalar_result",
                                         "stmt1": "py_bool_result"
                                     }
                                 },
@@ -5645,7 +5645,7 @@
                                             "py_var": "SHPy_name",
                                             "size_var": "SHSize_name",
                                             "stmt0": "py_string_&_in",
-                                            "stmt1": "py_string_in"
+                                            "stmt1": "py_string_&_in"
                                         }
                                     }
                                 },
@@ -5892,7 +5892,7 @@
                                             "py_var": "SHPy_name",
                                             "size_var": "SHSize_name",
                                             "stmt0": "py_string_&_in",
-                                            "stmt1": "py_string_in"
+                                            "stmt1": "py_string_&_in"
                                         }
                                     }
                                 },

--- a/regression/reference/example/pyUserLibrary_example_nestedmodule.cpp
+++ b/regression/reference/example/pyUserLibrary_example_nestedmodule.cpp
@@ -55,11 +55,11 @@ PP_local_function1(
 
 // ----------------------------------------
 // Function:  bool isNameValid
-// Exact:     py_bool_result
+// Requested: py_bool_scalar_result
+// Match:     py_bool_result
 // ----------------------------------------
 // Argument:  const std::string & name +intent(in)
-// Requested: py_string_&_in
-// Match:     py_string_in
+// Exact:     py_string_&_in
 static char PP_isNameValid__doc__[] =
 "documentation"
 ;
@@ -100,7 +100,8 @@ fail:
 
 // ----------------------------------------
 // Function:  bool isInitialized
-// Exact:     py_bool_result
+// Requested: py_bool_scalar_result
+// Match:     py_bool_result
 static char PP_isInitialized__doc__[] =
 "documentation"
 ;
@@ -133,8 +134,7 @@ fail:
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  const std::string & name +intent(in)
-// Requested: py_string_&_in
-// Match:     py_string_in
+// Exact:     py_string_&_in
 static PyObject *
 PP_test_names(
   PyObject *SHROUD_UNUSED(self),
@@ -164,8 +164,7 @@ PP_test_names(
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  const std::string & name +intent(in)
-// Requested: py_string_&_in
-// Match:     py_string_in
+// Exact:     py_string_&_in
 // ----------------------------------------
 // Argument:  int flag +intent(in)+value
 // Requested: py_native_scalar_in

--- a/regression/reference/example/pyUserLibraryutil.cpp
+++ b/regression/reference/example/pyUserLibraryutil.cpp
@@ -8,6 +8,20 @@
 //
 #include "pyUserLibrarymodule.hpp"
 
+#ifdef __cplusplus
+#define SHROUD_UNUSED(param)
+#else
+#define SHROUD_UNUSED(param) param
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+#define PyInt_AsLong PyLong_AsLong
+#define PyInt_FromLong PyLong_FromLong
+#define PyInt_FromSize_t PyLong_FromSize_t
+#define PyString_FromString PyUnicode_FromString
+#define PyString_FromStringAndSize PyUnicode_FromStringAndSize
+#endif
+
 const char *PY_ExClass1_capsule_name = "ExClass1";
 const char *PY_ExClass2_capsule_name = "ExClass2";
 

--- a/regression/reference/example/pyexample_nested_ExClass1type.cpp
+++ b/regression/reference/example/pyexample_nested_ExClass1type.cpp
@@ -155,7 +155,7 @@ PP_incrementCount(
 
 // ----------------------------------------
 // Function:  const string & getNameErrorCheck +deref(allocatable)
-// Exact:     py_string_result
+// Exact:     py_string_&_result
 static char PP_getNameErrorCheck__doc__[] =
 "documentation"
 ;
@@ -181,7 +181,7 @@ PP_getNameErrorCheck(
 
 // ----------------------------------------
 // Function:  const string & getNameArg +deref(result-as-arg)
-// Exact:     py_string_result
+// Exact:     py_string_&_result
 static char PP_getNameArg__doc__[] =
 "documentation"
 ;
@@ -275,7 +275,8 @@ PP_getValue_1(
 
 // ----------------------------------------
 // Function:  bool hasAddr
-// Exact:     py_bool_result
+// Requested: py_bool_scalar_result
+// Match:     py_bool_result
 // ----------------------------------------
 // Argument:  bool in +intent(in)+value
 // Requested: py_bool_scalar_in

--- a/regression/reference/example/pyexample_nested_ExClass2type.cpp
+++ b/regression/reference/example/pyexample_nested_ExClass2type.cpp
@@ -189,7 +189,7 @@ PP_ExClass2_tp_init(
 
 // ----------------------------------------
 // Function:  const string & getName +deref(result-as-arg)+len(aa_exclass2_get_name_length({F_this}%{F_derived_member}))
-// Exact:     py_string_result
+// Exact:     py_string_&_result
 static char PP_getName__doc__[] =
 "documentation"
 ;
@@ -215,7 +215,7 @@ PP_getName(
 
 // ----------------------------------------
 // Function:  const string & getName2 +deref(allocatable)
-// Exact:     py_string_result
+// Exact:     py_string_&_result
 static char PP_getName2__doc__[] =
 "documentation"
 ;
@@ -241,7 +241,7 @@ PP_getName2(
 
 // ----------------------------------------
 // Function:  string & getName3 +deref(allocatable)
-// Exact:     py_string_result
+// Exact:     py_string_&_result
 static char PP_getName3__doc__[] =
 "documentation"
 ;
@@ -267,7 +267,7 @@ PP_getName3(
 
 // ----------------------------------------
 // Function:  string & getName4 +deref(allocatable)
-// Exact:     py_string_result
+// Exact:     py_string_&_result
 static char PP_getName4__doc__[] =
 "documentation"
 ;
@@ -323,11 +323,10 @@ PP_GetNameLength(
 
 // ----------------------------------------
 // Function:  ExClass1 * get_class1
-// Exact:     py_shadow_result
+// Exact:     py_shadow_*_result
 // ----------------------------------------
 // Argument:  const ExClass1 * in +intent(in)
-// Requested: py_shadow_*_in
-// Match:     py_shadow_in
+// Exact:     py_shadow_*_in
 static char PP_get_class1__doc__[] =
 "documentation"
 ;

--- a/regression/reference/forward/forward.json
+++ b/regression/reference/forward/forward.json
@@ -269,7 +269,7 @@
                                     "py_var": "SHPy_arg",
                                     "size_var": "SHSize_arg",
                                     "stmt0": "py_shadow_*_in",
-                                    "stmt1": "py_shadow_in"
+                                    "stmt1": "py_shadow_*_in"
                                 }
                             }
                         },
@@ -396,7 +396,7 @@
                                     "py_var": "SHPy_arg",
                                     "size_var": "SHSize_arg",
                                     "stmt0": "py_shadow_*_in",
-                                    "stmt1": "py_shadow_in"
+                                    "stmt1": "py_shadow_*_in"
                                 }
                             }
                         },

--- a/regression/reference/forward/pyClass2type.cpp
+++ b/regression/reference/forward/pyClass2type.cpp
@@ -61,8 +61,7 @@ PY_Class2_tp_init(
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  tutorial::Class1 * arg +intent(in)
-// Requested: py_shadow_*_in
-// Match:     py_shadow_in
+// Exact:     py_shadow_*_in
 static char PY_func1__doc__[] =
 "documentation"
 ;
@@ -96,8 +95,7 @@ PY_func1(
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  Class3 * arg +intent(in)
-// Requested: py_shadow_*_in
-// Match:     py_shadow_in
+// Exact:     py_shadow_*_in
 static char PY_acceptClass3__doc__[] =
 "documentation"
 ;

--- a/regression/reference/forward/pyforwardutil.cpp
+++ b/regression/reference/forward/pyforwardutil.cpp
@@ -8,6 +8,20 @@
 //
 #include "pyforwardmodule.hpp"
 
+#ifdef __cplusplus
+#define SHROUD_UNUSED(param)
+#else
+#define SHROUD_UNUSED(param) param
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+#define PyInt_AsLong PyLong_AsLong
+#define PyInt_FromLong PyLong_FromLong
+#define PyInt_FromSize_t PyLong_FromSize_t
+#define PyString_FromString PyUnicode_FromString
+#define PyString_FromStringAndSize PyUnicode_FromStringAndSize
+#endif
+
 const char *PY_Class3_capsule_name = "Class3";
 const char *PY_Class2_capsule_name = "Class2";
 

--- a/regression/reference/names/names.json
+++ b/regression/reference/names/names.json
@@ -359,7 +359,7 @@
                             "idtor": "0",
                             "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_*_inout_buf",
-                            "stmt1": "c_char_inout_buf"
+                            "stmt1": "c_char_*_inout_buf"
                         },
                         "fmtf": {
                             "F_pointer": "SHPTR_name",
@@ -373,7 +373,7 @@
                             "stmt0": "f_char_*_inout",
                             "stmt1": "f_default",
                             "stmtc0": "c_char_*_inout_buf",
-                            "stmtc1": "c_char_inout_buf"
+                            "stmtc1": "c_char_*_inout_buf"
                         }
                     }
                 },

--- a/regression/reference/names/names.json
+++ b/regression/reference/names/names.json
@@ -745,7 +745,7 @@
                             "py_var": "SHPy_rv",
                             "size_var": "SHSize_rv",
                             "stmt0": "py_string_&_in",
-                            "stmt1": "py_string_in"
+                            "stmt1": "py_string_&_in"
                         }
                     }
                 },
@@ -1024,7 +1024,7 @@
                             "py_var": "SHPy_name",
                             "size_var": "SHSize_name",
                             "stmt0": "py_string_&_inout",
-                            "stmt1": "py_string_inout"
+                            "stmt1": "py_string_&_inout"
                         }
                     },
                     "value": {

--- a/regression/reference/names/pytestnamesmodule.cpp
+++ b/regression/reference/names/pytestnamesmodule.cpp
@@ -171,8 +171,7 @@ PY_function3a_1(
 // Match:     py_default
 // ----------------------------------------
 // Argument:  const std::string & rv +intent(in)
-// Requested: py_string_&_in
-// Match:     py_string_in
+// Exact:     py_string_&_in
 static char PY_function4__doc__[] =
 "documentation"
 ;
@@ -230,8 +229,7 @@ PY_fiveplus(
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  std::string & name +intent(inout)
-// Requested: py_string_&_inout
-// Match:     py_string_inout
+// Exact:     py_string_&_inout
 // ----------------------------------------
 // Argument:  int * value +intent(out)
 // Exact:     py_native_*_out

--- a/regression/reference/names/pytestnamesutil.cpp
+++ b/regression/reference/names/pytestnamesutil.cpp
@@ -8,6 +8,20 @@
 //
 #include "pytestnamesmodule.hpp"
 
+#ifdef __cplusplus
+#define SHROUD_UNUSED(param)
+#else
+#define SHROUD_UNUSED(param) param
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+#define PyInt_AsLong PyLong_AsLong
+#define PyInt_FromLong PyLong_FromLong
+#define PyInt_FromSize_t PyLong_FromSize_t
+#define PyString_FromString PyUnicode_FromString
+#define PyString_FromStringAndSize PyUnicode_FromStringAndSize
+#endif
+
 const char *PY_Names_capsule_name = "Names";
 const char *PY_Vvv1_capsule_name = "Vvv1";
 const char *PY_vector_double_capsule_name = "vector_double";

--- a/regression/reference/names/top.cpp
+++ b/regression/reference/names/top.cpp
@@ -78,8 +78,7 @@ void TES_get_name(char * name)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  char * name +intent(inout)+len(worklen)+len_trim(worktrim)
-// Requested: c_char_*_inout_buf
-// Match:     c_char_inout_buf
+// Exact:     c_char_*_inout_buf
 void TES_get_name_bufferify(char * name, int worktrim, int worklen)
 {
     // splicer begin function.get_name_bufferify

--- a/regression/reference/names/top.f
+++ b/regression/reference/names/top.f
@@ -121,8 +121,7 @@ module top_module
         ! Match:     c_default
         ! ----------------------------------------
         ! Argument:  char * name +intent(inout)+len(worklen)+len_trim(worktrim)
-        ! Requested: c_char_*_inout_buf
-        ! Match:     c_char_inout_buf
+        ! Exact:     c_char_*_inout_buf
         subroutine c_get_name_bufferify(name, worktrim, worklen) &
                 bind(C, name="TES_get_name_bufferify")
             use iso_c_binding, only : C_CHAR, C_INT
@@ -425,8 +424,7 @@ contains
     ! Argument:  char * name +intent(inout)+len(worklen)+len_trim(worktrim)
     ! Requested: f_char_*_inout
     ! Match:     f_default
-    ! Requested: c_char_*_inout_buf
-    ! Match:     c_char_inout_buf
+    ! Exact:     c_char_*_inout_buf
     subroutine get_name(name)
         use iso_c_binding, only : C_INT
         character(len=*), intent(INOUT) :: name

--- a/regression/reference/namespace/namespace.json
+++ b/regression/reference/namespace/namespace.json
@@ -55,8 +55,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_string_result",
-                        "stmt1": "py_string_result"
+                        "stmt0": "py_string_&_result",
+                        "stmt1": "py_string_&_result"
                     }
                 },
                 "ast": {

--- a/regression/reference/namespace/pynsmodule.cpp
+++ b/regression/reference/namespace/pynsmodule.cpp
@@ -35,7 +35,7 @@ PyObject *PY_init_ns_nswork(void);
 
 // ----------------------------------------
 // Function:  const std::string & LastFunctionCalled +deref(allocatable)
-// Exact:     py_string_result
+// Exact:     py_string_&_result
 static char PY_LastFunctionCalled__doc__[] =
 "documentation"
 ;

--- a/regression/reference/namespace/pynsutil.cpp
+++ b/regression/reference/namespace/pynsutil.cpp
@@ -8,6 +8,20 @@
 //
 #include "pynsmodule.hpp"
 
+#ifdef __cplusplus
+#define SHROUD_UNUSED(param)
+#else
+#define SHROUD_UNUSED(param) param
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+#define PyInt_AsLong PyLong_AsLong
+#define PyInt_FromLong PyLong_FromLong
+#define PyInt_FromSize_t PyLong_FromSize_t
+#define PyString_FromString PyUnicode_FromString
+#define PyString_FromStringAndSize PyUnicode_FromStringAndSize
+#endif
+
 const char *PY_Cstruct1_capsule_name = "Cstruct1";
 const char *PY_ClassWork_capsule_name = "ClassWork";
 

--- a/regression/reference/none/def_types.yaml
+++ b/regression/reference/none/def_types.yaml
@@ -80,28 +80,6 @@ typemap:
       LUA_push: lua_pushstring({LUA_state_var}, {c_var})
       sgroup: char
       sh_type: SH_TYPE_OTHER
-  - type: char_scalar
-    fields:
-      flat_name: char
-      base: unknown
-      idtor: 0
-      cxx_type: char
-      c_type: char
-      f_c_module:
-        iso_c_binding:
-        - C_CHAR
-      f_type: character
-      f_kind: C_CHAR
-      f_c_type: character(kind=C_CHAR)
-      f_cast: "{f_var}"
-      PY_format: c
-      PY_ctor: PyString_FromStringAndSize(&{c_var}, 1)
-      PY_build_arg: (int) {cxx_var}
-      LUA_type: LUA_TSTRING
-      LUA_pop: lua_tostring({LUA_state_var}, {LUA_index})
-      LUA_push: lua_pushstring({LUA_state_var}, {c_var})
-      sgroup: schar
-      sh_type: SH_TYPE_OTHER
   - type: double
     fields:
       flat_name: double

--- a/regression/reference/none/helpers.c
+++ b/regression/reference/none/helpers.c
@@ -2921,7 +2921,7 @@ static int SHROUD_get_from_object_char(PyObject *obj,
 #if PY_MAJOR_VERSION >= 3
         PyObject *strobj = PyUnicode_AsUTF8String(obj);
         out = PyBytes_AS_STRING(strobj);
-        size = PyString_Size(obj);
+        size = PyBytes_GET_SIZE(strobj);
         value->obj = strobj;  // steal reference
 #else
         PyObject *strobj = PyUnicode_AsUTF8String(obj);

--- a/regression/reference/none/helpers.c
+++ b/regression/reference/none/helpers.c
@@ -335,10 +335,10 @@ void LIB_ShroudCopyStringAndFree(LIB_SHROUD_array *data, char *c_var, size_t c_v
 ##### start create_from_PyObject_char source
 
 // helper create_from_PyObject_char
-// Convert obj into an array of type char *
+// Convert obj into an array of type char *.
 // Return -1 on error.
 static int SHROUD_create_from_PyObject_char(PyObject *obj,
-    const char *name, char * **pin, Py_ssize_t *psize)
+    const char *name, char ***pin, Py_ssize_t *psize)
 {
     PyObject *seq = PySequence_Fast(obj, "holder");
     if (seq == NULL) {
@@ -347,8 +347,7 @@ static int SHROUD_create_from_PyObject_char(PyObject *obj,
         return -1;
     }
     Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
-    char * *in = static_cast<char * *>
-        (std::malloc(size * sizeof(char *)));
+    char **in = static_cast<char **>(std::calloc(size, sizeof(char *)));
     for (Py_ssize_t i = 0; i < size; i++) {
         PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
         in[i] = PyString_AsString(item);

--- a/regression/reference/none/none.json
+++ b/regression/reference/none/none.json
@@ -283,26 +283,6 @@
             "flat_name": "char",
             "sgroup": "char"
         },
-        "char_scalar": {
-            "LUA_pop": "lua_tostring({LUA_state_var}, {LUA_index})",
-            "LUA_push": "lua_pushstring({LUA_state_var}, {c_var})",
-            "LUA_type": "LUA_TSTRING",
-            "PY_build_arg": "(int) {cxx_var}",
-            "PY_ctor": "PyString_FromStringAndSize(&{c_var}, 1)",
-            "PY_format": "c",
-            "c_type": "char",
-            "cxx_type": "char",
-            "f_c_module": {
-                "iso_c_binding": [
-                    "C_CHAR"
-                ]
-            },
-            "f_c_type": "character(kind=C_CHAR)",
-            "f_kind": "C_CHAR",
-            "f_type": "character",
-            "flat_name": "char",
-            "sgroup": "schar"
-        },
         "double": {
             "LUA_pop": "lua_tonumber({LUA_state_var}, {LUA_index})",
             "LUA_push": "lua_pushnumber({LUA_state_var}, {c_var})",

--- a/regression/reference/ownership/ownership.json
+++ b/regression/reference/ownership/ownership.json
@@ -2940,8 +2940,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_shadow_result",
-                        "stmt1": "py_shadow_result"
+                        "stmt0": "py_shadow_*_result",
+                        "stmt1": "py_shadow_*_result"
                     }
                 },
                 "ast": {
@@ -3079,8 +3079,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_shadow_result",
-                        "stmt1": "py_shadow_result"
+                        "stmt0": "py_shadow_*_result",
+                        "stmt1": "py_shadow_*_result"
                     }
                 },
                 "ast": {

--- a/regression/reference/ownership/pyownershipmodule.cpp
+++ b/regression/reference/ownership/pyownershipmodule.cpp
@@ -340,7 +340,7 @@ PY_createClassStatic(
 
 // ----------------------------------------
 // Function:  Class1 * getClassStatic +owner(library)
-// Exact:     py_shadow_result
+// Exact:     py_shadow_*_result
 static char PY_getClassStatic__doc__[] =
 "documentation"
 ;
@@ -364,7 +364,7 @@ PY_getClassStatic(
 
 // ----------------------------------------
 // Function:  Class1 * getClassNew +owner(caller)
-// Exact:     py_shadow_result
+// Exact:     py_shadow_*_result
 // ----------------------------------------
 // Argument:  int flag +intent(in)+value
 // Requested: py_native_scalar_in

--- a/regression/reference/ownership/pyownershiputil.cpp
+++ b/regression/reference/ownership/pyownershiputil.cpp
@@ -8,6 +8,20 @@
 //
 #include "pyownershipmodule.hpp"
 
+#ifdef __cplusplus
+#define SHROUD_UNUSED(param)
+#else
+#define SHROUD_UNUSED(param) param
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+#define PyInt_AsLong PyLong_AsLong
+#define PyInt_FromLong PyLong_FromLong
+#define PyInt_FromSize_t PyLong_FromSize_t
+#define PyString_FromString PyUnicode_FromString
+#define PyString_FromStringAndSize PyUnicode_FromStringAndSize
+#endif
+
 const char *PY_Class1_capsule_name = "Class1";
 
 

--- a/regression/reference/pointers-list-c/pointers.json
+++ b/regression/reference/pointers-list-c/pointers.json
@@ -2745,8 +2745,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_void_result",
-                        "stmt1": "py_void_result"
+                        "stmt0": "py_void_*_result",
+                        "stmt1": "py_void_*_result"
                     }
                 },
                 "ast": {
@@ -2826,8 +2826,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_void_result",
-                        "stmt1": "py_void_result"
+                        "stmt0": "py_void_*_result",
+                        "stmt1": "py_void_*_result"
                     }
                 },
                 "ast": {

--- a/regression/reference/pointers-list-c/pypointersmodule.c
+++ b/regression/reference/pointers-list-c/pypointersmodule.c
@@ -27,10 +27,10 @@
 #endif
 
 // helper create_from_PyObject_char
-// Convert obj into an array of type char *
+// Convert obj into an array of type char *.
 // Return -1 on error.
 static int SHROUD_create_from_PyObject_char(PyObject *obj,
-    const char *name, char * **pin, Py_ssize_t *psize)
+    const char *name, char ***pin, Py_ssize_t *psize)
 {
     PyObject *seq = PySequence_Fast(obj, "holder");
     if (seq == NULL) {
@@ -39,7 +39,7 @@ static int SHROUD_create_from_PyObject_char(PyObject *obj,
         return -1;
     }
     Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
-    char * *in = (char * *) malloc(size * sizeof(char *));
+    char **in = (char **) calloc(size, sizeof(char *));
     for (Py_ssize_t i = 0; i < size; i++) {
         PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
         in[i] = PyString_AsString(item);

--- a/regression/reference/pointers-list-c/pypointersmodule.c
+++ b/regression/reference/pointers-list-c/pypointersmodule.c
@@ -1349,7 +1349,7 @@ PY_getRawPtrToFixedArray(
 
 // ----------------------------------------
 // Function:  void * returnAddress1
-// Exact:     py_void_result
+// Exact:     py_void_*_result
 // ----------------------------------------
 // Argument:  int flag +intent(in)+value
 // Requested: py_native_scalar_in
@@ -1386,7 +1386,7 @@ PY_returnAddress1(
 
 // ----------------------------------------
 // Function:  void * returnAddress2
-// Exact:     py_void_result
+// Exact:     py_void_*_result
 // ----------------------------------------
 // Argument:  int flag +intent(in)+value
 // Requested: py_native_scalar_in

--- a/regression/reference/pointers-list-cxx/pointers.json
+++ b/regression/reference/pointers-list-cxx/pointers.json
@@ -2745,8 +2745,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_void_result",
-                        "stmt1": "py_void_result"
+                        "stmt0": "py_void_*_result",
+                        "stmt1": "py_void_*_result"
                     }
                 },
                 "ast": {
@@ -2826,8 +2826,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_void_result",
-                        "stmt1": "py_void_result"
+                        "stmt0": "py_void_*_result",
+                        "stmt1": "py_void_*_result"
                     }
                 },
                 "ast": {

--- a/regression/reference/pointers-list-cxx/pypointersmodule.cpp
+++ b/regression/reference/pointers-list-cxx/pypointersmodule.cpp
@@ -1352,7 +1352,7 @@ PY_getRawPtrToFixedArray(
 
 // ----------------------------------------
 // Function:  void * returnAddress1
-// Exact:     py_void_result
+// Exact:     py_void_*_result
 // ----------------------------------------
 // Argument:  int flag +intent(in)+value
 // Requested: py_native_scalar_in
@@ -1389,7 +1389,7 @@ PY_returnAddress1(
 
 // ----------------------------------------
 // Function:  void * returnAddress2
-// Exact:     py_void_result
+// Exact:     py_void_*_result
 // ----------------------------------------
 // Argument:  int flag +intent(in)+value
 // Requested: py_native_scalar_in

--- a/regression/reference/pointers-list-cxx/pypointersmodule.cpp
+++ b/regression/reference/pointers-list-cxx/pypointersmodule.cpp
@@ -27,10 +27,10 @@
 #endif
 
 // helper create_from_PyObject_char
-// Convert obj into an array of type char *
+// Convert obj into an array of type char *.
 // Return -1 on error.
 static int SHROUD_create_from_PyObject_char(PyObject *obj,
-    const char *name, char * **pin, Py_ssize_t *psize)
+    const char *name, char ***pin, Py_ssize_t *psize)
 {
     PyObject *seq = PySequence_Fast(obj, "holder");
     if (seq == NULL) {
@@ -39,8 +39,7 @@ static int SHROUD_create_from_PyObject_char(PyObject *obj,
         return -1;
     }
     Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
-    char * *in = static_cast<char * *>
-        (std::malloc(size * sizeof(char *)));
+    char **in = static_cast<char **>(std::calloc(size, sizeof(char *)));
     for (Py_ssize_t i = 0; i < size; i++) {
         PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
         in[i] = PyString_AsString(item);

--- a/regression/reference/pointers-numpy-c/pointers.json
+++ b/regression/reference/pointers-numpy-c/pointers.json
@@ -2724,8 +2724,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_void_result",
-                        "stmt1": "py_void_result"
+                        "stmt0": "py_void_*_result",
+                        "stmt1": "py_void_*_result"
                     }
                 },
                 "ast": {
@@ -2805,8 +2805,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_void_result",
-                        "stmt1": "py_void_result"
+                        "stmt0": "py_void_*_result",
+                        "stmt1": "py_void_*_result"
                     }
                 },
                 "ast": {

--- a/regression/reference/pointers-numpy-c/pypointersmodule.c
+++ b/regression/reference/pointers-numpy-c/pypointersmodule.c
@@ -30,10 +30,10 @@
 #endif
 
 // helper create_from_PyObject_char
-// Convert obj into an array of type char *
+// Convert obj into an array of type char *.
 // Return -1 on error.
 static int SHROUD_create_from_PyObject_char(PyObject *obj,
-    const char *name, char * **pin, Py_ssize_t *psize)
+    const char *name, char ***pin, Py_ssize_t *psize)
 {
     PyObject *seq = PySequence_Fast(obj, "holder");
     if (seq == NULL) {
@@ -42,7 +42,7 @@ static int SHROUD_create_from_PyObject_char(PyObject *obj,
         return -1;
     }
     Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
-    char * *in = (char * *) malloc(size * sizeof(char *));
+    char **in = (char **) calloc(size, sizeof(char *));
     for (Py_ssize_t i = 0; i < size; i++) {
         PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
         in[i] = PyString_AsString(item);

--- a/regression/reference/pointers-numpy-c/pypointersmodule.c
+++ b/regression/reference/pointers-numpy-c/pypointersmodule.c
@@ -1273,7 +1273,7 @@ PY_getRawPtrToFixedArray(
 
 // ----------------------------------------
 // Function:  void * returnAddress1
-// Exact:     py_void_result
+// Exact:     py_void_*_result
 // ----------------------------------------
 // Argument:  int flag +intent(in)+value
 // Requested: py_native_scalar_in
@@ -1310,7 +1310,7 @@ PY_returnAddress1(
 
 // ----------------------------------------
 // Function:  void * returnAddress2
-// Exact:     py_void_result
+// Exact:     py_void_*_result
 // ----------------------------------------
 // Argument:  int flag +intent(in)+value
 // Requested: py_native_scalar_in

--- a/regression/reference/pointers-numpy-cxx/pointers.json
+++ b/regression/reference/pointers-numpy-cxx/pointers.json
@@ -2724,8 +2724,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_void_result",
-                        "stmt1": "py_void_result"
+                        "stmt0": "py_void_*_result",
+                        "stmt1": "py_void_*_result"
                     }
                 },
                 "ast": {
@@ -2805,8 +2805,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_void_result",
-                        "stmt1": "py_void_result"
+                        "stmt0": "py_void_*_result",
+                        "stmt1": "py_void_*_result"
                     }
                 },
                 "ast": {

--- a/regression/reference/pointers-numpy-cxx/pypointersmodule.cpp
+++ b/regression/reference/pointers-numpy-cxx/pypointersmodule.cpp
@@ -30,10 +30,10 @@
 #endif
 
 // helper create_from_PyObject_char
-// Convert obj into an array of type char *
+// Convert obj into an array of type char *.
 // Return -1 on error.
 static int SHROUD_create_from_PyObject_char(PyObject *obj,
-    const char *name, char * **pin, Py_ssize_t *psize)
+    const char *name, char ***pin, Py_ssize_t *psize)
 {
     PyObject *seq = PySequence_Fast(obj, "holder");
     if (seq == NULL) {
@@ -42,8 +42,7 @@ static int SHROUD_create_from_PyObject_char(PyObject *obj,
         return -1;
     }
     Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
-    char * *in = static_cast<char * *>
-        (std::malloc(size * sizeof(char *)));
+    char **in = static_cast<char **>(std::calloc(size, sizeof(char *)));
     for (Py_ssize_t i = 0; i < size; i++) {
         PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
         in[i] = PyString_AsString(item);

--- a/regression/reference/pointers-numpy-cxx/pypointersmodule.cpp
+++ b/regression/reference/pointers-numpy-cxx/pypointersmodule.cpp
@@ -1282,7 +1282,7 @@ PY_getRawPtrToFixedArray(
 
 // ----------------------------------------
 // Function:  void * returnAddress1
-// Exact:     py_void_result
+// Exact:     py_void_*_result
 // ----------------------------------------
 // Argument:  int flag +intent(in)+value
 // Requested: py_native_scalar_in
@@ -1319,7 +1319,7 @@ PY_returnAddress1(
 
 // ----------------------------------------
 // Function:  void * returnAddress2
-// Exact:     py_void_result
+// Exact:     py_void_*_result
 // ----------------------------------------
 // Argument:  int flag +intent(in)+value
 // Requested: py_native_scalar_in

--- a/regression/reference/preprocess/pypreprocessutil.cpp
+++ b/regression/reference/preprocess/pypreprocessutil.cpp
@@ -8,6 +8,20 @@
 //
 #include "pypreprocessmodule.hpp"
 
+#ifdef __cplusplus
+#define SHROUD_UNUSED(param)
+#else
+#define SHROUD_UNUSED(param) param
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+#define PyInt_AsLong PyLong_AsLong
+#define PyInt_FromLong PyLong_FromLong
+#define PyInt_FromSize_t PyLong_FromSize_t
+#define PyString_FromString PyUnicode_FromString
+#define PyString_FromStringAndSize PyUnicode_FromStringAndSize
+#endif
+
 const char *PY_User1_capsule_name = "User1";
 #ifdef USE_USER2
 const char *PY_User2_capsule_name = "User2";

--- a/regression/reference/strings/pystringsmodule.cpp
+++ b/regression/reference/strings/pystringsmodule.cpp
@@ -68,8 +68,7 @@ PyObject *PY_error_obj;
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  char status +intent(in)+value
-// Requested: py_schar_scalar_in
-// Match:     py_default
+// Exact:     py_char_scalar_in
 static char PY_passChar__doc__[] =
 "documentation"
 ;
@@ -85,24 +84,23 @@ PY_passChar(
   PyObject *kwds)
 {
 // splicer begin function.pass_char
-    char status;
+    char *status;
     const char *SHT_kwlist[] = {
         "status",
         nullptr };
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "c:passChar",
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "s:passChar",
         const_cast<char **>(SHT_kwlist), &status))
         return nullptr;
 
-    passChar(status);
+    passChar(status[0]);
     Py_RETURN_NONE;
 // splicer end function.pass_char
 }
 
 // ----------------------------------------
 // Function:  char returnChar
-// Requested: py_schar_scalar_result
-// Match:     py_default
+// Exact:     py_char_scalar_result
 static char PY_returnChar__doc__[] =
 "documentation"
 ;
@@ -1114,8 +1112,7 @@ PY_explicit1(
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  char status +intent(in)+value
-// Requested: py_schar_scalar_in
-// Match:     py_default
+// Exact:     py_char_scalar_in
 static char PY_CpassChar__doc__[] =
 "documentation"
 ;
@@ -1131,24 +1128,23 @@ PY_CpassChar(
   PyObject *kwds)
 {
 // splicer begin function.cpass_char
-    char status;
+    char *status;
     const char *SHT_kwlist[] = {
         "status",
         nullptr };
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "c:CpassChar",
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "s:CpassChar",
         const_cast<char **>(SHT_kwlist), &status))
         return nullptr;
 
-    CpassChar(status);
+    CpassChar(status[0]);
     Py_RETURN_NONE;
 // splicer end function.cpass_char
 }
 
 // ----------------------------------------
 // Function:  char CreturnChar
-// Requested: py_schar_scalar_result
-// Match:     py_default
+// Exact:     py_char_scalar_result
 static char PY_CreturnChar__doc__[] =
 "documentation"
 ;

--- a/regression/reference/strings/pystringsmodule.cpp
+++ b/regression/reference/strings/pystringsmodule.cpp
@@ -101,7 +101,7 @@ PY_passChar(
 
 // ----------------------------------------
 // Function:  char returnChar
-// Requested: py_schar_result
+// Requested: py_schar_scalar_result
 // Match:     py_default
 static char PY_returnChar__doc__[] =
 "documentation"
@@ -220,7 +220,7 @@ PY_passCharPtrInOut(
 
 // ----------------------------------------
 // Function:  const char * getCharPtr1 +deref(allocatable)
-// Exact:     py_char_result
+// Exact:     py_char_*_result
 static char PY_getCharPtr1__doc__[] =
 "documentation"
 ;
@@ -249,7 +249,7 @@ PY_getCharPtr1(
 
 // ----------------------------------------
 // Function:  const char * getCharPtr2 +deref(result-as-arg)+len(30)
-// Exact:     py_char_result
+// Exact:     py_char_*_result
 static char PY_getCharPtr2__doc__[] =
 "documentation"
 ;
@@ -278,7 +278,7 @@ PY_getCharPtr2(
 
 // ----------------------------------------
 // Function:  const char * getCharPtr3 +deref(result-as-arg)
-// Exact:     py_char_result
+// Exact:     py_char_*_result
 static char PY_getCharPtr3__doc__[] =
 "documentation"
 ;
@@ -307,7 +307,7 @@ PY_getCharPtr3(
 
 // ----------------------------------------
 // Function:  const string getConstStringResult +deref(allocatable)
-// Exact:     py_string_result
+// Exact:     py_string_scalar_result
 static char PY_getConstStringResult__doc__[] =
 "documentation"
 ;
@@ -337,7 +337,7 @@ PY_getConstStringResult(
 
 // ----------------------------------------
 // Function:  const string getConstStringLen +deref(result-as-arg)+len(30)
-// Exact:     py_string_result
+// Exact:     py_string_scalar_result
 static char PY_getConstStringLen__doc__[] =
 "documentation"
 ;
@@ -367,7 +367,7 @@ PY_getConstStringLen(
 
 // ----------------------------------------
 // Function:  const string getConstStringAsArg +deref(result-as-arg)
-// Exact:     py_string_result
+// Exact:     py_string_scalar_result
 static char PY_getConstStringAsArg__doc__[] =
 "documentation"
 ;
@@ -397,7 +397,7 @@ PY_getConstStringAsArg(
 
 // ----------------------------------------
 // Function:  const std::string getConstStringAlloc +deref(allocatable)
-// Exact:     py_string_result
+// Exact:     py_string_scalar_result
 static char PY_getConstStringAlloc__doc__[] =
 "documentation"
 ;
@@ -423,7 +423,7 @@ PY_getConstStringAlloc(
 
 // ----------------------------------------
 // Function:  const string & getConstStringRefPure +deref(allocatable)
-// Exact:     py_string_result
+// Exact:     py_string_&_result
 static char PY_getConstStringRefPure__doc__[] =
 "documentation"
 ;
@@ -453,7 +453,7 @@ PY_getConstStringRefPure(
 
 // ----------------------------------------
 // Function:  const string & getConstStringRefLen +deref(result-as-arg)+len(30)
-// Exact:     py_string_result
+// Exact:     py_string_&_result
 static char PY_getConstStringRefLen__doc__[] =
 "documentation"
 ;
@@ -486,7 +486,7 @@ PY_getConstStringRefLen(
 
 // ----------------------------------------
 // Function:  const string & getConstStringRefAsArg +deref(result-as-arg)
-// Exact:     py_string_result
+// Exact:     py_string_&_result
 static char PY_getConstStringRefAsArg__doc__[] =
 "documentation"
 ;
@@ -518,7 +518,7 @@ PY_getConstStringRefAsArg(
 
 // ----------------------------------------
 // Function:  const string & getConstStringRefLenEmpty +deref(result-as-arg)+len(30)
-// Exact:     py_string_result
+// Exact:     py_string_&_result
 static char PY_getConstStringRefLenEmpty__doc__[] =
 "documentation"
 ;
@@ -548,7 +548,7 @@ PY_getConstStringRefLenEmpty(
 
 // ----------------------------------------
 // Function:  const std::string & getConstStringRefAlloc +deref(allocatable)
-// Exact:     py_string_result
+// Exact:     py_string_&_result
 static char PY_getConstStringRefAlloc__doc__[] =
 "documentation"
 ;
@@ -574,7 +574,7 @@ PY_getConstStringRefAlloc(
 
 // ----------------------------------------
 // Function:  const string * getConstStringPtrLen +deref(result-as-arg)+len(30)
-// Exact:     py_string_result
+// Exact:     py_string_*_result
 static char PY_getConstStringPtrLen__doc__[] =
 "documentation"
 ;
@@ -608,7 +608,7 @@ PY_getConstStringPtrLen(
 
 // ----------------------------------------
 // Function:  const std::string * getConstStringPtrAlloc +deref(allocatable)+owner(library)
-// Exact:     py_string_result
+// Exact:     py_string_*_result
 static char PY_getConstStringPtrAlloc__doc__[] =
 "documentation"
 ;
@@ -634,7 +634,7 @@ PY_getConstStringPtrAlloc(
 
 // ----------------------------------------
 // Function:  const std::string * getConstStringPtrOwnsAlloc +deref(allocatable)+owner(caller)
-// Exact:     py_string_result
+// Exact:     py_string_*_result
 static char PY_getConstStringPtrOwnsAlloc__doc__[] =
 "documentation"
 ;
@@ -667,7 +667,7 @@ PY_getConstStringPtrOwnsAlloc(
 
 // ----------------------------------------
 // Function:  const std::string * getConstStringPtrOwnsAllocPattern +deref(allocatable)+free_pattern(C_string_free)+owner(caller)
-// Exact:     py_string_result
+// Exact:     py_string_*_result
 static char PY_getConstStringPtrOwnsAllocPattern__doc__[] =
 "documentation"
 ;
@@ -699,8 +699,7 @@ PY_getConstStringPtrOwnsAllocPattern(
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  const std::string & arg1 +intent(in)
-// Requested: py_string_&_in
-// Match:     py_string_in
+// Exact:     py_string_&_in
 static char PY_acceptStringConstReference__doc__[] =
 "documentation"
 ;
@@ -742,8 +741,7 @@ PY_acceptStringConstReference(
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  std::string & arg1 +intent(out)
-// Requested: py_string_&_out
-// Match:     py_string_out
+// Exact:     py_string_&_out
 static char PY_acceptStringReferenceOut__doc__[] =
 "documentation"
 ;
@@ -782,8 +780,7 @@ PY_acceptStringReferenceOut(
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  std::string & arg1 +intent(inout)
-// Requested: py_string_&_inout
-// Match:     py_string_inout
+// Exact:     py_string_&_inout
 static char PY_acceptStringReference__doc__[] =
 "documentation"
 ;
@@ -1046,12 +1043,10 @@ PY_fetchStringPointerLen(
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  std::string & arg1 +intent(out)
-// Requested: py_string_&_out
-// Match:     py_string_out
+// Exact:     py_string_&_out
 // ----------------------------------------
 // Argument:  std::string & arg2 +intent(out)
-// Requested: py_string_&_out
-// Match:     py_string_out
+// Exact:     py_string_&_out
 static char PY_returnStrings__doc__[] =
 "documentation"
 ;
@@ -1152,7 +1147,7 @@ PY_CpassChar(
 
 // ----------------------------------------
 // Function:  char CreturnChar
-// Requested: py_schar_result
+// Requested: py_schar_scalar_result
 // Match:     py_default
 static char PY_CreturnChar__doc__[] =
 "documentation"
@@ -1188,8 +1183,7 @@ PY_CreturnChar(
 // Exact:     py_native_*_in_pointer_list
 // ----------------------------------------
 // Argument:  std::string & name +intent(inout)
-// Requested: py_string_&_inout
-// Match:     py_string_inout
+// Exact:     py_string_&_inout
 static char PY_PostDeclare__doc__[] =
 "documentation"
 ;

--- a/regression/reference/strings/strings.json
+++ b/regression/reference/strings/strings.json
@@ -479,7 +479,7 @@
                             "idtor": "0",
                             "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_*_out_buf",
-                            "stmt1": "c_char_out_buf"
+                            "stmt1": "c_char_*_out_buf"
                         },
                         "fmtf": {
                             "F_pointer": "SHPTR_dest",
@@ -492,7 +492,7 @@
                             "stmt0": "f_char_*_out",
                             "stmt1": "f_default",
                             "stmtc0": "c_char_*_out_buf",
-                            "stmtc1": "c_char_out_buf"
+                            "stmtc1": "c_char_*_out_buf"
                         }
                     },
                     "src": {
@@ -718,7 +718,7 @@
                             "idtor": "0",
                             "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_*_inout_buf",
-                            "stmt1": "c_char_inout_buf"
+                            "stmt1": "c_char_*_inout_buf"
                         },
                         "fmtf": {
                             "F_pointer": "SHPTR_s",
@@ -732,7 +732,7 @@
                             "stmt0": "f_char_*_inout",
                             "stmt1": "f_default",
                             "stmtc0": "c_char_*_inout_buf",
-                            "stmtc1": "c_char_inout_buf"
+                            "stmtc1": "c_char_*_inout_buf"
                         }
                     }
                 },
@@ -809,7 +809,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "c_char_*_result",
-                        "stmt1": "c_char_result"
+                        "stmt1": "c_char_*_result"
                     },
                     "fmtf": {
                         "cxx_type": "char",
@@ -819,7 +819,7 @@
                         "stmt0": "f_char_scalar_result_allocatable",
                         "stmt1": "f_char_scalar_result_allocatable",
                         "stmtc0": "c_char_scalar_result_buf",
-                        "stmtc1": "c_char_result_buf"
+                        "stmtc1": "c_default"
                     },
                     "fmtpy": {
                         "array_size": "1",
@@ -903,7 +903,7 @@
                             "idtor": "0",
                             "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_*_result_buf_allocatable",
-                            "stmt1": "c_char_result_buf_allocatable"
+                            "stmt1": "c_char_*_result_buf_allocatable"
                         },
                         "fmtf": {
                             "F_pointer": "SHPTR_SHF_rv",
@@ -916,7 +916,7 @@
                             "stmt0": "f_char_*_result_allocatable",
                             "stmt1": "f_char_*_result_allocatable",
                             "stmtc0": "c_char_*_result_buf_allocatable",
-                            "stmtc1": "c_char_result_buf_allocatable"
+                            "stmtc1": "c_char_*_result_buf_allocatable"
                         }
                     }
                 },
@@ -1008,7 +1008,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "c_char_*_result",
-                        "stmt1": "c_char_result"
+                        "stmt1": "c_char_*_result"
                     },
                     "fmtf": {
                         "c_var_len": "30",
@@ -1019,7 +1019,7 @@
                         "stmt0": "f_char_scalar_result_result-as-arg",
                         "stmt1": "f_default",
                         "stmtc0": "c_char_scalar_result_buf",
-                        "stmtc1": "c_char_result_buf"
+                        "stmtc1": "c_default"
                     },
                     "fmtpy": {
                         "array_size": "1",
@@ -1104,7 +1104,7 @@
                             "idtor": "0",
                             "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_*_result_buf",
-                            "stmt1": "c_char_result_buf"
+                            "stmt1": "c_char_*_result_buf"
                         },
                         "fmtf": {
                             "F_pointer": "SHPTR_SHF_rv",
@@ -1117,7 +1117,7 @@
                             "stmt0": "f_char_*_result",
                             "stmt1": "f_default",
                             "stmtc0": "c_char_*_result_buf",
-                            "stmtc1": "c_char_result_buf"
+                            "stmtc1": "c_char_*_result_buf"
                         }
                     }
                 },
@@ -1210,7 +1210,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "c_char_*_result",
-                        "stmt1": "c_char_result"
+                        "stmt1": "c_char_*_result"
                     },
                     "fmtpy": {
                         "array_size": "1",
@@ -1288,7 +1288,7 @@
                             "idtor": "0",
                             "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_*_result_buf",
-                            "stmt1": "c_char_result_buf"
+                            "stmt1": "c_char_*_result_buf"
                         },
                         "fmtf": {
                             "F_pointer": "SHPTR_output",
@@ -1301,7 +1301,7 @@
                             "stmt0": "f_char_*_result",
                             "stmt1": "f_default",
                             "stmtc0": "c_char_*_result_buf",
-                            "stmtc1": "c_char_result_buf"
+                            "stmtc1": "c_char_*_result_buf"
                         }
                     }
                 },
@@ -1454,7 +1454,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "c_char_*_result",
-                        "stmt1": "c_char_result"
+                        "stmt1": "c_char_*_result"
                     },
                     "fmtf": {
                         "cxx_type": "char",
@@ -1464,7 +1464,7 @@
                         "stmt0": "f_char_*_result_raw",
                         "stmt1": "f_char_*_result_raw",
                         "stmtc0": "c_char_*_result",
-                        "stmtc1": "c_char_result"
+                        "stmtc1": "c_char_*_result"
                     }
                 },
                 "ast": {
@@ -6193,7 +6193,7 @@
                             "idtor": "0",
                             "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_*_out_buf",
-                            "stmt1": "c_char_out_buf"
+                            "stmt1": "c_char_*_out_buf"
                         },
                         "fmtf": {
                             "F_pointer": "SHPTR_name",
@@ -6206,7 +6206,7 @@
                             "stmt0": "f_char_*_out",
                             "stmt1": "f_default",
                             "stmtc0": "c_char_*_out_buf",
-                            "stmtc1": "c_char_out_buf"
+                            "stmtc1": "c_char_*_out_buf"
                         }
                     }
                 },
@@ -6695,7 +6695,7 @@
                             "idtor": "0",
                             "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_*_out_buf",
-                            "stmt1": "c_char_out_buf"
+                            "stmt1": "c_char_*_out_buf"
                         },
                         "fmtf": {
                             "F_pointer": "SHPTR_dest",
@@ -6708,7 +6708,7 @@
                             "stmt0": "f_char_*_out",
                             "stmt1": "f_default",
                             "stmtc0": "c_char_*_out_buf",
-                            "stmtc1": "c_char_out_buf"
+                            "stmtc1": "c_char_*_out_buf"
                         }
                     },
                     "src": {

--- a/regression/reference/strings/strings.json
+++ b/regression/reference/strings/strings.json
@@ -29,20 +29,20 @@
                             "cxx_var": "status",
                             "idtor": "0",
                             "sh_type": "SH_TYPE_OTHER",
-                            "stmt0": "c_schar_scalar_in",
-                            "stmt1": "c_default"
+                            "stmt0": "c_char_scalar_in",
+                            "stmt1": "c_char_scalar_in"
                         },
                         "fmtf": {
                             "F_pointer": "SHPTR_status",
                             "c_var": "status",
                             "f_intent": "IN",
-                            "f_type": "character",
+                            "f_type": "character(*)",
                             "f_var": "status",
                             "sh_type": "SH_TYPE_OTHER",
-                            "stmt0": "f_schar_scalar_in",
+                            "stmt0": "f_char_scalar_in",
                             "stmt1": "f_default",
-                            "stmtc0": "c_schar_scalar_in",
-                            "stmtc1": "c_default"
+                            "stmtc0": "c_char_scalar_in",
+                            "stmtc1": "c_char_scalar_in"
                         },
                         "fmtpy": {
                             "c_const": "",
@@ -56,11 +56,12 @@
                             "cxx_type": "char",
                             "cxx_var": "status",
                             "data_var": "SHData_status",
-                            "numpy_type": null,
+                            "numpy_type": "NPY_INTP",
                             "py_var": "SHPy_status",
+                            "pytmp_var": "SHTPy_status",
                             "size_var": "SHSize_status",
-                            "stmt0": "py_schar_scalar_in",
-                            "stmt1": "py_default"
+                            "stmt0": "py_char_scalar_in",
+                            "stmt1": "py_char_scalar_in"
                         }
                     }
                 },
@@ -82,7 +83,7 @@
                             "specifier": [
                                 "char"
                             ],
-                            "typemap_name": "char_scalar"
+                            "typemap_name": "char"
                         }
                     ],
                     "specifier": [
@@ -132,18 +133,18 @@
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
                         "sh_type": "SH_TYPE_OTHER",
-                        "stmt0": "c_schar_scalar_result",
-                        "stmt1": "c_default"
+                        "stmt0": "c_char_scalar_result",
+                        "stmt1": "c_char_scalar_result"
                     },
                     "fmtf": {
                         "cxx_type": "char",
-                        "f_type": "character",
+                        "f_type": "character(*)",
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_OTHER",
-                        "stmt0": "f_schar_scalar_result",
+                        "stmt0": "f_char_scalar_result",
                         "stmt1": "f_default",
-                        "stmtc0": "c_schar_scalar_result_buf",
-                        "stmtc1": "c_schar_result_buf"
+                        "stmtc0": "c_char_scalar_result_buf",
+                        "stmtc1": "c_char_scalar_result_buf"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -155,11 +156,11 @@
                         "cxx_type": "char",
                         "cxx_var": "SHCXX_rv",
                         "data_var": "SHData_rv",
-                        "numpy_type": null,
+                        "numpy_type": "NPY_INTP",
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_schar_scalar_result",
-                        "stmt1": "py_default"
+                        "stmt0": "py_char_scalar_result",
+                        "stmt1": "py_char_scalar_result"
                     }
                 },
                 "ast": {
@@ -171,7 +172,7 @@
                     "specifier": [
                         "char"
                     ],
-                    "typemap_name": "char_scalar"
+                    "typemap_name": "char"
                 },
                 "decl": "char returnChar()",
                 "declgen": "char returnChar()",
@@ -215,21 +216,21 @@
                             "cxx_var": "SHC_rv",
                             "idtor": "0",
                             "sh_type": "SH_TYPE_OTHER",
-                            "stmt0": "c_schar_scalar_result_buf",
-                            "stmt1": "c_schar_result_buf"
+                            "stmt0": "c_char_scalar_result_buf",
+                            "stmt1": "c_char_scalar_result_buf"
                         },
                         "fmtf": {
                             "F_pointer": "SHPTR_SHF_rv",
                             "c_var": "SHT_rv",
                             "c_var_len": "NSHF_rv",
                             "f_intent": "OUT",
-                            "f_type": "character",
+                            "f_type": "character(*)",
                             "f_var": "SHT_rv",
                             "sh_type": "SH_TYPE_OTHER",
-                            "stmt0": "f_schar_*_result",
+                            "stmt0": "f_char_*_result",
                             "stmt1": "f_default",
-                            "stmtc0": "c_schar_*_result_buf",
-                            "stmtc1": "c_schar_result_buf"
+                            "stmtc0": "c_char_*_result_buf",
+                            "stmtc1": "c_char_*_result_buf"
                         }
                     }
                 },
@@ -272,7 +273,7 @@
                             "specifier": [
                                 "char"
                             ],
-                            "typemap_name": "char_scalar"
+                            "typemap_name": "char"
                         }
                     ],
                     "specifier": [
@@ -819,7 +820,7 @@
                         "stmt0": "f_char_scalar_result_allocatable",
                         "stmt1": "f_char_scalar_result_allocatable",
                         "stmtc0": "c_char_scalar_result_buf",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_char_scalar_result_buf"
                     },
                     "fmtpy": {
                         "array_size": "1",
@@ -1019,7 +1020,7 @@
                         "stmt0": "f_char_scalar_result_result-as-arg",
                         "stmt1": "f_default",
                         "stmtc0": "c_char_scalar_result_buf",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_char_scalar_result_buf"
                     },
                     "fmtpy": {
                         "array_size": "1",
@@ -6280,20 +6281,20 @@
                             "cxx_var": "status",
                             "idtor": "0",
                             "sh_type": "SH_TYPE_OTHER",
-                            "stmt0": "c_schar_scalar_in",
-                            "stmt1": "c_default"
+                            "stmt0": "c_char_scalar_in",
+                            "stmt1": "c_char_scalar_in"
                         },
                         "fmtf": {
                             "F_pointer": "SHPTR_status",
                             "c_var": "status",
                             "f_intent": "IN",
-                            "f_type": "character",
+                            "f_type": "character(*)",
                             "f_var": "status",
                             "sh_type": "SH_TYPE_OTHER",
-                            "stmt0": "f_schar_scalar_in",
+                            "stmt0": "f_char_scalar_in",
                             "stmt1": "f_default",
-                            "stmtc0": "c_schar_scalar_in",
-                            "stmtc1": "c_default"
+                            "stmtc0": "c_char_scalar_in",
+                            "stmtc1": "c_char_scalar_in"
                         },
                         "fmtpy": {
                             "c_const": "",
@@ -6307,11 +6308,12 @@
                             "cxx_type": "char",
                             "cxx_var": "status",
                             "data_var": "SHData_status",
-                            "numpy_type": null,
+                            "numpy_type": "NPY_INTP",
                             "py_var": "SHPy_status",
+                            "pytmp_var": "SHTPy_status",
                             "size_var": "SHSize_status",
-                            "stmt0": "py_schar_scalar_in",
-                            "stmt1": "py_default"
+                            "stmt0": "py_char_scalar_in",
+                            "stmt1": "py_char_scalar_in"
                         }
                     }
                 },
@@ -6333,7 +6335,7 @@
                             "specifier": [
                                 "char"
                             ],
-                            "typemap_name": "char_scalar"
+                            "typemap_name": "char"
                         }
                     ],
                     "specifier": [
@@ -6385,18 +6387,18 @@
                         "cxx_var": "SHC_rv",
                         "idtor": "0",
                         "sh_type": "SH_TYPE_OTHER",
-                        "stmt0": "c_schar_scalar_result",
-                        "stmt1": "c_default"
+                        "stmt0": "c_char_scalar_result",
+                        "stmt1": "c_char_scalar_result"
                     },
                     "fmtf": {
                         "cxx_type": "char",
-                        "f_type": "character",
+                        "f_type": "character(*)",
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_OTHER",
-                        "stmt0": "f_schar_scalar_result",
+                        "stmt0": "f_char_scalar_result",
                         "stmt1": "f_default",
-                        "stmtc0": "c_schar_scalar_result_buf",
-                        "stmtc1": "c_schar_result_buf"
+                        "stmtc0": "c_char_scalar_result_buf",
+                        "stmtc1": "c_char_scalar_result_buf"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -6408,11 +6410,11 @@
                         "cxx_type": "char",
                         "cxx_var": "SHCXX_rv",
                         "data_var": "SHData_rv",
-                        "numpy_type": null,
+                        "numpy_type": "NPY_INTP",
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_schar_scalar_result",
-                        "stmt1": "py_default"
+                        "stmt0": "py_char_scalar_result",
+                        "stmt1": "py_char_scalar_result"
                     }
                 },
                 "ast": {
@@ -6424,7 +6426,7 @@
                     "specifier": [
                         "char"
                     ],
-                    "typemap_name": "char_scalar"
+                    "typemap_name": "char"
                 },
                 "decl": "char CreturnChar()",
                 "declgen": "char CreturnChar()",
@@ -6470,21 +6472,21 @@
                             "cxx_var": "SHC_rv",
                             "idtor": "0",
                             "sh_type": "SH_TYPE_OTHER",
-                            "stmt0": "c_schar_scalar_result_buf",
-                            "stmt1": "c_schar_result_buf"
+                            "stmt0": "c_char_scalar_result_buf",
+                            "stmt1": "c_char_scalar_result_buf"
                         },
                         "fmtf": {
                             "F_pointer": "SHPTR_SHF_rv",
                             "c_var": "SHT_rv",
                             "c_var_len": "NSHF_rv",
                             "f_intent": "OUT",
-                            "f_type": "character",
+                            "f_type": "character(*)",
                             "f_var": "SHT_rv",
                             "sh_type": "SH_TYPE_OTHER",
-                            "stmt0": "f_schar_*_result",
+                            "stmt0": "f_char_*_result",
                             "stmt1": "f_default",
-                            "stmtc0": "c_schar_*_result_buf",
-                            "stmtc1": "c_schar_result_buf"
+                            "stmtc0": "c_char_*_result_buf",
+                            "stmtc1": "c_char_*_result_buf"
                         }
                     }
                 },
@@ -6527,7 +6529,7 @@
                             "specifier": [
                                 "char"
                             ],
-                            "typemap_name": "char_scalar"
+                            "typemap_name": "char"
                         }
                     ],
                     "specifier": [

--- a/regression/reference/strings/strings.json
+++ b/regression/reference/strings/strings.json
@@ -158,7 +158,7 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_schar_result",
+                        "stmt0": "py_schar_scalar_result",
                         "stmt1": "py_default"
                     }
                 },
@@ -835,8 +835,8 @@
                         "numpy_type": "NPY_INTP",
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_char_result",
-                        "stmt1": "py_char_result"
+                        "stmt0": "py_char_*_result",
+                        "stmt1": "py_char_*_result"
                     }
                 },
                 "ast": {
@@ -1035,8 +1035,8 @@
                         "numpy_type": "NPY_INTP",
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_char_result",
-                        "stmt1": "py_char_result"
+                        "stmt0": "py_char_*_result",
+                        "stmt1": "py_char_*_result"
                     }
                 },
                 "ast": {
@@ -1226,8 +1226,8 @@
                         "numpy_type": "NPY_INTP",
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_char_result",
-                        "stmt1": "py_char_result"
+                        "stmt0": "py_char_*_result",
+                        "stmt1": "py_char_*_result"
                     }
                 },
                 "ast": {
@@ -1537,8 +1537,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_string_result",
-                        "stmt1": "py_string_result"
+                        "stmt0": "py_string_scalar_result",
+                        "stmt1": "py_string_scalar_result"
                     }
                 },
                 "ast": {
@@ -1712,8 +1712,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_string_result",
-                        "stmt1": "py_string_result"
+                        "stmt0": "py_string_scalar_result",
+                        "stmt1": "py_string_scalar_result"
                     }
                 },
                 "ast": {
@@ -1879,8 +1879,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_string_result",
-                        "stmt1": "py_string_result"
+                        "stmt0": "py_string_scalar_result",
+                        "stmt1": "py_string_scalar_result"
                     }
                 },
                 "ast": {
@@ -2108,8 +2108,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_string_result",
-                        "stmt1": "py_string_result"
+                        "stmt0": "py_string_scalar_result",
+                        "stmt1": "py_string_scalar_result"
                     }
                 },
                 "ast": {
@@ -2291,8 +2291,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_string_result",
-                        "stmt1": "py_string_result"
+                        "stmt0": "py_string_&_result",
+                        "stmt1": "py_string_&_result"
                     }
                 },
                 "ast": {
@@ -2493,8 +2493,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_string_result",
-                        "stmt1": "py_string_result"
+                        "stmt0": "py_string_&_result",
+                        "stmt1": "py_string_&_result"
                     }
                 },
                 "ast": {
@@ -2686,8 +2686,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_string_result",
-                        "stmt1": "py_string_result"
+                        "stmt0": "py_string_&_result",
+                        "stmt1": "py_string_&_result"
                     }
                 },
                 "ast": {
@@ -2946,8 +2946,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_string_result",
-                        "stmt1": "py_string_result"
+                        "stmt0": "py_string_&_result",
+                        "stmt1": "py_string_&_result"
                     }
                 },
                 "ast": {
@@ -3146,8 +3146,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_string_result",
-                        "stmt1": "py_string_result"
+                        "stmt0": "py_string_&_result",
+                        "stmt1": "py_string_&_result"
                     }
                 },
                 "ast": {
@@ -3338,8 +3338,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_string_result",
-                        "stmt1": "py_string_result"
+                        "stmt0": "py_string_*_result",
+                        "stmt1": "py_string_*_result"
                     }
                 },
                 "ast": {
@@ -3553,8 +3553,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_string_result",
-                        "stmt1": "py_string_result"
+                        "stmt0": "py_string_*_result",
+                        "stmt1": "py_string_*_result"
                     }
                 },
                 "ast": {
@@ -3745,8 +3745,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_string_result",
-                        "stmt1": "py_string_result"
+                        "stmt0": "py_string_*_result",
+                        "stmt1": "py_string_*_result"
                     }
                 },
                 "ast": {
@@ -3943,8 +3943,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_string_result",
-                        "stmt1": "py_string_result"
+                        "stmt0": "py_string_*_result",
+                        "stmt1": "py_string_*_result"
                     }
                 },
                 "ast": {
@@ -4138,7 +4138,7 @@
                             "py_var": "SHPy_arg1",
                             "size_var": "SHSize_arg1",
                             "stmt0": "py_string_&_in",
-                            "stmt1": "py_string_in"
+                            "stmt1": "py_string_&_in"
                         }
                     }
                 },
@@ -4330,7 +4330,7 @@
                             "py_var": "SHPy_arg1",
                             "size_var": "SHSize_arg1",
                             "stmt0": "py_string_&_out",
-                            "stmt1": "py_string_out"
+                            "stmt1": "py_string_&_out"
                         }
                     }
                 },
@@ -4520,7 +4520,7 @@
                             "py_var": "SHPy_arg1",
                             "size_var": "SHSize_arg1",
                             "stmt0": "py_string_&_inout",
-                            "stmt1": "py_string_inout"
+                            "stmt1": "py_string_&_inout"
                         }
                     }
                 },
@@ -5858,7 +5858,7 @@
                             "py_var": "SHPy_arg1",
                             "size_var": "SHSize_arg1",
                             "stmt0": "py_string_&_out",
-                            "stmt1": "py_string_out"
+                            "stmt1": "py_string_&_out"
                         }
                     },
                     "arg2": {
@@ -5879,7 +5879,7 @@
                             "py_var": "SHPy_arg2",
                             "size_var": "SHSize_arg2",
                             "stmt0": "py_string_&_out",
-                            "stmt1": "py_string_out"
+                            "stmt1": "py_string_&_out"
                         }
                     }
                 },
@@ -6411,7 +6411,7 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_schar_result",
+                        "stmt0": "py_schar_scalar_result",
                         "stmt1": "py_default"
                     }
                 },
@@ -6891,7 +6891,7 @@
                             "py_var": "SHPy_name",
                             "size_var": "SHSize_name",
                             "stmt0": "py_string_&_inout",
-                            "stmt1": "py_string_inout"
+                            "stmt1": "py_string_&_inout"
                         }
                     }
                 },

--- a/regression/reference/strings/wrapfstrings.f
+++ b/regression/reference/strings/wrapfstrings.f
@@ -125,8 +125,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  char * dest +charlen(40)+intent(out)+len(Ndest)
-    ! Requested: c_char_*_out_buf
-    ! Match:     c_char_out_buf
+    ! Exact:     c_char_*_out_buf
     ! ----------------------------------------
     ! Argument:  const char * src +intent(in)
     ! Requested: c_char_*_in
@@ -167,8 +166,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  char * s +intent(inout)+len(Ns)+len_trim(Ls)
-    ! Requested: c_char_*_inout_buf
-    ! Match:     c_char_inout_buf
+    ! Exact:     c_char_*_inout_buf
     interface
         subroutine c_pass_char_ptr_in_out_bufferify(s, Ls, Ns) &
                 bind(C, name="STR_pass_char_ptr_in_out_bufferify")
@@ -182,8 +180,7 @@ module strings_mod
 
     ! ----------------------------------------
     ! Function:  const char * getCharPtr1 +deref(allocatable)
-    ! Requested: c_char_*_result
-    ! Match:     c_char_result
+    ! Exact:     c_char_*_result
     ! start c_get_char_ptr1
     interface
         function c_get_char_ptr1() &
@@ -202,8 +199,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  const char * SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
-    ! Requested: c_char_*_result_buf_allocatable
-    ! Match:     c_char_result_buf_allocatable
+    ! Exact:     c_char_*_result_buf_allocatable
     ! start c_get_char_ptr1_bufferify
     interface
         subroutine c_get_char_ptr1_bufferify(DSHF_rv) &
@@ -217,8 +213,7 @@ module strings_mod
 
     ! ----------------------------------------
     ! Function:  const char * getCharPtr2 +deref(result-as-arg)+len(30)
-    ! Requested: c_char_*_result
-    ! Match:     c_char_result
+    ! Exact:     c_char_*_result
     ! start c_get_char_ptr2
     interface
         function c_get_char_ptr2() &
@@ -237,8 +232,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  char * SHF_rv +intent(out)+len(NSHF_rv)
-    ! Requested: c_char_*_result_buf
-    ! Match:     c_char_result_buf
+    ! Exact:     c_char_*_result_buf
     ! start c_get_char_ptr2_bufferify
     interface
         subroutine c_get_char_ptr2_bufferify(SHF_rv, NSHF_rv) &
@@ -253,8 +247,7 @@ module strings_mod
 
     ! ----------------------------------------
     ! Function:  const char * getCharPtr3 +deref(result-as-arg)
-    ! Requested: c_char_*_result
-    ! Match:     c_char_result
+    ! Exact:     c_char_*_result
     ! start c_get_char_ptr3
     interface
         function c_get_char_ptr3() &
@@ -273,8 +266,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  char * output +intent(out)+len(Noutput)
-    ! Requested: c_char_*_result_buf
-    ! Match:     c_char_result_buf
+    ! Exact:     c_char_*_result_buf
     ! start c_get_char_ptr3_bufferify
     interface
         subroutine c_get_char_ptr3_bufferify(output, Noutput) &
@@ -289,8 +281,7 @@ module strings_mod
 
     ! ----------------------------------------
     ! Function:  const char * getCharPtr4 +deref(raw)
-    ! Requested: c_char_*_result
-    ! Match:     c_char_result
+    ! Exact:     c_char_*_result
     interface
         function get_char_ptr4() &
                 result(SHT_rv) &
@@ -1012,8 +1003,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  char * name +intent(out)+len(AAtrim)
-    ! Requested: c_char_*_out_buf
-    ! Match:     c_char_out_buf
+    ! Exact:     c_char_*_out_buf
     interface
         subroutine c_explicit2_bufferify(name, AAtrim) &
                 bind(C, name="STR_explicit2_bufferify")
@@ -1101,8 +1091,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  char * dest +intent(out)+len(Ndest)
-    ! Requested: c_char_*_out_buf
-    ! Match:     c_char_out_buf
+    ! Exact:     c_char_*_out_buf
     ! ----------------------------------------
     ! Argument:  const char * src +intent(in)
     ! Requested: c_char_*_in
@@ -1225,8 +1214,7 @@ contains
     ! Requested: f_char_*_out
     ! Match:     f_default
     ! Argument:  char * dest +charlen(40)+intent(out)+len(Ndest)
-    ! Requested: c_char_*_out_buf
-    ! Match:     c_char_out_buf
+    ! Exact:     c_char_*_out_buf
     !>
     !! \brief strcpy like behavior
     !!
@@ -1259,8 +1247,7 @@ contains
     ! Requested: f_char_*_inout
     ! Match:     f_default
     ! Argument:  char * s +intent(inout)+len(Ns)+len_trim(Ls)
-    ! Requested: c_char_*_inout_buf
-    ! Match:     c_char_inout_buf
+    ! Exact:     c_char_*_inout_buf
     !>
     !! \brief toupper
     !!
@@ -1283,12 +1270,11 @@ contains
     ! Exact:     f_char_scalar_result_allocatable
     ! Function:  void getCharPtr1
     ! Requested: c_char_scalar_result_buf
-    ! Match:     c_char_result_buf
+    ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  const char * SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
     ! Exact:     f_char_*_result_allocatable
-    ! Requested: c_char_*_result_buf_allocatable
-    ! Match:     c_char_result_buf_allocatable
+    ! Exact:     c_char_*_result_buf_allocatable
     !>
     !! \brief return a 'const char *' as character(*)
     !!
@@ -1314,13 +1300,12 @@ contains
     ! Match:     f_default
     ! Function:  void getCharPtr2 +len(30)
     ! Requested: c_char_scalar_result_buf
-    ! Match:     c_char_result_buf
+    ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  char * SHF_rv +intent(out)+len(NSHF_rv)
     ! Requested: f_char_*_result
     ! Match:     f_default
-    ! Requested: c_char_*_result_buf
-    ! Match:     c_char_result_buf
+    ! Exact:     c_char_*_result_buf
     !>
     !! \brief return 'const char *' with fixed size (len=30)
     !!
@@ -1348,8 +1333,7 @@ contains
     ! Argument:  char * output +intent(out)+len(Noutput)
     ! Requested: f_char_*_result
     ! Match:     f_default
-    ! Requested: c_char_*_result_buf
-    ! Match:     c_char_result_buf
+    ! Exact:     c_char_*_result_buf
     !>
     !! \brief return a 'const char *' as argument
     !!
@@ -2016,8 +2000,7 @@ contains
     ! Argument:  char * name +intent(out)+len(AAtrim)
     ! Requested: f_char_*_out
     ! Match:     f_default
-    ! Requested: c_char_*_out_buf
-    ! Match:     c_char_out_buf
+    ! Exact:     c_char_*_out_buf
     subroutine explicit2(name)
         use iso_c_binding, only : C_INT
         character(len=*), intent(OUT) :: name
@@ -2067,8 +2050,7 @@ contains
     ! Requested: f_char_*_out
     ! Match:     f_default
     ! Argument:  char * dest +intent(out)+len(Ndest)
-    ! Requested: c_char_*_out_buf
-    ! Match:     c_char_out_buf
+    ! Exact:     c_char_*_out_buf
     !>
     !! \brief strcpy like behavior
     !!

--- a/regression/reference/strings/wrapfstrings.f
+++ b/regression/reference/strings/wrapfstrings.f
@@ -52,8 +52,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  char status +intent(in)+value
-    ! Requested: c_schar_scalar_in
-    ! Match:     c_default
+    ! Exact:     c_char_scalar_in
     interface
         subroutine pass_char(status) &
                 bind(C, name="STR_pass_char")
@@ -65,8 +64,7 @@ module strings_mod
 
     ! ----------------------------------------
     ! Function:  char returnChar
-    ! Requested: c_schar_scalar_result
-    ! Match:     c_default
+    ! Exact:     c_char_scalar_result
     interface
         function c_return_char() &
                 result(SHT_rv) &
@@ -83,14 +81,13 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  char * SHF_rv +intent(out)+len(NSHF_rv)
-    ! Requested: c_schar_*_result_buf
-    ! Match:     c_schar_result_buf
+    ! Exact:     c_char_*_result_buf
     interface
         subroutine c_return_char_bufferify(SHF_rv, NSHF_rv) &
                 bind(C, name="STR_return_char_bufferify")
             use iso_c_binding, only : C_CHAR, C_INT
             implicit none
-            character(kind=C_CHAR), intent(OUT) :: SHF_rv
+            character(kind=C_CHAR), intent(OUT) :: SHF_rv(*)
             integer(C_INT), value, intent(IN) :: NSHF_rv
         end subroutine c_return_char_bufferify
     end interface
@@ -1020,8 +1017,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  char status +intent(in)+value
-    ! Requested: c_schar_scalar_in
-    ! Match:     c_default
+    ! Exact:     c_char_scalar_in
     interface
         subroutine cpass_char(status) &
                 bind(C, name="CpassChar")
@@ -1033,8 +1029,7 @@ module strings_mod
 
     ! ----------------------------------------
     ! Function:  char CreturnChar
-    ! Requested: c_schar_scalar_result
-    ! Match:     c_default
+    ! Exact:     c_char_scalar_result
     interface
         function c_creturn_char() &
                 result(SHT_rv) &
@@ -1051,14 +1046,13 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  char * SHF_rv +intent(out)+len(NSHF_rv)
-    ! Requested: c_schar_*_result_buf
-    ! Match:     c_schar_result_buf
+    ! Exact:     c_char_*_result_buf
     interface
         subroutine c_creturn_char_bufferify(SHF_rv, NSHF_rv) &
                 bind(C, name="STR_creturn_char_bufferify")
             use iso_c_binding, only : C_CHAR, C_INT
             implicit none
-            character(kind=C_CHAR), intent(OUT) :: SHF_rv
+            character(kind=C_CHAR), intent(OUT) :: SHF_rv(*)
             integer(C_INT), value, intent(IN) :: NSHF_rv
         end subroutine c_creturn_char_bufferify
     end interface
@@ -1177,17 +1171,15 @@ contains
     ! ----------------------------------------
     ! Function:  char returnChar
     ! char returnChar
-    ! Requested: f_schar_scalar_result
+    ! Requested: f_char_scalar_result
     ! Match:     f_default
     ! Function:  void returnChar
-    ! Requested: c_schar_scalar_result_buf
-    ! Match:     c_schar_result_buf
+    ! Exact:     c_char_scalar_result_buf
     ! ----------------------------------------
     ! Argument:  char * SHF_rv +intent(out)+len(NSHF_rv)
-    ! Requested: f_schar_*_result
+    ! Requested: f_char_*_result
     ! Match:     f_default
-    ! Requested: c_schar_*_result_buf
-    ! Match:     c_schar_result_buf
+    ! Exact:     c_char_*_result_buf
     !>
     !! \brief return a char argument (non-pointer)
     !!
@@ -1269,8 +1261,7 @@ contains
     ! const char * getCharPtr1 +deref(allocatable)
     ! Exact:     f_char_scalar_result_allocatable
     ! Function:  void getCharPtr1
-    ! Requested: c_char_scalar_result_buf
-    ! Match:     c_default
+    ! Exact:     c_char_scalar_result_buf
     ! ----------------------------------------
     ! Argument:  const char * SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
     ! Exact:     f_char_*_result_allocatable
@@ -1299,8 +1290,7 @@ contains
     ! Requested: f_char_scalar_result_result-as-arg
     ! Match:     f_default
     ! Function:  void getCharPtr2 +len(30)
-    ! Requested: c_char_scalar_result_buf
-    ! Match:     c_default
+    ! Exact:     c_char_scalar_result_buf
     ! ----------------------------------------
     ! Argument:  char * SHF_rv +intent(out)+len(NSHF_rv)
     ! Requested: f_char_*_result
@@ -2013,17 +2003,15 @@ contains
     ! ----------------------------------------
     ! Function:  char CreturnChar
     ! char CreturnChar
-    ! Requested: f_schar_scalar_result
+    ! Requested: f_char_scalar_result
     ! Match:     f_default
     ! Function:  void CreturnChar
-    ! Requested: c_schar_scalar_result_buf
-    ! Match:     c_schar_result_buf
+    ! Exact:     c_char_scalar_result_buf
     ! ----------------------------------------
     ! Argument:  char * SHF_rv +intent(out)+len(NSHF_rv)
-    ! Requested: f_schar_*_result
+    ! Requested: f_char_*_result
     ! Match:     f_default
-    ! Requested: c_schar_*_result_buf
-    ! Match:     c_schar_result_buf
+    ! Exact:     c_char_*_result_buf
     !>
     !! \brief return a char argument (non-pointer), extern "C"
     !!

--- a/regression/reference/strings/wrapstrings.cpp
+++ b/regression/reference/strings/wrapstrings.cpp
@@ -182,8 +182,7 @@ void STR_pass_char_ptr(char * dest, const char * src)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  char * dest +charlen(40)+intent(out)+len(Ndest)
-// Requested: c_char_*_out_buf
-// Match:     c_char_out_buf
+// Exact:     c_char_*_out_buf
 // ----------------------------------------
 // Argument:  const char * src +intent(in)
 // Requested: c_char_*_in
@@ -232,8 +231,7 @@ void STR_pass_char_ptr_in_out(char * s)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  char * s +intent(inout)+len(Ns)+len_trim(Ls)
-// Requested: c_char_*_inout_buf
-// Match:     c_char_inout_buf
+// Exact:     c_char_*_inout_buf
 void STR_pass_char_ptr_in_out_bufferify(char * s, int Ls, int Ns)
 {
     // splicer begin function.pass_char_ptr_in_out_bufferify
@@ -250,8 +248,7 @@ void STR_pass_char_ptr_in_out_bufferify(char * s, int Ls, int Ns)
  */
 // ----------------------------------------
 // Function:  const char * getCharPtr1 +deref(allocatable)
-// Requested: c_char_*_result
-// Match:     c_char_result
+// Exact:     c_char_*_result
 // start STR_get_char_ptr1
 const char * STR_get_char_ptr1(void)
 {
@@ -272,8 +269,7 @@ const char * STR_get_char_ptr1(void)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  const char * SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
-// Requested: c_char_*_result_buf_allocatable
-// Match:     c_char_result_buf_allocatable
+// Exact:     c_char_*_result_buf_allocatable
 // start STR_get_char_ptr1_bufferify
 void STR_get_char_ptr1_bufferify(STR_SHROUD_array *DSHF_rv)
 {
@@ -296,8 +292,7 @@ void STR_get_char_ptr1_bufferify(STR_SHROUD_array *DSHF_rv)
  */
 // ----------------------------------------
 // Function:  const char * getCharPtr2 +deref(result-as-arg)+len(30)
-// Requested: c_char_*_result
-// Match:     c_char_result
+// Exact:     c_char_*_result
 // start STR_get_char_ptr2
 const char * STR_get_char_ptr2(void)
 {
@@ -318,8 +313,7 @@ const char * STR_get_char_ptr2(void)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  char * SHF_rv +intent(out)+len(NSHF_rv)
-// Requested: c_char_*_result_buf
-// Match:     c_char_result_buf
+// Exact:     c_char_*_result_buf
 // start STR_get_char_ptr2_bufferify
 void STR_get_char_ptr2_bufferify(char * SHF_rv, int NSHF_rv)
 {
@@ -336,8 +330,7 @@ void STR_get_char_ptr2_bufferify(char * SHF_rv, int NSHF_rv)
  */
 // ----------------------------------------
 // Function:  const char * getCharPtr3 +deref(result-as-arg)
-// Requested: c_char_*_result
-// Match:     c_char_result
+// Exact:     c_char_*_result
 // start STR_get_char_ptr3
 const char * STR_get_char_ptr3(void)
 {
@@ -358,8 +351,7 @@ const char * STR_get_char_ptr3(void)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  char * output +intent(out)+len(Noutput)
-// Requested: c_char_*_result_buf
-// Match:     c_char_result_buf
+// Exact:     c_char_*_result_buf
 // start STR_get_char_ptr3_bufferify
 void STR_get_char_ptr3_bufferify(char * output, int Noutput)
 {
@@ -376,8 +368,7 @@ void STR_get_char_ptr3_bufferify(char * output, int Noutput)
  */
 // ----------------------------------------
 // Function:  const char * getCharPtr4 +deref(raw)
-// Requested: c_char_*_result
-// Match:     c_char_result
+// Exact:     c_char_*_result
 const char * STR_get_char_ptr4(void)
 {
     // splicer begin function.get_char_ptr4
@@ -1280,8 +1271,7 @@ void STR_explicit2(char * name)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  char * name +intent(out)+len(AAtrim)
-// Requested: c_char_*_out_buf
-// Match:     c_char_out_buf
+// Exact:     c_char_*_out_buf
 void STR_explicit2_bufferify(char * name, int AAtrim)
 {
     // splicer begin function.explicit2_bufferify
@@ -1324,8 +1314,7 @@ void STR_creturn_char_bufferify(char * SHF_rv, int NSHF_rv)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  char * dest +intent(out)+len(Ndest)
-// Requested: c_char_*_out_buf
-// Match:     c_char_out_buf
+// Exact:     c_char_*_out_buf
 // ----------------------------------------
 // Argument:  const char * src +intent(in)
 // Requested: c_char_*_in

--- a/regression/reference/strings/wrapstrings.cpp
+++ b/regression/reference/strings/wrapstrings.cpp
@@ -95,8 +95,7 @@ static void ShroudStrToArray(STR_SHROUD_array *array, const std::string * src, i
 // Match:     c_default
 // ----------------------------------------
 // Argument:  char status +intent(in)+value
-// Requested: c_schar_scalar_in
-// Match:     c_default
+// Exact:     c_char_scalar_in
 void STR_pass_char(char status)
 {
     // splicer begin function.pass_char
@@ -110,8 +109,7 @@ void STR_pass_char(char status)
  */
 // ----------------------------------------
 // Function:  char returnChar
-// Requested: c_schar_scalar_result
-// Match:     c_default
+// Exact:     c_char_scalar_result
 char STR_return_char(void)
 {
     // splicer begin function.return_char
@@ -130,8 +128,7 @@ char STR_return_char(void)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  char * SHF_rv +intent(out)+len(NSHF_rv)
-// Requested: c_schar_scalar_result_buf
-// Match:     c_schar_result_buf
+// Exact:     c_char_scalar_result_buf
 void STR_return_char_bufferify(char * SHF_rv, int NSHF_rv)
 {
     // splicer begin function.return_char_bufferify
@@ -1290,8 +1287,7 @@ void STR_explicit2_bufferify(char * name, int AAtrim)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  char * SHF_rv +intent(out)+len(NSHF_rv)
-// Requested: c_schar_scalar_result_buf
-// Match:     c_schar_result_buf
+// Exact:     c_char_scalar_result_buf
 void STR_creturn_char_bufferify(char * SHF_rv, int NSHF_rv)
 {
     // splicer begin function.creturn_char_bufferify

--- a/regression/reference/struct-c/struct.json
+++ b/regression/reference/struct-c/struct.json
@@ -924,7 +924,7 @@
                             "idtor": "0",
                             "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_*_out_buf",
-                            "stmt1": "c_char_out_buf"
+                            "stmt1": "c_char_*_out_buf"
                         },
                         "fmtf": {
                             "F_pointer": "SHPTR_outbuf",
@@ -937,7 +937,7 @@
                             "stmt0": "f_char_*_out",
                             "stmt1": "f_default",
                             "stmtc0": "c_char_*_out_buf",
-                            "stmtc1": "c_char_out_buf"
+                            "stmtc1": "c_char_*_out_buf"
                         }
                     },
                     "s1": {
@@ -2158,7 +2158,7 @@
                             "idtor": "0",
                             "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_*_out_buf",
-                            "stmt1": "c_char_out_buf"
+                            "stmt1": "c_char_*_out_buf"
                         },
                         "fmtf": {
                             "F_pointer": "SHPTR_outbuf",
@@ -2171,7 +2171,7 @@
                             "stmt0": "f_char_*_out",
                             "stmt1": "f_default",
                             "stmtc0": "c_char_*_out_buf",
-                            "stmtc1": "c_char_out_buf"
+                            "stmtc1": "c_char_*_out_buf"
                         }
                     }
                 },

--- a/regression/reference/struct-c/wrapfstruct.f
+++ b/regression/reference/struct-c/wrapfstruct.f
@@ -136,8 +136,7 @@ module struct_mod
     ! Match:     c_struct
     ! ----------------------------------------
     ! Argument:  char * outbuf +charlen(LENOUTBUF)+intent(out)+len(Noutbuf)
-    ! Requested: c_char_*_out_buf
-    ! Match:     c_char_out_buf
+    ! Exact:     c_char_*_out_buf
     interface
         function c_pass_struct2_bufferify(s1, outbuf, Noutbuf) &
                 result(SHT_rv) &
@@ -334,8 +333,7 @@ module struct_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  char * outbuf +charlen(LENOUTBUF)+intent(out)+len(Noutbuf)
-    ! Requested: c_char_*_out_buf
-    ! Match:     c_char_out_buf
+    ! Exact:     c_char_*_out_buf
     interface
         function c_return_struct_ptr2_bufferify(i, d, outbuf, Noutbuf) &
                 result(SHT_rv) &
@@ -390,8 +388,7 @@ contains
     ! Requested: f_char_*_out
     ! Match:     f_default
     ! Argument:  char * outbuf +charlen(LENOUTBUF)+intent(out)+len(Noutbuf)
-    ! Requested: c_char_*_out_buf
-    ! Match:     c_char_out_buf
+    ! Exact:     c_char_*_out_buf
     !>
     !! Pass name argument which will build a bufferify function.
     !<
@@ -469,8 +466,7 @@ contains
     ! Requested: f_char_*_out
     ! Match:     f_default
     ! Argument:  char * outbuf +charlen(LENOUTBUF)+intent(out)+len(Noutbuf)
-    ! Requested: c_char_*_out_buf
-    ! Match:     c_char_out_buf
+    ! Exact:     c_char_*_out_buf
     !>
     !! \brief Return a pointer to a struct
     !!

--- a/regression/reference/struct-c/wrapstruct.c
+++ b/regression/reference/struct-c/wrapstruct.c
@@ -36,8 +36,7 @@ static void ShroudStrBlankFill(char *dest, int ndest)
 // Match:     c_struct
 // ----------------------------------------
 // Argument:  char * outbuf +charlen(LENOUTBUF)+intent(out)+len(Noutbuf)
-// Requested: c_char_*_out_buf
-// Match:     c_char_out_buf
+// Exact:     c_char_*_out_buf
 int STR_pass_struct2_bufferify(const Cstruct1 * s1, char * outbuf,
     int Noutbuf)
 {
@@ -67,8 +66,7 @@ int STR_pass_struct2_bufferify(const Cstruct1 * s1, char * outbuf,
 // Match:     c_default
 // ----------------------------------------
 // Argument:  char * outbuf +charlen(LENOUTBUF)+intent(out)+len(Noutbuf)
-// Requested: c_char_*_out_buf
-// Match:     c_char_out_buf
+// Exact:     c_char_*_out_buf
 Cstruct1 * STR_return_struct_ptr2_bufferify(int i, double d,
     char * outbuf, int Noutbuf)
 {

--- a/regression/reference/struct-class-c/pystructmodule.h
+++ b/regression/reference/struct-class-c/pystructmodule.h
@@ -29,7 +29,7 @@ int STR_SHROUD_fill_from_PyObject_char(PyObject *obj, const char *name,
 int STR_SHROUD_fill_from_PyObject_int_numpy(PyObject *obj,
     const char *name, int *in, Py_ssize_t insize);
 int STR_SHROUD_create_from_PyObject_char(PyObject *obj,
-    const char *name, char * **pin, Py_ssize_t *psize);
+    const char *name, char ***pin, Py_ssize_t *psize);
 int STR_SHROUD_get_from_object_charptr(PyObject *obj,
     STR_SHROUD_converter_value *value);
 int STR_SHROUD_create_from_PyObject_double(PyObject *obj,

--- a/regression/reference/struct-class-c/pystructutil.c
+++ b/regression/reference/struct-class-c/pystructutil.c
@@ -137,10 +137,10 @@ int STR_SHROUD_fill_from_PyObject_int_numpy(PyObject *obj,
 }
 
 // helper create_from_PyObject_char
-// Convert obj into an array of type char *
+// Convert obj into an array of type char *.
 // Return -1 on error.
 int STR_SHROUD_create_from_PyObject_char(PyObject *obj,
-    const char *name, char * **pin, Py_ssize_t *psize)
+    const char *name, char ***pin, Py_ssize_t *psize)
 {
     PyObject *seq = PySequence_Fast(obj, "holder");
     if (seq == NULL) {
@@ -149,7 +149,7 @@ int STR_SHROUD_create_from_PyObject_char(PyObject *obj,
         return -1;
     }
     Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
-    char * *in = (char * *) malloc(size * sizeof(char *));
+    char **in = (char **) calloc(size, sizeof(char *));
     for (Py_ssize_t i = 0; i < size; i++) {
         PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
         in[i] = PyString_AsString(item);

--- a/regression/reference/struct-class-c/pystructutil.c
+++ b/regression/reference/struct-class-c/pystructutil.c
@@ -14,6 +14,20 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef __cplusplus
+#define SHROUD_UNUSED(param)
+#else
+#define SHROUD_UNUSED(param) param
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+#define PyInt_AsLong PyLong_AsLong
+#define PyInt_FromLong PyLong_FromLong
+#define PyInt_FromSize_t PyLong_FromSize_t
+#define PyString_FromString PyUnicode_FromString
+#define PyString_FromStringAndSize PyUnicode_FromStringAndSize
+#endif
+
 // helper get_from_object_char
 // Converter to PyObject to char *.
 // The returned status will be 1 for a successful conversion
@@ -27,7 +41,7 @@ int STR_SHROUD_get_from_object_char(PyObject *obj,
 #if PY_MAJOR_VERSION >= 3
         PyObject *strobj = PyUnicode_AsUTF8String(obj);
         out = PyBytes_AS_STRING(strobj);
-        size = PyString_Size(obj);
+        size = PyBytes_GET_SIZE(strobj);
         value->obj = strobj;  // steal reference
 #else
         PyObject *strobj = PyUnicode_AsUTF8String(obj);

--- a/regression/reference/struct-class-cxx/pystructmodule.hpp
+++ b/regression/reference/struct-class-cxx/pystructmodule.hpp
@@ -29,7 +29,7 @@ int STR_SHROUD_fill_from_PyObject_char(PyObject *obj, const char *name,
 int STR_SHROUD_fill_from_PyObject_int_numpy(PyObject *obj,
     const char *name, int *in, Py_ssize_t insize);
 int STR_SHROUD_create_from_PyObject_char(PyObject *obj,
-    const char *name, char * **pin, Py_ssize_t *psize);
+    const char *name, char ***pin, Py_ssize_t *psize);
 int STR_SHROUD_get_from_object_charptr(PyObject *obj,
     STR_SHROUD_converter_value *value);
 int STR_SHROUD_create_from_PyObject_double(PyObject *obj,

--- a/regression/reference/struct-class-cxx/pystructutil.cpp
+++ b/regression/reference/struct-class-cxx/pystructutil.cpp
@@ -137,10 +137,10 @@ int STR_SHROUD_fill_from_PyObject_int_numpy(PyObject *obj,
 }
 
 // helper create_from_PyObject_char
-// Convert obj into an array of type char *
+// Convert obj into an array of type char *.
 // Return -1 on error.
 int STR_SHROUD_create_from_PyObject_char(PyObject *obj,
-    const char *name, char * **pin, Py_ssize_t *psize)
+    const char *name, char ***pin, Py_ssize_t *psize)
 {
     PyObject *seq = PySequence_Fast(obj, "holder");
     if (seq == NULL) {
@@ -149,8 +149,7 @@ int STR_SHROUD_create_from_PyObject_char(PyObject *obj,
         return -1;
     }
     Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
-    char * *in = static_cast<char * *>
-        (std::malloc(size * sizeof(char *)));
+    char **in = static_cast<char **>(std::calloc(size, sizeof(char *)));
     for (Py_ssize_t i = 0; i < size; i++) {
         PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
         in[i] = PyString_AsString(item);

--- a/regression/reference/struct-class-cxx/pystructutil.cpp
+++ b/regression/reference/struct-class-cxx/pystructutil.cpp
@@ -14,6 +14,20 @@
 #include <cstdlib>
 #include <cstring>
 
+#ifdef __cplusplus
+#define SHROUD_UNUSED(param)
+#else
+#define SHROUD_UNUSED(param) param
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+#define PyInt_AsLong PyLong_AsLong
+#define PyInt_FromLong PyLong_FromLong
+#define PyInt_FromSize_t PyLong_FromSize_t
+#define PyString_FromString PyUnicode_FromString
+#define PyString_FromStringAndSize PyUnicode_FromStringAndSize
+#endif
+
 // helper get_from_object_char
 // Converter to PyObject to char *.
 // The returned status will be 1 for a successful conversion
@@ -27,7 +41,7 @@ int STR_SHROUD_get_from_object_char(PyObject *obj,
 #if PY_MAJOR_VERSION >= 3
         PyObject *strobj = PyUnicode_AsUTF8String(obj);
         out = PyBytes_AS_STRING(strobj);
-        size = PyString_Size(obj);
+        size = PyBytes_GET_SIZE(strobj);
         value->obj = strobj;  // steal reference
 #else
         PyObject *strobj = PyUnicode_AsUTF8String(obj);

--- a/regression/reference/struct-cxx/struct.json
+++ b/regression/reference/struct-cxx/struct.json
@@ -924,7 +924,7 @@
                             "idtor": "0",
                             "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_*_out_buf",
-                            "stmt1": "c_char_out_buf"
+                            "stmt1": "c_char_*_out_buf"
                         },
                         "fmtf": {
                             "F_pointer": "SHPTR_outbuf",
@@ -937,7 +937,7 @@
                             "stmt0": "f_char_*_out",
                             "stmt1": "f_default",
                             "stmtc0": "c_char_*_out_buf",
-                            "stmtc1": "c_char_out_buf"
+                            "stmtc1": "c_char_*_out_buf"
                         }
                     },
                     "s1": {
@@ -2158,7 +2158,7 @@
                             "idtor": "0",
                             "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "c_char_*_out_buf",
-                            "stmt1": "c_char_out_buf"
+                            "stmt1": "c_char_*_out_buf"
                         },
                         "fmtf": {
                             "F_pointer": "SHPTR_outbuf",
@@ -2171,7 +2171,7 @@
                             "stmt0": "f_char_*_out",
                             "stmt1": "f_default",
                             "stmtc0": "c_char_*_out_buf",
-                            "stmtc1": "c_char_out_buf"
+                            "stmtc1": "c_char_*_out_buf"
                         }
                     }
                 },

--- a/regression/reference/struct-cxx/wrapfstruct.f
+++ b/regression/reference/struct-cxx/wrapfstruct.f
@@ -132,8 +132,7 @@ module struct_mod
         ! Match:     c_struct
         ! ----------------------------------------
         ! Argument:  char * outbuf +charlen(LENOUTBUF)+intent(out)+len(Noutbuf)
-        ! Requested: c_char_*_out_buf
-        ! Match:     c_char_out_buf
+        ! Exact:     c_char_*_out_buf
         function c_pass_struct2_bufferify(s1, outbuf, Noutbuf) &
                 result(SHT_rv) &
                 bind(C, name="STR_pass_struct2_bufferify")
@@ -314,8 +313,7 @@ module struct_mod
         ! Match:     c_default
         ! ----------------------------------------
         ! Argument:  char * outbuf +charlen(LENOUTBUF)+intent(out)+len(Noutbuf)
-        ! Requested: c_char_*_out_buf
-        ! Match:     c_char_out_buf
+        ! Exact:     c_char_*_out_buf
         function c_return_struct_ptr2_bufferify(i, d, outbuf, Noutbuf) &
                 result(SHT_rv) &
                 bind(C, name="STR_return_struct_ptr2_bufferify")
@@ -365,8 +363,7 @@ contains
     ! Requested: f_char_*_out
     ! Match:     f_default
     ! Argument:  char * outbuf +charlen(LENOUTBUF)+intent(out)+len(Noutbuf)
-    ! Requested: c_char_*_out_buf
-    ! Match:     c_char_out_buf
+    ! Exact:     c_char_*_out_buf
     !>
     !! Pass name argument which will build a bufferify function.
     !<
@@ -444,8 +441,7 @@ contains
     ! Requested: f_char_*_out
     ! Match:     f_default
     ! Argument:  char * outbuf +charlen(LENOUTBUF)+intent(out)+len(Noutbuf)
-    ! Requested: c_char_*_out_buf
-    ! Match:     c_char_out_buf
+    ! Exact:     c_char_*_out_buf
     !>
     !! \brief Return a pointer to a struct
     !!

--- a/regression/reference/struct-cxx/wrapstruct.cpp
+++ b/regression/reference/struct-cxx/wrapstruct.cpp
@@ -106,8 +106,7 @@ int STR_pass_struct2(const STR_cstruct1 * s1, char * outbuf)
 // Match:     c_struct
 // ----------------------------------------
 // Argument:  char * outbuf +charlen(LENOUTBUF)+intent(out)+len(Noutbuf)
-// Requested: c_char_*_out_buf
-// Match:     c_char_out_buf
+// Exact:     c_char_*_out_buf
 int STR_pass_struct2_bufferify(const STR_cstruct1 * s1, char * outbuf,
     int Noutbuf)
 {
@@ -304,8 +303,7 @@ STR_cstruct1 * STR_return_struct_ptr2(int i, double d, char * outbuf)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  char * outbuf +charlen(LENOUTBUF)+intent(out)+len(Noutbuf)
-// Requested: c_char_*_out_buf
-// Match:     c_char_out_buf
+// Exact:     c_char_*_out_buf
 STR_cstruct1 * STR_return_struct_ptr2_bufferify(int i, double d,
     char * outbuf, int Noutbuf)
 {

--- a/regression/reference/struct-numpy-c/pystructutil.c
+++ b/regression/reference/struct-numpy-c/pystructutil.c
@@ -8,6 +8,20 @@
 //
 #include "pystructmodule.h"
 
+#ifdef __cplusplus
+#define SHROUD_UNUSED(param)
+#else
+#define SHROUD_UNUSED(param) param
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+#define PyInt_AsLong PyLong_AsLong
+#define PyInt_FromLong PyLong_FromLong
+#define PyInt_FromSize_t PyLong_FromSize_t
+#define PyString_FromString PyUnicode_FromString
+#define PyString_FromStringAndSize PyUnicode_FromStringAndSize
+#endif
+
 // ----------------------------------------
 typedef struct {
     const char *name;

--- a/regression/reference/struct-numpy-cxx/pystructutil.cpp
+++ b/regression/reference/struct-numpy-cxx/pystructutil.cpp
@@ -8,6 +8,20 @@
 //
 #include "pystructmodule.hpp"
 
+#ifdef __cplusplus
+#define SHROUD_UNUSED(param)
+#else
+#define SHROUD_UNUSED(param) param
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+#define PyInt_AsLong PyLong_AsLong
+#define PyInt_FromLong PyLong_FromLong
+#define PyInt_FromSize_t PyLong_FromSize_t
+#define PyString_FromString PyUnicode_FromString
+#define PyString_FromStringAndSize PyUnicode_FromStringAndSize
+#endif
+
 // ----------------------------------------
 typedef struct {
     const char *name;

--- a/regression/reference/struct-py-c/pystructutil.c
+++ b/regression/reference/struct-py-c/pystructutil.c
@@ -8,6 +8,20 @@
 //
 #include "pystructmodule.h"
 
+#ifdef __cplusplus
+#define SHROUD_UNUSED(param)
+#else
+#define SHROUD_UNUSED(param) param
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+#define PyInt_AsLong PyLong_AsLong
+#define PyInt_FromLong PyLong_FromLong
+#define PyInt_FromSize_t PyLong_FromSize_t
+#define PyString_FromString PyUnicode_FromString
+#define PyString_FromStringAndSize PyUnicode_FromStringAndSize
+#endif
+
 const char *PY_Cstruct_as_class_capsule_name = "Cstruct_as_class";
 
 

--- a/regression/reference/struct-py-cxx/pystructutil.cpp
+++ b/regression/reference/struct-py-cxx/pystructutil.cpp
@@ -8,6 +8,20 @@
 //
 #include "pystructmodule.hpp"
 
+#ifdef __cplusplus
+#define SHROUD_UNUSED(param)
+#else
+#define SHROUD_UNUSED(param) param
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+#define PyInt_AsLong PyLong_AsLong
+#define PyInt_FromLong PyLong_FromLong
+#define PyInt_FromSize_t PyLong_FromSize_t
+#define PyString_FromString PyUnicode_FromString
+#define PyString_FromStringAndSize PyUnicode_FromStringAndSize
+#endif
+
 const char *PY_Cstruct_as_class_capsule_name = "Cstruct_as_class";
 
 

--- a/regression/reference/structlist/pystructutil.c
+++ b/regression/reference/structlist/pystructutil.c
@@ -9,6 +9,20 @@
 #include "pystructmodule.h"
 #include <string.h>
 
+#ifdef __cplusplus
+#define SHROUD_UNUSED(param)
+#else
+#define SHROUD_UNUSED(param) param
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+#define PyInt_AsLong PyLong_AsLong
+#define PyInt_FromLong PyLong_FromLong
+#define PyInt_FromSize_t PyLong_FromSize_t
+#define PyString_FromString PyUnicode_FromString
+#define PyString_FromStringAndSize PyUnicode_FromStringAndSize
+#endif
+
 // helper get_from_object_char
 // Converter to PyObject to char *.
 // The returned status will be 1 for a successful conversion
@@ -22,7 +36,7 @@ int STR_SHROUD_get_from_object_char(PyObject *obj,
 #if PY_MAJOR_VERSION >= 3
         PyObject *strobj = PyUnicode_AsUTF8String(obj);
         out = PyBytes_AS_STRING(strobj);
-        size = PyString_Size(obj);
+        size = PyBytes_GET_SIZE(strobj);
         value->obj = strobj;  // steal reference
 #else
         PyObject *strobj = PyUnicode_AsUTF8String(obj);

--- a/regression/reference/templates/pytemplatesutil.cpp
+++ b/regression/reference/templates/pytemplatesutil.cpp
@@ -8,6 +8,20 @@
 //
 #include "pytemplatesmodule.hpp"
 
+#ifdef __cplusplus
+#define SHROUD_UNUSED(param)
+#else
+#define SHROUD_UNUSED(param) param
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+#define PyInt_AsLong PyLong_AsLong
+#define PyInt_FromLong PyLong_FromLong
+#define PyInt_FromSize_t PyLong_FromSize_t
+#define PyString_FromString PyUnicode_FromString
+#define PyString_FromStringAndSize PyUnicode_FromStringAndSize
+#endif
+
 const char *PY_vector_int_capsule_name = "vector_int";
 const char *PY_vector_double_capsule_name = "vector_double";
 const char *PY_ImplWorker1_capsule_name = "ImplWorker1";

--- a/regression/reference/tutorial/pyTutorialmodule.cpp
+++ b/regression/reference/tutorial/pyTutorialmodule.cpp
@@ -96,15 +96,13 @@ PY_PassByValue(
 
 // ----------------------------------------
 // Function:  const std::string ConcatenateStrings +deref(allocatable)
-// Exact:     py_string_result
+// Exact:     py_string_scalar_result
 // ----------------------------------------
 // Argument:  const std::string & arg1 +intent(in)
-// Requested: py_string_&_in
-// Match:     py_string_in
+// Exact:     py_string_&_in
 // ----------------------------------------
 // Argument:  const std::string & arg2 +intent(in)
-// Requested: py_string_&_in
-// Match:     py_string_in
+// Exact:     py_string_&_in
 static char PY_ConcatenateStrings__doc__[] =
 "documentation"
 ;
@@ -220,8 +218,7 @@ PY_UseDefaultArguments_arg1_arg2(
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  const std::string & name +intent(in)
-// Requested: py_string_&_in
-// Match:     py_string_in
+// Exact:     py_string_&_in
 static PyObject *
 PY_OverloadedFunction_from_name(
   PyObject *SHROUD_UNUSED(self),
@@ -350,8 +347,7 @@ PY_FortranGenericOverloaded_0(
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  const std::string & name +intent(in)
-// Requested: py_string_&_in
-// Match:     py_string_in
+// Exact:     py_string_&_in
 // ----------------------------------------
 // Argument:  double arg2 +intent(in)+value
 // Requested: py_native_scalar_in
@@ -676,7 +672,7 @@ PY_getMinMax(
 
 // ----------------------------------------
 // Function:  const std::string & LastFunctionCalled +deref(result-as-arg)+len(30)
-// Exact:     py_string_result
+// Exact:     py_string_&_result
 static char PY_LastFunctionCalled__doc__[] =
 "documentation"
 ;

--- a/regression/reference/tutorial/tutorial.json
+++ b/regression/reference/tutorial/tutorial.json
@@ -374,7 +374,7 @@
                             "py_var": "SHPy_arg1",
                             "size_var": "SHSize_arg1",
                             "stmt0": "py_string_&_in",
-                            "stmt1": "py_string_in"
+                            "stmt1": "py_string_&_in"
                         }
                     },
                     "arg2": {
@@ -406,7 +406,7 @@
                             "py_var": "SHPy_arg2",
                             "size_var": "SHSize_arg2",
                             "stmt0": "py_string_&_in",
-                            "stmt1": "py_string_in"
+                            "stmt1": "py_string_&_in"
                         }
                     }
                 },
@@ -440,8 +440,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_string_result",
-                        "stmt1": "py_string_result"
+                        "stmt0": "py_string_scalar_result",
+                        "stmt1": "py_string_scalar_result"
                     }
                 },
                 "ast": {
@@ -1232,7 +1232,7 @@
                             "py_var": "SHPy_name",
                             "size_var": "SHSize_name",
                             "stmt0": "py_string_&_in",
-                            "stmt1": "py_string_in"
+                            "stmt1": "py_string_&_in"
                         }
                     }
                 },
@@ -2272,7 +2272,7 @@
                             "py_var": "SHPy_name",
                             "size_var": "SHSize_name",
                             "stmt0": "py_string_&_in",
-                            "stmt1": "py_string_in"
+                            "stmt1": "py_string_&_in"
                         }
                     }
                 },
@@ -5050,8 +5050,8 @@
                         "numpy_type": null,
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_string_result",
-                        "stmt1": "py_string_result"
+                        "stmt0": "py_string_&_result",
+                        "stmt1": "py_string_&_result"
                     }
                 },
                 "ast": {

--- a/regression/reference/types/pytypesmodule.cpp
+++ b/regression/reference/types/pytypesmodule.cpp
@@ -869,7 +869,8 @@ PY_size_func(
 
 // ----------------------------------------
 // Function:  bool bool_func
-// Exact:     py_bool_result
+// Requested: py_bool_scalar_result
+// Match:     py_bool_result
 // ----------------------------------------
 // Argument:  bool arg +intent(in)+value
 // Requested: py_bool_scalar_in
@@ -915,7 +916,8 @@ fail:
 
 // ----------------------------------------
 // Function:  bool returnBoolAndOthers
-// Exact:     py_bool_result
+// Requested: py_bool_scalar_result
+// Match:     py_bool_result
 // ----------------------------------------
 // Argument:  int * flag +intent(out)
 // Exact:     py_native_*_out

--- a/regression/reference/types/types.json
+++ b/regression/reference/types/types.json
@@ -3282,7 +3282,7 @@
                         "numpy_type": "NPY_BOOL",
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_bool_result",
+                        "stmt0": "py_bool_scalar_result",
                         "stmt1": "py_bool_result"
                     }
                 },
@@ -3427,7 +3427,7 @@
                         "numpy_type": "NPY_BOOL",
                         "py_var": "SHTPy_rv",
                         "size_var": "SHSize_rv",
-                        "stmt0": "py_bool_result",
+                        "stmt0": "py_bool_scalar_result",
                         "stmt1": "py_bool_result"
                     }
                 },

--- a/regression/reference/vectors-numpy/pyvectorsutil.cpp
+++ b/regression/reference/vectors-numpy/pyvectorsutil.cpp
@@ -8,6 +8,20 @@
 //
 #include "pyvectorsmodule.hpp"
 
+#ifdef __cplusplus
+#define SHROUD_UNUSED(param)
+#else
+#define SHROUD_UNUSED(param) param
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+#define PyInt_AsLong PyLong_AsLong
+#define PyInt_FromLong PyLong_FromLong
+#define PyInt_FromSize_t PyLong_FromSize_t
+#define PyString_FromString PyUnicode_FromString
+#define PyString_FromStringAndSize PyUnicode_FromStringAndSize
+#endif
+
 // ----------------------------------------
 typedef struct {
     const char *name;

--- a/shroud/generate.py
+++ b/shroud/generate.py
@@ -1209,8 +1209,6 @@ class GenFunctions(object):
                     pass
                 elif arg.is_indirect():
                     has_buf_arg = True
-                else:
-                    arg.set_type(typemap.lookup_type("char_scalar"))
             elif arg_typemap.base == "vector":
                 has_buf_arg = True
             elif (arg_typemap.sgroup == "native" and
@@ -1232,9 +1230,6 @@ class GenFunctions(object):
             # No bufferify required for raw pointer result.
             pass
         elif result_typemap.base == "string":
-            if result_typemap.name == "char" and not result_is_ptr:
-                # char functions cannot be wrapped directly in intel 15.
-                ast.set_type(typemap.lookup_type("char_scalar"))
             has_string_result = True
             result_as_arg = fmt.F_string_result_as_arg
             result_name = result_as_arg or fmt.C_string_result_as_arg

--- a/shroud/typemap.py
+++ b/shroud/typemap.py
@@ -1732,11 +1732,11 @@ fc_statements = [
     ),
 
     dict(
-        name="c_char_result",
+        name="c_char_*_result",
         return_cptr=True,
     ),
     dict(
-        name="c_char_in_buf",
+        name="c_char_*_in_buf",
         buf_args=["arg", "len_trim"],
         cxx_local_var="pointer",
         c_helper="ShroudStrAlloc ShroudStrFree",
@@ -1749,7 +1749,7 @@ fc_statements = [
         ],
     ),
     dict(
-        name="c_char_out_buf",
+        name="c_char_*_out_buf",
         buf_args=["arg", "len"],
         c_helper="ShroudStrBlankFill",
         post_call=[
@@ -1757,7 +1757,7 @@ fc_statements = [
         ],
     ),
     dict(
-        name="c_char_inout_buf",
+        name="c_char_*_inout_buf",
         buf_args=["arg", "len_trim", "len"],
         cxx_local_var="pointer",
         c_helper="ShroudStrAlloc ShroudStrCopy ShroudStrFree",
@@ -1773,7 +1773,7 @@ fc_statements = [
         ],
     ),
     dict(
-        name="c_char_result_buf",
+        name="c_char_*_result_buf",
         buf_args=["arg", "len"],
         c_helper="ShroudStrCopy",
         post_call=[
@@ -1783,7 +1783,7 @@ fc_statements = [
         ],
     ),
     dict(
-        name="c_char_result_buf_allocatable",
+        name="c_char_*_result_buf_allocatable",
         buf_args=["context"],
         c_helper="ShroudTypeDefines",
         # Copy address of result into c_var and save length.

--- a/shroud/whelpers.py
+++ b/shroud/whelpers.py
@@ -916,7 +916,7 @@ def create_from_PyObject_charptr(fmt):
     fmt.hnamefunc = wformat(
         "{PY_helper_prefix}create_from_PyObject_{fcn_suffix}", fmt)
     fmt.hnameproto = wformat(
-            "int {hnamefunc}\t(PyObject *obj,\t const char *name,\t {c_type} **pin,\t Py_ssize_t *psize)", fmt)
+            "int {hnamefunc}\t(PyObject *obj,\t const char *name,\t char ***pin,\t Py_ssize_t *psize)", fmt)
     helper = dict(
         name=fmt.hnamefunc,
         c_include="<stdlib.h>",   # malloc/free
@@ -925,7 +925,7 @@ def create_from_PyObject_charptr(fmt):
         source=wformat(
                 """
 // helper {hname}
-// Convert obj into an array of type {c_type}
+// Convert obj into an array of type char *.
 // Return -1 on error.
 {PY_helper_static}{hnameproto}
 {{+
@@ -935,7 +935,7 @@ PyErr_Format(PyExc_TypeError,\t "argument '%s' must be iterable",\t name);
 return -1;
 -}}
 Py_ssize_t size = PySequence_Fast_GET_SIZE(seq);
-{c_type} *in = {cast_static}{c_type} *{cast1}{stdlib}malloc(size * sizeof({c_type})){cast2};
+char **in = {cast_static}char **{cast1}{stdlib}calloc(size, sizeof(char *)){cast2};
 for (Py_ssize_t i = 0; i < size; i++) {{+
 PyObject *item = PySequence_Fast_GET_ITEM(seq, i);
 in[i] = {Py_get};

--- a/shroud/whelpers.py
+++ b/shroud/whelpers.py
@@ -337,7 +337,7 @@ if (PyUnicode_Check(obj)) {{+
 ^#if PY_MAJOR_VERSION >= 3
 PyObject *strobj = PyUnicode_AsUTF8String(obj);
 out = PyBytes_AS_STRING(strobj);
-size = PyString_Size(obj);
+size = PyBytes_GET_SIZE(strobj);
 value->obj = strobj;  // steal reference
 ^#else
 PyObject *strobj = PyUnicode_AsUTF8String(obj);

--- a/shroud/whelpers.py
+++ b/shroud/whelpers.py
@@ -243,76 +243,8 @@ array->size = 1;
 array->rank = 0;  // scalar
 -}}{lend}""", fmt),
     )
-    ##########
-    # Generate C or C++ version of helper.
-    ##########
-    # 'char *' needs a custom handler because of the nature
-    # of NULL terminated strings.
-    ntypemap = typemap.lookup_type("char")
-    fmt.fcn_suffix = "char"
-    fmt.fcn_type = "string"
-    fmt.c_type = "char *"
-    fmt.Py_get = "PyString_AsString(item)"
-#    fmt.Py_get = ntypemap.PY_get.format(py_var="item")
-    fmt.Py_ctor = ntypemap.PY_ctor.format(ctor_expr="in[i]")
-    fmt.hname = "create_from_PyObject_char"
-    CHelpers["create_from_PyObject_char"] = create_from_PyObject_charptr(fmt)
-    fmt.c_const=""  # XXX issues with struct.yaml test, remove const.
-    fmt.hname = "to_PyList_char"
-    CHelpers["to_PyList_char"] = create_to_PyList(fmt)
 
-    name = "fill_from_PyObject_char"
-    fmt.hname = name
-    fmt.hnamefunc = fmt.PY_helper_prefix + name
-    fmt.hnameproto = wformat(
-            "int {hnamefunc}\t(PyObject *obj,\t const char *name,\t char *in,\t Py_ssize_t insize)", fmt)
-    CHelpers[name] = dict(
-        name=fmt.hnamefunc,
-        dependent_helpers=["get_from_object_char"],
-        c_include="<string.h>",
-        cxx_include="<cstring>",
-        proto=fmt.hnameproto + ";",
-        source=wformat("""
-// helper {hname}
-// Copy PyObject to char array.
-// Return 0 on success, -1 on error.
-{PY_helper_static}{hnameproto}
-{{+
-{PY_typedef_converter} value;
-int i = {PY_helper_prefix}get_from_object_char(obj, &value);
-if (i == 0) {{+
-Py_DECREF(obj);
-return -1;
--}}
-if (value.data == {nullptr}) {{+
-in[0] = '\\0';
--}} else {{+
-{stdlib}strncpy\t(in,\t {cast_static}char *{cast1}value.data{cast2},\t insize);
-Py_DECREF(value.obj);
--}}
-return 0;
--}}""", fmt),
-    )
-
-    ########################################
-    # char **
-    name = "get_from_object_charptr"
-    fmt.size_var="size"
-    fmt.c_var="in"
-    fmt.hname = name
-    fmt.hnamefunc = fmt.PY_helper_prefix + name
-    CHelpers[name] = create_get_from_object_list(fmt)
-    # There are no 'list' or 'numpy' version of these functions.
-    # Use the one-true-version SHROUD_get_from_object_charptr.
-    CHelpers['get_from_object_charptr_list'] = dict(
-        name=fmt.hnamefunc,
-        dependent_helpers=[name],
-    )
-    CHelpers['get_from_object_charptr_numpy'] = dict(
-        name=fmt.hnamefunc,
-        dependent_helpers=[name],
-    )
-
+    
     ########################################
     # char *
     name = "get_from_object_char"
@@ -379,6 +311,76 @@ return 1;
         dependent_helpers=[name],
     )
     CHelpers['get_from_object_char_numpy'] = dict(
+        name=fmt.hnamefunc,
+        dependent_helpers=[name],
+    )
+
+    ##########
+    # Generate C or C++ version of helper.
+    ##########
+    # 'char *' needs a custom handler because of the nature
+    # of NULL terminated strings.
+    ntypemap = typemap.lookup_type("char")
+    fmt.fcn_suffix = "char"
+    fmt.fcn_type = "string"
+    fmt.c_type = "char *"
+    fmt.Py_get = "PyString_AsString(item)"
+#    fmt.Py_get = ntypemap.PY_get.format(py_var="item")
+    fmt.Py_ctor = ntypemap.PY_ctor.format(ctor_expr="in[i]")
+    fmt.hname = "create_from_PyObject_char"
+    CHelpers["create_from_PyObject_char"] = create_from_PyObject_charptr(fmt)
+    fmt.c_const=""  # XXX issues with struct.yaml test, remove const.
+    fmt.hname = "to_PyList_char"
+    CHelpers["to_PyList_char"] = create_to_PyList(fmt)
+
+    name = "fill_from_PyObject_char"
+    fmt.hname = name
+    fmt.hnamefunc = fmt.PY_helper_prefix + name
+    fmt.hnameproto = wformat(
+            "int {hnamefunc}\t(PyObject *obj,\t const char *name,\t char *in,\t Py_ssize_t insize)", fmt)
+    CHelpers[name] = dict(
+        name=fmt.hnamefunc,
+        dependent_helpers=["get_from_object_char"],
+        c_include="<string.h>",
+        cxx_include="<cstring>",
+        proto=fmt.hnameproto + ";",
+        source=wformat("""
+// helper {hname}
+// Copy PyObject to char array.
+// Return 0 on success, -1 on error.
+{PY_helper_static}{hnameproto}
+{{+
+{PY_typedef_converter} value;
+int i = {PY_helper_prefix}get_from_object_char(obj, &value);
+if (i == 0) {{+
+Py_DECREF(obj);
+return -1;
+-}}
+if (value.data == {nullptr}) {{+
+in[0] = '\\0';
+-}} else {{+
+{stdlib}strncpy\t(in,\t {cast_static}char *{cast1}value.data{cast2},\t insize);
+Py_DECREF(value.obj);
+-}}
+return 0;
+-}}""", fmt),
+    )
+
+    ########################################
+    # char **
+    name = "get_from_object_charptr"
+    fmt.size_var="size"
+    fmt.c_var="in"
+    fmt.hname = name
+    fmt.hnamefunc = fmt.PY_helper_prefix + name
+    CHelpers[name] = create_get_from_object_list(fmt)
+    # There are no 'list' or 'numpy' version of these functions.
+    # Use the one-true-version SHROUD_get_from_object_charptr.
+    CHelpers['get_from_object_charptr_list'] = dict(
+        name=fmt.hnamefunc,
+        dependent_helpers=[name],
+    )
+    CHelpers['get_from_object_charptr_numpy'] = dict(
         name=fmt.hnamefunc,
         dependent_helpers=[name],
     )

--- a/shroud/wrapf.py
+++ b/shroud/wrapf.py
@@ -1150,7 +1150,13 @@ rv = .false.
 
         if fmt.F_C_subprogram == "function":
             return_deref_attr = ast.attrs["deref"]
-            if c_result_blk.return_cptr:
+            if c_result_blk.f_result_decl:
+                for arg in c_result_blk.f_result_decl:
+                    arg_c_decl.append(arg.format(c_var=fmt.F_result))
+                if c_result_blk.f_module:
+                    self.update_f_module(
+                        modules, imports, c_result_blk.f_module)
+            elif c_result_blk.return_cptr:
                 arg_c_decl.append("type(C_PTR) %s" % fmt.F_result)
                 self.set_f_module(modules, "iso_c_binding", "C_PTR")
             elif c_result_blk.return_type:

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -1931,7 +1931,8 @@ return 1;""",
                 if deref != "scalar":
                     stmts.append(options.PY_array_arg)
         else:
-            stmts = ["py", sgroup, "result"]
+            spointer = ast.get_indirect_stmt()
+            stmts = ["py", sgroup, spointer, "result"]
         if stmts is not None:
             result_blk = lookup_stmts(stmts)
             # Useful for debugging.  Requested and found path.
@@ -3648,7 +3649,7 @@ py_statements = [
         ]
     ),
     dict(
-        name="py_void_result",
+        name="py_void_*_result",
         fmtdict=dict(
             ctor_expr="{cxx_var}",
         ),
@@ -4049,7 +4050,7 @@ py_statements = [
 ########################################
 # char *
     dict(
-        name="py_char_result",
+        name="py_char_*_result",
         fmtdict=dict(
             ctor_expr="{c_var}",
         ),
@@ -4108,8 +4109,9 @@ py_statements = [
     
 ########################################
 # string
+# ctor_expr is arguments to PyString_FromStringAndSize.
     dict(
-        name="py_string_in",
+        name="py_string_scalar_in",
         cxx_local_var="scalar",
         post_declare=["{c_const}std::string {cxx_var}({c_var});"],
         fmtdict=dict(
@@ -4117,7 +4119,11 @@ py_statements = [
         ),
     ),
     dict(
-        name="py_string_inout",
+        name="py_string_&_in",
+        base="py_string_scalar_in",
+    ),
+    dict(
+        name="py_string_scalar_inout",
         cxx_local_var="scalar",
         post_declare=["{c_const}std::string {cxx_var}({c_var});"],
         fmtdict=dict(
@@ -4125,7 +4131,11 @@ py_statements = [
         ),
     ),
     dict(
-        name="py_string_out",
+        name="py_string_&_inout",
+        base="py_string_scalar_inout",
+    ),
+    dict(
+        name="py_string_scalar_out",
         arg_declare=[],
         cxx_local_var="scalar",
         post_declare=["{c_const}std::string {cxx_var};"],
@@ -4134,24 +4144,38 @@ py_statements = [
         ),
     ),
     dict(
-        name="py_string_result",
+        name="py_string_&_out",
+        base="py_string_scalar_out",
+    ),
+    dict(
+        name="py_string_scalar_result",
         fmtdict=dict(
             ctor_expr="{cxx_var}{cxx_member}data(),\t {cxx_var}{cxx_member}size()",
         ),
     ),
     dict(
+        name="py_string_*_result",
+        fmtdict=dict(
+            ctor_expr="{cxx_var}{cxx_member}data(),\t {cxx_var}{cxx_member}size()",
+        ),
+    ),
+    dict(
+        name="py_string_&_result",
+        base="py_string_*_result",
+    ),
+    dict(
         name="py_string_*_in",
-        base="py_string_in",
+        base="py_string_scalar_in",
         arg_call=["&{cxx_var}"],
     ),
     dict(
         name="py_string_*_inout",
-        base="py_string_inout",
+        base="py_string_scalar_inout",
         arg_call=["&{cxx_var}"],
     ),
     dict(
         name="py_string_*_out",
-        base="py_string_out",
+        base="py_string_scalar_out",
         arg_call=["&{cxx_var}"],
     ),
 
@@ -4457,7 +4481,7 @@ py_statements = [
 ########################################
 # shadow a.k.a class
     dict(
-        name="py_shadow_in",
+        name="py_shadow_*_in",
         arg_declare=[], # No C variable, the pointer is extracted from PyObject.
         cxx_local_var="pointer",
         post_declare=[
@@ -4466,7 +4490,7 @@ py_statements = [
         ],
     ),
     dict(
-        name="py_shadow_inout",
+        name="py_shadow_*_inout",
         arg_declare=[], # No C variable, the pointer is extracted from PyObject.
         cxx_local_var="pointer",
         post_declare=[
@@ -4475,7 +4499,7 @@ py_statements = [
         ],
     ),
     dict(
-        name="py_shadow_out",
+        name="py_shadow_*_out",
         declare=[
             "{PyObject} *{py_var} = {nullptr};"
         ],
@@ -4495,7 +4519,7 @@ py_statements = [
         goto_fail=True,
     ),
     dict(
-        name="py_shadow_result",
+        name="py_shadow_*_result",
 #            declare=[
 #                "{PyObject} *{py_var} = {nullptr};"
 #            ],
@@ -4515,13 +4539,17 @@ py_statements = [
 #            goto_fail=True,
     ),
     dict(
+        name="py_shadow_&_result",
+        base="py_shadow_*_result",
+    ),
+    dict(
         name="py_shadow_scalar_in",
-        base="py_shadow_in",
+        base="py_shadow_*_in",
         arg_call=["*{cxx_var}"],
     ),
     dict(
         name="py_shadow_&_in",
-        base="py_shadow_in",
+        base="py_shadow_*_in",
         arg_call=["*{cxx_var}"],
     ),
     

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -2624,6 +2624,7 @@ extern PyObject *{PY_prefix}error_obj;
         if need_numpy:
             self.add_numpy_includes(output)
         self.write_headers(hinclude, output)
+        output.append(cpp_boilerplate)
 
         if hsource:
             output.extend(hsource)

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -4048,7 +4048,29 @@ py_statements = [
         object_created=True,
     ),
 ########################################
-# char *
+# char
+    dict(
+        # Get a string from argument but only pass first character to C++.
+        # Since char is a scalar, need to actually get a char * - parse_format, parse_args.
+        # XXX - make sure c_var is only 1 long?
+        name="py_char_scalar_in",
+        arg_declare=[
+            "char *{c_var};",
+        ],
+        parse_format="s",
+        parse_args=["&{c_var}"],
+        arg_call=["{c_var}[0]"],
+    ),
+    dict(
+        name="py_char_scalar_result",
+        declare=[
+            "{PyObject} * {py_var} = {nullptr};",
+        ],
+        post_call=[
+            "{py_var} = PyString_FromStringAndSize(&{cxx_var}, 1);",
+        ],
+        object_created=True,
+    ),
     dict(
         name="py_char_*_result",
         fmtdict=dict(


### PR DESCRIPTION
Remove the typemap for *char_scalar*.  This was the original attempt to treat `char` and `char *` differently.  This is now implemented with fc_statements and py_statements which allows a more data-driven method to treat this sort of differences.  Strings are treated differently in both Fortran and Python and require code different than native types such as `int`.