### PR TITLE
Fix DeprecationWarnings

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -12,6 +12,15 @@ Defaults to Python 3.
     make venv=/usr/tce/packages/python/python-3.7.2/bin/virtualenv virtualenv
     make develop
 
+pythondevmode
+-------------
+
+If this environment variable is set to a non-empty string, enable
+Python Development Mode, introducing additional runtime checks that
+are too expensive to be enabled by default.  New in version 3.7.
+
+setenv PYTHONDEVMODE 1
+
 Run unittest
 ------------
 

--- a/shroud/util.py
+++ b/shroud/util.py
@@ -11,6 +11,15 @@ import collections
 import os
 import string
 
+try:
+    # Python 3
+    Mapping = collections.abc.Mapping
+    Sequence = collections.abc.Sequence
+except AttributeError:
+    # Python 2
+    Mapping = collections.Mapping
+    Sequence = collections.Sequence
+
 fmt = string.Formatter()
 
 def wformat(template, dct):
@@ -108,7 +117,7 @@ def as_yaml(obj, order, output):
     """
 
     for key in order:
-        if isinstance(obj, collections.Mapping):
+        if isinstance(obj, Mapping):
             value = obj[key]
         else:
             value = getattr(obj, key)
@@ -124,7 +133,7 @@ def as_yaml(obj, order, output):
                 output.append('{}: "{}"'.format(key, value))
             else:
                 output.append("{}: {}".format(key, value))
-        elif isinstance(value, collections.Sequence):
+        elif isinstance(value, Sequence):
             # Keys which are are an array of string (code templates)
             if key in (
                 "declare",
@@ -141,7 +150,7 @@ def as_yaml(obj, order, output):
                 output.append("{}:".format(key))
                 for i in value:
                     output.append("@- {}".format(i))
-        elif isinstance(value, collections.Mapping):
+        elif isinstance(value, Mapping):
             output.append("{}:".format(key))
             order0 = sorted(value.keys())
             output.append(1)


### PR DESCRIPTION
What's new Python 3.9:
When Python 2.7 was still supported, many functions were kept for
backward compatibility with Python 2.7. With the end of Python 2.7
support, these backward compatibility layers have been removed, or
will be removed soon. Most of them emitted a DeprecationWarning
warning for several years. For example, using collections.Mapping
instead of collections.abc.Mapping emits a DeprecationWarning since
Python 3.3, released in 2012.