### PR TITLE
String statement debug

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -54,6 +54,10 @@ write-helpers BASE
        Write files which contain the available helper functions
        into the files BASE.c and BASE.f.
 
+write-statements BASE
+       Write a file which contain the statements tree.
+       Used for debugging.
+
 write-version
        Write Shroud version into generated files.
        ``--nowrite-version`` will not write the version and is used

--- a/regression/do-test.py
+++ b/regression/do-test.py
@@ -322,7 +322,8 @@ if __name__ == "__main__":
                  cmdline=[
                      "--write-helpers", "helpers",
                      "--yaml-types", "def_types.yaml",
-                     "--write-version",  # Test writing vesion
+                     "--write-statements", "statements",
+                     "--write-version",  # Test writing version
                  ]),
         TestDesc("tutorial"),
         TestDesc("debugfalse", yaml="tutorial",

--- a/regression/reference/cdesc/cdesc.json
+++ b/regression/reference/cdesc/cdesc.json
@@ -136,7 +136,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_name",
                             "stmt0": "c_string_&_in",
-                            "stmt1": "c_string_in"
+                            "stmt1": "c_string_&_in"
                         },
                         "fmtf": {
                             "F_C_var": "name"
@@ -581,7 +581,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_name",
                             "stmt0": "c_string_&_in_buf",
-                            "stmt1": "c_string_in_buf"
+                            "stmt1": "c_string_&_in_buf"
                         },
                         "fmtf": {
                             "F_C_var": "name",
@@ -596,7 +596,7 @@
                             "stmt0": "f_string_&_in",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_&_in_buf",
-                            "stmtc1": "c_string_in_buf"
+                            "stmtc1": "c_string_&_in_buf"
                         }
                     },
                     "value": {
@@ -1120,7 +1120,7 @@
                             "stmt0": "f_string_&_in",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_&_in",
-                            "stmtc1": "c_string_in"
+                            "stmtc1": "c_string_&_in"
                         }
                     },
                     "value": {

--- a/regression/reference/cdesc/wrapcdesc.cpp
+++ b/regression/reference/cdesc/wrapcdesc.cpp
@@ -54,8 +54,7 @@ void CDE_rank2_in(CDE_SHROUD_array *Darg)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  std::string & name +intent(in)
-// Requested: c_string_&_in
-// Match:     c_string_in
+// Exact:     c_string_&_in
 // ----------------------------------------
 // Argument:  void * value +cdesc+context(Dvalue)+intent(out)+rank(0)+value
 // Requested: c_void_*_out_cdesc
@@ -82,8 +81,7 @@ void CDE_get_scalar1(char * name, CDE_SHROUD_array *Dvalue)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  std::string & name +intent(in)+len_trim(Lname)
-// Requested: c_string_&_in_buf
-// Match:     c_string_in_buf
+// Exact:     c_string_&_in_buf
 // ----------------------------------------
 // Argument:  void * value +cdesc+context(Dvalue)+intent(out)+rank(0)+value
 // Requested: c_void_*_out_buf_cdesc

--- a/regression/reference/cdesc/wrapfcdesc.f
+++ b/regression/reference/cdesc/wrapfcdesc.f
@@ -99,8 +99,7 @@ module cdesc_mod
         ! Match:     c_default
         ! ----------------------------------------
         ! Argument:  std::string & name +intent(in)
-        ! Requested: c_string_&_in
-        ! Match:     c_string_in
+        ! Exact:     c_string_&_in
         ! ----------------------------------------
         ! Argument:  void * value +cdesc+context(Dvalue)+intent(out)+rank(0)+value
         ! Requested: c_void_*_out_cdesc
@@ -120,8 +119,7 @@ module cdesc_mod
         ! Match:     c_default
         ! ----------------------------------------
         ! Argument:  std::string & name +intent(in)+len_trim(Lname)
-        ! Requested: c_string_&_in_buf
-        ! Match:     c_string_in_buf
+        ! Exact:     c_string_&_in_buf
         ! ----------------------------------------
         ! Argument:  void * value +cdesc+context(Dvalue)+intent(out)+rank(0)+value
         ! Requested: c_void_*_out_buf_cdesc
@@ -215,8 +213,7 @@ contains
     ! Requested: f_string_&_in
     ! Match:     f_default
     ! Argument:  std::string & name +intent(in)+len_trim(Lname)
-    ! Requested: c_string_&_in_buf
-    ! Match:     c_string_in_buf
+    ! Exact:     c_string_&_in_buf
     ! ----------------------------------------
     ! Argument:  int * value +cdesc+context(Dvalue)+intent(out)+rank(0)
     ! Exact:     f_native_*_out_cdesc
@@ -262,8 +259,7 @@ contains
     ! Requested: f_string_&_in
     ! Match:     f_default
     ! Argument:  std::string & name +intent(in)+len_trim(Lname)
-    ! Requested: c_string_&_in_buf
-    ! Match:     c_string_in_buf
+    ! Exact:     c_string_&_in_buf
     ! ----------------------------------------
     ! Argument:  double * value +cdesc+context(Dvalue)+intent(out)+rank(0)
     ! Exact:     f_native_*_out_cdesc
@@ -348,8 +344,7 @@ contains
     ! Argument:  std::string & name +intent(in)
     ! Requested: f_string_&_in
     ! Match:     f_default
-    ! Requested: c_string_&_in
-    ! Match:     c_string_in
+    ! Exact:     c_string_&_in
     ! ----------------------------------------
     ! Argument:  int * value +intent(out)
     ! Requested: f_native_*_out
@@ -385,8 +380,7 @@ contains
     ! Argument:  std::string & name +intent(in)
     ! Requested: f_string_&_in
     ! Match:     f_default
-    ! Requested: c_string_&_in
-    ! Match:     c_string_in
+    ! Exact:     c_string_&_in
     ! ----------------------------------------
     ! Argument:  double * value +intent(out)
     ! Requested: f_native_*_out

--- a/regression/reference/classes/classes.json
+++ b/regression/reference/classes/classes.json
@@ -856,7 +856,7 @@
                                     "sh_type": "SH_TYPE_OTHER",
                                     "shadow_var": "SHadow_name",
                                     "stmt0": "c_string_&_in",
-                                    "stmt1": "c_string_in"
+                                    "stmt1": "c_string_&_in"
                                 },
                                 "fmtf": {
                                     "F_C_var": "name"
@@ -1030,7 +1030,7 @@
                                     "sh_type": "SH_TYPE_OTHER",
                                     "shadow_var": "SHadow_name",
                                     "stmt0": "c_string_&_in_buf",
-                                    "stmt1": "c_string_in_buf"
+                                    "stmt1": "c_string_&_in_buf"
                                 },
                                 "fmtf": {
                                     "F_C_var": "name",
@@ -1045,7 +1045,7 @@
                                     "stmt0": "f_string_&_in",
                                     "stmt1": "f_default",
                                     "stmtc0": "c_string_&_in_buf",
-                                    "stmtc1": "c_string_in_buf"
+                                    "stmtc1": "c_string_&_in_buf"
                                 }
                             }
                         },
@@ -1274,7 +1274,7 @@
                                 "sh_type": "SH_TYPE_OTHER",
                                 "shadow_var": "SHadow_rv",
                                 "stmt0": "c_string_&_result",
-                                "stmt1": "c_string_result"
+                                "stmt1": "c_string_&_result"
                             },
                             "fmtf": {
                                 "cxx_type": "std::string",
@@ -1396,7 +1396,7 @@
                                     "sh_type": "SH_TYPE_OTHER",
                                     "shadow_var": "SHadow_SHF_rv",
                                     "stmt0": "c_string_&_result_buf_allocatable",
-                                    "stmt1": "c_string_result_buf_allocatable"
+                                    "stmt1": "c_string_&_result_buf_allocatable"
                                 },
                                 "fmtf": {
                                     "F_C_var": "SHF_rv",
@@ -1412,7 +1412,7 @@
                                     "stmt0": "f_string_&_result_buf_allocatable",
                                     "stmt1": "f_string_&_result_buf_allocatable",
                                     "stmtc0": "c_string_&_result_buf_allocatable",
-                                    "stmtc1": "c_string_result_buf_allocatable"
+                                    "stmtc1": "c_string_&_result_buf_allocatable"
                                 }
                             }
                         },
@@ -2088,7 +2088,7 @@
                                 "sh_type": "SH_TYPE_OTHER",
                                 "shadow_var": "SHadow_rv",
                                 "stmt0": "c_string_&_result",
-                                "stmt1": "c_string_result"
+                                "stmt1": "c_string_&_result"
                             },
                             "fmtf": {
                                 "cxx_type": "std::string",
@@ -2210,7 +2210,7 @@
                                     "sh_type": "SH_TYPE_OTHER",
                                     "shadow_var": "SHadow_SHF_rv",
                                     "stmt0": "c_string_&_result_buf_allocatable",
-                                    "stmt1": "c_string_result_buf_allocatable"
+                                    "stmt1": "c_string_&_result_buf_allocatable"
                                 },
                                 "fmtf": {
                                     "F_C_var": "SHF_rv",
@@ -2226,7 +2226,7 @@
                                     "stmt0": "f_string_&_result_buf_allocatable",
                                     "stmt1": "f_string_&_result_buf_allocatable",
                                     "stmtc0": "c_string_&_result_buf_allocatable",
-                                    "stmtc1": "c_string_result_buf_allocatable"
+                                    "stmtc1": "c_string_&_result_buf_allocatable"
                                 }
                             }
                         },
@@ -4108,7 +4108,7 @@
                         "sh_type": "SH_TYPE_OTHER",
                         "shadow_var": "SHadow_rv",
                         "stmt0": "c_string_&_result",
-                        "stmt1": "c_string_result"
+                        "stmt1": "c_string_&_result"
                     },
                     "fmtf": {
                         "c_var_len": "30",
@@ -4224,7 +4224,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_SHF_rv",
                             "stmt0": "c_string_&_result_buf",
-                            "stmt1": "c_string_result_buf"
+                            "stmt1": "c_string_&_result_buf"
                         },
                         "fmtf": {
                             "F_C_var": "SHF_rv",
@@ -4239,7 +4239,7 @@
                             "stmt0": "f_string_&_result_buf",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_&_result_buf",
-                            "stmtc1": "c_string_result_buf"
+                            "stmtc1": "c_string_&_result_buf"
                         }
                     }
                 },

--- a/regression/reference/classes/wrapClass1.cpp
+++ b/regression/reference/classes/wrapClass1.cpp
@@ -168,8 +168,7 @@ void CLA_Class1_return_this(CLA_Class1 * self)
 // Match:     c_shadow_result
 // ----------------------------------------
 // Argument:  std::string & name +intent(in)
-// Requested: c_string_&_in
-// Match:     c_string_in
+// Exact:     c_string_&_in
 // ----------------------------------------
 // Argument:  bool flag +intent(in)+value
 // Requested: c_bool_scalar_in
@@ -201,8 +200,7 @@ CLA_Class1 * CLA_Class1_return_this_buffer(CLA_Class1 * self,
 // Match:     c_shadow_result
 // ----------------------------------------
 // Argument:  std::string & name +intent(in)+len_trim(Lname)
-// Requested: c_string_&_in_buf
-// Match:     c_string_in_buf
+// Exact:     c_string_&_in_buf
 // ----------------------------------------
 // Argument:  bool flag +intent(in)+value
 // Requested: c_bool_scalar_in_buf
@@ -253,8 +251,7 @@ CLA_Class1 * CLA_Class1_getclass3(const CLA_Class1 * self,
  */
 // ----------------------------------------
 // Function:  const std::string & getName +deref(allocatable)
-// Requested: c_string_&_result
-// Match:     c_string_result
+// Exact:     c_string_&_result
 // start CLA_Class1_get_name
 const char * CLA_Class1_get_name(CLA_Class1 * self)
 {
@@ -278,8 +275,7 @@ const char * CLA_Class1_get_name(CLA_Class1 * self)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  const std::string & SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
-// Requested: c_string_&_result_buf_allocatable
-// Match:     c_string_result_buf_allocatable
+// Exact:     c_string_&_result_buf_allocatable
 // start CLA_Class1_get_name_bufferify
 void CLA_Class1_get_name_bufferify(CLA_Class1 * self,
     CLA_SHROUD_array *DSHF_rv)

--- a/regression/reference/classes/wrapClass2.cpp
+++ b/regression/reference/classes/wrapClass2.cpp
@@ -50,8 +50,7 @@ static void ShroudStrToArray(CLA_SHROUD_array *array, const std::string * src, i
  */
 // ----------------------------------------
 // Function:  const std::string & getName +deref(allocatable)
-// Requested: c_string_&_result
-// Match:     c_string_result
+// Exact:     c_string_&_result
 const char * CLA_Class2_get_name(CLA_Class2 * self)
 {
     classes::Class2 *SH_this = static_cast<classes::Class2 *>
@@ -73,8 +72,7 @@ const char * CLA_Class2_get_name(CLA_Class2 * self)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  const std::string & SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
-// Requested: c_string_&_result_buf_allocatable
-// Match:     c_string_result_buf_allocatable
+// Exact:     c_string_&_result_buf_allocatable
 void CLA_Class2_get_name_bufferify(CLA_Class2 * self,
     CLA_SHROUD_array *DSHF_rv)
 {

--- a/regression/reference/classes/wrapclasses.cpp
+++ b/regression/reference/classes/wrapclasses.cpp
@@ -207,8 +207,7 @@ int CLA_get_global_flag(void)
 
 // ----------------------------------------
 // Function:  const std::string & LastFunctionCalled +deref(result-as-arg)+len(30)
-// Requested: c_string_&_result
-// Match:     c_string_result
+// Exact:     c_string_&_result
 const char * CLA_last_function_called(void)
 {
     // splicer begin function.last_function_called
@@ -224,8 +223,7 @@ const char * CLA_last_function_called(void)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  std::string & SHF_rv +intent(out)+len(NSHF_rv)
-// Requested: c_string_&_result_buf
-// Match:     c_string_result_buf
+// Exact:     c_string_&_result_buf
 void CLA_last_function_called_bufferify(char * SHF_rv, int NSHF_rv)
 {
     // splicer begin function.last_function_called_bufferify

--- a/regression/reference/classes/wrapfclasses.f
+++ b/regression/reference/classes/wrapfclasses.f
@@ -258,8 +258,7 @@ module classes_mod
     ! Match:     c_shadow_result
     ! ----------------------------------------
     ! Argument:  std::string & name +intent(in)
-    ! Requested: c_string_&_in
-    ! Match:     c_string_in
+    ! Exact:     c_string_&_in
     ! ----------------------------------------
     ! Argument:  bool flag +intent(in)+value
     ! Requested: c_bool_scalar_in
@@ -287,8 +286,7 @@ module classes_mod
     ! Match:     c_shadow_result
     ! ----------------------------------------
     ! Argument:  std::string & name +intent(in)+len_trim(Lname)
-    ! Requested: c_string_&_in_buf
-    ! Match:     c_string_in_buf
+    ! Exact:     c_string_&_in_buf
     ! ----------------------------------------
     ! Argument:  bool flag +intent(in)+value
     ! Requested: c_bool_scalar_in_buf
@@ -333,8 +331,7 @@ module classes_mod
 
     ! ----------------------------------------
     ! Function:  const std::string & getName +deref(allocatable)
-    ! Requested: c_string_&_result
-    ! Match:     c_string_result
+    ! Exact:     c_string_&_result
     ! start c_class1_get_name
     interface
         function c_class1_get_name(self) &
@@ -355,8 +352,7 @@ module classes_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  const std::string & SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
-    ! Requested: c_string_&_result_buf_allocatable
-    ! Match:     c_string_result_buf_allocatable
+    ! Exact:     c_string_&_result_buf_allocatable
     ! start c_class1_get_name_bufferify
     interface
         subroutine c_class1_get_name_bufferify(self, DSHF_rv) &
@@ -454,8 +450,7 @@ module classes_mod
 
     ! ----------------------------------------
     ! Function:  const std::string & getName +deref(allocatable)
-    ! Requested: c_string_&_result
-    ! Match:     c_string_result
+    ! Exact:     c_string_&_result
     interface
         function c_class2_get_name(self) &
                 result(SHT_rv) &
@@ -474,8 +469,7 @@ module classes_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  const std::string & SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
-    ! Requested: c_string_&_result_buf_allocatable
-    ! Match:     c_string_result_buf_allocatable
+    ! Exact:     c_string_&_result_buf_allocatable
     interface
         subroutine c_class2_get_name_bufferify(self, DSHF_rv) &
                 bind(C, name="CLA_Class2_get_name_bufferify")
@@ -732,8 +726,7 @@ module classes_mod
 
     ! ----------------------------------------
     ! Function:  const std::string & LastFunctionCalled +deref(result-as-arg)+len(30)
-    ! Requested: c_string_&_result
-    ! Match:     c_string_result
+    ! Exact:     c_string_&_result
     interface
         function c_last_function_called() &
                 result(SHT_rv) &
@@ -750,8 +743,7 @@ module classes_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  std::string & SHF_rv +intent(out)+len(NSHF_rv)
-    ! Requested: c_string_&_result_buf
-    ! Match:     c_string_result_buf
+    ! Exact:     c_string_&_result_buf
     interface
         subroutine c_last_function_called_bufferify(SHF_rv, NSHF_rv) &
                 bind(C, name="CLA_last_function_called_bufferify")
@@ -939,8 +931,7 @@ contains
     ! Requested: f_string_&_in
     ! Match:     f_default
     ! Argument:  std::string & name +intent(in)+len_trim(Lname)
-    ! Requested: c_string_&_in_buf
-    ! Match:     c_string_in_buf
+    ! Exact:     c_string_&_in_buf
     ! ----------------------------------------
     ! Argument:  bool flag +intent(in)+value
     ! Requested: f_bool_scalar_in
@@ -1003,8 +994,7 @@ contains
     ! ----------------------------------------
     ! Argument:  const std::string & SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
     ! Exact:     f_string_&_result_buf_allocatable
-    ! Requested: c_string_&_result_buf_allocatable
-    ! Match:     c_string_result_buf_allocatable
+    ! Exact:     c_string_&_result_buf_allocatable
     !>
     !! \brief test helper
     !!
@@ -1147,8 +1137,7 @@ contains
     ! ----------------------------------------
     ! Argument:  const std::string & SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
     ! Exact:     f_string_&_result_buf_allocatable
-    ! Requested: c_string_&_result_buf_allocatable
-    ! Match:     c_string_result_buf_allocatable
+    ! Exact:     c_string_&_result_buf_allocatable
     !>
     !! \brief test helper
     !!
@@ -1463,8 +1452,7 @@ contains
     ! Argument:  std::string & SHF_rv +intent(out)+len(NSHF_rv)
     ! Requested: f_string_&_result_buf
     ! Match:     f_default
-    ! Requested: c_string_&_result_buf
-    ! Match:     c_string_result_buf
+    ! Exact:     c_string_&_result_buf
     function last_function_called() &
             result(SHT_rv)
         use iso_c_binding, only : C_INT

--- a/regression/reference/debugfalse/tutorial.json
+++ b/regression/reference/debugfalse/tutorial.json
@@ -623,7 +623,7 @@
                             "stmt0": "f_string_*_result_buf_allocatable",
                             "stmt1": "f_string_*_result_buf_allocatable",
                             "stmtc0": "c_string_*_result_buf_allocatable",
-                            "stmtc1": "c_string_result_buf_allocatable"
+                            "stmtc1": "c_string_*_result_buf_allocatable"
                         }
                     },
                     "arg1": {
@@ -643,7 +643,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_arg1",
                             "stmt0": "c_string_&_in_buf",
-                            "stmt1": "c_string_in_buf"
+                            "stmt1": "c_string_&_in_buf"
                         },
                         "fmtf": {
                             "F_C_var": "arg1",
@@ -658,7 +658,7 @@
                             "stmt0": "f_string_&_in",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_&_in_buf",
-                            "stmtc1": "c_string_in_buf"
+                            "stmtc1": "c_string_&_in_buf"
                         }
                     },
                     "arg2": {
@@ -678,7 +678,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_arg2",
                             "stmt0": "c_string_&_in_buf",
-                            "stmt1": "c_string_in_buf"
+                            "stmt1": "c_string_&_in_buf"
                         },
                         "fmtf": {
                             "F_C_var": "arg2",
@@ -693,7 +693,7 @@
                             "stmt0": "f_string_&_in",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_&_in_buf",
-                            "stmtc1": "c_string_in_buf"
+                            "stmtc1": "c_string_&_in_buf"
                         }
                     }
                 },
@@ -1329,7 +1329,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_name",
                             "stmt0": "c_string_&_in",
-                            "stmt1": "c_string_in"
+                            "stmt1": "c_string_&_in"
                         },
                         "fmtf": {
                             "F_C_var": "name"
@@ -1462,7 +1462,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_name",
                             "stmt0": "c_string_&_in_buf",
-                            "stmt1": "c_string_in_buf"
+                            "stmt1": "c_string_&_in_buf"
                         },
                         "fmtf": {
                             "F_C_var": "name",
@@ -1477,7 +1477,7 @@
                             "stmt0": "f_string_&_in",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_&_in_buf",
-                            "stmtc1": "c_string_in_buf"
+                            "stmtc1": "c_string_&_in_buf"
                         }
                     }
                 },
@@ -2481,7 +2481,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_name",
                             "stmt0": "c_string_&_in",
-                            "stmt1": "c_string_in"
+                            "stmt1": "c_string_&_in"
                         },
                         "fmtf": {
                             "F_C_var": "name"
@@ -2873,7 +2873,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_name",
                             "stmt0": "c_string_&_in_buf",
-                            "stmt1": "c_string_in_buf"
+                            "stmt1": "c_string_&_in_buf"
                         },
                         "fmtf": {
                             "F_C_var": "name",
@@ -2888,7 +2888,7 @@
                             "stmt0": "f_string_&_in",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_&_in_buf",
-                            "stmtc1": "c_string_in_buf"
+                            "stmtc1": "c_string_&_in_buf"
                         }
                     }
                 },
@@ -5512,7 +5512,7 @@
                         "sh_type": "SH_TYPE_OTHER",
                         "shadow_var": "SHadow_rv",
                         "stmt0": "c_string_&_result",
-                        "stmt1": "c_string_result"
+                        "stmt1": "c_string_&_result"
                     },
                     "fmtf": {
                         "c_var_len": "30",
@@ -5628,7 +5628,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_SHF_rv",
                             "stmt0": "c_string_&_result_buf",
-                            "stmt1": "c_string_result_buf"
+                            "stmt1": "c_string_&_result_buf"
                         },
                         "fmtf": {
                             "F_C_var": "SHF_rv",
@@ -5643,7 +5643,7 @@
                             "stmt0": "f_string_&_result_buf",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_&_result_buf",
-                            "stmtc1": "c_string_result_buf"
+                            "stmtc1": "c_string_&_result_buf"
                         }
                     }
                 },

--- a/regression/reference/example/example.json
+++ b/regression/reference/example/example.json
@@ -193,7 +193,7 @@
                                                     "sh_type": "SH_TYPE_OTHER",
                                                     "shadow_var": "SHadow_name",
                                                     "stmt0": "c_string_*_in",
-                                                    "stmt1": "c_string_in"
+                                                    "stmt1": "c_string_*_in"
                                                 },
                                                 "fmtf": {
                                                     "F_C_var": "name"
@@ -383,7 +383,7 @@
                                                     "sh_type": "SH_TYPE_OTHER",
                                                     "shadow_var": "SHadow_name",
                                                     "stmt0": "c_string_*_in_buf",
-                                                    "stmt1": "c_string_in_buf"
+                                                    "stmt1": "c_string_*_in_buf"
                                                 },
                                                 "fmtf": {
                                                     "F_C_var": "name",
@@ -398,7 +398,7 @@
                                                     "stmt0": "f_string_*_in",
                                                     "stmt1": "f_default",
                                                     "stmtc0": "c_string_*_in_buf",
-                                                    "stmtc1": "c_string_in_buf"
+                                                    "stmtc1": "c_string_*_in_buf"
                                                 }
                                             }
                                         },
@@ -751,7 +751,7 @@
                                                 "sh_type": "SH_TYPE_OTHER",
                                                 "shadow_var": "SHadow_rv",
                                                 "stmt0": "c_string_&_result",
-                                                "stmt1": "c_string_result"
+                                                "stmt1": "c_string_&_result"
                                             },
                                             "fmtf": {
                                                 "cxx_type": "std::string",
@@ -872,7 +872,7 @@
                                                     "sh_type": "SH_TYPE_OTHER",
                                                     "shadow_var": "SHadow_SHF_rv",
                                                     "stmt0": "c_string_&_result_buf_allocatable",
-                                                    "stmt1": "c_string_result_buf_allocatable"
+                                                    "stmt1": "c_string_&_result_buf_allocatable"
                                                 },
                                                 "fmtf": {
                                                     "F_C_var": "SHF_rv",
@@ -888,7 +888,7 @@
                                                     "stmt0": "f_string_&_result_buf_allocatable",
                                                     "stmt1": "f_string_&_result_buf_allocatable",
                                                     "stmtc0": "c_string_&_result_buf_allocatable",
-                                                    "stmtc1": "c_string_result_buf_allocatable"
+                                                    "stmtc1": "c_string_&_result_buf_allocatable"
                                                 }
                                             }
                                         },
@@ -985,7 +985,7 @@
                                                 "sh_type": "SH_TYPE_OTHER",
                                                 "shadow_var": "SHadow_rv",
                                                 "stmt0": "c_string_&_result",
-                                                "stmt1": "c_string_result"
+                                                "stmt1": "c_string_&_result"
                                             },
                                             "fmtl": {
                                                 "c_var": "SHCXX_rv.c_str()",
@@ -1087,7 +1087,7 @@
                                                     "sh_type": "SH_TYPE_OTHER",
                                                     "shadow_var": "SHadow_name",
                                                     "stmt0": "c_string_&_result_buf",
-                                                    "stmt1": "c_string_result_buf"
+                                                    "stmt1": "c_string_&_result_buf"
                                                 },
                                                 "fmtf": {
                                                     "F_C_var": "name",
@@ -1102,7 +1102,7 @@
                                                     "stmt0": "f_string_&_result_buf",
                                                     "stmt1": "f_default",
                                                     "stmtc0": "c_string_&_result_buf",
-                                                    "stmtc1": "c_string_result_buf"
+                                                    "stmtc1": "c_string_&_result_buf"
                                                 }
                                             }
                                         },
@@ -1976,7 +1976,7 @@
                                                     "sh_type": "SH_TYPE_OTHER",
                                                     "shadow_var": "SHadow_name",
                                                     "stmt0": "c_string_*_in",
-                                                    "stmt1": "c_string_in"
+                                                    "stmt1": "c_string_*_in"
                                                 },
                                                 "fmtf": {
                                                     "F_C_var": "name"
@@ -2166,7 +2166,7 @@
                                                     "sh_type": "SH_TYPE_OTHER",
                                                     "shadow_var": "SHadow_name",
                                                     "stmt0": "c_string_*_in_buf",
-                                                    "stmt1": "c_string_in_buf"
+                                                    "stmt1": "c_string_*_in_buf"
                                                 },
                                                 "fmtf": {
                                                     "F_C_var": "name",
@@ -2181,7 +2181,7 @@
                                                     "stmt0": "f_string_*_in",
                                                     "stmt1": "f_default",
                                                     "stmtc0": "c_string_*_in_buf",
-                                                    "stmtc1": "c_string_in_buf"
+                                                    "stmtc1": "c_string_*_in_buf"
                                                 }
                                             }
                                         },
@@ -2341,7 +2341,7 @@
                                                 "sh_type": "SH_TYPE_OTHER",
                                                 "shadow_var": "SHadow_rv",
                                                 "stmt0": "c_string_&_result",
-                                                "stmt1": "c_string_result"
+                                                "stmt1": "c_string_&_result"
                                             },
                                             "fmtf": {
                                                 "c_var_len": "aa_exclass2_get_name_length({F_this}%{F_derived_member})",
@@ -2464,7 +2464,7 @@
                                                     "sh_type": "SH_TYPE_OTHER",
                                                     "shadow_var": "SHadow_SHF_rv",
                                                     "stmt0": "c_string_&_result_buf",
-                                                    "stmt1": "c_string_result_buf"
+                                                    "stmt1": "c_string_&_result_buf"
                                                 },
                                                 "fmtf": {
                                                     "F_C_var": "SHF_rv",
@@ -2479,7 +2479,7 @@
                                                     "stmt0": "f_string_&_result_buf",
                                                     "stmt1": "f_default",
                                                     "stmtc0": "c_string_&_result_buf",
-                                                    "stmtc1": "c_string_result_buf"
+                                                    "stmtc1": "c_string_&_result_buf"
                                                 }
                                             }
                                         },
@@ -2578,7 +2578,7 @@
                                                 "sh_type": "SH_TYPE_OTHER",
                                                 "shadow_var": "SHadow_rv",
                                                 "stmt0": "c_string_&_result",
-                                                "stmt1": "c_string_result"
+                                                "stmt1": "c_string_&_result"
                                             },
                                             "fmtf": {
                                                 "cxx_type": "std::string",
@@ -2697,7 +2697,7 @@
                                                     "sh_type": "SH_TYPE_OTHER",
                                                     "shadow_var": "SHadow_SHF_rv",
                                                     "stmt0": "c_string_&_result_buf_allocatable",
-                                                    "stmt1": "c_string_result_buf_allocatable"
+                                                    "stmt1": "c_string_&_result_buf_allocatable"
                                                 },
                                                 "fmtf": {
                                                     "F_C_var": "SHF_rv",
@@ -2713,7 +2713,7 @@
                                                     "stmt0": "f_string_&_result_buf_allocatable",
                                                     "stmt1": "f_string_&_result_buf_allocatable",
                                                     "stmtc0": "c_string_&_result_buf_allocatable",
-                                                    "stmtc1": "c_string_result_buf_allocatable"
+                                                    "stmtc1": "c_string_&_result_buf_allocatable"
                                                 }
                                             }
                                         },
@@ -2809,7 +2809,7 @@
                                                 "sh_type": "SH_TYPE_OTHER",
                                                 "shadow_var": "SHadow_rv",
                                                 "stmt0": "c_string_&_result",
-                                                "stmt1": "c_string_result"
+                                                "stmt1": "c_string_&_result"
                                             },
                                             "fmtf": {
                                                 "cxx_type": "std::string",
@@ -2929,7 +2929,7 @@
                                                     "sh_type": "SH_TYPE_OTHER",
                                                     "shadow_var": "SHadow_SHF_rv",
                                                     "stmt0": "c_string_&_result_buf_allocatable",
-                                                    "stmt1": "c_string_result_buf_allocatable"
+                                                    "stmt1": "c_string_&_result_buf_allocatable"
                                                 },
                                                 "fmtf": {
                                                     "F_C_var": "SHF_rv",
@@ -2945,7 +2945,7 @@
                                                     "stmt0": "f_string_&_result_buf_allocatable",
                                                     "stmt1": "f_string_&_result_buf_allocatable",
                                                     "stmtc0": "c_string_&_result_buf_allocatable",
-                                                    "stmtc1": "c_string_result_buf_allocatable"
+                                                    "stmtc1": "c_string_&_result_buf_allocatable"
                                                 }
                                             }
                                         },
@@ -3041,7 +3041,7 @@
                                                 "sh_type": "SH_TYPE_OTHER",
                                                 "shadow_var": "SHadow_rv",
                                                 "stmt0": "c_string_&_result",
-                                                "stmt1": "c_string_result"
+                                                "stmt1": "c_string_&_result"
                                             },
                                             "fmtf": {
                                                 "cxx_type": "std::string",
@@ -3159,7 +3159,7 @@
                                                     "sh_type": "SH_TYPE_OTHER",
                                                     "shadow_var": "SHadow_SHF_rv",
                                                     "stmt0": "c_string_&_result_buf_allocatable",
-                                                    "stmt1": "c_string_result_buf_allocatable"
+                                                    "stmt1": "c_string_&_result_buf_allocatable"
                                                 },
                                                 "fmtf": {
                                                     "F_C_var": "SHF_rv",
@@ -3175,7 +3175,7 @@
                                                     "stmt0": "f_string_&_result_buf_allocatable",
                                                     "stmt1": "f_string_&_result_buf_allocatable",
                                                     "stmtc0": "c_string_&_result_buf_allocatable",
-                                                    "stmtc1": "c_string_result_buf_allocatable"
+                                                    "stmtc1": "c_string_&_result_buf_allocatable"
                                                 }
                                             }
                                         },
@@ -5856,7 +5856,7 @@
                                             "sh_type": "SH_TYPE_OTHER",
                                             "shadow_var": "SHadow_name",
                                             "stmt0": "c_string_&_in",
-                                            "stmt1": "c_string_in"
+                                            "stmt1": "c_string_&_in"
                                         },
                                         "fmtf": {
                                             "F_C_var": "name"
@@ -6049,7 +6049,7 @@
                                             "sh_type": "SH_TYPE_OTHER",
                                             "shadow_var": "SHadow_name",
                                             "stmt0": "c_string_&_in_buf",
-                                            "stmt1": "c_string_in_buf"
+                                            "stmt1": "c_string_&_in_buf"
                                         },
                                         "fmtf": {
                                             "F_C_var": "name",
@@ -6064,7 +6064,7 @@
                                             "stmt0": "f_string_&_in",
                                             "stmt1": "f_default",
                                             "stmtc0": "c_string_&_in_buf",
-                                            "stmtc1": "c_string_in_buf"
+                                            "stmtc1": "c_string_&_in_buf"
                                         }
                                     }
                                 },
@@ -6273,7 +6273,7 @@
                                             "sh_type": "SH_TYPE_OTHER",
                                             "shadow_var": "SHadow_name",
                                             "stmt0": "c_string_&_in",
-                                            "stmt1": "c_string_in"
+                                            "stmt1": "c_string_&_in"
                                         },
                                         "fmtf": {
                                             "F_C_var": "name"
@@ -6406,7 +6406,7 @@
                                             "sh_type": "SH_TYPE_OTHER",
                                             "shadow_var": "SHadow_name",
                                             "stmt0": "c_string_&_in_buf",
-                                            "stmt1": "c_string_in_buf"
+                                            "stmt1": "c_string_&_in_buf"
                                         },
                                         "fmtf": {
                                             "F_C_var": "name",
@@ -6421,7 +6421,7 @@
                                             "stmt0": "f_string_&_in",
                                             "stmt1": "f_default",
                                             "stmtc0": "c_string_&_in_buf",
-                                            "stmtc1": "c_string_in_buf"
+                                            "stmtc1": "c_string_&_in_buf"
                                         }
                                     }
                                 },
@@ -6554,7 +6554,7 @@
                                             "sh_type": "SH_TYPE_OTHER",
                                             "shadow_var": "SHadow_name",
                                             "stmt0": "c_string_&_in",
-                                            "stmt1": "c_string_in"
+                                            "stmt1": "c_string_&_in"
                                         },
                                         "fmtf": {
                                             "F_C_var": "name"
@@ -6732,7 +6732,7 @@
                                             "sh_type": "SH_TYPE_OTHER",
                                             "shadow_var": "SHadow_name",
                                             "stmt0": "c_string_&_in_buf",
-                                            "stmt1": "c_string_in_buf"
+                                            "stmt1": "c_string_&_in_buf"
                                         },
                                         "fmtf": {
                                             "F_C_var": "name",
@@ -6747,7 +6747,7 @@
                                             "stmt0": "f_string_&_in",
                                             "stmt1": "f_default",
                                             "stmtc0": "c_string_&_in_buf",
-                                            "stmtc1": "c_string_in_buf"
+                                            "stmtc1": "c_string_&_in_buf"
                                         }
                                     }
                                 },

--- a/regression/reference/example/wrapUserLibrary_example_nested.cpp
+++ b/regression/reference/example/wrapUserLibrary_example_nested.cpp
@@ -36,8 +36,7 @@ void AA_example_nested_local_function1(void)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  const std::string & name +intent(in)
-// Requested: c_string_&_in
-// Match:     c_string_in
+// Exact:     c_string_&_in
 bool AA_example_nested_is_name_valid(const char * name)
 {
     // splicer begin namespace.example::nested.function.is_name_valid
@@ -51,8 +50,7 @@ bool AA_example_nested_is_name_valid(const char * name)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  const std::string & name +intent(in)+len_trim(Lname)
-// Requested: c_string_&_in_buf
-// Match:     c_string_in_buf
+// Exact:     c_string_&_in_buf
 bool AA_example_nested_is_name_valid_bufferify(const char * name,
     int Lname)
 {
@@ -79,8 +77,7 @@ bool AA_example_nested_is_initialized(void)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  const std::string & name +intent(in)
-// Requested: c_string_&_in
-// Match:     c_string_in
+// Exact:     c_string_&_in
 void AA_example_nested_test_names(const char * name)
 {
     // splicer begin namespace.example::nested.function.test_names
@@ -95,8 +92,7 @@ void AA_example_nested_test_names(const char * name)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  const std::string & name +intent(in)+len_trim(Lname)
-// Requested: c_string_&_in_buf
-// Match:     c_string_in_buf
+// Exact:     c_string_&_in_buf
 void AA_example_nested_test_names_bufferify(const char * name,
     int Lname)
 {
@@ -112,8 +108,7 @@ void AA_example_nested_test_names_bufferify(const char * name,
 // Match:     c_default
 // ----------------------------------------
 // Argument:  const std::string & name +intent(in)
-// Requested: c_string_&_in
-// Match:     c_string_in
+// Exact:     c_string_&_in
 // ----------------------------------------
 // Argument:  int flag +intent(in)+value
 // Requested: c_native_scalar_in
@@ -132,8 +127,7 @@ void AA_example_nested_test_names_flag(const char * name, int flag)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  const std::string & name +intent(in)+len_trim(Lname)
-// Requested: c_string_&_in_buf
-// Match:     c_string_in_buf
+// Exact:     c_string_&_in_buf
 // ----------------------------------------
 // Argument:  int flag +intent(in)+value
 // Requested: c_native_scalar_in_buf

--- a/regression/reference/example/wrapexample_nested_ExClass1.cpp
+++ b/regression/reference/example/wrapexample_nested_ExClass1.cpp
@@ -87,8 +87,7 @@ AA_example_nested_ExClass1 * AA_example_nested_ExClass1_ctor_0(
 // Exact:     c_shadow_scalar_ctor
 // ----------------------------------------
 // Argument:  const string * name +intent(in)
-// Requested: c_string_*_in
-// Match:     c_string_in
+// Exact:     c_string_*_in
 AA_example_nested_ExClass1 * AA_example_nested_ExClass1_ctor_1(
     const char * name, AA_example_nested_ExClass1 * SHadow_rv)
 {
@@ -116,8 +115,7 @@ AA_example_nested_ExClass1 * AA_example_nested_ExClass1_ctor_1(
 // Match:     c_shadow_scalar_ctor
 // ----------------------------------------
 // Argument:  const string * name +intent(in)+len_trim(Lname)
-// Requested: c_string_*_in_buf
-// Match:     c_string_in_buf
+// Exact:     c_string_*_in_buf
 AA_example_nested_ExClass1 * AA_example_nested_ExClass1_ctor_1_bufferify(
     const char * name, int Lname,
     AA_example_nested_ExClass1 * SHadow_rv)
@@ -171,8 +169,7 @@ int AA_example_nested_ExClass1_increment_count(
 
 // ----------------------------------------
 // Function:  const string & getNameErrorCheck +deref(allocatable)
-// Requested: c_string_&_result
-// Match:     c_string_result
+// Exact:     c_string_&_result
 const char * AA_example_nested_ExClass1_get_name_error_check(
     const AA_example_nested_ExClass1 * self)
 {
@@ -191,8 +188,7 @@ const char * AA_example_nested_ExClass1_get_name_error_check(
 // Match:     c_default
 // ----------------------------------------
 // Argument:  const string & SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
-// Requested: c_string_&_result_buf_allocatable
-// Match:     c_string_result_buf_allocatable
+// Exact:     c_string_&_result_buf_allocatable
 void AA_example_nested_ExClass1_get_name_error_check_bufferify(
     const AA_example_nested_ExClass1 * self, AA_SHROUD_array *DSHF_rv)
 {
@@ -206,8 +202,7 @@ void AA_example_nested_ExClass1_get_name_error_check_bufferify(
 
 // ----------------------------------------
 // Function:  const string & getNameArg +deref(result-as-arg)
-// Requested: c_string_&_result
-// Match:     c_string_result
+// Exact:     c_string_&_result
 const char * AA_example_nested_ExClass1_get_name_arg(
     const AA_example_nested_ExClass1 * self)
 {
@@ -226,8 +221,7 @@ const char * AA_example_nested_ExClass1_get_name_arg(
 // Match:     c_default
 // ----------------------------------------
 // Argument:  string & name +intent(out)+len(Nname)
-// Requested: c_string_&_result_buf
-// Match:     c_string_result_buf
+// Exact:     c_string_&_result_buf
 void AA_example_nested_ExClass1_get_name_arg_bufferify(
     const AA_example_nested_ExClass1 * self, char * name, int Nname)
 {

--- a/regression/reference/example/wrapexample_nested_ExClass2.cpp
+++ b/regression/reference/example/wrapexample_nested_ExClass2.cpp
@@ -69,8 +69,7 @@ static void ShroudStrToArray(AA_SHROUD_array *array, const std::string * src, in
 // Exact:     c_shadow_scalar_ctor
 // ----------------------------------------
 // Argument:  const string * name +intent(in)+len_trim(trim_name)
-// Requested: c_string_*_in
-// Match:     c_string_in
+// Exact:     c_string_*_in
 AA_example_nested_ExClass2 * AA_example_nested_ExClass2_ctor(
     const char * name, AA_example_nested_ExClass2 * SHadow_rv)
 {
@@ -94,8 +93,7 @@ AA_example_nested_ExClass2 * AA_example_nested_ExClass2_ctor(
 // Match:     c_shadow_scalar_ctor
 // ----------------------------------------
 // Argument:  const string * name +intent(in)+len_trim(trim_name)
-// Requested: c_string_*_in_buf
-// Match:     c_string_in_buf
+// Exact:     c_string_*_in_buf
 AA_example_nested_ExClass2 * AA_example_nested_ExClass2_ctor_bufferify(
     const char * name, int trim_name,
     AA_example_nested_ExClass2 * SHadow_rv)
@@ -129,8 +127,7 @@ void AA_example_nested_ExClass2_dtor(AA_example_nested_ExClass2 * self)
 
 // ----------------------------------------
 // Function:  const string & getName +deref(result-as-arg)+len(aa_exclass2_get_name_length({F_this}%{F_derived_member}))
-// Requested: c_string_&_result
-// Match:     c_string_result
+// Exact:     c_string_&_result
 const char * AA_example_nested_ExClass2_get_name(
     const AA_example_nested_ExClass2 * self)
 {
@@ -149,8 +146,7 @@ const char * AA_example_nested_ExClass2_get_name(
 // Match:     c_default
 // ----------------------------------------
 // Argument:  string & SHF_rv +intent(out)+len(NSHF_rv)
-// Requested: c_string_&_result_buf
-// Match:     c_string_result_buf
+// Exact:     c_string_&_result_buf
 void AA_example_nested_ExClass2_get_name_bufferify(
     const AA_example_nested_ExClass2 * self, char * SHF_rv, int NSHF_rv)
 {
@@ -169,8 +165,7 @@ void AA_example_nested_ExClass2_get_name_bufferify(
 
 // ----------------------------------------
 // Function:  const string & getName2 +deref(allocatable)
-// Requested: c_string_&_result
-// Match:     c_string_result
+// Exact:     c_string_&_result
 const char * AA_example_nested_ExClass2_get_name2(
     AA_example_nested_ExClass2 * self)
 {
@@ -189,8 +184,7 @@ const char * AA_example_nested_ExClass2_get_name2(
 // Match:     c_default
 // ----------------------------------------
 // Argument:  const string & SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
-// Requested: c_string_&_result_buf_allocatable
-// Match:     c_string_result_buf_allocatable
+// Exact:     c_string_&_result_buf_allocatable
 void AA_example_nested_ExClass2_get_name2_bufferify(
     AA_example_nested_ExClass2 * self, AA_SHROUD_array *DSHF_rv)
 {
@@ -204,8 +198,7 @@ void AA_example_nested_ExClass2_get_name2_bufferify(
 
 // ----------------------------------------
 // Function:  string & getName3 +deref(allocatable)
-// Requested: c_string_&_result
-// Match:     c_string_result
+// Exact:     c_string_&_result
 char * AA_example_nested_ExClass2_get_name3(
     const AA_example_nested_ExClass2 * self)
 {
@@ -224,8 +217,7 @@ char * AA_example_nested_ExClass2_get_name3(
 // Match:     c_default
 // ----------------------------------------
 // Argument:  string & SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
-// Requested: c_string_&_result_buf_allocatable
-// Match:     c_string_result_buf_allocatable
+// Exact:     c_string_&_result_buf_allocatable
 void AA_example_nested_ExClass2_get_name3_bufferify(
     const AA_example_nested_ExClass2 * self, AA_SHROUD_array *DSHF_rv)
 {
@@ -239,8 +231,7 @@ void AA_example_nested_ExClass2_get_name3_bufferify(
 
 // ----------------------------------------
 // Function:  string & getName4 +deref(allocatable)
-// Requested: c_string_&_result
-// Match:     c_string_result
+// Exact:     c_string_&_result
 char * AA_example_nested_ExClass2_get_name4(
     AA_example_nested_ExClass2 * self)
 {
@@ -259,8 +250,7 @@ char * AA_example_nested_ExClass2_get_name4(
 // Match:     c_default
 // ----------------------------------------
 // Argument:  string & SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
-// Requested: c_string_&_result_buf_allocatable
-// Match:     c_string_result_buf_allocatable
+// Exact:     c_string_&_result_buf_allocatable
 void AA_example_nested_ExClass2_get_name4_bufferify(
     AA_example_nested_ExClass2 * self, AA_SHROUD_array *DSHF_rv)
 {

--- a/regression/reference/example/wrapfUserLibrary_example_nested.f
+++ b/regression/reference/example/wrapfUserLibrary_example_nested.f
@@ -179,8 +179,7 @@ module userlibrary_example_nested_mod
         ! Exact:     c_shadow_scalar_result
         ! ----------------------------------------
         ! Argument:  const string * name +intent(in)
-        ! Requested: c_string_*_in
-        ! Match:     c_string_in
+        ! Exact:     c_string_*_in
         function c_exclass1_ctor_1(name, SHT_crv) &
                 result(SHT_rv) &
                 bind(C, name="AA_example_nested_ExClass1_ctor_1")
@@ -198,8 +197,7 @@ module userlibrary_example_nested_mod
         ! Match:     c_shadow_scalar_result
         ! ----------------------------------------
         ! Argument:  const string * name +intent(in)+len_trim(Lname)
-        ! Requested: c_string_*_in_buf
-        ! Match:     c_string_in_buf
+        ! Exact:     c_string_*_in_buf
         function c_exclass1_ctor_1_bufferify(name, Lname, SHT_crv) &
                 result(SHT_rv) &
                 bind(C, name="AA_example_nested_ExClass1_ctor_1_bufferify")
@@ -244,8 +242,7 @@ module userlibrary_example_nested_mod
 
         ! ----------------------------------------
         ! Function:  const string & getNameErrorCheck +deref(allocatable)
-        ! Requested: c_string_&_result
-        ! Match:     c_string_result
+        ! Exact:     c_string_&_result
         pure function c_exclass1_get_name_error_check(self) &
                 result(SHT_rv) &
                 bind(C, name="AA_example_nested_ExClass1_get_name_error_check")
@@ -262,8 +259,7 @@ module userlibrary_example_nested_mod
         ! Match:     c_default
         ! ----------------------------------------
         ! Argument:  const string & SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
-        ! Requested: c_string_&_result_buf_allocatable
-        ! Match:     c_string_result_buf_allocatable
+        ! Exact:     c_string_&_result_buf_allocatable
         subroutine c_exclass1_get_name_error_check_bufferify(self, &
                 DSHF_rv) &
                 bind(C, name="AA_example_nested_ExClass1_get_name_error_check_bufferify")
@@ -275,8 +271,7 @@ module userlibrary_example_nested_mod
 
         ! ----------------------------------------
         ! Function:  const string & getNameArg +deref(result-as-arg)
-        ! Requested: c_string_&_result
-        ! Match:     c_string_result
+        ! Exact:     c_string_&_result
         pure function c_exclass1_get_name_arg(self) &
                 result(SHT_rv) &
                 bind(C, name="AA_example_nested_ExClass1_get_name_arg")
@@ -293,8 +288,7 @@ module userlibrary_example_nested_mod
         ! Match:     c_default
         ! ----------------------------------------
         ! Argument:  string & name +intent(out)+len(Nname)
-        ! Requested: c_string_&_result_buf
-        ! Match:     c_string_result_buf
+        ! Exact:     c_string_&_result_buf
         subroutine c_exclass1_get_name_arg_bufferify(self, name, Nname) &
                 bind(C, name="AA_example_nested_ExClass1_get_name_arg_bufferify")
             use iso_c_binding, only : C_CHAR, C_INT
@@ -381,8 +375,7 @@ module userlibrary_example_nested_mod
         ! Exact:     c_shadow_scalar_result
         ! ----------------------------------------
         ! Argument:  const string * name +intent(in)+len_trim(trim_name)
-        ! Requested: c_string_*_in
-        ! Match:     c_string_in
+        ! Exact:     c_string_*_in
         function c_exclass2_ctor(name, SHT_crv) &
                 result(SHT_rv) &
                 bind(C, name="AA_example_nested_ExClass2_ctor")
@@ -400,8 +393,7 @@ module userlibrary_example_nested_mod
         ! Match:     c_shadow_scalar_result
         ! ----------------------------------------
         ! Argument:  const string * name +intent(in)+len_trim(trim_name)
-        ! Requested: c_string_*_in_buf
-        ! Match:     c_string_in_buf
+        ! Exact:     c_string_*_in_buf
         function c_exclass2_ctor_bufferify(name, trim_name, SHT_crv) &
                 result(SHT_rv) &
                 bind(C, name="AA_example_nested_ExClass2_ctor_bufferify")
@@ -427,8 +419,7 @@ module userlibrary_example_nested_mod
 
         ! ----------------------------------------
         ! Function:  const string & getName +deref(result-as-arg)+len(aa_exclass2_get_name_length({F_this}%{F_derived_member}))
-        ! Requested: c_string_&_result
-        ! Match:     c_string_result
+        ! Exact:     c_string_&_result
         pure function c_exclass2_get_name(self) &
                 result(SHT_rv) &
                 bind(C, name="AA_example_nested_ExClass2_get_name")
@@ -445,8 +436,7 @@ module userlibrary_example_nested_mod
         ! Match:     c_default
         ! ----------------------------------------
         ! Argument:  string & SHF_rv +intent(out)+len(NSHF_rv)
-        ! Requested: c_string_&_result_buf
-        ! Match:     c_string_result_buf
+        ! Exact:     c_string_&_result_buf
         subroutine c_exclass2_get_name_bufferify(self, SHF_rv, NSHF_rv) &
                 bind(C, name="AA_example_nested_ExClass2_get_name_bufferify")
             use iso_c_binding, only : C_CHAR, C_INT
@@ -459,8 +449,7 @@ module userlibrary_example_nested_mod
 
         ! ----------------------------------------
         ! Function:  const string & getName2 +deref(allocatable)
-        ! Requested: c_string_&_result
-        ! Match:     c_string_result
+        ! Exact:     c_string_&_result
         function c_exclass2_get_name2(self) &
                 result(SHT_rv) &
                 bind(C, name="AA_example_nested_ExClass2_get_name2")
@@ -477,8 +466,7 @@ module userlibrary_example_nested_mod
         ! Match:     c_default
         ! ----------------------------------------
         ! Argument:  const string & SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
-        ! Requested: c_string_&_result_buf_allocatable
-        ! Match:     c_string_result_buf_allocatable
+        ! Exact:     c_string_&_result_buf_allocatable
         subroutine c_exclass2_get_name2_bufferify(self, DSHF_rv) &
                 bind(C, name="AA_example_nested_ExClass2_get_name2_bufferify")
             import :: AA_SHROUD_array, AA_SHROUD_capsule_data
@@ -489,8 +477,7 @@ module userlibrary_example_nested_mod
 
         ! ----------------------------------------
         ! Function:  string & getName3 +deref(allocatable)
-        ! Requested: c_string_&_result
-        ! Match:     c_string_result
+        ! Exact:     c_string_&_result
         pure function c_exclass2_get_name3(self) &
                 result(SHT_rv) &
                 bind(C, name="AA_example_nested_ExClass2_get_name3")
@@ -507,8 +494,7 @@ module userlibrary_example_nested_mod
         ! Match:     c_default
         ! ----------------------------------------
         ! Argument:  string & SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
-        ! Requested: c_string_&_result_buf_allocatable
-        ! Match:     c_string_result_buf_allocatable
+        ! Exact:     c_string_&_result_buf_allocatable
         subroutine c_exclass2_get_name3_bufferify(self, DSHF_rv) &
                 bind(C, name="AA_example_nested_ExClass2_get_name3_bufferify")
             import :: AA_SHROUD_array, AA_SHROUD_capsule_data
@@ -519,8 +505,7 @@ module userlibrary_example_nested_mod
 
         ! ----------------------------------------
         ! Function:  string & getName4 +deref(allocatable)
-        ! Requested: c_string_&_result
-        ! Match:     c_string_result
+        ! Exact:     c_string_&_result
         function c_exclass2_get_name4(self) &
                 result(SHT_rv) &
                 bind(C, name="AA_example_nested_ExClass2_get_name4")
@@ -537,8 +522,7 @@ module userlibrary_example_nested_mod
         ! Match:     c_default
         ! ----------------------------------------
         ! Argument:  string & SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
-        ! Requested: c_string_&_result_buf_allocatable
-        ! Match:     c_string_result_buf_allocatable
+        ! Exact:     c_string_&_result_buf_allocatable
         subroutine c_exclass2_get_name4_bufferify(self, DSHF_rv) &
                 bind(C, name="AA_example_nested_ExClass2_get_name4_bufferify")
             import :: AA_SHROUD_array, AA_SHROUD_capsule_data
@@ -759,8 +743,7 @@ module userlibrary_example_nested_mod
         ! Match:     c_default
         ! ----------------------------------------
         ! Argument:  const std::string & name +intent(in)
-        ! Requested: c_string_&_in
-        ! Match:     c_string_in
+        ! Exact:     c_string_&_in
         function c_is_name_valid(name) &
                 result(SHT_rv) &
                 bind(C, name="AA_example_nested_is_name_valid")
@@ -776,8 +759,7 @@ module userlibrary_example_nested_mod
         ! Match:     c_default
         ! ----------------------------------------
         ! Argument:  const std::string & name +intent(in)+len_trim(Lname)
-        ! Requested: c_string_&_in_buf
-        ! Match:     c_string_in_buf
+        ! Exact:     c_string_&_in_buf
         function c_is_name_valid_bufferify(name, Lname) &
                 result(SHT_rv) &
                 bind(C, name="AA_example_nested_is_name_valid_bufferify")
@@ -806,8 +788,7 @@ module userlibrary_example_nested_mod
         ! Match:     c_default
         ! ----------------------------------------
         ! Argument:  const std::string & name +intent(in)
-        ! Requested: c_string_&_in
-        ! Match:     c_string_in
+        ! Exact:     c_string_&_in
         subroutine c_test_names(name) &
                 bind(C, name="AA_example_nested_test_names")
             use iso_c_binding, only : C_CHAR
@@ -821,8 +802,7 @@ module userlibrary_example_nested_mod
         ! Match:     c_default
         ! ----------------------------------------
         ! Argument:  const std::string & name +intent(in)+len_trim(Lname)
-        ! Requested: c_string_&_in_buf
-        ! Match:     c_string_in_buf
+        ! Exact:     c_string_&_in_buf
         subroutine c_test_names_bufferify(name, Lname) &
                 bind(C, name="AA_example_nested_test_names_bufferify")
             use iso_c_binding, only : C_CHAR, C_INT
@@ -837,8 +817,7 @@ module userlibrary_example_nested_mod
         ! Match:     c_default
         ! ----------------------------------------
         ! Argument:  const std::string & name +intent(in)
-        ! Requested: c_string_&_in
-        ! Match:     c_string_in
+        ! Exact:     c_string_&_in
         ! ----------------------------------------
         ! Argument:  int flag +intent(in)+value
         ! Requested: c_native_scalar_in
@@ -857,8 +836,7 @@ module userlibrary_example_nested_mod
         ! Match:     c_default
         ! ----------------------------------------
         ! Argument:  const std::string & name +intent(in)+len_trim(Lname)
-        ! Requested: c_string_&_in_buf
-        ! Match:     c_string_in_buf
+        ! Exact:     c_string_&_in_buf
         ! ----------------------------------------
         ! Argument:  int flag +intent(in)+value
         ! Requested: c_native_scalar_in_buf
@@ -1258,8 +1236,7 @@ contains
     ! Requested: f_string_*_in
     ! Match:     f_default
     ! Argument:  const string * name +intent(in)+len_trim(Lname)
-    ! Requested: c_string_*_in_buf
-    ! Match:     c_string_in_buf
+    ! Exact:     c_string_*_in_buf
     !>
     !! \brief constructor
     !!
@@ -1332,8 +1309,7 @@ contains
     ! ----------------------------------------
     ! Argument:  const string & SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
     ! Exact:     f_string_&_result_buf_allocatable
-    ! Requested: c_string_&_result_buf_allocatable
-    ! Match:     c_string_result_buf_allocatable
+    ! Exact:     c_string_&_result_buf_allocatable
     function exclass1_get_name_error_check(obj) &
             result(SHT_rv)
         class(exclass1) :: obj
@@ -1359,8 +1335,7 @@ contains
     ! Argument:  string & name +intent(out)+len(Nname)
     ! Requested: f_string_&_result_buf
     ! Match:     f_default
-    ! Requested: c_string_&_result_buf
-    ! Match:     c_string_result_buf
+    ! Exact:     c_string_&_result_buf
     subroutine exclass1_get_name_arg(obj, name)
         use iso_c_binding, only : C_INT
         class(exclass1) :: obj
@@ -1488,8 +1463,7 @@ contains
     ! Argument:  const string * name +intent(in)+len_trim(trim_name)
     ! Requested: f_string_*_in
     ! Match:     f_default
-    ! Requested: c_string_*_in_buf
-    ! Match:     c_string_in_buf
+    ! Exact:     c_string_*_in_buf
     !>
     !! \brief constructor
     !!
@@ -1535,8 +1509,7 @@ contains
     ! Argument:  string & SHF_rv +intent(out)+len(NSHF_rv)
     ! Requested: f_string_&_result_buf
     ! Match:     f_default
-    ! Requested: c_string_&_result_buf
-    ! Match:     c_string_result_buf
+    ! Exact:     c_string_&_result_buf
     function exclass2_get_name(obj) &
             result(SHT_rv)
         use iso_c_binding, only : C_INT
@@ -1558,8 +1531,7 @@ contains
     ! ----------------------------------------
     ! Argument:  const string & SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
     ! Exact:     f_string_&_result_buf_allocatable
-    ! Requested: c_string_&_result_buf_allocatable
-    ! Match:     c_string_result_buf_allocatable
+    ! Exact:     c_string_&_result_buf_allocatable
     function exclass2_get_name2(obj) &
             result(SHT_rv)
         class(exclass2) :: obj
@@ -1582,8 +1554,7 @@ contains
     ! ----------------------------------------
     ! Argument:  string & SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
     ! Exact:     f_string_&_result_buf_allocatable
-    ! Requested: c_string_&_result_buf_allocatable
-    ! Match:     c_string_result_buf_allocatable
+    ! Exact:     c_string_&_result_buf_allocatable
     function exclass2_get_name3(obj) &
             result(SHT_rv)
         class(exclass2) :: obj
@@ -1606,8 +1577,7 @@ contains
     ! ----------------------------------------
     ! Argument:  string & SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
     ! Exact:     f_string_&_result_buf_allocatable
-    ! Requested: c_string_&_result_buf_allocatable
-    ! Match:     c_string_result_buf_allocatable
+    ! Exact:     c_string_&_result_buf_allocatable
     function exclass2_get_name4(obj) &
             result(SHT_rv)
         class(exclass2) :: obj
@@ -1965,8 +1935,7 @@ contains
     ! Requested: f_string_&_in
     ! Match:     f_default
     ! Argument:  const std::string & name +intent(in)+len_trim(Lname)
-    ! Requested: c_string_&_in_buf
-    ! Match:     c_string_in_buf
+    ! Exact:     c_string_&_in_buf
     function is_name_valid(name) &
             result(SHT_rv)
         use iso_c_binding, only : C_BOOL, C_INT
@@ -2006,8 +1975,7 @@ contains
     ! Requested: f_string_&_in
     ! Match:     f_default
     ! Argument:  const std::string & name +intent(in)+len_trim(Lname)
-    ! Requested: c_string_&_in_buf
-    ! Match:     c_string_in_buf
+    ! Exact:     c_string_&_in_buf
     subroutine test_names(name)
         use iso_c_binding, only : C_INT
         character(len=*), intent(IN) :: name
@@ -2029,8 +1997,7 @@ contains
     ! Requested: f_string_&_in
     ! Match:     f_default
     ! Argument:  const std::string & name +intent(in)+len_trim(Lname)
-    ! Requested: c_string_&_in_buf
-    ! Match:     c_string_in_buf
+    ! Exact:     c_string_&_in_buf
     ! ----------------------------------------
     ! Argument:  int flag +intent(in)+value
     ! Requested: f_native_scalar_in

--- a/regression/reference/memdoc/memdoc.json
+++ b/regression/reference/memdoc/memdoc.json
@@ -27,7 +27,7 @@
                         "sh_type": "SH_TYPE_OTHER",
                         "shadow_var": "SHadow_rv",
                         "stmt0": "c_string_*_result",
-                        "stmt1": "c_string_result"
+                        "stmt1": "c_string_*_result"
                     },
                     "fmtf": {
                         "cxx_type": "std::string",
@@ -109,7 +109,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_SHF_rv",
                             "stmt0": "c_string_*_result_buf_allocatable",
-                            "stmt1": "c_string_result_buf_allocatable"
+                            "stmt1": "c_string_*_result_buf_allocatable"
                         },
                         "fmtf": {
                             "F_C_var": "SHF_rv",
@@ -125,7 +125,7 @@
                             "stmt0": "f_string_*_result_buf_allocatable",
                             "stmt1": "f_string_*_result_buf_allocatable",
                             "stmtc0": "c_string_*_result_buf_allocatable",
-                            "stmtc1": "c_string_result_buf_allocatable"
+                            "stmtc1": "c_string_*_result_buf_allocatable"
                         }
                     }
                 },

--- a/regression/reference/memdoc/wrapfmemdoc.f
+++ b/regression/reference/memdoc/wrapfmemdoc.f
@@ -50,8 +50,7 @@ module memdoc_mod
 
     ! ----------------------------------------
     ! Function:  const std::string * getConstStringPtrAlloc +deref(allocatable)+owner(library)
-    ! Requested: c_string_*_result
-    ! Match:     c_string_result
+    ! Exact:     c_string_*_result
     ! start c_get_const_string_ptr_alloc
     interface
         function c_get_const_string_ptr_alloc() &
@@ -70,8 +69,7 @@ module memdoc_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  const std::string * SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)+owner(library)
-    ! Requested: c_string_*_result_buf_allocatable
-    ! Match:     c_string_result_buf_allocatable
+    ! Exact:     c_string_*_result_buf_allocatable
     ! start c_get_const_string_ptr_alloc_bufferify
     interface
         subroutine c_get_const_string_ptr_alloc_bufferify(DSHF_rv) &
@@ -114,8 +112,7 @@ contains
     ! ----------------------------------------
     ! Argument:  const std::string * SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)+owner(library)
     ! Exact:     f_string_*_result_buf_allocatable
-    ! Requested: c_string_*_result_buf_allocatable
-    ! Match:     c_string_result_buf_allocatable
+    ! Exact:     c_string_*_result_buf_allocatable
     ! start get_const_string_ptr_alloc
     function get_const_string_ptr_alloc() &
             result(SHT_rv)

--- a/regression/reference/memdoc/wrapmemdoc.cpp
+++ b/regression/reference/memdoc/wrapmemdoc.cpp
@@ -46,8 +46,7 @@ static void ShroudStrToArray(STR_SHROUD_array *array, const std::string * src, i
 
 // ----------------------------------------
 // Function:  const std::string * getConstStringPtrAlloc +deref(allocatable)+owner(library)
-// Requested: c_string_*_result
-// Match:     c_string_result
+// Exact:     c_string_*_result
 // start STR_get_const_string_ptr_alloc
 const char * STR_get_const_string_ptr_alloc(void)
 {
@@ -65,8 +64,7 @@ const char * STR_get_const_string_ptr_alloc(void)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  const std::string * SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)+owner(library)
-// Requested: c_string_*_result_buf_allocatable
-// Match:     c_string_result_buf_allocatable
+// Exact:     c_string_*_result_buf_allocatable
 // start STR_get_const_string_ptr_alloc_bufferify
 void STR_get_const_string_ptr_alloc_bufferify(STR_SHROUD_array *DSHF_rv)
 {

--- a/regression/reference/names/names.json
+++ b/regression/reference/names/names.json
@@ -880,7 +880,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_rv",
                             "stmt0": "c_string_&_in",
-                            "stmt1": "c_string_in"
+                            "stmt1": "c_string_&_in"
                         },
                         "fmtf": {
                             "F_C_var": "rv"
@@ -1034,7 +1034,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_rv",
                             "stmt0": "c_string_&_in_buf",
-                            "stmt1": "c_string_in_buf"
+                            "stmt1": "c_string_&_in_buf"
                         },
                         "fmtf": {
                             "F_C_var": "rv",
@@ -1049,7 +1049,7 @@
                             "stmt0": "f_string_&_in",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_&_in_buf",
-                            "stmtc1": "c_string_in_buf"
+                            "stmtc1": "c_string_&_in_buf"
                         }
                     }
                 },
@@ -1190,7 +1190,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_name",
                             "stmt0": "c_string_&_inout",
-                            "stmt1": "c_string_inout"
+                            "stmt1": "c_string_&_inout"
                         },
                         "fmtf": {
                             "F_C_var": "name"
@@ -1378,7 +1378,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_name",
                             "stmt0": "c_string_&_inout_buf",
-                            "stmt1": "c_string_inout_buf"
+                            "stmt1": "c_string_&_inout_buf"
                         },
                         "fmtf": {
                             "F_C_var": "name",
@@ -1394,7 +1394,7 @@
                             "stmt0": "f_string_&_inout",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_&_inout_buf",
-                            "stmtc1": "c_string_inout_buf"
+                            "stmtc1": "c_string_&_inout_buf"
                         }
                     },
                     "value": {

--- a/regression/reference/names/top.cpp
+++ b/regression/reference/names/top.cpp
@@ -150,8 +150,7 @@ void YYY_TES_function3a_1(long i)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  const std::string & rv +intent(in)
-// Requested: c_string_&_in
-// Match:     c_string_in
+// Exact:     c_string_&_in
 int YYY_TES_function4(const char * rv)
 {
     // splicer begin function.function4
@@ -167,8 +166,7 @@ int YYY_TES_function4(const char * rv)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  const std::string & rv +intent(in)+len_trim(Lrv)
-// Requested: c_string_&_in_buf
-// Match:     c_string_in_buf
+// Exact:     c_string_&_in_buf
 int YYY_TES_function4_bufferify(const char * rv, int Lrv)
 {
     // splicer begin function.function4_bufferify
@@ -198,8 +196,7 @@ void YYY_TES_fiveplus(void)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  std::string & name +intent(inout)
-// Requested: c_string_&_inout
-// Match:     c_string_inout
+// Exact:     c_string_&_inout
 // ----------------------------------------
 // Argument:  int * value +intent(out)
 // Requested: c_native_*_out
@@ -221,8 +218,7 @@ void TES_test_multiline_splicer(char * name, int * value)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  std::string & name +intent(inout)+len(Nname)+len_trim(Lname)
-// Requested: c_string_&_inout_buf
-// Match:     c_string_inout_buf
+// Exact:     c_string_&_inout_buf
 // ----------------------------------------
 // Argument:  int * value +intent(out)
 // Requested: c_native_*_out_buf

--- a/regression/reference/names/top.f
+++ b/regression/reference/names/top.f
@@ -210,8 +210,7 @@ module top_module
         ! Match:     c_default
         ! ----------------------------------------
         ! Argument:  const std::string & rv +intent(in)
-        ! Requested: c_string_&_in
-        ! Match:     c_string_in
+        ! Exact:     c_string_&_in
         function yyy_tes_function4(rv) &
                 result(SHT_rv) &
                 bind(C, name="YYY_TES_function4")
@@ -227,8 +226,7 @@ module top_module
         ! Match:     c_default
         ! ----------------------------------------
         ! Argument:  const std::string & rv +intent(in)+len_trim(Lrv)
-        ! Requested: c_string_&_in_buf
-        ! Match:     c_string_in_buf
+        ! Exact:     c_string_&_in_buf
         function yyy_tes_function4_bufferify(rv, Lrv) &
                 result(SHT_rv) &
                 bind(C, name="YYY_TES_function4_bufferify")
@@ -254,8 +252,7 @@ module top_module
         ! Match:     c_default
         ! ----------------------------------------
         ! Argument:  std::string & name +intent(inout)
-        ! Requested: c_string_&_inout
-        ! Match:     c_string_inout
+        ! Exact:     c_string_&_inout
         ! ----------------------------------------
         ! Argument:  int * value +intent(out)
         ! Requested: c_native_*_out
@@ -274,8 +271,7 @@ module top_module
         ! Match:     c_default
         ! ----------------------------------------
         ! Argument:  std::string & name +intent(inout)+len(Nname)+len_trim(Lname)
-        ! Requested: c_string_&_inout_buf
-        ! Match:     c_string_inout_buf
+        ! Exact:     c_string_&_inout_buf
         ! ----------------------------------------
         ! Argument:  int * value +intent(out)
         ! Requested: c_native_*_out_buf
@@ -610,8 +606,7 @@ contains
     ! Requested: f_string_&_in
     ! Match:     f_default
     ! Argument:  const std::string & rv +intent(in)+len_trim(Lrv)
-    ! Requested: c_string_&_in_buf
-    ! Match:     c_string_in_buf
+    ! Exact:     c_string_&_in_buf
     function testnames_function4(rv) &
             result(SHT_rv)
         use iso_c_binding, only : C_INT
@@ -649,8 +644,7 @@ contains
     ! Requested: f_string_&_inout
     ! Match:     f_default
     ! Argument:  std::string & name +intent(inout)+len(Nname)+len_trim(Lname)
-    ! Requested: c_string_&_inout_buf
-    ! Match:     c_string_inout_buf
+    ! Exact:     c_string_&_inout_buf
     ! ----------------------------------------
     ! Argument:  int * value +intent(out)
     ! Requested: f_native_*_out

--- a/regression/reference/namespace/namespace.json
+++ b/regression/reference/namespace/namespace.json
@@ -30,7 +30,7 @@
                         "sh_type": "SH_TYPE_OTHER",
                         "shadow_var": "SHadow_rv",
                         "stmt0": "c_string_&_result",
-                        "stmt1": "c_string_result"
+                        "stmt1": "c_string_&_result"
                     },
                     "fmtf": {
                         "cxx_type": "std::string",
@@ -131,7 +131,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_SHF_rv",
                             "stmt0": "c_string_&_result_buf_allocatable",
-                            "stmt1": "c_string_result_buf_allocatable"
+                            "stmt1": "c_string_&_result_buf_allocatable"
                         },
                         "fmtf": {
                             "F_C_var": "SHF_rv",
@@ -147,7 +147,7 @@
                             "stmt0": "f_string_&_result_buf_allocatable",
                             "stmt1": "f_string_&_result_buf_allocatable",
                             "stmtc0": "c_string_&_result_buf_allocatable",
-                            "stmtc1": "c_string_result_buf_allocatable"
+                            "stmtc1": "c_string_&_result_buf_allocatable"
                         }
                     }
                 },

--- a/regression/reference/namespace/wrapfns.f
+++ b/regression/reference/namespace/wrapfns.f
@@ -72,8 +72,7 @@ module ns_mod
 
         ! ----------------------------------------
         ! Function:  const std::string & LastFunctionCalled +deref(allocatable)
-        ! Requested: c_string_&_result
-        ! Match:     c_string_result
+        ! Exact:     c_string_&_result
         function c_last_function_called() &
                 result(SHT_rv) &
                 bind(C, name="NS_last_function_called")
@@ -88,8 +87,7 @@ module ns_mod
         ! Match:     c_default
         ! ----------------------------------------
         ! Argument:  const std::string & SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
-        ! Requested: c_string_&_result_buf_allocatable
-        ! Match:     c_string_result_buf_allocatable
+        ! Exact:     c_string_&_result_buf_allocatable
         subroutine c_last_function_called_bufferify(DSHF_rv) &
                 bind(C, name="NS_last_function_called_bufferify")
             import :: NS_SHROUD_array
@@ -138,8 +136,7 @@ contains
     ! ----------------------------------------
     ! Argument:  const std::string & SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
     ! Exact:     f_string_&_result_buf_allocatable
-    ! Requested: c_string_&_result_buf_allocatable
-    ! Match:     c_string_result_buf_allocatable
+    ! Exact:     c_string_&_result_buf_allocatable
     function last_function_called() &
             result(SHT_rv)
         type(NS_SHROUD_array) :: DSHF_rv

--- a/regression/reference/namespace/wrapns.cpp
+++ b/regression/reference/namespace/wrapns.cpp
@@ -46,8 +46,7 @@ static void ShroudStrToArray(NS_SHROUD_array *array, const std::string * src, in
 
 // ----------------------------------------
 // Function:  const std::string & LastFunctionCalled +deref(allocatable)
-// Requested: c_string_&_result
-// Match:     c_string_result
+// Exact:     c_string_&_result
 const char * NS_last_function_called(void)
 {
     // splicer begin function.last_function_called
@@ -63,8 +62,7 @@ const char * NS_last_function_called(void)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  const std::string & SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
-// Requested: c_string_&_result_buf_allocatable
-// Match:     c_string_result_buf_allocatable
+// Exact:     c_string_&_result_buf_allocatable
 void NS_last_function_called_bufferify(NS_SHROUD_array *DSHF_rv)
 {
     // splicer begin function.last_function_called_bufferify

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -47,20 +47,31 @@ root
         in -- c_shadow_scalar_in
         result -- c_shadow_scalar_result
     string
-      in -- c_string_in
-        buf -- c_string_in_buf
-      inout -- c_string_inout
-        buf -- c_string_inout_buf
-      out -- c_string_out
-        buf -- c_string_out_buf
-      result -- c_string_result
-        buf -- c_string_result_buf
-          allocatable -- c_string_result_buf_allocatable
+      &
+        in -- c_string_*/&_in
+          buf -- c_string_*/&_in_buf
+        inout -- c_string_*/&_inout
+          buf -- c_string_*/&_inout_buf
+        out -- c_string_*/&_out
+          buf -- c_string_*/&_out_buf
+        result -- c_string_scalar/*/&_result
+          buf -- c_string_scalar/*/&_result_buf
+            allocatable -- c_string_*/&_result_buf_allocatable
+      *
+        in -- c_string_*/&_in
+          buf -- c_string_*/&_in_buf
+        inout -- c_string_*/&_inout
+          buf -- c_string_*/&_inout_buf
+        out -- c_string_*/&_out
+          buf -- c_string_*/&_out_buf
+        result -- c_string_scalar/*/&_result
+          buf -- c_string_scalar/*/&_result_buf
+            allocatable -- c_string_*/&_result_buf_allocatable
       scalar
         in -- c_string_scalar_in
           buf -- c_string_scalar_in_buf
-        result
-          buf -- c_string_scalar_result_buf
+        result -- c_string_scalar/*/&_result
+          buf -- c_string_scalar/*/&_result_buf
             allocatable -- c_string_scalar_result_buf_allocatable
     struct -- c_struct
       result -- c_struct_result

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -1,0 +1,167 @@
+root
+  c
+    char
+      *
+        in
+          buf -- c_char_*_in_buf
+        inout
+          buf -- c_char_*_inout_buf
+        out
+          buf -- c_char_*_out_buf
+        result -- c_char_*_result
+          buf -- c_char_*_result_buf
+            allocatable -- c_char_*_result_buf_allocatable
+      **
+        in -- c_char_**_in
+          buf -- c_char_**_in_buf
+      scalar
+        in -- c_char_scalar_in
+        result -- c_char_scalar_result
+          buf -- c_char_scalar_result_buf
+    native
+      *
+        in
+          cdesc -- c_native_*_in_cdesc
+          cfi -- c_native_*_in_cfi
+        inout
+          cdesc -- c_native_*_inout_cdesc
+        out
+          cdesc -- c_native_*_out_cdesc
+        result
+          buf -- c_native_*_result_buf
+      *&
+        out
+          buf -- c_native_*&_out_buf
+      **
+        in -- c_native_**_in
+        out
+          buf -- c_native_**_out_buf
+    shadow
+      ctor -- c_shadow_ctor
+      dtor -- c_shadow_dtor
+      in -- c_shadow_in
+      inout -- c_shadow_inout
+      result -- c_shadow_result
+      scalar
+        ctor -- c_shadow_scalar_ctor
+        in -- c_shadow_scalar_in
+        result -- c_shadow_scalar_result
+    string
+      in -- c_string_in
+        buf -- c_string_in_buf
+      inout -- c_string_inout
+        buf -- c_string_inout_buf
+      out -- c_string_out
+        buf -- c_string_out_buf
+      result -- c_string_result
+        buf -- c_string_result_buf
+          allocatable -- c_string_result_buf_allocatable
+      scalar
+        in -- c_string_scalar_in
+          buf -- c_string_scalar_in_buf
+        result
+          buf -- c_string_scalar_result_buf
+            allocatable -- c_string_scalar_result_buf_allocatable
+    struct -- c_struct
+      result -- c_struct_result
+    vector
+      in
+        buf -- c_vector_in_buf
+          string -- c_vector_in_buf_string
+      inout
+        buf -- c_vector_inout_buf
+          string -- c_vector_inout_buf_string
+      out
+        buf -- c_vector_out_buf
+          string -- c_vector_out_buf_string
+      result
+        buf -- c_vector_result_buf
+    void
+      *
+        cdesc -- c_void_*_cdesc
+      **
+        in -- c_void_**_in
+  f
+    XXX
+      native
+        **
+          out -- f_XXX_native_**_out
+    bool
+      in -- f_bool_in
+      inout -- f_bool_inout
+      out -- f_bool_out
+      result -- f_bool_result
+    char
+      *
+        result
+          buf
+            allocatable -- f_char_*_result_buf_allocatable
+          raw -- f_char_*_result_raw
+      scalar
+        in -- f_char_scalar_in
+        result
+          buf
+            allocatable -- f_char_scalar_result_buf_allocatable
+    native
+      &
+        result -- f_native_&_result
+      *
+        in
+          cdesc -- f_native_*_in_cdesc
+          raw -- f_native_*_in_raw
+        inout
+          cdesc -- f_native_*_inout_cdesc
+        out
+          allocatable -- f_native_*_out_allocatable
+          cdesc -- f_native_*_out_cdesc
+        result
+          buf
+            allocatable -- f_native_*_result_buf_allocatable
+            pointer -- f_native_*_result_buf_pointer
+              caller -- f_native_*_result_buf_pointer_caller
+          pointer -- f_native_*_result_pointer
+          raw -- f_native_*_result_raw
+          scalar -- f_native_*_result_scalar
+      *&
+        out -- f_native_*&_out
+      **
+        out -- f_native_**_out
+          raw -- f_native_**_out_raw
+        result -- f_native_**_result
+    shadow
+      ctor -- f_shadow_ctor
+      result -- f_shadow_result
+    string
+      &
+        result
+          buf
+            allocatable -- f_string_&_result_buf_allocatable
+      *
+        result
+          buf
+            allocatable -- f_string_*_result_buf_allocatable
+      scalar
+        in -- f_string_scalar_in
+        result
+          buf
+            allocatable -- f_string_scalar_result_buf_allocatable
+    struct
+      *
+        result -- f_struct_*_result
+      scalar
+        result -- f_struct_scalar_result
+    vector
+      inout -- f_vector_inout
+        allocatable -- f_vector_inout_allocatable
+      out -- f_vector_out
+        allocatable -- f_vector_out_allocatable
+      result -- f_vector_result
+        allocatable -- f_vector_result_allocatable
+    void
+      *
+        cdesc -- f_void_*_cdesc
+        in -- f_void_*_in
+        result -- f_void_*_result
+      **
+        in -- f_void_**_in
+        out -- f_void_**_out

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -21,12 +21,12 @@ root
     native
       *
         in
-          cdesc -- c_native_*_in_cdesc
+          cdesc -- c_native_*_in/out/inout_cdesc
           cfi -- c_native_*_in_cfi
         inout
-          cdesc -- c_native_*_inout_cdesc
+          cdesc -- c_native_*_in/out/inout_cdesc
         out
-          cdesc -- c_native_*_out_cdesc
+          cdesc -- c_native_*_in/out/inout_cdesc
         result
           buf -- c_native_*_result_buf
       *&
@@ -95,25 +95,25 @@ root
       *
         result
           buf
-            allocatable -- f_char_*_result_buf_allocatable
+            allocatable -- f_char_scalar/*_result_buf_allocatable
           raw -- f_char_*_result_raw
       scalar
         in -- f_char_scalar_in
         result
           buf
-            allocatable -- f_char_scalar_result_buf_allocatable
+            allocatable -- f_char_scalar/*_result_buf_allocatable
     native
       &
         result -- f_native_&_result
       *
         in
-          cdesc -- f_native_*_in_cdesc
+          cdesc -- f_native_*_in/out/inout_cdesc
           raw -- f_native_*_in_raw
         inout
-          cdesc -- f_native_*_inout_cdesc
+          cdesc -- f_native_*_in/out/inout_cdesc
         out
           allocatable -- f_native_*_out_allocatable
-          cdesc -- f_native_*_out_cdesc
+          cdesc -- f_native_*_in/out/inout_cdesc
         result
           buf
             allocatable -- f_native_*_result_buf_allocatable
@@ -135,16 +135,16 @@ root
       &
         result
           buf
-            allocatable -- f_string_&_result_buf_allocatable
+            allocatable -- f_string_scalar/*/&_result_buf_allocatable
       *
         result
           buf
-            allocatable -- f_string_*_result_buf_allocatable
+            allocatable -- f_string_scalar/*/&_result_buf_allocatable
       scalar
         in -- f_string_scalar_in
         result
           buf
-            allocatable -- f_string_scalar_result_buf_allocatable
+            allocatable -- f_string_scalar/*/&_result_buf_allocatable
     struct
       *
         result -- f_struct_*_result

--- a/regression/reference/statement/statement.json
+++ b/regression/reference/statement/statement.json
@@ -114,7 +114,7 @@
                         "sh_type": "SH_TYPE_OTHER",
                         "shadow_var": "SHadow_rv",
                         "stmt0": "c_string_&_result",
-                        "stmt1": "c_string_result"
+                        "stmt1": "c_string_&_result"
                     },
                     "fmtf": {
                         "c_var_len": "get_name_length()",
@@ -199,7 +199,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_SHF_rv",
                             "stmt0": "c_string_&_result_buf",
-                            "stmt1": "c_string_result_buf"
+                            "stmt1": "c_string_&_result_buf"
                         },
                         "fmtf": {
                             "F_C_var": "SHF_rv",
@@ -214,7 +214,7 @@
                             "stmt0": "f_string_&_result_buf",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_&_result_buf",
-                            "stmtc1": "c_string_result_buf"
+                            "stmtc1": "c_string_&_result_buf"
                         }
                     }
                 },

--- a/regression/reference/statement/wrapfstatement.f
+++ b/regression/reference/statement/wrapfstatement.f
@@ -36,8 +36,7 @@ module statement_mod
 
         ! ----------------------------------------
         ! Function:  const string & getNameErrorPattern +deref(result-as-arg)+len(get_name_length())
-        ! Requested: c_string_&_result
-        ! Match:     c_string_result
+        ! Exact:     c_string_&_result
         function c_get_name_error_pattern() &
                 result(SHT_rv) &
                 bind(C, name="STMT_get_name_error_pattern")
@@ -52,8 +51,7 @@ module statement_mod
         ! Match:     c_default
         ! ----------------------------------------
         ! Argument:  string & SHF_rv +intent(out)+len(NSHF_rv)
-        ! Requested: c_string_&_result_buf
-        ! Match:     c_string_result_buf
+        ! Exact:     c_string_&_result_buf
         subroutine c_get_name_error_pattern_bufferify(SHF_rv, NSHF_rv) &
                 bind(C, name="STMT_get_name_error_pattern_bufferify")
             use iso_c_binding, only : C_CHAR, C_INT
@@ -80,8 +78,7 @@ contains
     ! Argument:  string & SHF_rv +intent(out)+len(NSHF_rv)
     ! Requested: f_string_&_result_buf
     ! Match:     f_default
-    ! Requested: c_string_&_result_buf
-    ! Match:     c_string_result_buf
+    ! Exact:     c_string_&_result_buf
     function get_name_error_pattern() &
             result(SHT_rv)
         use iso_c_binding, only : C_INT

--- a/regression/reference/statement/wrapstatement.cpp
+++ b/regression/reference/statement/wrapstatement.cpp
@@ -58,8 +58,7 @@ int STMT_get_name_length(void)
 
 // ----------------------------------------
 // Function:  const string & getNameErrorPattern +deref(result-as-arg)+len(get_name_length())
-// Requested: c_string_&_result
-// Match:     c_string_result
+// Exact:     c_string_&_result
 const char * STMT_get_name_error_pattern(void)
 {
     // splicer begin function.get_name_error_pattern
@@ -80,8 +79,7 @@ const char * STMT_get_name_error_pattern(void)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  string & SHF_rv +intent(out)+len(NSHF_rv)
-// Requested: c_string_&_result_buf
-// Match:     c_string_result_buf
+// Exact:     c_string_&_result_buf
 void STMT_get_name_error_pattern_bufferify(char * SHF_rv, int NSHF_rv)
 {
     // splicer begin function.get_name_error_pattern_bufferify

--- a/regression/reference/strings/strings.json
+++ b/regression/reference/strings/strings.json
@@ -1848,7 +1848,7 @@
                             "stmt0": "f_string_*_result_buf_allocatable",
                             "stmt1": "f_string_*_result_buf_allocatable",
                             "stmtc0": "c_string_*_result_buf_allocatable",
-                            "stmtc1": "c_string_result_buf_allocatable"
+                            "stmtc1": "c_string_*_result_buf_allocatable"
                         }
                     }
                 },
@@ -2033,7 +2033,7 @@
                             "stmt0": "f_string_*_result_buf",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_*_result_buf",
-                            "stmtc1": "c_string_result_buf"
+                            "stmtc1": "c_string_*_result_buf"
                         }
                     }
                 },
@@ -2199,7 +2199,7 @@
                             "stmt0": "f_string_*_result_buf",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_*_result_buf",
-                            "stmtc1": "c_string_result_buf"
+                            "stmtc1": "c_string_*_result_buf"
                         }
                     }
                 },
@@ -2439,7 +2439,7 @@
                             "stmt0": "f_string_*_result_buf_allocatable",
                             "stmt1": "f_string_*_result_buf_allocatable",
                             "stmtc0": "c_string_*_result_buf_allocatable",
-                            "stmtc1": "c_string_result_buf_allocatable"
+                            "stmtc1": "c_string_*_result_buf_allocatable"
                         }
                     }
                 },
@@ -2530,7 +2530,7 @@
                         "sh_type": "SH_TYPE_OTHER",
                         "shadow_var": "SHadow_rv",
                         "stmt0": "c_string_&_result",
-                        "stmt1": "c_string_result"
+                        "stmt1": "c_string_&_result"
                     },
                     "fmtf": {
                         "cxx_type": "std::string",
@@ -2636,7 +2636,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_SHF_rv",
                             "stmt0": "c_string_&_result_buf_allocatable",
-                            "stmt1": "c_string_result_buf_allocatable"
+                            "stmt1": "c_string_&_result_buf_allocatable"
                         },
                         "fmtf": {
                             "F_C_var": "SHF_rv",
@@ -2652,7 +2652,7 @@
                             "stmt0": "f_string_&_result_buf_allocatable",
                             "stmt1": "f_string_&_result_buf_allocatable",
                             "stmtc0": "c_string_&_result_buf_allocatable",
-                            "stmtc1": "c_string_result_buf_allocatable"
+                            "stmtc1": "c_string_&_result_buf_allocatable"
                         }
                     }
                 },
@@ -2750,7 +2750,7 @@
                         "sh_type": "SH_TYPE_OTHER",
                         "shadow_var": "SHadow_rv",
                         "stmt0": "c_string_&_result",
-                        "stmt1": "c_string_result"
+                        "stmt1": "c_string_&_result"
                     },
                     "fmtf": {
                         "c_var_len": 30,
@@ -2858,7 +2858,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_SHF_rv",
                             "stmt0": "c_string_&_result_buf",
-                            "stmt1": "c_string_result_buf"
+                            "stmt1": "c_string_&_result_buf"
                         },
                         "fmtf": {
                             "F_C_var": "SHF_rv",
@@ -2873,7 +2873,7 @@
                             "stmt0": "f_string_&_result_buf",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_&_result_buf",
-                            "stmtc1": "c_string_result_buf"
+                            "stmtc1": "c_string_&_result_buf"
                         }
                     }
                 },
@@ -2971,7 +2971,7 @@
                         "sh_type": "SH_TYPE_OTHER",
                         "shadow_var": "SHadow_rv",
                         "stmt0": "c_string_&_result",
-                        "stmt1": "c_string_result"
+                        "stmt1": "c_string_&_result"
                     },
                     "fmtpy": {
                         "array_size": "1",
@@ -3058,7 +3058,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_output",
                             "stmt0": "c_string_&_result_buf",
-                            "stmt1": "c_string_result_buf"
+                            "stmt1": "c_string_&_result_buf"
                         },
                         "fmtf": {
                             "F_C_var": "output",
@@ -3073,7 +3073,7 @@
                             "stmt0": "f_string_&_result_buf",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_&_result_buf",
-                            "stmtc1": "c_string_result_buf"
+                            "stmtc1": "c_string_&_result_buf"
                         }
                     }
                 },
@@ -3232,7 +3232,7 @@
                         "sh_type": "SH_TYPE_OTHER",
                         "shadow_var": "SHadow_rv",
                         "stmt0": "c_string_&_result",
-                        "stmt1": "c_string_result"
+                        "stmt1": "c_string_&_result"
                     },
                     "fmtf": {
                         "c_var_len": 30,
@@ -3339,7 +3339,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_SHF_rv",
                             "stmt0": "c_string_&_result_buf",
-                            "stmt1": "c_string_result_buf"
+                            "stmt1": "c_string_&_result_buf"
                         },
                         "fmtf": {
                             "F_C_var": "SHF_rv",
@@ -3354,7 +3354,7 @@
                             "stmt0": "f_string_&_result_buf",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_&_result_buf",
-                            "stmtc1": "c_string_result_buf"
+                            "stmtc1": "c_string_&_result_buf"
                         }
                     }
                 },
@@ -3450,7 +3450,7 @@
                         "sh_type": "SH_TYPE_OTHER",
                         "shadow_var": "SHadow_rv",
                         "stmt0": "c_string_&_result",
-                        "stmt1": "c_string_result"
+                        "stmt1": "c_string_&_result"
                     },
                     "fmtf": {
                         "cxx_type": "std::string",
@@ -3551,7 +3551,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_SHF_rv",
                             "stmt0": "c_string_&_result_buf_allocatable",
-                            "stmt1": "c_string_result_buf_allocatable"
+                            "stmt1": "c_string_&_result_buf_allocatable"
                         },
                         "fmtf": {
                             "F_C_var": "SHF_rv",
@@ -3567,7 +3567,7 @@
                             "stmt0": "f_string_&_result_buf_allocatable",
                             "stmt1": "f_string_&_result_buf_allocatable",
                             "stmtc0": "c_string_&_result_buf_allocatable",
-                            "stmtc1": "c_string_result_buf_allocatable"
+                            "stmtc1": "c_string_&_result_buf_allocatable"
                         }
                     }
                 },
@@ -3659,7 +3659,7 @@
                         "sh_type": "SH_TYPE_OTHER",
                         "shadow_var": "SHadow_rv",
                         "stmt0": "c_string_*_result",
-                        "stmt1": "c_string_result"
+                        "stmt1": "c_string_*_result"
                     },
                     "fmtf": {
                         "c_var_len": 30,
@@ -3773,7 +3773,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_SHF_rv",
                             "stmt0": "c_string_*_result_buf",
-                            "stmt1": "c_string_result_buf"
+                            "stmt1": "c_string_*_result_buf"
                         },
                         "fmtf": {
                             "F_C_var": "SHF_rv",
@@ -3788,7 +3788,7 @@
                             "stmt0": "f_string_*_result_buf",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_*_result_buf",
-                            "stmtc1": "c_string_result_buf"
+                            "stmtc1": "c_string_*_result_buf"
                         }
                     }
                 },
@@ -3892,7 +3892,7 @@
                         "sh_type": "SH_TYPE_OTHER",
                         "shadow_var": "SHadow_rv",
                         "stmt0": "c_string_*_result",
-                        "stmt1": "c_string_result"
+                        "stmt1": "c_string_*_result"
                     },
                     "fmtf": {
                         "cxx_type": "std::string",
@@ -3994,7 +3994,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_SHF_rv",
                             "stmt0": "c_string_*_result_buf_allocatable",
-                            "stmt1": "c_string_result_buf_allocatable"
+                            "stmt1": "c_string_*_result_buf_allocatable"
                         },
                         "fmtf": {
                             "F_C_var": "SHF_rv",
@@ -4010,7 +4010,7 @@
                             "stmt0": "f_string_*_result_buf_allocatable",
                             "stmt1": "f_string_*_result_buf_allocatable",
                             "stmtc0": "c_string_*_result_buf_allocatable",
-                            "stmtc1": "c_string_result_buf_allocatable"
+                            "stmtc1": "c_string_*_result_buf_allocatable"
                         }
                     }
                 },
@@ -4102,7 +4102,7 @@
                         "sh_type": "SH_TYPE_OTHER",
                         "shadow_var": "SHadow_rv",
                         "stmt0": "c_string_*_result",
-                        "stmt1": "c_string_result"
+                        "stmt1": "c_string_*_result"
                     },
                     "fmtf": {
                         "cxx_type": "std::string",
@@ -4207,7 +4207,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_SHF_rv",
                             "stmt0": "c_string_*_result_buf_allocatable",
-                            "stmt1": "c_string_result_buf_allocatable"
+                            "stmt1": "c_string_*_result_buf_allocatable"
                         },
                         "fmtf": {
                             "F_C_var": "SHF_rv",
@@ -4223,7 +4223,7 @@
                             "stmt0": "f_string_*_result_buf_allocatable",
                             "stmt1": "f_string_*_result_buf_allocatable",
                             "stmtc0": "c_string_*_result_buf_allocatable",
-                            "stmtc1": "c_string_result_buf_allocatable"
+                            "stmtc1": "c_string_*_result_buf_allocatable"
                         }
                     }
                 },
@@ -4318,7 +4318,7 @@
                         "sh_type": "SH_TYPE_OTHER",
                         "shadow_var": "SHadow_rv",
                         "stmt0": "c_string_*_result",
-                        "stmt1": "c_string_result"
+                        "stmt1": "c_string_*_result"
                     },
                     "fmtf": {
                         "cxx_type": "std::string",
@@ -4424,7 +4424,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_SHF_rv",
                             "stmt0": "c_string_*_result_buf_allocatable",
-                            "stmt1": "c_string_result_buf_allocatable"
+                            "stmt1": "c_string_*_result_buf_allocatable"
                         },
                         "fmtf": {
                             "F_C_var": "SHF_rv",
@@ -4440,7 +4440,7 @@
                             "stmt0": "f_string_*_result_buf_allocatable",
                             "stmt1": "f_string_*_result_buf_allocatable",
                             "stmtc0": "c_string_*_result_buf_allocatable",
-                            "stmtc1": "c_string_result_buf_allocatable"
+                            "stmtc1": "c_string_*_result_buf_allocatable"
                         }
                     }
                 },
@@ -4538,7 +4538,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_arg1",
                             "stmt0": "c_string_&_in",
-                            "stmt1": "c_string_in"
+                            "stmt1": "c_string_&_in"
                         },
                         "fmtf": {
                             "F_C_var": "arg1"
@@ -4650,7 +4650,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_arg1",
                             "stmt0": "c_string_&_in_buf",
-                            "stmt1": "c_string_in_buf"
+                            "stmt1": "c_string_&_in_buf"
                         },
                         "fmtf": {
                             "F_C_var": "arg1",
@@ -4665,7 +4665,7 @@
                             "stmt0": "f_string_&_in",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_&_in_buf",
-                            "stmtc1": "c_string_in_buf"
+                            "stmtc1": "c_string_&_in_buf"
                         }
                     }
                 },
@@ -4746,7 +4746,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_arg1",
                             "stmt0": "c_string_&_out",
-                            "stmt1": "c_string_out"
+                            "stmt1": "c_string_&_out"
                         },
                         "fmtf": {
                             "F_C_var": "arg1"
@@ -4857,7 +4857,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_arg1",
                             "stmt0": "c_string_&_out_buf",
-                            "stmt1": "c_string_out_buf"
+                            "stmt1": "c_string_&_out_buf"
                         },
                         "fmtf": {
                             "F_C_var": "arg1",
@@ -4872,7 +4872,7 @@
                             "stmt0": "f_string_&_out",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_&_out_buf",
-                            "stmtc1": "c_string_out_buf"
+                            "stmtc1": "c_string_&_out_buf"
                         }
                     }
                 },
@@ -4952,7 +4952,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_arg1",
                             "stmt0": "c_string_&_inout",
-                            "stmt1": "c_string_inout"
+                            "stmt1": "c_string_&_inout"
                         },
                         "fmtf": {
                             "F_C_var": "arg1"
@@ -5066,7 +5066,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_arg1",
                             "stmt0": "c_string_&_inout_buf",
-                            "stmt1": "c_string_inout_buf"
+                            "stmt1": "c_string_&_inout_buf"
                         },
                         "fmtf": {
                             "F_C_var": "arg1",
@@ -5082,7 +5082,7 @@
                             "stmt0": "f_string_&_inout",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_&_inout_buf",
-                            "stmtc1": "c_string_inout_buf"
+                            "stmtc1": "c_string_&_inout_buf"
                         }
                     }
                 },
@@ -5165,7 +5165,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_arg1",
                             "stmt0": "c_string_*_in",
-                            "stmt1": "c_string_in"
+                            "stmt1": "c_string_*_in"
                         },
                         "fmtf": {
                             "F_C_var": "arg1"
@@ -5276,7 +5276,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_arg1",
                             "stmt0": "c_string_*_in_buf",
-                            "stmt1": "c_string_in_buf"
+                            "stmt1": "c_string_*_in_buf"
                         },
                         "fmtf": {
                             "F_C_var": "arg1",
@@ -5291,7 +5291,7 @@
                             "stmt0": "f_string_*_in",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_*_in_buf",
-                            "stmtc1": "c_string_in_buf"
+                            "stmtc1": "c_string_*_in_buf"
                         }
                     }
                 },
@@ -5371,7 +5371,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_arg1",
                             "stmt0": "c_string_*_inout",
-                            "stmt1": "c_string_inout"
+                            "stmt1": "c_string_*_inout"
                         },
                         "fmtf": {
                             "F_C_var": "arg1"
@@ -5482,7 +5482,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_arg1",
                             "stmt0": "c_string_*_inout_buf",
-                            "stmt1": "c_string_inout_buf"
+                            "stmt1": "c_string_*_inout_buf"
                         },
                         "fmtf": {
                             "F_C_var": "arg1",
@@ -5498,7 +5498,7 @@
                             "stmt0": "f_string_*_inout",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_*_inout_buf",
-                            "stmtc1": "c_string_inout_buf"
+                            "stmtc1": "c_string_*_inout_buf"
                         }
                     }
                 },
@@ -5578,7 +5578,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_arg1",
                             "stmt0": "c_string_*_out",
-                            "stmt1": "c_string_out"
+                            "stmt1": "c_string_*_out"
                         },
                         "fmtf": {
                             "F_C_var": "arg1"
@@ -5689,7 +5689,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_arg1",
                             "stmt0": "c_string_*_out_buf",
-                            "stmt1": "c_string_out_buf"
+                            "stmt1": "c_string_*_out_buf"
                         },
                         "fmtf": {
                             "F_C_var": "arg1",
@@ -5704,7 +5704,7 @@
                             "stmt0": "f_string_*_out",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_*_out_buf",
-                            "stmtc1": "c_string_out_buf"
+                            "stmtc1": "c_string_*_out_buf"
                         }
                     }
                 },
@@ -5784,7 +5784,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_arg1",
                             "stmt0": "c_string_*_inout",
-                            "stmt1": "c_string_inout"
+                            "stmt1": "c_string_*_inout"
                         },
                         "fmtf": {
                             "F_C_var": "arg1"
@@ -5955,7 +5955,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_arg1",
                             "stmt0": "c_string_*_inout_buf",
-                            "stmt1": "c_string_inout_buf"
+                            "stmt1": "c_string_*_inout_buf"
                         },
                         "fmtf": {
                             "F_C_var": "arg1",
@@ -5971,7 +5971,7 @@
                             "stmt0": "f_string_*_inout",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_*_inout_buf",
-                            "stmtc1": "c_string_inout_buf"
+                            "stmtc1": "c_string_*_inout_buf"
                         }
                     },
                     "nlen": {
@@ -6103,7 +6103,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_arg1",
                             "stmt0": "c_string_*_out",
-                            "stmt1": "c_string_out"
+                            "stmt1": "c_string_*_out"
                         },
                         "fmtf": {
                             "F_C_var": "arg1"
@@ -6273,7 +6273,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_arg1",
                             "stmt0": "c_string_*_out_buf",
-                            "stmt1": "c_string_out_buf"
+                            "stmt1": "c_string_*_out_buf"
                         },
                         "fmtf": {
                             "F_C_var": "arg1",
@@ -6288,7 +6288,7 @@
                             "stmt0": "f_string_*_out",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_*_out_buf",
-                            "stmtc1": "c_string_out_buf"
+                            "stmtc1": "c_string_*_out_buf"
                         }
                     },
                     "nlen": {
@@ -7789,7 +7789,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_name",
                             "stmt0": "c_string_&_inout",
-                            "stmt1": "c_string_inout"
+                            "stmt1": "c_string_&_inout"
                         },
                         "fmtf": {
                             "F_C_var": "name"
@@ -7957,7 +7957,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_name",
                             "stmt0": "c_string_&_inout_buf",
-                            "stmt1": "c_string_inout_buf"
+                            "stmt1": "c_string_&_inout_buf"
                         },
                         "fmtf": {
                             "F_C_var": "name",
@@ -7973,7 +7973,7 @@
                             "stmt0": "f_string_&_inout",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_&_inout_buf",
-                            "stmtc1": "c_string_inout_buf"
+                            "stmtc1": "c_string_&_inout_buf"
                         }
                     }
                 },

--- a/regression/reference/strings/wrapfstrings.f
+++ b/regression/reference/strings/wrapfstrings.f
@@ -313,8 +313,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  const string * SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
-    ! Requested: c_string_*_result_buf_allocatable
-    ! Match:     c_string_result_buf_allocatable
+    ! Exact:     c_string_*_result_buf_allocatable
     interface
         subroutine c_get_const_string_result_bufferify(DSHF_rv) &
                 bind(C, name="STR_get_const_string_result_bufferify")
@@ -330,8 +329,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  string * SHF_rv +intent(out)+len(NSHF_rv)
-    ! Requested: c_string_*_result_buf
-    ! Match:     c_string_result_buf
+    ! Exact:     c_string_*_result_buf
     interface
         subroutine c_get_const_string_len_bufferify(SHF_rv, NSHF_rv) &
                 bind(C, name="STR_get_const_string_len_bufferify")
@@ -348,8 +346,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  string * output +intent(out)+len(Noutput)
-    ! Requested: c_string_*_result_buf
-    ! Match:     c_string_result_buf
+    ! Exact:     c_string_*_result_buf
     interface
         subroutine c_get_const_string_as_arg_bufferify(output, Noutput) &
                 bind(C, name="STR_get_const_string_as_arg_bufferify")
@@ -366,8 +363,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  const std::string * SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
-    ! Requested: c_string_*_result_buf_allocatable
-    ! Match:     c_string_result_buf_allocatable
+    ! Exact:     c_string_*_result_buf_allocatable
     interface
         subroutine c_get_const_string_alloc_bufferify(DSHF_rv) &
                 bind(C, name="STR_get_const_string_alloc_bufferify")
@@ -379,8 +375,7 @@ module strings_mod
 
     ! ----------------------------------------
     ! Function:  const string & getConstStringRefPure +deref(allocatable)
-    ! Requested: c_string_&_result
-    ! Match:     c_string_result
+    ! Exact:     c_string_&_result
     ! start c_get_const_string_ref_pure
     interface
         function c_get_const_string_ref_pure() &
@@ -399,8 +394,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  const string & SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
-    ! Requested: c_string_&_result_buf_allocatable
-    ! Match:     c_string_result_buf_allocatable
+    ! Exact:     c_string_&_result_buf_allocatable
     ! start c_get_const_string_ref_pure_bufferify
     interface
         subroutine c_get_const_string_ref_pure_bufferify(DSHF_rv) &
@@ -414,8 +408,7 @@ module strings_mod
 
     ! ----------------------------------------
     ! Function:  const string & getConstStringRefLen +deref(result-as-arg)+len(30)
-    ! Requested: c_string_&_result
-    ! Match:     c_string_result
+    ! Exact:     c_string_&_result
     interface
         function c_get_const_string_ref_len() &
                 result(SHT_rv) &
@@ -432,8 +425,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  string & SHF_rv +intent(out)+len(NSHF_rv)
-    ! Requested: c_string_&_result_buf
-    ! Match:     c_string_result_buf
+    ! Exact:     c_string_&_result_buf
     interface
         subroutine c_get_const_string_ref_len_bufferify(SHF_rv, NSHF_rv) &
                 bind(C, name="STR_get_const_string_ref_len_bufferify")
@@ -446,8 +438,7 @@ module strings_mod
 
     ! ----------------------------------------
     ! Function:  const string & getConstStringRefAsArg +deref(result-as-arg)
-    ! Requested: c_string_&_result
-    ! Match:     c_string_result
+    ! Exact:     c_string_&_result
     interface
         function c_get_const_string_ref_as_arg() &
                 result(SHT_rv) &
@@ -464,8 +455,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  string & output +intent(out)+len(Noutput)
-    ! Requested: c_string_&_result_buf
-    ! Match:     c_string_result_buf
+    ! Exact:     c_string_&_result_buf
     interface
         subroutine c_get_const_string_ref_as_arg_bufferify(output, &
                 Noutput) &
@@ -479,8 +469,7 @@ module strings_mod
 
     ! ----------------------------------------
     ! Function:  const string & getConstStringRefLenEmpty +deref(result-as-arg)+len(30)
-    ! Requested: c_string_&_result
-    ! Match:     c_string_result
+    ! Exact:     c_string_&_result
     interface
         function c_get_const_string_ref_len_empty() &
                 result(SHT_rv) &
@@ -497,8 +486,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  string & SHF_rv +intent(out)+len(NSHF_rv)
-    ! Requested: c_string_&_result_buf
-    ! Match:     c_string_result_buf
+    ! Exact:     c_string_&_result_buf
     interface
         subroutine c_get_const_string_ref_len_empty_bufferify(SHF_rv, &
                 NSHF_rv) &
@@ -512,8 +500,7 @@ module strings_mod
 
     ! ----------------------------------------
     ! Function:  const std::string & getConstStringRefAlloc +deref(allocatable)
-    ! Requested: c_string_&_result
-    ! Match:     c_string_result
+    ! Exact:     c_string_&_result
     interface
         function c_get_const_string_ref_alloc() &
                 result(SHT_rv) &
@@ -530,8 +517,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  const std::string & SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
-    ! Requested: c_string_&_result_buf_allocatable
-    ! Match:     c_string_result_buf_allocatable
+    ! Exact:     c_string_&_result_buf_allocatable
     interface
         subroutine c_get_const_string_ref_alloc_bufferify(DSHF_rv) &
                 bind(C, name="STR_get_const_string_ref_alloc_bufferify")
@@ -543,8 +529,7 @@ module strings_mod
 
     ! ----------------------------------------
     ! Function:  const string * getConstStringPtrLen +deref(result-as-arg)+len(30)
-    ! Requested: c_string_*_result
-    ! Match:     c_string_result
+    ! Exact:     c_string_*_result
     interface
         function c_get_const_string_ptr_len() &
                 result(SHT_rv) &
@@ -561,8 +546,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  string * SHF_rv +intent(out)+len(NSHF_rv)
-    ! Requested: c_string_*_result_buf
-    ! Match:     c_string_result_buf
+    ! Exact:     c_string_*_result_buf
     interface
         subroutine c_get_const_string_ptr_len_bufferify(SHF_rv, NSHF_rv) &
                 bind(C, name="STR_get_const_string_ptr_len_bufferify")
@@ -575,8 +559,7 @@ module strings_mod
 
     ! ----------------------------------------
     ! Function:  const std::string * getConstStringPtrAlloc +deref(allocatable)+owner(library)
-    ! Requested: c_string_*_result
-    ! Match:     c_string_result
+    ! Exact:     c_string_*_result
     interface
         function c_get_const_string_ptr_alloc() &
                 result(SHT_rv) &
@@ -593,8 +576,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  const std::string * SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)+owner(library)
-    ! Requested: c_string_*_result_buf_allocatable
-    ! Match:     c_string_result_buf_allocatable
+    ! Exact:     c_string_*_result_buf_allocatable
     interface
         subroutine c_get_const_string_ptr_alloc_bufferify(DSHF_rv) &
                 bind(C, name="STR_get_const_string_ptr_alloc_bufferify")
@@ -606,8 +588,7 @@ module strings_mod
 
     ! ----------------------------------------
     ! Function:  const std::string * getConstStringPtrOwnsAlloc +deref(allocatable)+owner(caller)
-    ! Requested: c_string_*_result
-    ! Match:     c_string_result
+    ! Exact:     c_string_*_result
     interface
         function c_get_const_string_ptr_owns_alloc() &
                 result(SHT_rv) &
@@ -624,8 +605,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  const std::string * SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)+owner(caller)
-    ! Requested: c_string_*_result_buf_allocatable
-    ! Match:     c_string_result_buf_allocatable
+    ! Exact:     c_string_*_result_buf_allocatable
     interface
         subroutine c_get_const_string_ptr_owns_alloc_bufferify(DSHF_rv) &
                 bind(C, name="STR_get_const_string_ptr_owns_alloc_bufferify")
@@ -637,8 +617,7 @@ module strings_mod
 
     ! ----------------------------------------
     ! Function:  const std::string * getConstStringPtrOwnsAllocPattern +deref(allocatable)+free_pattern(C_string_free)+owner(caller)
-    ! Requested: c_string_*_result
-    ! Match:     c_string_result
+    ! Exact:     c_string_*_result
     interface
         function c_get_const_string_ptr_owns_alloc_pattern() &
                 result(SHT_rv) &
@@ -655,8 +634,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  const std::string * SHF_rv +context(DSHF_rv)+deref(allocatable)+free_pattern(C_string_free)+intent(out)+owner(caller)
-    ! Requested: c_string_*_result_buf_allocatable
-    ! Match:     c_string_result_buf_allocatable
+    ! Exact:     c_string_*_result_buf_allocatable
     interface
         subroutine c_get_const_string_ptr_owns_alloc_pattern_bufferify( &
                 DSHF_rv) &
@@ -673,8 +651,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  const std::string & arg1 +intent(in)
-    ! Requested: c_string_&_in
-    ! Match:     c_string_in
+    ! Exact:     c_string_&_in
     interface
         subroutine c_accept_string_const_reference(arg1) &
                 bind(C, name="STR_accept_string_const_reference")
@@ -690,8 +667,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  const std::string & arg1 +intent(in)+len_trim(Larg1)
-    ! Requested: c_string_&_in_buf
-    ! Match:     c_string_in_buf
+    ! Exact:     c_string_&_in_buf
     interface
         subroutine c_accept_string_const_reference_bufferify(arg1, &
                 Larg1) &
@@ -709,8 +685,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  std::string & arg1 +intent(out)
-    ! Requested: c_string_&_out
-    ! Match:     c_string_out
+    ! Exact:     c_string_&_out
     interface
         subroutine c_accept_string_reference_out(arg1) &
                 bind(C, name="STR_accept_string_reference_out")
@@ -726,8 +701,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  std::string & arg1 +intent(out)+len(Narg1)
-    ! Requested: c_string_&_out_buf
-    ! Match:     c_string_out_buf
+    ! Exact:     c_string_&_out_buf
     interface
         subroutine c_accept_string_reference_out_bufferify(arg1, Narg1) &
                 bind(C, name="STR_accept_string_reference_out_bufferify")
@@ -744,8 +718,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  std::string & arg1 +intent(inout)
-    ! Requested: c_string_&_inout
-    ! Match:     c_string_inout
+    ! Exact:     c_string_&_inout
     ! start c_accept_string_reference
     interface
         subroutine c_accept_string_reference(arg1) &
@@ -763,8 +736,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  std::string & arg1 +intent(inout)+len(Narg1)+len_trim(Larg1)
-    ! Requested: c_string_&_inout_buf
-    ! Match:     c_string_inout_buf
+    ! Exact:     c_string_&_inout_buf
     ! start c_accept_string_reference_bufferify
     interface
         subroutine c_accept_string_reference_bufferify(arg1, Larg1, &
@@ -785,8 +757,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  const std::string * arg1 +intent(in)
-    ! Requested: c_string_*_in
-    ! Match:     c_string_in
+    ! Exact:     c_string_*_in
     interface
         subroutine c_accept_string_pointer_const(arg1) &
                 bind(C, name="STR_accept_string_pointer_const")
@@ -802,8 +773,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  const std::string * arg1 +intent(in)+len_trim(Larg1)
-    ! Requested: c_string_*_in_buf
-    ! Match:     c_string_in_buf
+    ! Exact:     c_string_*_in_buf
     interface
         subroutine c_accept_string_pointer_const_bufferify(arg1, Larg1) &
                 bind(C, name="STR_accept_string_pointer_const_bufferify")
@@ -820,8 +790,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  std::string * arg1 +intent(inout)
-    ! Requested: c_string_*_inout
-    ! Match:     c_string_inout
+    ! Exact:     c_string_*_inout
     interface
         subroutine c_accept_string_pointer(arg1) &
                 bind(C, name="STR_accept_string_pointer")
@@ -837,8 +806,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  std::string * arg1 +intent(inout)+len(Narg1)+len_trim(Larg1)
-    ! Requested: c_string_*_inout_buf
-    ! Match:     c_string_inout_buf
+    ! Exact:     c_string_*_inout_buf
     interface
         subroutine c_accept_string_pointer_bufferify(arg1, Larg1, Narg1) &
                 bind(C, name="STR_accept_string_pointer_bufferify")
@@ -856,8 +824,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  std::string * arg1 +intent(out)
-    ! Requested: c_string_*_out
-    ! Match:     c_string_out
+    ! Exact:     c_string_*_out
     interface
         subroutine c_fetch_string_pointer(arg1) &
                 bind(C, name="STR_fetch_string_pointer")
@@ -873,8 +840,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  std::string * arg1 +intent(out)+len(Narg1)
-    ! Requested: c_string_*_out_buf
-    ! Match:     c_string_out_buf
+    ! Exact:     c_string_*_out_buf
     interface
         subroutine c_fetch_string_pointer_bufferify(arg1, Narg1) &
                 bind(C, name="STR_fetch_string_pointer_bufferify")
@@ -891,8 +857,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  std::string * arg1 +intent(inout)
-    ! Requested: c_string_*_inout
-    ! Match:     c_string_inout
+    ! Exact:     c_string_*_inout
     ! ----------------------------------------
     ! Argument:  int * nlen +intent(out)
     ! Requested: c_native_*_out
@@ -913,8 +878,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  std::string * arg1 +intent(inout)+len(Narg1)+len_trim(Larg1)
-    ! Requested: c_string_*_inout_buf
-    ! Match:     c_string_inout_buf
+    ! Exact:     c_string_*_inout_buf
     ! ----------------------------------------
     ! Argument:  int * nlen +intent(out)
     ! Requested: c_native_*_out_buf
@@ -938,8 +902,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  std::string * arg1 +intent(out)
-    ! Requested: c_string_*_out
-    ! Match:     c_string_out
+    ! Exact:     c_string_*_out
     ! ----------------------------------------
     ! Argument:  int * nlen +intent(out)
     ! Requested: c_native_*_out
@@ -960,8 +923,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  std::string * arg1 +intent(out)+len(Narg1)
-    ! Requested: c_string_*_out_buf
-    ! Match:     c_string_out_buf
+    ! Exact:     c_string_*_out_buf
     ! ----------------------------------------
     ! Argument:  int * nlen +intent(out)
     ! Requested: c_native_*_out_buf
@@ -1166,8 +1128,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  std::string & name +intent(inout)
-    ! Requested: c_string_&_inout
-    ! Match:     c_string_inout
+    ! Exact:     c_string_&_inout
     interface
         subroutine c_post_declare(count, name) &
                 bind(C, name="STR_post_declare")
@@ -1188,8 +1149,7 @@ module strings_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  std::string & name +intent(inout)+len(Nname)+len_trim(Lname)
-    ! Requested: c_string_&_inout_buf
-    ! Match:     c_string_inout_buf
+    ! Exact:     c_string_&_inout_buf
     interface
         subroutine c_post_declare_bufferify(count, name, Lname, Nname) &
                 bind(C, name="STR_post_declare_bufferify")
@@ -1425,8 +1385,7 @@ contains
     ! ----------------------------------------
     ! Argument:  const string * SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
     ! Exact:     f_string_*_result_buf_allocatable
-    ! Requested: c_string_*_result_buf_allocatable
-    ! Match:     c_string_result_buf_allocatable
+    ! Exact:     c_string_*_result_buf_allocatable
     !>
     !! \brief return an ALLOCATABLE CHARACTER from std::string
     !!
@@ -1454,8 +1413,7 @@ contains
     ! Argument:  string * SHF_rv +intent(out)+len(NSHF_rv)
     ! Requested: f_string_*_result_buf
     ! Match:     f_default
-    ! Requested: c_string_*_result_buf
-    ! Match:     c_string_result_buf
+    ! Exact:     c_string_*_result_buf
     !>
     !! \brief return a 'const string' as argument
     !!
@@ -1482,8 +1440,7 @@ contains
     ! Argument:  string * output +intent(out)+len(Noutput)
     ! Requested: f_string_*_result_buf
     ! Match:     f_default
-    ! Requested: c_string_*_result_buf
-    ! Match:     c_string_result_buf
+    ! Exact:     c_string_*_result_buf
     !>
     !! \brief return a 'const string' as argument
     !!
@@ -1507,8 +1464,7 @@ contains
     ! ----------------------------------------
     ! Argument:  const std::string * SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
     ! Exact:     f_string_*_result_buf_allocatable
-    ! Requested: c_string_*_result_buf_allocatable
-    ! Match:     c_string_result_buf_allocatable
+    ! Exact:     c_string_*_result_buf_allocatable
     function get_const_string_alloc() &
             result(SHT_rv)
         type(STR_SHROUD_array) :: DSHF_rv
@@ -1530,8 +1486,7 @@ contains
     ! ----------------------------------------
     ! Argument:  const string & SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
     ! Exact:     f_string_&_result_buf_allocatable
-    ! Requested: c_string_&_result_buf_allocatable
-    ! Match:     c_string_result_buf_allocatable
+    ! Exact:     c_string_&_result_buf_allocatable
     !>
     !! \brief return a 'const string&' as ALLOCATABLE character
     !!
@@ -1561,8 +1516,7 @@ contains
     ! Argument:  string & SHF_rv +intent(out)+len(NSHF_rv)
     ! Requested: f_string_&_result_buf
     ! Match:     f_default
-    ! Requested: c_string_&_result_buf
-    ! Match:     c_string_result_buf
+    ! Exact:     c_string_&_result_buf
     !>
     !! \brief return 'const string&' with fixed size (len=30)
     !!
@@ -1592,8 +1546,7 @@ contains
     ! Argument:  string & output +intent(out)+len(Noutput)
     ! Requested: f_string_&_result_buf
     ! Match:     f_default
-    ! Requested: c_string_&_result_buf
-    ! Match:     c_string_result_buf
+    ! Exact:     c_string_&_result_buf
     !>
     !! \brief return a 'const string&' as argument
     !!
@@ -1621,8 +1574,7 @@ contains
     ! Argument:  string & SHF_rv +intent(out)+len(NSHF_rv)
     ! Requested: f_string_&_result_buf
     ! Match:     f_default
-    ! Requested: c_string_&_result_buf
-    ! Match:     c_string_result_buf
+    ! Exact:     c_string_&_result_buf
     !>
     !! \brief Test returning empty string reference
     !!
@@ -1647,8 +1599,7 @@ contains
     ! ----------------------------------------
     ! Argument:  const std::string & SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
     ! Exact:     f_string_&_result_buf_allocatable
-    ! Requested: c_string_&_result_buf_allocatable
-    ! Match:     c_string_result_buf_allocatable
+    ! Exact:     c_string_&_result_buf_allocatable
     function get_const_string_ref_alloc() &
             result(SHT_rv)
         type(STR_SHROUD_array) :: DSHF_rv
@@ -1672,8 +1623,7 @@ contains
     ! Argument:  string * SHF_rv +intent(out)+len(NSHF_rv)
     ! Requested: f_string_*_result_buf
     ! Match:     f_default
-    ! Requested: c_string_*_result_buf
-    ! Match:     c_string_result_buf
+    ! Exact:     c_string_*_result_buf
     !>
     !! \brief return a 'const string *' as character(30)
     !!
@@ -1703,8 +1653,7 @@ contains
     ! ----------------------------------------
     ! Argument:  const std::string * SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)+owner(library)
     ! Exact:     f_string_*_result_buf_allocatable
-    ! Requested: c_string_*_result_buf_allocatable
-    ! Match:     c_string_result_buf_allocatable
+    ! Exact:     c_string_*_result_buf_allocatable
     function get_const_string_ptr_alloc() &
             result(SHT_rv)
         type(STR_SHROUD_array) :: DSHF_rv
@@ -1727,8 +1676,7 @@ contains
     ! ----------------------------------------
     ! Argument:  const std::string * SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)+owner(caller)
     ! Exact:     f_string_*_result_buf_allocatable
-    ! Requested: c_string_*_result_buf_allocatable
-    ! Match:     c_string_result_buf_allocatable
+    ! Exact:     c_string_*_result_buf_allocatable
     !>
     !! It is the caller's responsibility to release the string
     !! created by the C++ library.
@@ -1758,8 +1706,7 @@ contains
     ! ----------------------------------------
     ! Argument:  const std::string * SHF_rv +context(DSHF_rv)+deref(allocatable)+free_pattern(C_string_free)+intent(out)+owner(caller)
     ! Exact:     f_string_*_result_buf_allocatable
-    ! Requested: c_string_*_result_buf_allocatable
-    ! Match:     c_string_result_buf_allocatable
+    ! Exact:     c_string_*_result_buf_allocatable
     !>
     !! Similar to getConstStringPtrOwnsAlloc, but uses pattern to release memory.
     !<
@@ -1787,8 +1734,7 @@ contains
     ! Requested: f_string_&_in
     ! Match:     f_default
     ! Argument:  const std::string & arg1 +intent(in)+len_trim(Larg1)
-    ! Requested: c_string_&_in_buf
-    ! Match:     c_string_in_buf
+    ! Exact:     c_string_&_in_buf
     !>
     !! \brief Accept a const string reference
     !!
@@ -1818,8 +1764,7 @@ contains
     ! Requested: f_string_&_out
     ! Match:     f_default
     ! Argument:  std::string & arg1 +intent(out)+len(Narg1)
-    ! Requested: c_string_&_out_buf
-    ! Match:     c_string_out_buf
+    ! Exact:     c_string_&_out_buf
     !>
     !! \brief Accept a string reference
     !!
@@ -1849,8 +1794,7 @@ contains
     ! Requested: f_string_&_inout
     ! Match:     f_default
     ! Argument:  std::string & arg1 +intent(inout)+len(Narg1)+len_trim(Larg1)
-    ! Requested: c_string_&_inout_buf
-    ! Match:     c_string_inout_buf
+    ! Exact:     c_string_&_inout_buf
     !>
     !! \brief Accept a string reference
     !!
@@ -1882,8 +1826,7 @@ contains
     ! Requested: f_string_*_in
     ! Match:     f_default
     ! Argument:  const std::string * arg1 +intent(in)+len_trim(Larg1)
-    ! Requested: c_string_*_in_buf
-    ! Match:     c_string_in_buf
+    ! Exact:     c_string_*_in_buf
     !>
     !! \brief Accept a const string pointer - intent(in)
     !!
@@ -1910,8 +1853,7 @@ contains
     ! Requested: f_string_*_inout
     ! Match:     f_default
     ! Argument:  std::string * arg1 +intent(inout)+len(Narg1)+len_trim(Larg1)
-    ! Requested: c_string_*_inout_buf
-    ! Match:     c_string_inout_buf
+    ! Exact:     c_string_*_inout_buf
     !>
     !! \brief Accept a string pointer - intent(inout)
     !!
@@ -1938,8 +1880,7 @@ contains
     ! Requested: f_string_*_out
     ! Match:     f_default
     ! Argument:  std::string * arg1 +intent(out)+len(Narg1)
-    ! Requested: c_string_*_out_buf
-    ! Match:     c_string_out_buf
+    ! Exact:     c_string_*_out_buf
     !>
     !! \brief Accept a string pointer - intent(out)
     !!
@@ -1967,8 +1908,7 @@ contains
     ! Requested: f_string_*_inout
     ! Match:     f_default
     ! Argument:  std::string * arg1 +intent(inout)+len(Narg1)+len_trim(Larg1)
-    ! Requested: c_string_*_inout_buf
-    ! Match:     c_string_inout_buf
+    ! Exact:     c_string_*_inout_buf
     ! ----------------------------------------
     ! Argument:  int * nlen +intent(out)
     ! Requested: f_native_*_out
@@ -2004,8 +1944,7 @@ contains
     ! Requested: f_string_*_out
     ! Match:     f_default
     ! Argument:  std::string * arg1 +intent(out)+len(Narg1)
-    ! Requested: c_string_*_out_buf
-    ! Match:     c_string_out_buf
+    ! Exact:     c_string_*_out_buf
     ! ----------------------------------------
     ! Argument:  int * nlen +intent(out)
     ! Requested: f_native_*_out
@@ -2169,8 +2108,7 @@ contains
     ! Requested: f_string_&_inout
     ! Match:     f_default
     ! Argument:  std::string & name +intent(inout)+len(Nname)+len_trim(Lname)
-    ! Requested: c_string_&_inout_buf
-    ! Match:     c_string_inout_buf
+    ! Exact:     c_string_&_inout_buf
     !>
     !! Test post_declare.
     !! The std::string in py_string_inout must be declared before the

--- a/regression/reference/strings/wrapstrings.cpp
+++ b/regression/reference/strings/wrapstrings.cpp
@@ -486,8 +486,7 @@ void STR_get_const_string_alloc_bufferify(STR_SHROUD_array *DSHF_rv)
  */
 // ----------------------------------------
 // Function:  const string & getConstStringRefPure +deref(allocatable)
-// Requested: c_string_&_result
-// Match:     c_string_result
+// Exact:     c_string_&_result
 // start STR_get_const_string_ref_pure
 const char * STR_get_const_string_ref_pure(void)
 {
@@ -509,8 +508,7 @@ const char * STR_get_const_string_ref_pure(void)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  const string & SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
-// Requested: c_string_&_result_buf_allocatable
-// Match:     c_string_result_buf_allocatable
+// Exact:     c_string_&_result_buf_allocatable
 // start STR_get_const_string_ref_pure_bufferify
 void STR_get_const_string_ref_pure_bufferify(STR_SHROUD_array *DSHF_rv)
 {
@@ -530,8 +528,7 @@ void STR_get_const_string_ref_pure_bufferify(STR_SHROUD_array *DSHF_rv)
  */
 // ----------------------------------------
 // Function:  const string & getConstStringRefLen +deref(result-as-arg)+len(30)
-// Requested: c_string_&_result
-// Match:     c_string_result
+// Exact:     c_string_&_result
 const char * STR_get_const_string_ref_len(void)
 {
     // splicer begin function.get_const_string_ref_len
@@ -559,8 +556,7 @@ const char * STR_get_const_string_ref_len(void)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  string & SHF_rv +intent(out)+len(NSHF_rv)
-// Requested: c_string_&_result_buf
-// Match:     c_string_result_buf
+// Exact:     c_string_&_result_buf
 void STR_get_const_string_ref_len_bufferify(char * SHF_rv, int NSHF_rv)
 {
     // splicer begin function.get_const_string_ref_len_bufferify
@@ -582,8 +578,7 @@ void STR_get_const_string_ref_len_bufferify(char * SHF_rv, int NSHF_rv)
  */
 // ----------------------------------------
 // Function:  const string & getConstStringRefAsArg +deref(result-as-arg)
-// Requested: c_string_&_result
-// Match:     c_string_result
+// Exact:     c_string_&_result
 const char * STR_get_const_string_ref_as_arg(void)
 {
     // splicer begin function.get_const_string_ref_as_arg
@@ -610,8 +605,7 @@ const char * STR_get_const_string_ref_as_arg(void)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  string & output +intent(out)+len(Noutput)
-// Requested: c_string_&_result_buf
-// Match:     c_string_result_buf
+// Exact:     c_string_&_result_buf
 void STR_get_const_string_ref_as_arg_bufferify(char * output,
     int Noutput)
 {
@@ -632,8 +626,7 @@ void STR_get_const_string_ref_as_arg_bufferify(char * output,
  */
 // ----------------------------------------
 // Function:  const string & getConstStringRefLenEmpty +deref(result-as-arg)+len(30)
-// Requested: c_string_&_result
-// Match:     c_string_result
+// Exact:     c_string_&_result
 const char * STR_get_const_string_ref_len_empty(void)
 {
     // splicer begin function.get_const_string_ref_len_empty
@@ -658,8 +651,7 @@ const char * STR_get_const_string_ref_len_empty(void)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  string & SHF_rv +intent(out)+len(NSHF_rv)
-// Requested: c_string_&_result_buf
-// Match:     c_string_result_buf
+// Exact:     c_string_&_result_buf
 void STR_get_const_string_ref_len_empty_bufferify(char * SHF_rv,
     int NSHF_rv)
 {
@@ -676,8 +668,7 @@ void STR_get_const_string_ref_len_empty_bufferify(char * SHF_rv,
 
 // ----------------------------------------
 // Function:  const std::string & getConstStringRefAlloc +deref(allocatable)
-// Requested: c_string_&_result
-// Match:     c_string_result
+// Exact:     c_string_&_result
 const char * STR_get_const_string_ref_alloc(void)
 {
     // splicer begin function.get_const_string_ref_alloc
@@ -693,8 +684,7 @@ const char * STR_get_const_string_ref_alloc(void)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  const std::string & SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
-// Requested: c_string_&_result_buf_allocatable
-// Match:     c_string_result_buf_allocatable
+// Exact:     c_string_&_result_buf_allocatable
 void STR_get_const_string_ref_alloc_bufferify(STR_SHROUD_array *DSHF_rv)
 {
     // splicer begin function.get_const_string_ref_alloc_bufferify
@@ -713,8 +703,7 @@ void STR_get_const_string_ref_alloc_bufferify(STR_SHROUD_array *DSHF_rv)
  */
 // ----------------------------------------
 // Function:  const string * getConstStringPtrLen +deref(result-as-arg)+len(30)
-// Requested: c_string_*_result
-// Match:     c_string_result
+// Exact:     c_string_*_result
 const char * STR_get_const_string_ptr_len(void)
 {
     // splicer begin function.get_const_string_ptr_len
@@ -738,8 +727,7 @@ const char * STR_get_const_string_ptr_len(void)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  string * SHF_rv +intent(out)+len(NSHF_rv)
-// Requested: c_string_*_result_buf
-// Match:     c_string_result_buf
+// Exact:     c_string_*_result_buf
 void STR_get_const_string_ptr_len_bufferify(char * SHF_rv, int NSHF_rv)
 {
     // splicer begin function.get_const_string_ptr_len_bufferify
@@ -759,8 +747,7 @@ void STR_get_const_string_ptr_len_bufferify(char * SHF_rv, int NSHF_rv)
 
 // ----------------------------------------
 // Function:  const std::string * getConstStringPtrAlloc +deref(allocatable)+owner(library)
-// Requested: c_string_*_result
-// Match:     c_string_result
+// Exact:     c_string_*_result
 const char * STR_get_const_string_ptr_alloc(void)
 {
     // splicer begin function.get_const_string_ptr_alloc
@@ -776,8 +763,7 @@ const char * STR_get_const_string_ptr_alloc(void)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  const std::string * SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)+owner(library)
-// Requested: c_string_*_result_buf_allocatable
-// Match:     c_string_result_buf_allocatable
+// Exact:     c_string_*_result_buf_allocatable
 void STR_get_const_string_ptr_alloc_bufferify(STR_SHROUD_array *DSHF_rv)
 {
     // splicer begin function.get_const_string_ptr_alloc_bufferify
@@ -795,8 +781,7 @@ void STR_get_const_string_ptr_alloc_bufferify(STR_SHROUD_array *DSHF_rv)
  */
 // ----------------------------------------
 // Function:  const std::string * getConstStringPtrOwnsAlloc +deref(allocatable)+owner(caller)
-// Requested: c_string_*_result
-// Match:     c_string_result
+// Exact:     c_string_*_result
 const char * STR_get_const_string_ptr_owns_alloc(void)
 {
     // splicer begin function.get_const_string_ptr_owns_alloc
@@ -819,8 +804,7 @@ const char * STR_get_const_string_ptr_owns_alloc(void)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  const std::string * SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)+owner(caller)
-// Requested: c_string_*_result_buf_allocatable
-// Match:     c_string_result_buf_allocatable
+// Exact:     c_string_*_result_buf_allocatable
 void STR_get_const_string_ptr_owns_alloc_bufferify(
     STR_SHROUD_array *DSHF_rv)
 {
@@ -835,8 +819,7 @@ void STR_get_const_string_ptr_owns_alloc_bufferify(
  */
 // ----------------------------------------
 // Function:  const std::string * getConstStringPtrOwnsAllocPattern +deref(allocatable)+free_pattern(C_string_free)+owner(caller)
-// Requested: c_string_*_result
-// Match:     c_string_result
+// Exact:     c_string_*_result
 const char * STR_get_const_string_ptr_owns_alloc_pattern(void)
 {
     // splicer begin function.get_const_string_ptr_owns_alloc_pattern
@@ -855,8 +838,7 @@ const char * STR_get_const_string_ptr_owns_alloc_pattern(void)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  const std::string * SHF_rv +context(DSHF_rv)+deref(allocatable)+free_pattern(C_string_free)+intent(out)+owner(caller)
-// Requested: c_string_*_result_buf_allocatable
-// Match:     c_string_result_buf_allocatable
+// Exact:     c_string_*_result_buf_allocatable
 void STR_get_const_string_ptr_owns_alloc_pattern_bufferify(
     STR_SHROUD_array *DSHF_rv)
 {
@@ -879,8 +861,7 @@ void STR_get_const_string_ptr_owns_alloc_pattern_bufferify(
 // Match:     c_default
 // ----------------------------------------
 // Argument:  const std::string & arg1 +intent(in)
-// Requested: c_string_&_in
-// Match:     c_string_in
+// Exact:     c_string_&_in
 void STR_accept_string_const_reference(const char * arg1)
 {
     // splicer begin function.accept_string_const_reference
@@ -902,8 +883,7 @@ void STR_accept_string_const_reference(const char * arg1)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  const std::string & arg1 +intent(in)+len_trim(Larg1)
-// Requested: c_string_&_in_buf
-// Match:     c_string_in_buf
+// Exact:     c_string_&_in_buf
 void STR_accept_string_const_reference_bufferify(const char * arg1,
     int Larg1)
 {
@@ -926,8 +906,7 @@ void STR_accept_string_const_reference_bufferify(const char * arg1,
 // Match:     c_default
 // ----------------------------------------
 // Argument:  std::string & arg1 +intent(out)
-// Requested: c_string_&_out
-// Match:     c_string_out
+// Exact:     c_string_&_out
 void STR_accept_string_reference_out(char * arg1)
 {
     // splicer begin function.accept_string_reference_out
@@ -950,8 +929,7 @@ void STR_accept_string_reference_out(char * arg1)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  std::string & arg1 +intent(out)+len(Narg1)
-// Requested: c_string_&_out_buf
-// Match:     c_string_out_buf
+// Exact:     c_string_&_out_buf
 void STR_accept_string_reference_out_bufferify(char * arg1, int Narg1)
 {
     // splicer begin function.accept_string_reference_out_bufferify
@@ -974,8 +952,7 @@ void STR_accept_string_reference_out_bufferify(char * arg1, int Narg1)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  std::string & arg1 +intent(inout)
-// Requested: c_string_&_inout
-// Match:     c_string_inout
+// Exact:     c_string_&_inout
 // start STR_accept_string_reference
 void STR_accept_string_reference(char * arg1)
 {
@@ -1000,8 +977,7 @@ void STR_accept_string_reference(char * arg1)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  std::string & arg1 +intent(inout)+len(Narg1)+len_trim(Larg1)
-// Requested: c_string_&_inout_buf
-// Match:     c_string_inout_buf
+// Exact:     c_string_&_inout_buf
 // start STR_accept_string_reference_bufferify
 void STR_accept_string_reference_bufferify(char * arg1, int Larg1,
     int Narg1)
@@ -1024,8 +1000,7 @@ void STR_accept_string_reference_bufferify(char * arg1, int Larg1,
 // Match:     c_default
 // ----------------------------------------
 // Argument:  const std::string * arg1 +intent(in)
-// Requested: c_string_*_in
-// Match:     c_string_in
+// Exact:     c_string_*_in
 void STR_accept_string_pointer_const(const char * arg1)
 {
     // splicer begin function.accept_string_pointer_const
@@ -1044,8 +1019,7 @@ void STR_accept_string_pointer_const(const char * arg1)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  const std::string * arg1 +intent(in)+len_trim(Larg1)
-// Requested: c_string_*_in_buf
-// Match:     c_string_in_buf
+// Exact:     c_string_*_in_buf
 void STR_accept_string_pointer_const_bufferify(const char * arg1,
     int Larg1)
 {
@@ -1065,8 +1039,7 @@ void STR_accept_string_pointer_const_bufferify(const char * arg1,
 // Match:     c_default
 // ----------------------------------------
 // Argument:  std::string * arg1 +intent(inout)
-// Requested: c_string_*_inout
-// Match:     c_string_inout
+// Exact:     c_string_*_inout
 void STR_accept_string_pointer(char * arg1)
 {
     // splicer begin function.accept_string_pointer
@@ -1086,8 +1059,7 @@ void STR_accept_string_pointer(char * arg1)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  std::string * arg1 +intent(inout)+len(Narg1)+len_trim(Larg1)
-// Requested: c_string_*_inout_buf
-// Match:     c_string_inout_buf
+// Exact:     c_string_*_inout_buf
 void STR_accept_string_pointer_bufferify(char * arg1, int Larg1,
     int Narg1)
 {
@@ -1109,8 +1081,7 @@ void STR_accept_string_pointer_bufferify(char * arg1, int Larg1,
 // Match:     c_default
 // ----------------------------------------
 // Argument:  std::string * arg1 +intent(out)
-// Requested: c_string_*_out
-// Match:     c_string_out
+// Exact:     c_string_*_out
 void STR_fetch_string_pointer(char * arg1)
 {
     // splicer begin function.fetch_string_pointer
@@ -1131,8 +1102,7 @@ void STR_fetch_string_pointer(char * arg1)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  std::string * arg1 +intent(out)+len(Narg1)
-// Requested: c_string_*_out_buf
-// Match:     c_string_out_buf
+// Exact:     c_string_*_out_buf
 void STR_fetch_string_pointer_bufferify(char * arg1, int Narg1)
 {
     // splicer begin function.fetch_string_pointer_bufferify
@@ -1154,8 +1124,7 @@ void STR_fetch_string_pointer_bufferify(char * arg1, int Narg1)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  std::string * arg1 +intent(inout)
-// Requested: c_string_*_inout
-// Match:     c_string_inout
+// Exact:     c_string_*_inout
 // ----------------------------------------
 // Argument:  int * nlen +intent(out)
 // Requested: c_native_*_out
@@ -1181,8 +1150,7 @@ void STR_accept_string_pointer_len(char * arg1, int * nlen)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  std::string * arg1 +intent(inout)+len(Narg1)+len_trim(Larg1)
-// Requested: c_string_*_inout_buf
-// Match:     c_string_inout_buf
+// Exact:     c_string_*_inout_buf
 // ----------------------------------------
 // Argument:  int * nlen +intent(out)
 // Requested: c_native_*_out_buf
@@ -1210,8 +1178,7 @@ void STR_accept_string_pointer_len_bufferify(char * arg1, int Larg1,
 // Match:     c_default
 // ----------------------------------------
 // Argument:  std::string * arg1 +intent(out)
-// Requested: c_string_*_out
-// Match:     c_string_out
+// Exact:     c_string_*_out
 // ----------------------------------------
 // Argument:  int * nlen +intent(out)
 // Requested: c_native_*_out
@@ -1238,8 +1205,7 @@ void STR_fetch_string_pointer_len(char * arg1, int * nlen)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  std::string * arg1 +intent(out)+len(Narg1)
-// Requested: c_string_*_out_buf
-// Match:     c_string_out_buf
+// Exact:     c_string_*_out_buf
 // ----------------------------------------
 // Argument:  int * nlen +intent(out)
 // Requested: c_native_*_out_buf
@@ -1401,8 +1367,7 @@ void STR_cpass_char_ptr_bufferify(char * dest, int Ndest,
 // Match:     c_default
 // ----------------------------------------
 // Argument:  std::string & name +intent(inout)
-// Requested: c_string_&_inout
-// Match:     c_string_inout
+// Exact:     c_string_&_inout
 void STR_post_declare(int * count, char * name)
 {
     // splicer begin function.post_declare
@@ -1428,8 +1393,7 @@ void STR_post_declare(int * count, char * name)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  std::string & name +intent(inout)+len(Nname)+len_trim(Lname)
-// Requested: c_string_&_inout_buf
-// Match:     c_string_inout_buf
+// Exact:     c_string_&_inout_buf
 void STR_post_declare_bufferify(int * count, char * name, int Lname,
     int Nname)
 {

--- a/regression/reference/tutorial/tutorial.json
+++ b/regression/reference/tutorial/tutorial.json
@@ -623,7 +623,7 @@
                             "stmt0": "f_string_*_result_buf_allocatable",
                             "stmt1": "f_string_*_result_buf_allocatable",
                             "stmtc0": "c_string_*_result_buf_allocatable",
-                            "stmtc1": "c_string_result_buf_allocatable"
+                            "stmtc1": "c_string_*_result_buf_allocatable"
                         }
                     },
                     "arg1": {
@@ -643,7 +643,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_arg1",
                             "stmt0": "c_string_&_in_buf",
-                            "stmt1": "c_string_in_buf"
+                            "stmt1": "c_string_&_in_buf"
                         },
                         "fmtf": {
                             "F_C_var": "arg1",
@@ -658,7 +658,7 @@
                             "stmt0": "f_string_&_in",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_&_in_buf",
-                            "stmtc1": "c_string_in_buf"
+                            "stmtc1": "c_string_&_in_buf"
                         }
                     },
                     "arg2": {
@@ -678,7 +678,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_arg2",
                             "stmt0": "c_string_&_in_buf",
-                            "stmt1": "c_string_in_buf"
+                            "stmt1": "c_string_&_in_buf"
                         },
                         "fmtf": {
                             "F_C_var": "arg2",
@@ -693,7 +693,7 @@
                             "stmt0": "f_string_&_in",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_&_in_buf",
-                            "stmtc1": "c_string_in_buf"
+                            "stmtc1": "c_string_&_in_buf"
                         }
                     }
                 },
@@ -1329,7 +1329,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_name",
                             "stmt0": "c_string_&_in",
-                            "stmt1": "c_string_in"
+                            "stmt1": "c_string_&_in"
                         },
                         "fmtf": {
                             "F_C_var": "name"
@@ -1462,7 +1462,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_name",
                             "stmt0": "c_string_&_in_buf",
-                            "stmt1": "c_string_in_buf"
+                            "stmt1": "c_string_&_in_buf"
                         },
                         "fmtf": {
                             "F_C_var": "name",
@@ -1477,7 +1477,7 @@
                             "stmt0": "f_string_&_in",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_&_in_buf",
-                            "stmtc1": "c_string_in_buf"
+                            "stmtc1": "c_string_&_in_buf"
                         }
                     }
                 },
@@ -2481,7 +2481,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_name",
                             "stmt0": "c_string_&_in",
-                            "stmt1": "c_string_in"
+                            "stmt1": "c_string_&_in"
                         },
                         "fmtf": {
                             "F_C_var": "name"
@@ -2873,7 +2873,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_name",
                             "stmt0": "c_string_&_in_buf",
-                            "stmt1": "c_string_in_buf"
+                            "stmt1": "c_string_&_in_buf"
                         },
                         "fmtf": {
                             "F_C_var": "name",
@@ -2888,7 +2888,7 @@
                             "stmt0": "f_string_&_in",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_&_in_buf",
-                            "stmtc1": "c_string_in_buf"
+                            "stmtc1": "c_string_&_in_buf"
                         }
                     }
                 },
@@ -5512,7 +5512,7 @@
                         "sh_type": "SH_TYPE_OTHER",
                         "shadow_var": "SHadow_rv",
                         "stmt0": "c_string_&_result",
-                        "stmt1": "c_string_result"
+                        "stmt1": "c_string_&_result"
                     },
                     "fmtf": {
                         "c_var_len": "30",
@@ -5628,7 +5628,7 @@
                             "sh_type": "SH_TYPE_OTHER",
                             "shadow_var": "SHadow_SHF_rv",
                             "stmt0": "c_string_&_result_buf",
-                            "stmt1": "c_string_result_buf"
+                            "stmt1": "c_string_&_result_buf"
                         },
                         "fmtf": {
                             "F_C_var": "SHF_rv",
@@ -5643,7 +5643,7 @@
                             "stmt0": "f_string_&_result_buf",
                             "stmt1": "f_default",
                             "stmtc0": "c_string_&_result_buf",
-                            "stmtc1": "c_string_result_buf"
+                            "stmtc1": "c_string_&_result_buf"
                         }
                     }
                 },

--- a/regression/reference/tutorial/wrapTutorial.cpp
+++ b/regression/reference/tutorial/wrapTutorial.cpp
@@ -105,12 +105,10 @@ double TUT_pass_by_value(double arg1, int arg2)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  const std::string & arg1 +intent(in)+len_trim(Larg1)
-// Requested: c_string_&_in_buf
-// Match:     c_string_in_buf
+// Exact:     c_string_&_in_buf
 // ----------------------------------------
 // Argument:  const std::string & arg2 +intent(in)+len_trim(Larg2)
-// Requested: c_string_&_in_buf
-// Match:     c_string_in_buf
+// Exact:     c_string_&_in_buf
 // ----------------------------------------
 // Argument:  const std::string * SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
 // Exact:     c_string_scalar_result_buf_allocatable
@@ -186,8 +184,7 @@ double TUT_use_default_arguments_arg1_arg2(double arg1, bool arg2)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  const std::string & name +intent(in)
-// Requested: c_string_&_in
-// Match:     c_string_in
+// Exact:     c_string_&_in
 void TUT_overloaded_function_from_name(const char * name)
 {
     // splicer begin function.overloaded_function_from_name
@@ -202,8 +199,7 @@ void TUT_overloaded_function_from_name(const char * name)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  const std::string & name +intent(in)+len_trim(Lname)
-// Requested: c_string_&_in_buf
-// Match:     c_string_in_buf
+// Exact:     c_string_&_in_buf
 void TUT_overloaded_function_from_name_bufferify(const char * name,
     int Lname)
 {
@@ -299,8 +295,7 @@ void TUT_fortran_generic_overloaded_0(void)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  const std::string & name +intent(in)
-// Requested: c_string_&_in
-// Match:     c_string_in
+// Exact:     c_string_&_in
 // ----------------------------------------
 // Argument:  double arg2 +intent(in)+value
 // Requested: c_native_scalar_in
@@ -319,8 +314,7 @@ void TUT_fortran_generic_overloaded_1(const char * name, double arg2)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  const std::string & name +intent(in)+len_trim(Lname)
-// Requested: c_string_&_in_buf
-// Match:     c_string_in_buf
+// Exact:     c_string_&_in_buf
 // ----------------------------------------
 // Argument:  double arg2 +intent(in)+value
 // Requested: c_native_scalar_in_buf
@@ -575,8 +569,7 @@ int TUT_callback1(int in, int ( * incr)(int))
 
 // ----------------------------------------
 // Function:  const std::string & LastFunctionCalled +deref(result-as-arg)+len(30)
-// Requested: c_string_&_result
-// Match:     c_string_result
+// Exact:     c_string_&_result
 const char * TUT_last_function_called(void)
 {
     // splicer begin function.last_function_called
@@ -592,8 +585,7 @@ const char * TUT_last_function_called(void)
 // Match:     c_default
 // ----------------------------------------
 // Argument:  std::string & SHF_rv +intent(out)+len(NSHF_rv)
-// Requested: c_string_&_result_buf
-// Match:     c_string_result_buf
+// Exact:     c_string_&_result_buf
 void TUT_last_function_called_bufferify(char * SHF_rv, int NSHF_rv)
 {
     // splicer begin function.last_function_called_bufferify

--- a/regression/reference/tutorial/wrapftutorial.f
+++ b/regression/reference/tutorial/wrapftutorial.f
@@ -107,16 +107,13 @@ module tutorial_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  const std::string & arg1 +intent(in)+len_trim(Larg1)
-    ! Requested: c_string_&_in_buf
-    ! Match:     c_string_in_buf
+    ! Exact:     c_string_&_in_buf
     ! ----------------------------------------
     ! Argument:  const std::string & arg2 +intent(in)+len_trim(Larg2)
-    ! Requested: c_string_&_in_buf
-    ! Match:     c_string_in_buf
+    ! Exact:     c_string_&_in_buf
     ! ----------------------------------------
     ! Argument:  const std::string * SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
-    ! Requested: c_string_*_result_buf_allocatable
-    ! Match:     c_string_result_buf_allocatable
+    ! Exact:     c_string_*_result_buf_allocatable
     interface
         subroutine c_concatenate_strings_bufferify(arg1, Larg1, arg2, &
                 Larg2, DSHF_rv) &
@@ -201,8 +198,7 @@ module tutorial_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  const std::string & name +intent(in)
-    ! Requested: c_string_&_in
-    ! Match:     c_string_in
+    ! Exact:     c_string_&_in
     interface
         subroutine c_overloaded_function_from_name(name) &
                 bind(C, name="TUT_overloaded_function_from_name")
@@ -218,8 +214,7 @@ module tutorial_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  const std::string & name +intent(in)+len_trim(Lname)
-    ! Requested: c_string_&_in_buf
-    ! Match:     c_string_in_buf
+    ! Exact:     c_string_&_in_buf
     interface
         subroutine c_overloaded_function_from_name_bufferify(name, &
                 Lname) &
@@ -327,8 +322,7 @@ module tutorial_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  const std::string & name +intent(in)
-    ! Requested: c_string_&_in
-    ! Match:     c_string_in
+    ! Exact:     c_string_&_in
     ! ----------------------------------------
     ! Argument:  double arg2 +intent(in)+value
     ! Requested: c_native_scalar_in
@@ -349,8 +343,7 @@ module tutorial_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  const std::string & name +intent(in)+len_trim(Lname)
-    ! Requested: c_string_&_in_buf
-    ! Match:     c_string_in_buf
+    ! Exact:     c_string_&_in_buf
     ! ----------------------------------------
     ! Argument:  double arg2 +intent(in)+value
     ! Requested: c_native_scalar_in_buf
@@ -637,8 +630,7 @@ module tutorial_mod
 
     ! ----------------------------------------
     ! Function:  const std::string & LastFunctionCalled +deref(result-as-arg)+len(30)
-    ! Requested: c_string_&_result
-    ! Match:     c_string_result
+    ! Exact:     c_string_&_result
     interface
         function c_last_function_called() &
                 result(SHT_rv) &
@@ -655,8 +647,7 @@ module tutorial_mod
     ! Match:     c_default
     ! ----------------------------------------
     ! Argument:  std::string & SHF_rv +intent(out)+len(NSHF_rv)
-    ! Requested: c_string_&_result_buf
-    ! Match:     c_string_result_buf
+    ! Exact:     c_string_&_result_buf
     interface
         subroutine c_last_function_called_bufferify(SHF_rv, NSHF_rv) &
                 bind(C, name="TUT_last_function_called_bufferify")
@@ -736,20 +727,17 @@ contains
     ! Requested: f_string_&_in
     ! Match:     f_default
     ! Argument:  const std::string & arg1 +intent(in)+len_trim(Larg1)
-    ! Requested: c_string_&_in_buf
-    ! Match:     c_string_in_buf
+    ! Exact:     c_string_&_in_buf
     ! ----------------------------------------
     ! Argument:  const std::string & arg2 +intent(in)
     ! Requested: f_string_&_in
     ! Match:     f_default
     ! Argument:  const std::string & arg2 +intent(in)+len_trim(Larg2)
-    ! Requested: c_string_&_in_buf
-    ! Match:     c_string_in_buf
+    ! Exact:     c_string_&_in_buf
     ! ----------------------------------------
     ! Argument:  const std::string * SHF_rv +context(DSHF_rv)+deref(allocatable)+intent(out)
     ! Exact:     f_string_*_result_buf_allocatable
-    ! Requested: c_string_*_result_buf_allocatable
-    ! Match:     c_string_result_buf_allocatable
+    ! Exact:     c_string_*_result_buf_allocatable
     !>
     !! Note that since a reference is returned, no intermediate string
     !! is allocated.  It is assumed +owner(library).
@@ -862,8 +850,7 @@ contains
     ! Requested: f_string_&_in
     ! Match:     f_default
     ! Argument:  const std::string & name +intent(in)+len_trim(Lname)
-    ! Requested: c_string_&_in_buf
-    ! Match:     c_string_in_buf
+    ! Exact:     c_string_&_in_buf
     subroutine overloaded_function_from_name(name)
         use iso_c_binding, only : C_INT
         character(len=*), intent(IN) :: name
@@ -998,8 +985,7 @@ contains
     ! Requested: f_string_&_in
     ! Match:     f_default
     ! Argument:  const std::string & name +intent(in)+len_trim(Lname)
-    ! Requested: c_string_&_in_buf
-    ! Match:     c_string_in_buf
+    ! Exact:     c_string_&_in_buf
     ! ----------------------------------------
     ! Argument:  float arg2 +intent(in)+value
     ! Requested: f_native_scalar_in
@@ -1030,8 +1016,7 @@ contains
     ! Requested: f_string_&_in
     ! Match:     f_default
     ! Argument:  const std::string & name +intent(in)+len_trim(Lname)
-    ! Requested: c_string_&_in_buf
-    ! Match:     c_string_in_buf
+    ! Exact:     c_string_&_in_buf
     ! ----------------------------------------
     ! Argument:  double arg2 +intent(in)+value
     ! Requested: f_native_scalar_in
@@ -1266,8 +1251,7 @@ contains
     ! Argument:  std::string & SHF_rv +intent(out)+len(NSHF_rv)
     ! Requested: f_string_&_result_buf
     ! Match:     f_default
-    ! Requested: c_string_&_result_buf
-    ! Match:     c_string_result_buf
+    ! Exact:     c_string_&_result_buf
     function last_function_called() &
             result(SHT_rv)
         use iso_c_binding, only : C_INT

--- a/shroud/main.py
+++ b/shroud/main.py
@@ -24,6 +24,7 @@ from . import ast
 from . import generate
 from . import metadata
 from . import splicer
+from . import statements
 from . import todict
 from . import typemap
 from . import util
@@ -275,6 +276,9 @@ def main():
         "--write-helpers", default="", help="Write a file with helper functions."
     )
     parser.add_argument(
+        "--write-statements", default="", help="Write a file with statements."
+    )
+    parser.add_argument(
         "--write-version", "--nowrite-version",
         dest="write_version",
         action=BooleanAction,
@@ -320,6 +324,7 @@ def create_wrapper(filename, outdir="", path=None):
     else:
         args.path = path
     args.write_helpers = ""
+    args.write_statements = ""
     args.yaml_types = ""
 
     config = main_with_args(args)
@@ -384,6 +389,7 @@ def main_with_args(args):
     config.lua_dir = args.outdir_lua or args.outdir
     config.yaml_dir = args.outdir_yaml or args.outdir
     config.write_helpers = args.write_helpers
+    config.write_statements = args.write_statements
     config.yaml_types = args.yaml_types
     config.log = log
     if args.write_version:
@@ -544,6 +550,11 @@ def main_with_args(args):
         hfile = os.path.join(args.logdir, args.write_helpers + ".f")
         with open(hfile, "w") as fp:
             whelpers.write_f_helpers(fp)
+
+    if args.write_statements:
+        hfile = os.path.join(args.logdir, args.write_statements)
+        with open(hfile, "w") as fp:
+            statements.write_cf_tree(fp)
             
     log.close()
 

--- a/shroud/statements.py
+++ b/shroud/statements.py
@@ -999,12 +999,12 @@ fc_statements = [
     ),
 
     dict(
-        name="c_string_in",
+        name="c_string_*/&_in",
         cxx_local_var="scalar",
         pre_call=["{c_const}std::string {cxx_var}({c_var});"],
     ),
     dict(
-        name="c_string_out",
+        name="c_string_*/&_out",
         cxx_impl_header=["<cstring>"],
         # #- pre_call=[
         # #-     'int {c_var_trim} = strlen({c_var});',
@@ -1017,7 +1017,7 @@ fc_statements = [
         ],
     ),
     dict(
-        name="c_string_inout",
+        name="c_string_*/&_inout",
         cxx_impl_header=["<cstring>"],
         cxx_local_var="scalar",
         pre_call=["{c_const}std::string {cxx_var}({c_var});"],
@@ -1027,7 +1027,7 @@ fc_statements = [
         ],
     ),
     dict(
-        name="c_string_in_buf",
+        name="c_string_*/&_in_buf",
         buf_args=["arg", "len_trim"],
         cxx_local_var="scalar",
         pre_call=[
@@ -1038,7 +1038,7 @@ fc_statements = [
         ],
     ),
     dict(
-        name="c_string_out_buf",
+        name="c_string_*/&_out_buf",
         buf_args=["arg", "len"],
         c_helper="ShroudStrCopy",
         cxx_local_var="scalar",
@@ -1050,7 +1050,7 @@ fc_statements = [
         ],
     ),
     dict(
-        name="c_string_inout_buf",
+        name="c_string_*/&_inout_buf",
         buf_args=["arg", "len_trim", "len"],
         c_helper="ShroudStrCopy",
         cxx_local_var="scalar",
@@ -1062,7 +1062,7 @@ fc_statements = [
         ],
     ),
     dict(
-        name="c_string_result",
+        name="c_string_scalar/*/&_result",
         # cxx_to_c creates a pointer from a value via c_str()
         # The default behavior will dereference the value.
         ret=[
@@ -1071,7 +1071,9 @@ fc_statements = [
         return_cptr=True,
     ),
     dict(
-        name="c_string_result_buf",
+        # No need to allocate a local copy since the string is copied
+        # into a Fortran variable before the string is deleted.
+        name="c_string_scalar/*/&_result_buf",
         buf_args=["arg", "len"],
         c_helper="ShroudStrCopy",
         post_call=[
@@ -1131,7 +1133,7 @@ fc_statements = [
     # only used with bufferifed routines and intent(out) or result
     # std::string * function()
     dict(
-        name="c_string_result_buf_allocatable",
+        name="c_string_*/&_result_buf_allocatable",
         # pass address of string and length back to Fortran
         buf_args=["context"],
         c_helper="ShroudStrToArray",
@@ -1144,15 +1146,6 @@ fc_statements = [
         ],
     ),
 
-    # Since 'c_string_scalar_result_buf_allocatable' exists,
-    # must set an alias for c_string_scalar.
-    # No need to allocate a local copy since the string is copied
-    # into a Fortran variable before the string is deleted.
-    dict(
-        name="c_string_scalar_result_buf",
-        base="c_string_result_buf",
-    ),
-    
     # std::string function()
     # Must allocate the std::string then assign to it via cxx_rv_decl.
     # This allows the std::string to outlast the function return.

--- a/shroud/statements.py
+++ b/shroud/statements.py
@@ -338,6 +338,7 @@ def update_stmt_tree(stmts, tree, defaults):
                                    format(name))
             add_statement_to_tree(tree, nodes, node_stmts, node, namelst)
 
+
 def write_cf_tree(fp):
     """Write out statements tree.
 
@@ -348,6 +349,7 @@ def write_cf_tree(fp):
     lines = []
     print_tree(cf_tree, lines)
     fp.writelines(lines)
+
 
 def print_tree(tree, lines, indent=""):
     """Print statements search tree.
@@ -365,7 +367,8 @@ def print_tree(tree, lines, indent=""):
     parts = tree.get('_key', 'root').split('_')
     if "_node" in tree:
         #        final = '' # + tree["_node"]["scope"].name + '-'
-        lines.append("{}{} -- {}\n".format(indent, parts[-1], tree.get('_key', '??')))
+        origname = tree["_node"]["name"]
+        lines.append("{}{} -- {}\n".format(indent, parts[-1], origname))
     else:
         lines.append("{}{}\n".format(indent, parts[-1]))
     indent += '  '

--- a/shroud/statements.py
+++ b/shroud/statements.py
@@ -337,19 +337,37 @@ def update_stmt_tree(stmts, tree, defaults):
                 raise RuntimeError("Duplicate key in statements: {}".
                                    format(name))
             add_statement_to_tree(tree, nodes, node_stmts, node, namelst)
-#    print_tree(tree)
 
-def print_tree(tree, indent=""):
+def write_cf_tree(fp):
+    """Write out statements tree.
+
+    Parameters
+    ----------
+    fp : file
+    """
+    lines = []
+    print_tree(cf_tree, lines)
+    fp.writelines(lines)
+
+def print_tree(tree, lines, indent=""):
     """Print statements search tree.
     Intermediate nodes are prefixed with --.
     Useful for debugging.
+
+    Parameters
+    ----------
+    fp : file
+    lines : list
+        list of output lines
+    indent : str
+        indention for recursion.
     """
     parts = tree.get('_key', 'root').split('_')
     if "_node" in tree:
         #        final = '' # + tree["_node"]["scope"].name + '-'
-        print("{}{} -- {}".format(indent, parts[-1], tree.get('_key', '??')))
+        lines.append("{}{} -- {}\n".format(indent, parts[-1], tree.get('_key', '??')))
     else:
-        print("{}{}".format(indent, parts[-1]))
+        lines.append("{}{}\n".format(indent, parts[-1]))
     indent += '  '
     for key in sorted(tree.keys()):
         if key == '_node':
@@ -360,7 +378,7 @@ def print_tree(tree, indent=""):
             continue
         value = tree[key]
         if isinstance(value, dict):
-            print_tree(value, indent)
+            print_tree(value, lines, indent)
 
 def lookup_stmts_tree(tree, path):
     """


### PR DESCRIPTION
* Add --write-statements command line option to aid debugging. Prints a tree of statement paths.
* Use variants for c_string statements.  This will help when adding C/Fortran Interoperability to locate *buf* vs *cfi* statements.