### PR TITLE
Allow YAML multiline text in splicer_code

### DIFF
--- a/regression/input/names.yaml
+++ b/regression/input/names.yaml
@@ -270,11 +270,14 @@ splicer_code:
          - // lines from explict splicer - namespace ns0
          class:
            Names:
-             CXX_definitions:
-             - // CXX_definitions for ns0 class Names
+             CXX_definitions: |
+               // CXX_definitions for ns0 class Names
+               // allow YAML multiline strings
        ns0::inner:
           CXX_definitions:
           - // CXX_definitions for ns0::inner
+          - // Allow blank line below (convert None to '')
+          -
      class:
        Names2:
          C_definitions:

--- a/regression/reference/names/foo.cpp
+++ b/regression/reference/names/foo.cpp
@@ -10,6 +10,7 @@
 
 // splicer begin namespace.ns0.class.Names.CXX_definitions
 // CXX_definitions for ns0 class Names
+// allow YAML multiline strings
 // splicer end namespace.ns0.class.Names.CXX_definitions
 
 extern "C" {

--- a/regression/reference/names/wraptestnames_ns0_inner.cc
+++ b/regression/reference/names/wraptestnames_ns0_inner.cc
@@ -9,6 +9,8 @@
 
 // splicer begin namespace.ns0::inner.CXX_definitions
 // CXX_definitions for ns0::inner
+// Allow blank line below (convert None to '')
+
 // splicer end namespace.ns0::inner.CXX_definitions
 
 extern "C" {


### PR DESCRIPTION
It also cleans up empty lines. They are convert by libyaml to None and
must be changed to ''.

#243