### PR TITLE
Allow struct to be define without members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   Add options *wrap_class_as*, *wrap_struct_as*, *class_ctor* and *class_method*.
   Attribute *+pass* defines the passed-object dummy argument. Defines ``PASS``
   Fortran keyword with type-bound procedures.
+- ``struct`` can now be defined the same as a ``class`` by using a
+  *declarations* field in the YAML file.  The entire struct can
+  continue to be declared in a single *decl* field as before.  This
+  makes it easier to define opaque structs where the members are not
+  listed. Useful with *wrap_struct_as=class*.
 
 ### Fixed
 - Order of header files in *cxx_header* is preserved in the generated code.

--- a/docs/struct.rst
+++ b/docs/struct.rst
@@ -320,7 +320,9 @@ same thing, Shroud treats structs as a C style struct.  They do not
 have associated methods.  This allows them to be mapped to a Fortran
 derived type with the ``bind(C)`` attribute and a Python NumPy array.
 
-A struct is defined in a single ``decl`` in the YAML file.
+A struct is defined the same as a class with a *declarations* field
+for struct members.
+In addition, a struct can be defined in a single ``decl`` in the YAML file.
 
 .. code-block:: yaml
 

--- a/regression/input/struct.yaml
+++ b/regression/input/struct.yaml
@@ -77,11 +77,10 @@ declarations:
       Generates a bufferify C wrapper function.
 
 ######################################################################
-- decl: struct Cstruct_ptr {
-          char *cfield;
-          const double *const_dvalue;
-        };
-#          double *dvalue;
+- decl: struct Cstruct_ptr
+  declarations:
+  - decl: char *cfield;
+  - decl: const double *const_dvalue;
         # dvalue is implied +readonly because of const.
 
 ######################################################################

--- a/shroud/declast.py
+++ b/shroud/declast.py
@@ -852,13 +852,13 @@ class Parser(ExprParser):
         self.enter("struct_statement")
         self.mustbe("STRUCT")
         name = self.mustbe("ID")
-        self.mustbe("LCURLY")
         node = Struct(name.value)
-        members = node.members
-        while self.token.typ != "RCURLY":
-            members.append(self.declaration())
-            self.mustbe("SEMICOLON")
-        self.mustbe("RCURLY")
+        if self.have("LCURLY"):
+            members = node.members
+            while self.token.typ != "RCURLY":
+                members.append(self.declaration())
+                self.mustbe("SEMICOLON")
+            self.mustbe("RCURLY")
         self.exit("struct_statement")
         return node
 


### PR DESCRIPTION
Useful for opaque structs.

This also makes it possible to define members via the declarations
field in the YAML file. That's useful when options or format fields
need to be set on individual members.