### PR TITLE
allowing for yaml extension to be yml or yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   Used when option *F_CFI* is True (C/Fortran Interoperability).
 
 ### Fixed
+- yaml extensions supported include .yml in addition to the previous .yaml
 - Order of header files in *cxx_header* is preserved in the generated code.
 - Struct in an inner namespace using Py_struct_arg=numpy is now properly wrapped.
 - Support an array of pointers - ``void **addr+rank(1)``.

--- a/shroud/main.py
+++ b/shroud/main.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 import argparse
 import json
 import os
+import re
 import sys
 import yaml
 from yaml.composer import Composer
@@ -406,7 +407,7 @@ def main_with_args(args):
 
     for filename in args.filename:
         ext = os.path.splitext(filename)[1]
-        if ext == ".yaml":
+        if re.search(ext, "[.](yaml|yml)$"):
             # print("Read %s" % os.path.basename(filename))
             log.write("Read yaml %s\n" % os.path.basename(filename))
             fp = open(filename, "r")

--- a/shroud/main.py
+++ b/shroud/main.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 import argparse
 import json
 import os
-import re
 import sys
 import yaml
 from yaml.composer import Composer
@@ -407,7 +406,7 @@ def main_with_args(args):
 
     for filename in args.filename:
         ext = os.path.splitext(filename)[1]
-        if re.search(ext, "[.](yaml|yml)$"):
+        if ext in [".yaml", ".yml"]:
             # print("Read %s" % os.path.basename(filename))
             log.write("Read yaml %s\n" % os.path.basename(filename))
             fp = open(filename, "r")


### PR DESCRIPTION
Currently, we do a hard coded check for yaml in main.py, but it is often the case that the user might use yml. This small change allows for using either by using re.search on the extension pattern instead of a hard `==`. This will fix #221.

The way I ran into this bug was having a whole ton of options, etc., in my yml file, and absolutely nothing was seeming to work (e.g., I was generating .f for fortran when I expected python). I'm wondering how it knew to do anything if it couldn't read my yaml *.yml" file. I hope this helps a future user!

Signed-off-by: vsoch <vsoch@users.noreply.github.com>