### PR TITLE
Add CStmts.iface_header and impl_header

### DIFF
--- a/docs/cstatements.rst
+++ b/docs/cstatements.rst
@@ -47,7 +47,7 @@ arg
     This is the default when *buf_args* is not explicit.
 
 arg_decl
-    The explicit declarations will be provided in the fields
+    The explicit dummy/prototype declarations will be provided in the fields
     *c_arg_decl* and *f_arg_decl*.
     
 capsule
@@ -109,21 +109,24 @@ Used to add argument for return values.
 For example, function which return class instance.
 
 
-c_header
-^^^^^^^^
+iface_header
+^^^^^^^^^^^^
 
-List of blank delimited header files which will be included by the generated header
+List of header files which will be included in the generated header
 for the C wrapper.  These headers must be C only.
-For example, ``size_t`` requires stddef.h:
+Used for headers needed when *buf_args* contains *arg_decl*.
+Can contain headers required for the generated prototypes.
 
-.. code-block:: yaml
+.. note that typemaps will also add c_headers.
 
-    type: size_t
-    fields:
-        c_type: size_t 
-        cxx_type: size_t
-        c_header: <stddef.h>
+impl_header
+^^^^^^^^^^^
 
+A list of header files which will be added to the C
+wrapper implementation.
+These headers may include C++ code.
+
+.. listed in fc_statements as *c_impl_header* and *cxx_impl_header*
 
 c_helper
 ^^^^^^^^
@@ -154,13 +157,6 @@ If true, generate a local variable using the C declaration for the argument.
 This variable can be used by the pre_call and post_call statements.
 A single declaration will be added even if with ``intent(inout)``.
 
-cxx_header
-^^^^^^^^^^
-
-A blank delimited list of header files which will be added to the C
-wrapper implementation.
-These headers may include C++ code.
-
 cxx_local_var
 ^^^^^^^^^^^^^
 
@@ -172,19 +168,27 @@ This in turns will set the format fields *cxx_member*.
 For example, a ``std::string`` argument is created for the C++ function
 from the ``char *`` argument passed into the C API wrapper.
 
+.. code-block:: yaml
+
+        name="c_string_inout",
+        cxx_local_var="scalar",
+        pre_call=["{c_const}std::string {cxx_var}({c_var});"],
+
 c_arg_decl
 ^^^^^^^^^^
 
-A list of declarations in the C wrapper when buf_arg includes "arg_decl".
+A list of declarations to append to the prototype in the C wrapper
+when buf_arg includes "arg_decl".
 
 f_arg_decl
 ^^^^^^^^^^
 
-A list of declarations in the Fortran interface when buf_arg includes "arg_decl".
-The variable to be declared is *c_var*.
-*f_module* can be used to add ``USE`` statements.
+A list of dummy argument declarations in the Fortran ``bind(C)``
+interface when buf_arg includes "arg_decl".  The variable to be
+declared is *c_var*.  *f_module* can be used to add ``USE`` statements
+needed by the declarations.
 
-.. c_var
+.. c_var  c_f_dimension
 
 
 f_result_decl

--- a/docs/typemaps.rst
+++ b/docs/typemaps.rst
@@ -104,6 +104,16 @@ Defaults to *None*.
 
 See also *cxx_header*.
 
+For example, ``size_t`` requires stddef.h:
+
+.. code-block:: yaml
+
+    type: size_t
+    fields:
+        c_type: size_t 
+        cxx_type: size_t
+        c_header: <stddef.h>
+
 
 c_to_cxx
 ^^^^^^^^

--- a/shroud/statements.py
+++ b/shroud/statements.py
@@ -182,9 +182,16 @@ def update_for_language(stmts, lang):
       foo_bar["declare"] = foo_bar["c_declare"]
     """
     for item in stmts:
-        for clause in ["cxx_local_var", "declare", "post_parse",
-                       "pre_call", "post_call",
-                       "cleanup", "fail"]:
+        for clause in [
+                "impl_header",
+                "cxx_local_var",
+                "declare",
+                "post_parse",
+                "pre_call",
+                "post_call",
+                "cleanup",
+                "fail",
+        ]:
             specific = lang + "_" + clause
             if specific in item:
                 # XXX - maybe make sure clause does not already exist.
@@ -344,8 +351,10 @@ class CStmts(object):
     def __init__(self,
         name="c_default",
         buf_args=[], buf_extra=[],
-        c_header=[], c_helper="", c_local_var=None,
-        cxx_header=[], cxx_local_var=None,
+        iface_header=[],
+        impl_header=[],
+        c_helper="", c_local_var=None,
+        cxx_local_var=None,
         arg_call=[],
         pre_call=[], call=[], post_call=[], final=[], ret=[],
         destructor_name=None,
@@ -359,10 +368,10 @@ class CStmts(object):
         self.name = name
         self.buf_args = buf_args
         self.buf_extra = buf_extra
-        self.c_header = c_header
+        self.iface_header = iface_header
+        self.impl_header = impl_header
         self.c_helper = c_helper
         self.c_local_var = c_local_var
-        self.cxx_header = cxx_header
         self.cxx_local_var = cxx_local_var
 
         self.pre_call = pre_call
@@ -816,8 +825,8 @@ fc_statements = [
     dict(
         name="c_char_scalar_result_buf",
         buf_args=["arg", "len"],
-        c_header=["<string.h>"],
-        cxx_header=["<cstring>"],
+        c_impl_header=["<string.h>"],
+        cxx_impl_header=["<cstring>"],
         post_call=[
             "{stdlib}memset({c_var}, ' ', {c_var_len});",
             "{c_var}[0] = {cxx_var};",
@@ -962,7 +971,7 @@ fc_statements = [
     ),
     dict(
         name="c_string_out",
-        cxx_header=["<cstring>"],
+        cxx_impl_header=["<cstring>"],
         # #- pre_call=[
         # #-     'int {c_var_trim} = strlen({c_var});',
         # #-     ],
@@ -975,7 +984,7 @@ fc_statements = [
     ),
     dict(
         name="c_string_inout",
-        cxx_header=["<cstring>"],
+        cxx_impl_header=["<cstring>"],
         cxx_local_var="scalar",
         pre_call=["{c_const}std::string {cxx_var}({c_var});"],
         post_call=[
@@ -1525,8 +1534,8 @@ fc_statements = [
     dict(
         # NULL in stddef.h
         name="c_shadow_dtor",
-        c_header=["<stddef.h>"],
-        cxx_header=["<cstddef>"],
+        c_impl_header=["<stddef.h>"],
+        cxx_impl_header=["<cstddef>"],
         call=[
             "delete {CXX_this};",
             "{C_this}->addr = {nullptr};",

--- a/shroud/util.py
+++ b/shroud/util.py
@@ -512,7 +512,7 @@ class Header(object):
         self.typemap_field = field
 
     def add_shroud_file(self, name):
-        """Add a dict of headers.
+        """Add a header file.
         """
         self.header_impl_include_order["shroud"][name] = True
 
@@ -522,7 +522,7 @@ class Header(object):
         for name in sorted(dct.keys()):
             self.header_impl_include_order["shroud"][name] = True
     
-    def add_statements_headers(self, intent_blk):
+    def add_statements_headers_PY(self, intent_blk):
         """Add headers required by intent_blk to self.header_impl_include.
 
         Args:
@@ -534,6 +534,18 @@ class Header(object):
         else:
             headers = intent_blk.cxx_header
         for name in headers:
+            self.header_impl_include_order["shroud"][name] = True
+
+    def add_statements_headers(self, lang, intent_blk):
+        """Add headers required by intent_blk to self.header_impl_include.
+
+        Parameters
+        ----------
+        lang : str
+            "impl_header", "iface_header"
+        intent_blk : CStmts
+        """
+        for name in getattr(intent_blk, lang):
             self.header_impl_include_order["shroud"][name] = True
 
     def write_headers(self, output):

--- a/shroud/wrapc.py
+++ b/shroud/wrapc.py
@@ -71,6 +71,9 @@ class Wrapc(util.WrapperMixin):
         self.impl_typedef_nodes = OrderedDict()  # [typemap.name] = typemap
         # Headers needed by implementation, i.e. helper functions.
         self.header_impl = util.Header(self.newlibrary)
+        # Headers needed by interface.
+        self.header_iface = util.Header(self.newlibrary)
+        # Prototype for wrapped functions.
         self.header_proto_c = []
         self.impl = []
         self.enum_impl = []
@@ -366,7 +369,7 @@ class Wrapc(util.WrapperMixin):
             output.append("#" + node.cpp_if)
 
         # headers required by typedefs and helpers
-        headers = util.Header(self.newlibrary)
+        headers = self.header_iface
         headers.add_typemaps_xxx(self.header_typedef_nodes)
         headers.add_shroud_dict(self.c_helper_include)
         headers.write_headers(output)
@@ -695,7 +698,8 @@ class Wrapc(util.WrapperMixin):
         return need_wrapper
         A wrapper is needed if code is added.
         """
-        self.header_impl.add_statements_headers(intent_blk)
+        self.header_impl.add_statements_headers("impl_header", intent_blk)
+        self.header_iface.add_statements_headers("iface_header", intent_blk)
 
         if intent_blk.pre_call:
             need_wrapper = True

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -1480,7 +1480,7 @@ return 1;""",
             goto_fail = goto_fail or intent_blk.goto_fail
             self.need_numpy = self.need_numpy or intent_blk.need_numpy
             update_code_blocks(locals(), intent_blk, fmt_arg)
-            self.header_impl.add_statements_headers(intent_blk)
+            self.header_impl.add_statements_headers_PY(intent_blk)
 
             # Pass correct value to wrapped function.
             if intent_blk.arg_call:


### PR DESCRIPTION
c_header and cxx_header replaced by c_impl_header and cxx_impl_header
and assigned to impl_header based on language by
update_for_language. Used in implementation.

impl_header will be added to C header file.
Useful for creating function prototypes.