### PR TITLE
Stmts fix

### DIFF
--- a/regression/reference/cdesc/cdesc.json
+++ b/regression/reference/cdesc/cdesc.json
@@ -32,7 +32,7 @@
                             "sh_type": "SH_TYPE_INT",
                             "shadow_var": "SHadow_arg",
                             "stmt0": "c_native_*_in_cdesc",
-                            "stmt1": "c_native_*_in/out/inout_cdesc"
+                            "stmt1": "c_native_*_in_cdesc"
                         },
                         "fmtf": {
                             "F_C_var": "arg",
@@ -50,9 +50,9 @@
                             "sh_type": "SH_TYPE_INT",
                             "size": "size(arg)",
                             "stmt0": "f_native_*_in_cdesc",
-                            "stmt1": "f_native_*_in/out/inout_cdesc",
+                            "stmt1": "f_native_*_in_cdesc",
                             "stmtc0": "c_native_*_in_cdesc",
-                            "stmtc1": "c_native_*_in/out/inout_cdesc"
+                            "stmtc1": "c_native_*_in_cdesc"
                         }
                     }
                 },
@@ -632,7 +632,7 @@
                             "sh_type": "SH_TYPE_DOUBLE",
                             "size": "1",
                             "stmt0": "f_native_*_out_cdesc",
-                            "stmt1": "f_native_*_in/out/inout_cdesc",
+                            "stmt1": "f_native_*_out_cdesc",
                             "stmtc0": "c_void_*_out_buf_cdesc",
                             "stmtc1": "c_void_*_cdesc"
                         }

--- a/regression/reference/cdesc/wrapcdesc.cpp
+++ b/regression/reference/cdesc/wrapcdesc.cpp
@@ -30,8 +30,7 @@ extern "C" {
 // Match:     c_default
 // ----------------------------------------
 // Argument:  int * arg +cdesc+context(Darg)+intent(in)+rank(2)
-// Requested: c_native_*_in_cdesc
-// Match:     c_native_*_in/out/inout_cdesc
+// Exact:     c_native_*_in_cdesc
 void CDE_rank2_in(CDE_SHROUD_array *Darg)
 {
     // splicer begin function.rank2_in

--- a/regression/reference/cdesc/wrapfcdesc.f
+++ b/regression/reference/cdesc/wrapfcdesc.f
@@ -85,8 +85,7 @@ module cdesc_mod
         ! Match:     c_default
         ! ----------------------------------------
         ! Argument:  int * arg +cdesc+context(Darg)+intent(in)+rank(2)
-        ! Requested: c_native_*_in_cdesc
-        ! Match:     c_native_*_in/out/inout_cdesc
+        ! Exact:     c_native_*_in_cdesc
         subroutine c_rank2_in(Darg) &
                 bind(C, name="CDE_rank2_in")
             import :: CDE_SHROUD_array
@@ -186,10 +185,8 @@ contains
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  int * arg +cdesc+context(Darg)+intent(in)+rank(2)
-    ! Requested: f_native_*_in_cdesc
-    ! Match:     f_native_*_in/out/inout_cdesc
-    ! Requested: c_native_*_in_cdesc
-    ! Match:     c_native_*_in/out/inout_cdesc
+    ! Exact:     f_native_*_in_cdesc
+    ! Exact:     c_native_*_in_cdesc
     subroutine rank2_in(arg)
         use iso_c_binding, only : C_INT, C_LOC
         integer(C_INT), intent(IN), target :: arg(:,:)
@@ -222,8 +219,7 @@ contains
     ! Match:     c_string_in_buf
     ! ----------------------------------------
     ! Argument:  int * value +cdesc+context(Dvalue)+intent(out)+rank(0)
-    ! Requested: f_native_*_out_cdesc
-    ! Match:     f_native_*_in/out/inout_cdesc
+    ! Exact:     f_native_*_out_cdesc
     ! Argument:  void * value +cdesc+context(Dvalue)+intent(out)+rank(0)+value
     ! Requested: c_void_*_out_buf_cdesc
     ! Match:     c_void_*_cdesc
@@ -270,8 +266,7 @@ contains
     ! Match:     c_string_in_buf
     ! ----------------------------------------
     ! Argument:  double * value +cdesc+context(Dvalue)+intent(out)+rank(0)
-    ! Requested: f_native_*_out_cdesc
-    ! Match:     f_native_*_in/out/inout_cdesc
+    ! Exact:     f_native_*_out_cdesc
     ! Argument:  void * value +cdesc+context(Dvalue)+intent(out)+rank(0)+value
     ! Requested: c_void_*_out_buf_cdesc
     ! Match:     c_void_*_cdesc

--- a/regression/reference/strings/strings.json
+++ b/regression/reference/strings/strings.json
@@ -987,7 +987,7 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "f_char_scalar_result_allocatable",
-                        "stmt1": "f_char_scalar/*_result_allocatable",
+                        "stmt1": "f_char_scalar_result_allocatable",
                         "stmtc0": "c_char_scalar_result_buf",
                         "stmtc1": "c_char_scalar_result_buf"
                     },
@@ -1098,7 +1098,7 @@
                             "hnamefunc0": "STR_SHROUD_copy_string_and_free",
                             "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "f_char_*_result_allocatable",
-                            "stmt1": "f_char_scalar/*_result_allocatable",
+                            "stmt1": "f_char_*_result_allocatable",
                             "stmtc0": "c_char_*_result_buf_allocatable",
                             "stmtc1": "c_char_*_result_buf_allocatable"
                         }

--- a/regression/reference/strings/wrapfstrings.f
+++ b/regression/reference/strings/wrapfstrings.f
@@ -1336,14 +1336,12 @@ contains
     ! ----------------------------------------
     ! Function:  const char * getCharPtr1 +deref(allocatable)
     ! const char * getCharPtr1 +deref(allocatable)
-    ! Requested: f_char_scalar_result_allocatable
-    ! Match:     f_char_scalar/*_result_allocatable
+    ! Exact:     f_char_scalar_result_allocatable
     ! Function:  void getCharPtr1
     ! Exact:     c_char_scalar_result_buf
     ! ----------------------------------------
     ! Argument:  const char * SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
-    ! Requested: f_char_*_result_allocatable
-    ! Match:     f_char_scalar/*_result_allocatable
+    ! Exact:     f_char_*_result_allocatable
     ! Exact:     c_char_*_result_buf_allocatable
     !>
     !! \brief return a 'const char *' as character(*)

--- a/shroud/statements.py
+++ b/shroud/statements.py
@@ -264,7 +264,8 @@ def add_statement_to_tree(tree, nodes, node_stmts, node, steps):
     scope.update(node)
     step["_stmts"] = scope
     name = step["_key"]
-#keep    scope.name = name
+    # Name scope using variant name (ex in/out/inout).
+    scope.name = name
     nodes[name] = scope
     node_stmts[name] = node
     

--- a/shroud/statements.py
+++ b/shroud/statements.py
@@ -230,7 +230,7 @@ def compute_stmt_permutations(out, parts):
         out.append(tmp)
                 
 
-def add_statement_to_tree(tree, nodes, node, steps):
+def add_statement_to_tree(tree, nodes, node_stmts, node, steps):
     """Add node to tree.
 
     Parameters
@@ -238,9 +238,11 @@ def add_statement_to_tree(tree, nodes, node, steps):
     tree : dict
         The accumulated tree.
     nodes : dict
-        nodes indexed by name to implement 'base'
+        Scopes indexed by name to implement 'base'.
+    node_stmts : dict
+        nodes indexed by name to implement 'mixin'.
     node : dict
-        A single 'statements' dict.
+        A 'statements' dict from fc_statement to add.
     steps : list of str
         ['c', 'native', '*', 'in', 'cfi']
     """
@@ -252,17 +254,19 @@ def add_statement_to_tree(tree, nodes, node, steps):
         step["_key"] = "_".join(label)
     if "base" in node:
         step['_node'] = node
-        scope = util.Scope(nodes[node["base"]]["scope"])
-        scope.update(node)
-        node["scope"] = scope
+        scope = util.Scope(nodes[node["base"]])
     else:
         step['_node'] = node
         scope = util.Scope(default_scopes[steps[0]])
         if "mixin" in node:
             for mpart in node["mixin"]:
-                scope.update(nodes[mpart])
-        scope.update(node)
-        node["scope"] = scope
+                scope.update(node_stmts[mpart])
+    scope.update(node)
+    step["_stmts"] = scope
+    name = step["_key"]
+#keep    scope.name = name
+    nodes[name] = scope
+    node_stmts[name] = node
     
         
 def update_stmt_tree(stmts, tree, defaults):
@@ -307,7 +311,8 @@ def update_stmt_tree(stmts, tree, defaults):
         default_scopes[key] = node()
 
     # Index by name to find alias, base, mixin.
-    nodes = {}
+    nodes = {}      # Created Scope members for 'base'.
+    node_stmts = {} # Dict from fc_statements for 'mixin'.
     for node in stmts:
         # node is a dict.
         if "name" not in node:
@@ -330,8 +335,7 @@ def update_stmt_tree(stmts, tree, defaults):
             if name in nodes:
                 raise RuntimeError("Duplicate key in statements: {}".
                                    format(name))
-            nodes[name] = node
-            add_statement_to_tree(tree, nodes, node, namelst)
+            add_statement_to_tree(tree, nodes, node_stmts, node, namelst)
 #    print_tree(tree)
 
 def print_tree(tree, indent=""):
@@ -388,7 +392,7 @@ def lookup_stmts_tree(tree, path):
         step = step[part]
         if "_node" in step:
             # Path ends here.
-            found = step["_node"]["scope"]
+            found = step["_stmts"]
 #    if not isinstance(found, util.Scope):
 #        raise RuntimeError
     return found


### PR DESCRIPTION
Fix a problem in generated code where the statements variant ``scalar/*`` was getting added as a comment in the Fortran source. However, the C preprocessor saw the ``/*`` as a C comment without a terminating comment causing a compile error in the generated source.
 