### PR TITLE
Cleanup buf args

### DIFF
--- a/docs/cstatements.rst
+++ b/docs/cstatements.rst
@@ -41,6 +41,7 @@ A corresponding ``bind(C)`` interface can be created for Fortran.
 Where
 F_C_clause =
 F_C_arguments =   f_c_arg_names
+arg_c_decl = f_arg_decl
     
 c_statements
 ------------
@@ -182,6 +183,9 @@ f_c_arg_names
 Names of arguments to pass to C function.
 Used when *buf_arg* is ``arg_decl``.
 Defaults to ``{F_C_var}``.
+
+.. note:: *c_arg_decl*, *f_arg_decl*, and *f_c_arg_names* must all
+          exist as a group and be the same length.
 
 f_result_decl
 ^^^^^^^^^^^^^

--- a/docs/cstatements.rst
+++ b/docs/cstatements.rst
@@ -14,7 +14,7 @@ C Statements
 
     extern "C" {
 
-    {C_return_type} {C_name}({C_prototype})    buf_args
+    {C_return_type} {C_name}({C_prototype})
     {
         {pre_call}
         {call_code}   {call}    arg_call
@@ -23,6 +23,8 @@ C Statements
         {final}
         {ret}
     }
+
+C_prototype -> c_arg_decl
 
 A corresponding ``bind(C)`` interface can be created for Fortran.
     
@@ -160,7 +162,9 @@ c_arg_decl
 ^^^^^^^^^^
 
 A list of declarations to append to the prototype in the C wrapper.
-Used when *buf_arg* includes "arg_decl".
+Defaults to *None* which will cause Shroud to generate an argument from
+the wrapped function's argument.
+Functions do not add arguments by default.
 
 f_arg_decl
 ^^^^^^^^^^

--- a/regression/reference/arrayclass/arrayclass.json
+++ b/regression/reference/arrayclass/arrayclass.json
@@ -300,7 +300,7 @@
                                 "idtor": "0",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "c_function_native_scalar",
-                                "stmt1": "c_default"
+                                "stmt1": "c_function"
                             },
                             "fmtf": {
                                 "F_C_var": "SHT_rv",
@@ -312,9 +312,9 @@
                                 "f_var": "SHT_rv",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "f_function_native_scalar",
-                                "stmt1": "f_default",
+                                "stmt1": "f_function",
                                 "stmtc0": "c_function_native_scalar",
-                                "stmtc1": "c_default"
+                                "stmtc1": "c_function"
                             },
                             "fmtpy": {
                                 "c_deref": "",
@@ -3285,7 +3285,7 @@
                                 "idtor": "0",
                                 "sh_type": "SH_TYPE_BOOL",
                                 "stmt0": "c_function_bool_scalar",
-                                "stmt1": "c_default"
+                                "stmt1": "c_function"
                             },
                             "fmtf": {
                                 "F_C_var": "SHT_rv",
@@ -3299,7 +3299,7 @@
                                 "stmt0": "f_function_bool_scalar",
                                 "stmt1": "f_function_bool",
                                 "stmtc0": "c_function_bool_scalar",
-                                "stmtc1": "c_default"
+                                "stmtc1": "c_function"
                             },
                             "fmtpy": {
                                 "PyTypeObject": "PyBool_Type",
@@ -3385,7 +3385,7 @@
                                 "idtor": "0",
                                 "sh_type": "SH_TYPE_DOUBLE",
                                 "stmt0": "c_function_native_scalar",
-                                "stmt1": "c_default"
+                                "stmt1": "c_function"
                             },
                             "fmtf": {
                                 "F_C_var": "SHT_rv",
@@ -3397,9 +3397,9 @@
                                 "f_var": "SHT_rv",
                                 "sh_type": "SH_TYPE_DOUBLE",
                                 "stmt0": "f_function_native_scalar",
-                                "stmt1": "f_default",
+                                "stmt1": "f_function",
                                 "stmtc0": "c_function_native_scalar",
-                                "stmtc1": "c_default"
+                                "stmtc1": "c_function"
                             },
                             "fmtpy": {
                                 "c_deref": "",

--- a/regression/reference/arrayclass/wrapArrayWrapper.cpp
+++ b/regression/reference/arrayclass/wrapArrayWrapper.cpp
@@ -54,7 +54,7 @@ void ARR_ArrayWrapper_set_size(ARR_ArrayWrapper * self, int size)
 // Function:  int getSize
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 int ARR_ArrayWrapper_get_size(const ARR_ArrayWrapper * self)
 {
     const ArrayWrapper *SH_this = static_cast<const ArrayWrapper *>
@@ -505,7 +505,7 @@ void ARR_ArrayWrapper_fetch_void_ref(ARR_ArrayWrapper * self,
 // Function:  bool checkPtr
 // Attrs:     +intent(function)
 // Requested: c_function_bool_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  void * array +value
 // Attrs:     +intent(in)
@@ -524,7 +524,7 @@ bool ARR_ArrayWrapper_check_ptr(ARR_ArrayWrapper * self, void * array)
 // Function:  double sumArray
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 double ARR_ArrayWrapper_sum_array(ARR_ArrayWrapper * self)
 {
     ArrayWrapper *SH_this = static_cast<ArrayWrapper *>(self->addr);

--- a/regression/reference/arrayclass/wrapfarrayclass.f
+++ b/regression/reference/arrayclass/wrapfarrayclass.f
@@ -116,7 +116,7 @@ module arrayclass_mod
         ! Function:  int getSize
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         pure function c_arraywrapper_get_size(self) &
                 result(SHT_rv) &
                 bind(C, name="ARR_ArrayWrapper_get_size")
@@ -520,7 +520,7 @@ module arrayclass_mod
         ! Function:  bool checkPtr
         ! Attrs:     +intent(function)
         ! Requested: c_function_bool_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  void * array +value
         ! Attrs:     +intent(in)
@@ -541,7 +541,7 @@ module arrayclass_mod
         ! Function:  double sumArray
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         function c_arraywrapper_sum_array(self) &
                 result(SHT_rv) &
                 bind(C, name="ARR_ArrayWrapper_sum_array")
@@ -606,10 +606,10 @@ contains
     ! Function:  int getSize
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     function arraywrapper_get_size(obj) &
             result(SHT_rv)
         use iso_c_binding, only : C_INT
@@ -939,7 +939,7 @@ contains
     ! Match:     f_function_bool
     ! Attrs:     +intent(function)
     ! Requested: c_function_bool_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  void * array +value
     ! Attrs:     +intent(in)
@@ -962,10 +962,10 @@ contains
     ! Function:  double sumArray
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     function arraywrapper_sum_array(obj) &
             result(SHT_rv)
         use iso_c_binding, only : C_DOUBLE

--- a/regression/reference/cdesc/cdesc.json
+++ b/regression/reference/cdesc/cdesc.json
@@ -1159,7 +1159,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -1171,9 +1171,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -1278,7 +1278,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -1290,9 +1290,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },

--- a/regression/reference/cdesc/wrapcdesc.cpp
+++ b/regression/reference/cdesc/wrapcdesc.cpp
@@ -201,7 +201,7 @@ void CDE_get_scalar1_1_bufferify(char *name, int SHT_name_len,
 // Function:  int getData
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 int CDE_get_data_int(void)
 {
     // splicer begin function.get_data_int
@@ -217,7 +217,7 @@ int CDE_get_data_int(void)
 // Function:  double getData
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 double CDE_get_data_double(void)
 {
     // splicer begin function.get_data_double

--- a/regression/reference/cdesc/wrapfcdesc.f
+++ b/regression/reference/cdesc/wrapfcdesc.f
@@ -169,7 +169,7 @@ module cdesc_mod
         ! Function:  int getData
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         function c_get_data_int() &
                 result(SHT_rv) &
                 bind(C, name="CDE_get_data_int")
@@ -182,7 +182,7 @@ module cdesc_mod
         ! Function:  double getData
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         function c_get_data_double() &
                 result(SHT_rv) &
                 bind(C, name="CDE_get_data_double")
@@ -329,10 +329,10 @@ contains
     ! Function:  int getData
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     !>
     !! Wrapper for function which is templated on the return value.
     !<
@@ -350,10 +350,10 @@ contains
     ! Function:  double getData
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     !>
     !! Wrapper for function which is templated on the return value.
     !<

--- a/regression/reference/classes/classes.json
+++ b/regression/reference/classes/classes.json
@@ -534,7 +534,7 @@
                                 "idtor": "0",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "c_function_native_scalar",
-                                "stmt1": "c_default"
+                                "stmt1": "c_function"
                             },
                             "fmtf": {
                                 "F_C_var": "SHT_rv",
@@ -546,9 +546,9 @@
                                 "f_var": "SHT_rv",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "f_function_native_scalar",
-                                "stmt1": "f_default",
+                                "stmt1": "f_function",
                                 "stmtc0": "c_function_native_scalar",
-                                "stmtc1": "c_default"
+                                "stmtc1": "c_function"
                             },
                             "fmtl": {
                                 "c_var": "SHCXX_rv",
@@ -730,7 +730,7 @@
                                 "idtor": "0",
                                 "sh_type": "SH_TYPE_BOOL",
                                 "stmt0": "c_function_bool_scalar",
-                                "stmt1": "c_default"
+                                "stmt1": "c_function"
                             },
                             "fmtf": {
                                 "F_C_var": "SHT_rv",
@@ -744,7 +744,7 @@
                                 "stmt0": "f_function_bool_scalar",
                                 "stmt1": "f_function_bool",
                                 "stmtc0": "c_function_bool_scalar",
-                                "stmtc1": "c_default"
+                                "stmtc1": "c_function"
                             },
                             "fmtpy": {
                                 "PyTypeObject": "PyBool_Type",
@@ -1706,7 +1706,7 @@
                                 "idtor": "0",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "c_function_native_scalar",
-                                "stmt1": "c_default"
+                                "stmt1": "c_function"
                             },
                             "fmtf": {
                                 "F_C_var": "SHT_rv",
@@ -1718,9 +1718,9 @@
                                 "f_var": "SHT_rv",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "f_function_native_scalar",
-                                "stmt1": "f_default",
+                                "stmt1": "f_function",
                                 "stmtc0": "c_function_native_scalar",
-                                "stmtc1": "c_default"
+                                "stmtc1": "c_function"
                             },
                             "fmtl": {
                                 "c_var": "static_cast<int>(SHCXX_rv)",
@@ -1828,9 +1828,9 @@
                                 "f_var": "SHT_rv",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "f_function_native_scalar",
-                                "stmt1": "f_default",
+                                "stmt1": "f_function",
                                 "stmtc0": "c_function_native_scalar",
-                                "stmtc1": "c_default"
+                                "stmtc1": "c_function"
                             }
                         }
                     },
@@ -1911,9 +1911,9 @@
                                 "f_var": "SHT_rv",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "f_function_native_scalar",
-                                "stmt1": "f_default",
+                                "stmt1": "f_function",
                                 "stmtc0": "c_function_native_scalar",
-                                "stmtc1": "c_default"
+                                "stmtc1": "c_function"
                             }
                         }
                     },
@@ -3059,7 +3059,7 @@
                                 "idtor": "0",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "c_function_native_scalar",
-                                "stmt1": "c_default"
+                                "stmt1": "c_function"
                             },
                             "fmtf": {
                                 "F_C_var": "SHT_rv",
@@ -3071,9 +3071,9 @@
                                 "f_var": "SHT_rv",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "f_function_native_scalar",
-                                "stmt1": "f_default",
+                                "stmt1": "f_function",
                                 "stmtc0": "c_function_native_scalar",
-                                "stmtc1": "c_default"
+                                "stmtc1": "c_function"
                             },
                             "fmtl": {
                                 "c_var": "SHCXX_rv",
@@ -3486,7 +3486,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -3498,9 +3498,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtl": {
                         "c_var": "static_cast<int>(SHCXX_rv)",
@@ -3803,7 +3803,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -3815,9 +3815,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -4556,7 +4556,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -4568,9 +4568,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtl": {
                         "c_var": "SHCXX_rv",

--- a/regression/reference/classes/classes.json
+++ b/regression/reference/classes/classes.json
@@ -452,7 +452,7 @@
                             "c_var": "self",
                             "function_name": "delete",
                             "stmt0": "f_dtor",
-                            "stmt1": "f_default",
+                            "stmt1": "f_dtor",
                             "stmtc0": "c_dtor",
                             "stmtc1": "c_dtor",
                             "underscore_name": "delete"
@@ -1992,7 +1992,7 @@
                                     "f_var": "val",
                                     "sh_type": "SH_TYPE_INT",
                                     "stmt0": "f_setter_native_scalar",
-                                    "stmt1": "f_setter",
+                                    "stmt1": "f_setter_native",
                                     "stmtc0": "c_setter_native_scalar",
                                     "stmtc1": "c_setter_native_scalar"
                                 }

--- a/regression/reference/classes/wrapClass1.cpp
+++ b/regression/reference/classes/wrapClass1.cpp
@@ -121,7 +121,7 @@ void CLA_Class1_delete(CLA_Class1 * self)
 // Function:  int Method1
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // start CLA_Class1_method1
 int CLA_Class1_method1(CLA_Class1 * self)
 {
@@ -142,7 +142,7 @@ int CLA_Class1_method1(CLA_Class1 * self)
 // Function:  bool equivalent
 // Attrs:     +intent(function)
 // Requested: c_function_bool_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  const Class1 & obj2
 // Attrs:     +intent(in)
@@ -318,7 +318,7 @@ void CLA_Class1_get_name_bufferify(CLA_Class1 * self,
 // Function:  DIRECTION directionFunc
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  DIRECTION arg +value
 // Attrs:     +intent(in)

--- a/regression/reference/classes/wrapShape.cpp
+++ b/regression/reference/classes/wrapShape.cpp
@@ -37,7 +37,7 @@ void CLA_Shape_ctor(CLA_Shape * SHC_rv)
 // Function:  int get_ivar
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 int CLA_Shape_get_ivar(const CLA_Shape * self)
 {
     const classes::Shape *SH_this = static_cast<const classes::Shape *>

--- a/regression/reference/classes/wrapclasses.cpp
+++ b/regression/reference/classes/wrapclasses.cpp
@@ -43,7 +43,7 @@ static void ShroudStrCopy(char *dest, int ndest, const char *src, int nsrc)
 // Function:  Class1::DIRECTION directionFunc
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  Class1::DIRECTION arg +value
 // Attrs:     +intent(in)
@@ -87,7 +87,7 @@ void CLA_pass_class_by_value(CLA_Class1 * arg)
 // Function:  int useclass
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  const Class1 * arg
 // Attrs:     +intent(in)
@@ -203,7 +203,7 @@ void CLA_set_global_flag(int arg)
 // Function:  int get_global_flag
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 int CLA_get_global_flag(void)
 {
     // splicer begin function.get_global_flag

--- a/regression/reference/classes/wrapfclasses.f
+++ b/regression/reference/classes/wrapfclasses.f
@@ -201,7 +201,7 @@ module classes_mod
     ! Function:  int Method1
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! start c_class1_method1
     interface
         function c_class1_method1(self) &
@@ -220,7 +220,7 @@ module classes_mod
     ! Function:  bool equivalent
     ! Attrs:     +intent(function)
     ! Requested: c_function_bool_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const Class1 & obj2
     ! Attrs:     +intent(in)
@@ -373,7 +373,7 @@ module classes_mod
     ! Function:  DIRECTION directionFunc
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  DIRECTION arg +value
     ! Attrs:     +intent(in)
@@ -563,7 +563,7 @@ module classes_mod
     ! Function:  int get_ivar
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     interface
         pure function c_shape_get_ivar(self) &
                 result(SHT_rv) &
@@ -599,7 +599,7 @@ module classes_mod
     ! Function:  Class1::DIRECTION directionFunc
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  Class1::DIRECTION arg +value
     ! Attrs:     +intent(in)
@@ -639,7 +639,7 @@ module classes_mod
     ! Function:  int useclass
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const Class1 * arg
     ! Attrs:     +intent(in)
@@ -756,7 +756,7 @@ module classes_mod
     ! Function:  int get_global_flag
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     interface
         function get_global_flag() &
                 result(SHT_rv) &
@@ -894,10 +894,10 @@ contains
     ! Function:  int Method1
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     !>
     !! \brief returns the value of flag member
     !!
@@ -921,7 +921,7 @@ contains
     ! Match:     f_function_bool
     ! Attrs:     +intent(function)
     ! Requested: c_function_bool_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const Class1 & obj2
     ! Attrs:     +intent(in)
@@ -1064,10 +1064,10 @@ contains
     ! Function:  DIRECTION directionFunc
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  DIRECTION arg +value
     ! Attrs:     +intent(in)
@@ -1094,10 +1094,10 @@ contains
     ! Function:  int getM_flag
     ! Attrs:     +intent(getter)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(getter)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! start class1_get_m_flag
     function class1_get_m_flag(obj) &
             result(SHT_rv)
@@ -1115,10 +1115,10 @@ contains
     ! Function:  int getTest
     ! Attrs:     +intent(getter)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(getter)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! start class1_get_test
     function class1_get_test(obj) &
             result(SHT_rv)
@@ -1339,10 +1339,10 @@ contains
     ! Function:  int get_ivar
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     function shape_get_ivar(obj) &
             result(SHT_rv)
         use iso_c_binding, only : C_INT
@@ -1425,10 +1425,10 @@ contains
     ! Function:  int useclass
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const Class1 * arg
     ! Attrs:     +intent(in)

--- a/regression/reference/classes/wrapfclasses.f
+++ b/regression/reference/classes/wrapfclasses.f
@@ -877,8 +877,7 @@ contains
     ! ----------------------------------------
     ! Function:  ~Class1 +name(delete)
     ! Attrs:     +intent(dtor)
-    ! Requested: f_dtor
-    ! Match:     f_default
+    ! Exact:     f_dtor
     ! Attrs:     +intent(dtor)
     ! Exact:     c_dtor
     ! start class1_delete
@@ -1142,7 +1141,7 @@ contains
     ! Argument:  int val +intent(in)+value
     ! Attrs:     +intent(setter)
     ! Requested: f_setter_native_scalar
-    ! Match:     f_setter
+    ! Match:     f_setter_native
     ! Attrs:     +intent(setter)
     ! Exact:     c_setter_native_scalar
     ! start class1_set_test

--- a/regression/reference/clibrary/clibrary.json
+++ b/regression/reference/clibrary/clibrary.json
@@ -326,7 +326,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -338,9 +338,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -698,7 +698,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -710,9 +710,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -2949,7 +2949,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2961,9 +2961,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -3253,7 +3253,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -3265,9 +3265,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -3421,7 +3421,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_BOOL",
                         "stmt0": "c_function_bool_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -3435,7 +3435,7 @@
                         "stmt0": "f_function_bool_scalar",
                         "stmt1": "f_function_bool",
                         "stmtc0": "c_function_bool_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "PyTypeObject": "PyBool_Type",
@@ -3590,7 +3590,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_BOOL",
                         "stmt0": "c_function_bool_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -3604,7 +3604,7 @@
                         "stmt0": "f_function_bool_scalar",
                         "stmt1": "f_function_bool",
                         "stmtc0": "c_function_bool_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "PyTypeObject": "PyBool_Type",
@@ -4167,7 +4167,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -4179,9 +4179,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -4451,7 +4451,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -4463,9 +4463,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -4635,7 +4635,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",

--- a/regression/reference/clibrary/wrapClibrary.c
+++ b/regression/reference/clibrary/wrapClibrary.c
@@ -88,7 +88,7 @@ static void ShroudStrFree(char *src)
 // Function:  double PassByValueMacro
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  int arg2 +value
 // Attrs:     +intent(in)
@@ -264,7 +264,7 @@ void CLI_bind_c2_bufferify(char *outbuf, int SHT_outbuf_len)
 // Function:  int passAssumedTypeBuf
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  void * arg +assumedtype
 // Attrs:     +intent(in)

--- a/regression/reference/clibrary/wrapfclibrary.f
+++ b/regression/reference/clibrary/wrapfclibrary.f
@@ -87,7 +87,7 @@ module clibrary_mod
     ! Function:  double PassByValue
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  double arg1 +value
     ! Attrs:     +intent(in)
@@ -143,7 +143,7 @@ module clibrary_mod
     ! Function:  double PassByValueMacro
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  int arg2 +value
     ! Attrs:     +intent(in)
@@ -459,7 +459,7 @@ module clibrary_mod
     ! Function:  int ImpliedLen
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const char * text
     ! Attrs:     +intent(in)
@@ -492,7 +492,7 @@ module clibrary_mod
     ! Function:  int ImpliedLenTrim
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const char * text
     ! Attrs:     +intent(in)
@@ -525,7 +525,7 @@ module clibrary_mod
     ! Function:  bool ImpliedBoolTrue
     ! Attrs:     +intent(function)
     ! Requested: c_function_bool_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  bool flag +implied(true)+value
     ! Attrs:     +intent(in)
@@ -546,7 +546,7 @@ module clibrary_mod
     ! Function:  bool ImpliedBoolFalse
     ! Attrs:     +intent(function)
     ! Requested: c_function_bool_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  bool flag +implied(false)+value
     ! Attrs:     +intent(in)
@@ -644,7 +644,7 @@ module clibrary_mod
     ! Function:  int passAssumedType
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  void * arg +assumedtype
     ! Attrs:     +intent(in)
@@ -687,7 +687,7 @@ module clibrary_mod
     ! Function:  int passAssumedTypeBuf
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  void * arg +assumedtype
     ! Attrs:     +intent(in)
@@ -714,7 +714,7 @@ module clibrary_mod
     ! Function:  int passAssumedTypeBuf
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  void * arg +assumedtype
     ! Attrs:     +intent(in)
@@ -1159,10 +1159,10 @@ contains
     ! Function:  int ImpliedLen
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     !>
     !! \brief Return the implied argument - text length
     !!
@@ -1188,10 +1188,10 @@ contains
     ! Function:  int ImpliedLenTrim
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     !>
     !! \brief Return the implied argument - text length
     !!
@@ -1220,7 +1220,7 @@ contains
     ! Match:     f_function_bool
     ! Attrs:     +intent(function)
     ! Requested: c_function_bool_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     !>
     !! \brief Single, implied bool argument
     !!
@@ -1243,7 +1243,7 @@ contains
     ! Match:     f_function_bool
     ! Attrs:     +intent(function)
     ! Requested: c_function_bool_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     !>
     !! \brief Single, implied bool argument
     !!
@@ -1290,10 +1290,10 @@ contains
     ! Function:  int passAssumedTypeBuf
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  char * outbuf +intent(out)
     ! Attrs:     +intent(out)

--- a/regression/reference/cxxlibrary/cxxlibrary.json
+++ b/regression/reference/cxxlibrary/cxxlibrary.json
@@ -661,7 +661,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_BOOL",
                         "stmt0": "c_function_bool_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -675,7 +675,7 @@
                         "stmt0": "f_function_bool_scalar",
                         "stmt1": "f_function_bool",
                         "stmtc0": "c_function_bool_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -834,7 +834,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_BOOL",
                         "stmt0": "c_function_bool_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -848,7 +848,7 @@
                         "stmt0": "f_function_bool_scalar",
                         "stmt1": "f_function_bool",
                         "stmtc0": "c_function_bool_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "PyTypeObject": "PyBool_Type",
@@ -1672,7 +1672,7 @@
                                 "idtor": "0",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "c_function_native_scalar",
-                                "stmt1": "c_default"
+                                "stmt1": "c_function"
                             },
                             "fmtf": {
                                 "F_C_var": "SHT_rv",
@@ -1684,9 +1684,9 @@
                                 "f_var": "SHT_rv",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "f_function_native_scalar",
-                                "stmt1": "f_default",
+                                "stmt1": "f_function",
                                 "stmtc0": "c_function_native_scalar",
-                                "stmtc1": "c_default"
+                                "stmtc1": "c_function"
                             },
                             "fmtpy": {
                                 "c_deref": "",
@@ -1849,7 +1849,7 @@
                                 "idtor": "0",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "c_function_native_scalar",
-                                "stmt1": "c_default"
+                                "stmt1": "c_function"
                             },
                             "fmtf": {
                                 "F_C_var": "SHT_rv",
@@ -1861,9 +1861,9 @@
                                 "f_var": "SHT_rv",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "f_function_native_scalar",
-                                "stmt1": "f_default",
+                                "stmt1": "f_function",
                                 "stmtc0": "c_function_native_scalar",
-                                "stmtc1": "c_default"
+                                "stmtc1": "c_function"
                             },
                             "fmtpy": {
                                 "c_deref": "",

--- a/regression/reference/cxxlibrary/wrapcxxlibrary.cpp
+++ b/regression/reference/cxxlibrary/wrapcxxlibrary.cpp
@@ -23,7 +23,7 @@ extern "C" {
 // Function:  bool defaultPtrIsNULL
 // Attrs:     +intent(function)
 // Requested: c_function_bool_scalar
-// Match:     c_default
+// Match:     c_function
 bool CXX_default_ptr_is_null_0(void)
 {
     // splicer begin function.default_ptr_is_null_0
@@ -36,7 +36,7 @@ bool CXX_default_ptr_is_null_0(void)
 // Function:  bool defaultPtrIsNULL
 // Attrs:     +intent(function)
 // Requested: c_function_bool_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  double * data=nullptr +intent(IN)+rank(1)
 // Attrs:     +intent(in)

--- a/regression/reference/cxxlibrary/wrapcxxlibrary_structns.cpp
+++ b/regression/reference/cxxlibrary/wrapcxxlibrary_structns.cpp
@@ -26,7 +26,7 @@ extern "C" {
 // Function:  int passStructByReference
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  Cstruct1 & arg
 // Attrs:     +intent(inout)
@@ -49,7 +49,7 @@ int CXX_structns_pass_struct_by_reference(CXX_cstruct1 * arg)
 // Function:  int passStructByReferenceIn
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  const Cstruct1 & arg
 // Attrs:     +intent(in)

--- a/regression/reference/cxxlibrary/wrapfcxxlibrary.f
+++ b/regression/reference/cxxlibrary/wrapfcxxlibrary.f
@@ -26,7 +26,7 @@ module cxxlibrary_mod
         ! Function:  bool defaultPtrIsNULL
         ! Attrs:     +intent(function)
         ! Requested: c_function_bool_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         function c_default_ptr_is_null_0() &
                 result(SHT_rv) &
                 bind(C, name="CXX_default_ptr_is_null_0")
@@ -39,7 +39,7 @@ module cxxlibrary_mod
         ! Function:  bool defaultPtrIsNULL
         ! Attrs:     +intent(function)
         ! Requested: c_function_bool_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  double * data=nullptr +intent(IN)+rank(1)
         ! Attrs:     +intent(in)
@@ -142,7 +142,7 @@ contains
     ! Match:     f_function_bool
     ! Attrs:     +intent(function)
     ! Requested: c_function_bool_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     function default_ptr_is_null_0() &
             result(SHT_rv)
         use iso_c_binding, only : C_BOOL
@@ -159,7 +159,7 @@ contains
     ! Match:     f_function_bool
     ! Attrs:     +intent(function)
     ! Requested: c_function_bool_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  double * data=nullptr +intent(IN)+rank(1)
     ! Attrs:     +intent(in)

--- a/regression/reference/cxxlibrary/wrapfcxxlibrary_structns.f
+++ b/regression/reference/cxxlibrary/wrapfcxxlibrary_structns.f
@@ -33,7 +33,7 @@ module cxxlibrary_structns_mod
         ! Function:  int passStructByReference
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  Cstruct1 & arg
         ! Attrs:     +intent(inout)
@@ -53,7 +53,7 @@ module cxxlibrary_structns_mod
         ! Function:  int passStructByReferenceIn
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  const Cstruct1 & arg
         ! Attrs:     +intent(in)

--- a/regression/reference/debugfalse/tutorial.json
+++ b/regression/reference/debugfalse/tutorial.json
@@ -365,7 +365,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -377,9 +377,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtl": {
                         "c_var": "SHCXX_rv",
@@ -866,7 +866,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -878,9 +878,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -1009,7 +1009,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -1021,9 +1021,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -1281,7 +1281,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -1293,9 +1293,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtl": {
                         "c_var": "SHCXX_rv",
@@ -2302,7 +2302,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2314,9 +2314,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -2420,7 +2420,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2432,9 +2432,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -3369,7 +3369,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -3381,9 +3381,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -3559,7 +3559,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -3571,9 +3571,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -3909,7 +3909,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -3921,9 +3921,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtl": {
                         "c_var": "SHCXX_rv",
@@ -4120,7 +4120,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -4132,9 +4132,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -4354,7 +4354,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -4366,9 +4366,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -4779,7 +4779,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -4791,9 +4791,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtl": {
                         "c_var": "SHCXX_rv",
@@ -4973,7 +4973,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -4985,9 +4985,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtl": {
                         "c_var": "SHCXX_rv",
@@ -5173,7 +5173,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -5185,9 +5185,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtl": {
                         "c_var": "static_cast<int>(SHCXX_rv)",
@@ -5373,7 +5373,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -5385,9 +5385,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtl": {
                         "c_var": "static_cast<int>(SHCXX_rv)",
@@ -5803,7 +5803,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -5815,9 +5815,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },

--- a/regression/reference/example/example.json
+++ b/regression/reference/example/example.json
@@ -522,7 +522,7 @@
                                             "c_var": "self",
                                             "function_name": "dtor",
                                             "stmt0": "f_dtor",
-                                            "stmt1": "f_default",
+                                            "stmt1": "f_dtor",
                                             "stmtc0": "c_dtor",
                                             "stmtc1": "c_dtor",
                                             "underscore_name": "dtor"
@@ -2356,7 +2356,7 @@
                                             "c_var": "self",
                                             "function_name": "dtor",
                                             "stmt0": "f_dtor",
-                                            "stmt1": "f_default",
+                                            "stmt1": "f_dtor",
                                             "stmtc0": "c_dtor",
                                             "stmtc1": "c_dtor",
                                             "underscore_name": "dtor"

--- a/regression/reference/example/example.json
+++ b/regression/reference/example/example.json
@@ -687,7 +687,7 @@
                                                 "idtor": "0",
                                                 "sh_type": "SH_TYPE_INT",
                                                 "stmt0": "c_function_native_scalar",
-                                                "stmt1": "c_default"
+                                                "stmt1": "c_function"
                                             },
                                             "fmtf": {
                                                 "F_C_var": "SHT_rv",
@@ -699,9 +699,9 @@
                                                 "f_var": "SHT_rv",
                                                 "sh_type": "SH_TYPE_INT",
                                                 "stmt0": "f_function_native_scalar",
-                                                "stmt1": "f_default",
+                                                "stmt1": "f_function",
                                                 "stmtc0": "c_function_native_scalar",
-                                                "stmtc1": "c_default"
+                                                "stmtc1": "c_function"
                                             },
                                             "fmtl": {
                                                 "c_var": "SHCXX_rv",
@@ -1382,7 +1382,7 @@
                                                 "idtor": "0",
                                                 "sh_type": "SH_TYPE_INT",
                                                 "stmt0": "c_function_native_scalar",
-                                                "stmt1": "c_default"
+                                                "stmt1": "c_function"
                                             },
                                             "fmtf": {
                                                 "F_C_var": "SHT_rv",
@@ -1394,9 +1394,9 @@
                                                 "f_var": "SHT_rv",
                                                 "sh_type": "SH_TYPE_INT",
                                                 "stmt0": "f_function_native_scalar",
-                                                "stmt1": "f_default",
+                                                "stmt1": "f_function",
                                                 "stmtc0": "c_function_native_scalar",
-                                                "stmtc1": "c_default"
+                                                "stmtc1": "c_function"
                                             },
                                             "fmtl": {
                                                 "c_var": "SHCXX_rv",
@@ -1580,7 +1580,7 @@
                                                 "idtor": "0",
                                                 "sh_type": "SH_TYPE_LONG",
                                                 "stmt0": "c_function_native_scalar",
-                                                "stmt1": "c_default"
+                                                "stmt1": "c_function"
                                             },
                                             "fmtf": {
                                                 "F_C_var": "SHT_rv",
@@ -1592,9 +1592,9 @@
                                                 "f_var": "SHT_rv",
                                                 "sh_type": "SH_TYPE_LONG",
                                                 "stmt0": "f_function_native_scalar",
-                                                "stmt1": "f_default",
+                                                "stmt1": "f_function",
                                                 "stmtc0": "c_function_native_scalar",
-                                                "stmtc1": "c_default"
+                                                "stmtc1": "c_function"
                                             },
                                             "fmtl": {
                                                 "c_var": "SHCXX_rv",
@@ -1780,7 +1780,7 @@
                                                 "idtor": "0",
                                                 "sh_type": "SH_TYPE_BOOL",
                                                 "stmt0": "c_function_bool_scalar",
-                                                "stmt1": "c_default"
+                                                "stmt1": "c_function"
                                             },
                                             "fmtf": {
                                                 "F_C_var": "SHT_rv",
@@ -1794,7 +1794,7 @@
                                                 "stmt0": "f_function_bool_scalar",
                                                 "stmt1": "f_function_bool",
                                                 "stmtc0": "c_function_bool_scalar",
-                                                "stmtc1": "c_default"
+                                                "stmtc1": "c_function"
                                             },
                                             "fmtl": {
                                                 "c_var": "SHCXX_rv",
@@ -3250,7 +3250,7 @@
                                                 "idtor": "0",
                                                 "sh_type": "SH_TYPE_INT",
                                                 "stmt0": "c_function_native_scalar",
-                                                "stmt1": "c_default"
+                                                "stmt1": "c_function"
                                             },
                                             "fmtf": {
                                                 "F_C_var": "SHT_rv",
@@ -3262,9 +3262,9 @@
                                                 "f_var": "SHT_rv",
                                                 "sh_type": "SH_TYPE_INT",
                                                 "stmt0": "f_function_native_scalar",
-                                                "stmt1": "f_default",
+                                                "stmt1": "f_function",
                                                 "stmtc0": "c_function_native_scalar",
-                                                "stmtc1": "c_default"
+                                                "stmtc1": "c_function"
                                             },
                                             "fmtl": {
                                                 "c_var": "SHCXX_rv",
@@ -4792,7 +4792,7 @@
                                                 "idtor": "0",
                                                 "sh_type": "SH_TYPE_INT",
                                                 "stmt0": "c_function_native_scalar",
-                                                "stmt1": "c_default"
+                                                "stmt1": "c_function"
                                             },
                                             "fmtf": {
                                                 "F_C_var": "SHT_rv",
@@ -4804,9 +4804,9 @@
                                                 "f_var": "SHT_rv",
                                                 "sh_type": "SH_TYPE_INT",
                                                 "stmt0": "f_function_native_scalar",
-                                                "stmt1": "f_default",
+                                                "stmt1": "f_function",
                                                 "stmtc0": "c_function_native_scalar",
-                                                "stmtc1": "c_default"
+                                                "stmtc1": "c_function"
                                             },
                                             "fmtl": {
                                                 "c_var": "static_cast<int>(SHCXX_rv)",
@@ -5918,7 +5918,7 @@
                                                 "idtor": "0",
                                                 "sh_type": "SH_TYPE_INT",
                                                 "stmt0": "c_function_native_scalar",
-                                                "stmt1": "c_default"
+                                                "stmt1": "c_function"
                                             },
                                             "fmtf": {
                                                 "F_C_var": "SHT_rv",
@@ -5930,9 +5930,9 @@
                                                 "f_var": "SHT_rv",
                                                 "sh_type": "SH_TYPE_INT",
                                                 "stmt0": "f_function_native_scalar",
-                                                "stmt1": "f_default",
+                                                "stmt1": "f_function",
                                                 "stmtc0": "c_function_native_scalar",
-                                                "stmtc1": "c_default"
+                                                "stmtc1": "c_function"
                                             },
                                             "fmtl": {
                                                 "c_var": "SHCXX_rv",
@@ -6069,7 +6069,7 @@
                                                 "idtor": "0",
                                                 "sh_type": "SH_TYPE_DOUBLE",
                                                 "stmt0": "c_function_native_scalar",
-                                                "stmt1": "c_default"
+                                                "stmt1": "c_function"
                                             },
                                             "fmtf": {
                                                 "F_C_var": "SHT_rv",
@@ -6081,9 +6081,9 @@
                                                 "f_var": "SHT_rv",
                                                 "sh_type": "SH_TYPE_DOUBLE",
                                                 "stmt0": "f_function_native_scalar",
-                                                "stmt1": "f_default",
+                                                "stmt1": "f_function",
                                                 "stmtc0": "c_function_native_scalar",
-                                                "stmtc1": "c_default"
+                                                "stmtc1": "c_function"
                                             },
                                             "fmtl": {
                                                 "c_var": "SHCXX_rv",
@@ -6391,7 +6391,7 @@
                                         "idtor": "0",
                                         "sh_type": "SH_TYPE_BOOL",
                                         "stmt0": "c_function_bool_scalar",
-                                        "stmt1": "c_default"
+                                        "stmt1": "c_function"
                                     },
                                     "fmtf": {
                                         "F_C_var": "SHT_rv",
@@ -6405,7 +6405,7 @@
                                         "stmt0": "f_function_bool_scalar",
                                         "stmt1": "f_function_bool",
                                         "stmtc0": "c_function_bool_scalar",
-                                        "stmtc1": "c_default"
+                                        "stmtc1": "c_function"
                                     },
                                     "fmtl": {
                                         "c_var": "SHCXX_rv",
@@ -6558,7 +6558,7 @@
                                         "idtor": "0",
                                         "sh_type": "SH_TYPE_BOOL",
                                         "stmt0": "c_function_bool_scalar",
-                                        "stmt1": "c_default"
+                                        "stmt1": "c_function"
                                     },
                                     "fmtf": {
                                         "F_C_var": "SHT_rv",
@@ -6630,7 +6630,7 @@
                                         "idtor": "0",
                                         "sh_type": "SH_TYPE_BOOL",
                                         "stmt0": "c_function_bool_scalar",
-                                        "stmt1": "c_default"
+                                        "stmt1": "c_function"
                                     },
                                     "fmtf": {
                                         "F_C_var": "SHT_rv",
@@ -6644,7 +6644,7 @@
                                         "stmt0": "f_function_bool_scalar",
                                         "stmt1": "f_function_bool",
                                         "stmtc0": "c_function_bool_scalar",
-                                        "stmtc1": "c_default"
+                                        "stmtc1": "c_function"
                                     },
                                     "fmtl": {
                                         "c_var": "SHCXX_rv",
@@ -7731,7 +7731,7 @@
                                         "idtor": "0",
                                         "sh_type": "SH_TYPE_SIZE_T",
                                         "stmt0": "c_function_native_scalar",
-                                        "stmt1": "c_default"
+                                        "stmt1": "c_function"
                                     },
                                     "fmtf": {
                                         "F_C_var": "SHT_rv",
@@ -7743,9 +7743,9 @@
                                         "f_var": "SHT_rv",
                                         "sh_type": "SH_TYPE_SIZE_T",
                                         "stmt0": "f_function_native_scalar",
-                                        "stmt1": "f_default",
+                                        "stmt1": "f_function",
                                         "stmtc0": "c_function_native_scalar",
-                                        "stmtc1": "c_default"
+                                        "stmtc1": "c_function"
                                     },
                                     "fmtl": {
                                         "c_var": "SHCXX_rv",
@@ -10681,7 +10681,7 @@
                                         "idtor": "0",
                                         "sh_type": "SH_TYPE_INT",
                                         "stmt0": "c_function_native_scalar",
-                                        "stmt1": "c_default"
+                                        "stmt1": "c_function"
                                     },
                                     "fmtf": {
                                         "F_C_var": "SHT_rv",
@@ -10693,9 +10693,9 @@
                                         "f_var": "SHT_rv",
                                         "sh_type": "SH_TYPE_INT",
                                         "stmt0": "f_function_native_scalar",
-                                        "stmt1": "f_default",
+                                        "stmt1": "f_function",
                                         "stmtc0": "c_function_native_scalar",
-                                        "stmtc1": "c_default"
+                                        "stmtc1": "c_function"
                                     },
                                     "fmtl": {
                                         "c_var": "SHCXX_rv",

--- a/regression/reference/example/wrapUserLibrary_example_nested.cpp
+++ b/regression/reference/example/wrapUserLibrary_example_nested.cpp
@@ -50,7 +50,7 @@ void AA_example_nested_local_function1(void)
 // Function:  bool isNameValid
 // Attrs:     +intent(function)
 // Requested: c_function_bool_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  const std::string & name
 // Attrs:     +intent(in)
@@ -66,7 +66,7 @@ bool AA_example_nested_is_name_valid(const char * name)
 // Function:  bool isNameValid
 // Attrs:     +intent(function)
 // Requested: c_function_bool_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  const std::string & name
 // Attrs:     +api(buf)+intent(in)
@@ -83,7 +83,7 @@ bool AA_example_nested_is_name_valid_bufferify(char *name,
 // Function:  bool isInitialized
 // Attrs:     +intent(function)
 // Requested: c_function_bool_scalar
-// Match:     c_default
+// Match:     c_function
 bool AA_example_nested_is_initialized(void)
 {
     // splicer begin namespace.example::nested.function.is_initialized
@@ -222,7 +222,7 @@ void AA_example_nested_testoptional_2(int i, long j)
 // Function:  size_t test_size_t
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 size_t AA_example_nested_test_size_t(void)
 {
     // splicer begin namespace.example::nested.function.test_size_t
@@ -432,7 +432,7 @@ void AA_example_nested_verylongfunctionname1(int * verylongname1,
 // Function:  int verylongfunctionname2
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  int verylongname1 +value
 // Attrs:     +intent(in)

--- a/regression/reference/example/wrapexample_nested_ExClass1.cpp
+++ b/regression/reference/example/wrapexample_nested_ExClass1.cpp
@@ -173,7 +173,7 @@ void AA_example_nested_ExClass1_dtor(AA_example_nested_ExClass1 * self)
 // Function:  int incrementCount
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  int incr +value
 // Attrs:     +intent(in)
@@ -270,7 +270,7 @@ void AA_example_nested_ExClass1_get_name_arg_bufferify(
 // Function:  int getValue
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  int value +value
 // Attrs:     +intent(in)
@@ -291,7 +291,7 @@ int AA_example_nested_ExClass1_get_value_from_int(
 // Function:  long getValue
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  long value +value
 // Attrs:     +intent(in)
@@ -312,7 +312,7 @@ long AA_example_nested_ExClass1_get_value_1(
 // Function:  bool hasAddr
 // Attrs:     +intent(function)
 // Requested: c_function_bool_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  bool in +value
 // Attrs:     +intent(in)

--- a/regression/reference/example/wrapexample_nested_ExClass2.cpp
+++ b/regression/reference/example/wrapexample_nested_ExClass2.cpp
@@ -289,7 +289,7 @@ void AA_example_nested_ExClass2_get_name4_bufferify(
 // Function:  int GetNameLength
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 int AA_example_nested_ExClass2_get_name_length(
     const AA_example_nested_ExClass2 * self)
 {
@@ -390,7 +390,7 @@ void AA_example_nested_ExClass2_destroyall(
 // Function:  TypeID getTypeID
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 int AA_example_nested_ExClass2_get_type_id(
     const AA_example_nested_ExClass2 * self)
 {
@@ -483,7 +483,7 @@ void AA_example_nested_ExClass2_set_value_double(
 // Function:  int getValue
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 int AA_example_nested_ExClass2_get_value_int(
     AA_example_nested_ExClass2 * self)
 {
@@ -499,7 +499,7 @@ int AA_example_nested_ExClass2_get_value_int(
 // Function:  double getValue
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 double AA_example_nested_ExClass2_get_value_double(
     AA_example_nested_ExClass2 * self)
 {

--- a/regression/reference/example/wrapfUserLibrary_example_nested.f
+++ b/regression/reference/example/wrapfUserLibrary_example_nested.f
@@ -224,7 +224,7 @@ module userlibrary_example_nested_mod
         ! Function:  int incrementCount
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  int incr +value
         ! Attrs:     +intent(in)
@@ -308,7 +308,7 @@ module userlibrary_example_nested_mod
         ! Function:  int getValue
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  int value +value
         ! Attrs:     +intent(in)
@@ -329,7 +329,7 @@ module userlibrary_example_nested_mod
         ! Function:  long getValue
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  long value +value
         ! Attrs:     +intent(in)
@@ -350,7 +350,7 @@ module userlibrary_example_nested_mod
         ! Function:  bool hasAddr
         ! Attrs:     +intent(function)
         ! Requested: c_function_bool_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  bool in +value
         ! Attrs:     +intent(in)
@@ -545,7 +545,7 @@ module userlibrary_example_nested_mod
         ! Function:  int GetNameLength
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         pure function c_exclass2_get_name_length(self) &
                 result(SHT_rv) &
                 bind(C, name="AA_example_nested_ExClass2_get_name_length")
@@ -635,7 +635,7 @@ module userlibrary_example_nested_mod
         ! Function:  TypeID getTypeID
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         pure function c_exclass2_get_type_id(self) &
                 result(SHT_rv) &
                 bind(C, name="AA_example_nested_ExClass2_get_type_id")
@@ -726,7 +726,7 @@ module userlibrary_example_nested_mod
         ! Function:  int getValue
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         function c_exclass2_get_value_int(self) &
                 result(SHT_rv) &
                 bind(C, name="AA_example_nested_ExClass2_get_value_int")
@@ -741,7 +741,7 @@ module userlibrary_example_nested_mod
         ! Function:  double getValue
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         function c_exclass2_get_value_double(self) &
                 result(SHT_rv) &
                 bind(C, name="AA_example_nested_ExClass2_get_value_double")
@@ -769,7 +769,7 @@ module userlibrary_example_nested_mod
         ! Function:  bool isNameValid
         ! Attrs:     +intent(function)
         ! Requested: c_function_bool_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  const std::string & name
         ! Attrs:     +intent(in)
@@ -787,7 +787,7 @@ module userlibrary_example_nested_mod
         ! Function:  bool isNameValid
         ! Attrs:     +intent(function)
         ! Requested: c_function_bool_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  const std::string & name
         ! Attrs:     +api(buf)+intent(in)
@@ -806,7 +806,7 @@ module userlibrary_example_nested_mod
         ! Function:  bool isInitialized
         ! Attrs:     +intent(function)
         ! Requested: c_function_bool_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         function c_is_initialized() &
                 result(SHT_rv) &
                 bind(C, name="AA_example_nested_is_initialized")
@@ -947,7 +947,7 @@ module userlibrary_example_nested_mod
         ! Function:  size_t test_size_t
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         function test_size_t() &
                 result(SHT_rv) &
                 bind(C, name="AA_example_nested_test_size_t")
@@ -1150,7 +1150,7 @@ module userlibrary_example_nested_mod
         ! Function:  int verylongfunctionname2
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  int verylongname1 +value
         ! Attrs:     +intent(in)
@@ -1368,10 +1368,10 @@ contains
     ! Function:  int incrementCount
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  int incr +value
     ! Attrs:     +intent(in)
@@ -1441,10 +1441,10 @@ contains
     ! Function:  int getValue
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  int value +value
     ! Attrs:     +intent(in)
@@ -1468,10 +1468,10 @@ contains
     ! Function:  long getValue
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  long value +value
     ! Attrs:     +intent(in)
@@ -1498,7 +1498,7 @@ contains
     ! Match:     f_function_bool
     ! Attrs:     +intent(function)
     ! Requested: c_function_bool_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  bool in +value
     ! Attrs:     +intent(in)
@@ -1682,10 +1682,10 @@ contains
     ! Function:  int GetNameLength
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     !>
     !! \brief helper function for Fortran
     !!
@@ -1859,10 +1859,10 @@ contains
     ! Function:  TypeID getTypeID
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     function exclass2_get_type_id(obj) &
             result(SHT_rv)
         use iso_c_binding, only : C_INT
@@ -1974,10 +1974,10 @@ contains
     ! Function:  int getValue
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     function exclass2_get_value_int(obj) &
             result(SHT_rv)
         use iso_c_binding, only : C_INT
@@ -1993,10 +1993,10 @@ contains
     ! Function:  double getValue
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     function exclass2_get_value_double(obj) &
             result(SHT_rv)
         use iso_c_binding, only : C_DOUBLE
@@ -2033,7 +2033,7 @@ contains
     ! Match:     f_function_bool
     ! Attrs:     +intent(function)
     ! Requested: c_function_bool_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const std::string & name
     ! Attrs:     +intent(in)
@@ -2057,7 +2057,7 @@ contains
     ! Match:     f_function_bool
     ! Attrs:     +intent(function)
     ! Requested: c_function_bool_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     function is_initialized() &
             result(SHT_rv)
         use iso_c_binding, only : C_BOOL
@@ -2368,10 +2368,10 @@ contains
     ! Function:  int verylongfunctionname2
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  int verylongname1 +value
     ! Attrs:     +intent(in)

--- a/regression/reference/example/wrapfUserLibrary_example_nested.f
+++ b/regression/reference/example/wrapfUserLibrary_example_nested.f
@@ -1348,8 +1348,7 @@ contains
     ! ----------------------------------------
     ! Function:  ~ExClass1
     ! Attrs:     +intent(dtor)
-    ! Requested: f_dtor
-    ! Match:     f_default
+    ! Exact:     f_dtor
     ! Attrs:     +intent(dtor)
     ! Exact:     c_dtor
     !>
@@ -1583,8 +1582,7 @@ contains
     ! ----------------------------------------
     ! Function:  ~ExClass2
     ! Attrs:     +intent(dtor)
-    ! Requested: f_dtor
-    ! Match:     f_default
+    ! Exact:     f_dtor
     ! Attrs:     +intent(dtor)
     ! Exact:     c_dtor
     !>

--- a/regression/reference/forward/forward.json
+++ b/regression/reference/forward/forward.json
@@ -218,7 +218,7 @@
                             "c_var": "self",
                             "function_name": "dtor",
                             "stmt0": "f_dtor",
-                            "stmt1": "f_default",
+                            "stmt1": "f_dtor",
                             "stmtc0": "c_dtor",
                             "stmtc1": "c_dtor",
                             "underscore_name": "dtor"

--- a/regression/reference/forward/forward.json
+++ b/regression/reference/forward/forward.json
@@ -713,7 +713,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -725,9 +725,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             }

--- a/regression/reference/forward/wrapfforward.f
+++ b/regression/reference/forward/wrapfforward.f
@@ -205,8 +205,7 @@ contains
     ! ----------------------------------------
     ! Function:  ~Class2
     ! Attrs:     +intent(dtor)
-    ! Requested: f_dtor
-    ! Match:     f_default
+    ! Exact:     f_dtor
     ! Attrs:     +intent(dtor)
     ! Exact:     c_dtor
     subroutine class2_dtor(obj)

--- a/regression/reference/forward/wrapfforward.f
+++ b/regression/reference/forward/wrapfforward.f
@@ -136,7 +136,7 @@ module forward_mod
         ! Function:  int passStruct1
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  const Cstruct1 * arg
         ! Attrs:     +intent(in)
@@ -291,10 +291,10 @@ contains
     ! Function:  int passStruct1
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const Cstruct1 * arg
     ! Attrs:     +intent(in)

--- a/regression/reference/forward/wrapforward.cpp
+++ b/regression/reference/forward/wrapforward.cpp
@@ -23,7 +23,7 @@ extern "C" {
 // Function:  int passStruct1
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  const Cstruct1 * arg
 // Attrs:     +intent(in)

--- a/regression/reference/generic-cfi/generic.json
+++ b/regression/reference/generic-cfi/generic.json
@@ -273,7 +273,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -285,9 +285,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -800,7 +800,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_LONG",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -898,9 +898,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_LONG",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -992,9 +992,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_LONG",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -1158,7 +1158,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -1170,9 +1170,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -1350,7 +1350,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",

--- a/regression/reference/generic-cfi/wrapfgeneric.f
+++ b/regression/reference/generic-cfi/wrapfgeneric.f
@@ -127,7 +127,7 @@ module generic_mod
     ! Function:  double GetGlobalDouble
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     interface
         function get_global_double() &
                 result(SHT_rv) &
@@ -163,7 +163,7 @@ module generic_mod
     ! Function:  long GenericReal2
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  long arg1 +value
     ! Attrs:     +intent(in)
@@ -190,7 +190,7 @@ module generic_mod
     ! Function:  int SumValues
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const int * values +dimension(..)
     ! Attrs:     +assumed-rank+intent(in)
@@ -217,7 +217,7 @@ module generic_mod
     ! Function:  int SumValues
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const int * values +dimension(..)
     ! Attrs:     +api(cfi)+assumed-rank+intent(in)
@@ -870,10 +870,10 @@ contains
     ! Function:  long GenericReal2
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  int arg1 +value
     ! Attrs:     +intent(in)
@@ -914,10 +914,10 @@ contains
     ! Function:  long GenericReal2
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  long arg1 +value
     ! Attrs:     +intent(in)

--- a/regression/reference/generic-cfi/wrapgeneric.c
+++ b/regression/reference/generic-cfi/wrapgeneric.c
@@ -23,7 +23,7 @@
 // Function:  int SumValues
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  const int * values +dimension(..)
 // Attrs:     +api(cfi)+assumed-rank+intent(in)

--- a/regression/reference/generic/generic.json
+++ b/regression/reference/generic/generic.json
@@ -273,7 +273,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -285,9 +285,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -800,7 +800,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_LONG",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -898,9 +898,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_LONG",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -992,9 +992,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_LONG",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -1284,7 +1284,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -1480,7 +1480,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -1492,9 +1492,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -1685,7 +1685,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -1697,9 +1697,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -1890,7 +1890,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -1902,9 +1902,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },

--- a/regression/reference/generic/wrapfgeneric.f
+++ b/regression/reference/generic/wrapfgeneric.f
@@ -127,7 +127,7 @@ module generic_mod
     ! Function:  double GetGlobalDouble
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     interface
         function get_global_double() &
                 result(SHT_rv) &
@@ -163,7 +163,7 @@ module generic_mod
     ! Function:  long GenericReal2
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  long arg1 +value
     ! Attrs:     +intent(in)
@@ -190,7 +190,7 @@ module generic_mod
     ! Function:  int SumValues
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const int * values
     ! Attrs:     +assumed-rank+intent(in)
@@ -217,7 +217,7 @@ module generic_mod
     ! Function:  int SumValues
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const int * values +rank(0)
     ! Attrs:     +assumed-rank+intent(in)
@@ -244,7 +244,7 @@ module generic_mod
     ! Function:  int SumValues
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const int * values +rank(1)
     ! Attrs:     +assumed-rank+intent(in)
@@ -271,7 +271,7 @@ module generic_mod
     ! Function:  int SumValues
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const int * values +rank(2)
     ! Attrs:     +assumed-rank+intent(in)
@@ -931,10 +931,10 @@ contains
     ! Function:  long GenericReal2
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  int arg1 +value
     ! Attrs:     +intent(in)
@@ -975,10 +975,10 @@ contains
     ! Function:  long GenericReal2
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  long arg1 +value
     ! Attrs:     +intent(in)
@@ -1017,10 +1017,10 @@ contains
     ! Function:  int SumValues
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const int * values +rank(0)
     ! Attrs:     +assumed-rank+intent(in)
@@ -1057,10 +1057,10 @@ contains
     ! Function:  int SumValues
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const int * values +rank(1)
     ! Attrs:     +assumed-rank+intent(in)
@@ -1097,10 +1097,10 @@ contains
     ! Function:  int SumValues
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const int * values +rank(2)
     ! Attrs:     +assumed-rank+intent(in)

--- a/regression/reference/generic/wrapgeneric.c
+++ b/regression/reference/generic/wrapgeneric.c
@@ -23,7 +23,7 @@
 // Function:  int SumValues
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  const int * values +rank(0)
 // Attrs:     +assumed-rank+intent(in)
@@ -50,7 +50,7 @@ int GEN_sum_values_0d(const int * values, int nvalues)
 // Function:  int SumValues
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  const int * values +rank(1)
 // Attrs:     +assumed-rank+intent(in)
@@ -77,7 +77,7 @@ int GEN_sum_values_1d(const int * values, int nvalues)
 // Function:  int SumValues
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  const int * values +rank(2)
 // Attrs:     +assumed-rank+intent(in)

--- a/regression/reference/interface/interface.json
+++ b/regression/reference/interface/interface.json
@@ -218,7 +218,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -230,9 +230,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             }

--- a/regression/reference/interface/wrapfinterface.f
+++ b/regression/reference/interface/wrapfinterface.f
@@ -36,7 +36,7 @@ module interface_mod
         ! Function:  double Function2
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  double arg1 +value
         ! Attrs:     +intent(in)

--- a/regression/reference/names/names.json
+++ b/regression/reference/names/names.json
@@ -1039,7 +1039,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -1051,9 +1051,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -1184,7 +1184,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2371,7 +2371,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2383,9 +2383,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -2551,7 +2551,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2563,9 +2563,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",

--- a/regression/reference/names/top.cpp
+++ b/regression/reference/names/top.cpp
@@ -170,7 +170,7 @@ void YYY_TES_function3a_1(long i)
 // Function:  int function4
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  const std::string & rv
 // Attrs:     +intent(in)
@@ -188,7 +188,7 @@ int YYY_TES_function4(const char * rv)
 // Function:  int function4
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  const std::string & rv
 // Attrs:     +api(buf)+intent(in)
@@ -320,7 +320,7 @@ void TES_function_tu_instantiation2(float arg1, double arg2)
 // Function:  int UseImplWorker
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 int TES_use_impl_worker_instantiation3(void)
 {
     // splicer begin function.use_impl_worker_instantiation3
@@ -333,7 +333,7 @@ int TES_use_impl_worker_instantiation3(void)
 // Function:  int Cstruct_as_class_sum
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  const Cstruct_as_class * point +pass
 // Attrs:     +intent(in)

--- a/regression/reference/names/top.f
+++ b/regression/reference/names/top.f
@@ -217,7 +217,7 @@ module top_module
         ! Function:  int function4
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  const std::string & rv
         ! Attrs:     +intent(in)
@@ -235,7 +235,7 @@ module top_module
         ! Function:  int function4
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  const std::string & rv
         ! Attrs:     +api(buf)+intent(in)
@@ -356,7 +356,7 @@ module top_module
         ! Function:  int UseImplWorker
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         function c_use_impl_worker_instantiation3() &
                 result(SHT_rv) &
                 bind(C, name="TES_use_impl_worker_instantiation3")
@@ -369,7 +369,7 @@ module top_module
         ! Function:  int Cstruct_as_class_sum
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  const Cstruct_as_class * point +pass
         ! Attrs:     +intent(in)
@@ -625,10 +625,10 @@ contains
     ! Function:  int function4
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const std::string & rv
     ! Attrs:     +intent(in)
@@ -768,10 +768,10 @@ contains
     ! Function:  int UseImplWorker
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     !>
     !! \brief Function which uses a templated T in the implemetation.
     !!
@@ -789,10 +789,10 @@ contains
     ! Function:  int Cstruct_as_class_sum
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const Cstruct_as_class * point +pass
     ! Attrs:     +intent(in)

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -118,6 +118,7 @@ root
       inout
         array
           buf -- c_mixin_inout_array_buf
+      noargs -- c_mixin_noargs
       out
         array
           buf -- c_mixin_out_array_buf
@@ -332,6 +333,8 @@ c_ctor:
   cxx_local_var: pointer
   f_arg_decl:
   - 'type({f_capsule_data_type}), intent({f_intent}) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   f_module_line: '{f_c_module_line}'
   intent: ctor
   name: c_ctor
@@ -390,6 +393,8 @@ c_function_char_*_buf_allocatable:
   c_helper: ShroudTypeDefines
   f_arg_decl:
   - 'type({F_array_type}), intent(OUT) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   f_import:
   - '{F_array_type}'
   intent: function
@@ -415,6 +420,8 @@ c_function_char_*_cfi:
   cxx_local_var: result
   f_arg_decl:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   iface_header:
   - ISO_Fortran_binding.h
   intent: function
@@ -467,6 +474,8 @@ c_function_char_scalar_cfi:
   - CFI_cdesc_t *{c_var_cfi}
   f_arg_decl:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   iface_header:
   - ISO_Fortran_binding.h
   impl_header:
@@ -515,6 +524,8 @@ c_function_native_*_buf:
   c_helper: ShroudTypeDefines array_context
   f_arg_decl:
   - 'type({F_array_type}), intent(OUT) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   f_import:
   - '{F_array_type}'
   intent: function
@@ -547,6 +558,8 @@ c_function_shadow:
   cxx_local_var: result
   f_arg_decl:
   - 'type({f_capsule_data_type}), intent({f_intent}) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   f_module_line: '{f_c_module_line}'
   intent: function
   name: c_function_shadow
@@ -564,6 +577,8 @@ c_function_shadow_scalar:
   cxx_local_var: pointer
   f_arg_decl:
   - 'type({f_capsule_data_type}), intent({f_intent}) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   f_module_line: '{f_c_module_line}'
   intent: function
   name: c_function_shadow_scalar
@@ -618,6 +633,8 @@ c_function_string_&_buf_allocatable:
   c_helper: ShroudStrToArray
   f_arg_decl:
   - 'type({F_array_type}), intent(OUT) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   f_import:
   - '{F_array_type}'
   intent: function
@@ -636,6 +653,8 @@ c_function_string_&_cfi:
   c_helper: ShroudStrCopy
   f_arg_decl:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   iface_header:
   - ISO_Fortran_binding.h
   intent: function
@@ -721,6 +740,8 @@ c_function_string_*_buf_allocatable:
   c_helper: ShroudStrToArray
   f_arg_decl:
   - 'type({F_array_type}), intent(OUT) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   f_import:
   - '{F_array_type}'
   intent: function
@@ -739,6 +760,8 @@ c_function_string_*_cfi:
   c_helper: ShroudStrCopy
   f_arg_decl:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   iface_header:
   - ISO_Fortran_binding.h
   intent: function
@@ -826,6 +849,8 @@ c_function_string_scalar_buf_allocatable:
   destructor_name: new_string
   f_arg_decl:
   - 'type({F_array_type}), intent(OUT) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   f_import:
   - '{F_array_type}'
   intent: function
@@ -846,6 +871,8 @@ c_function_string_scalar_cfi:
   c_helper: ShroudStrCopy
   f_arg_decl:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   iface_header:
   - ISO_Fortran_binding.h
   intent: function
@@ -917,6 +944,8 @@ c_function_vector_buf:
   destructor_name: std_vector_{cxx_T}
   f_arg_decl:
   - 'type({F_array_type}), intent(OUT) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   f_import:
   - '{F_array_type}'
   intent: function
@@ -959,6 +988,8 @@ c_getter_string_scalar_buf:
   - // skip call c_getter
   f_arg_decl:
   - 'type({F_array_type}), intent(OUT) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   f_import:
   - '{F_array_type}'
   intent: getter
@@ -979,6 +1010,8 @@ c_in_char_**:
   - char **{c_var}
   f_arg_decl:
   - 'type(C_PTR), intent(IN) :: {c_var}(*)'
+  f_c_arg_names:
+  - '{c_var}'
   f_module:
     iso_c_binding:
     - C_PTR
@@ -1021,6 +1054,8 @@ c_in_char_*_cfi:
   cxx_local_var: pointer
   f_arg_decl:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   iface_header:
   - ISO_Fortran_binding.h
   intent: in
@@ -1040,6 +1075,8 @@ c_in_char_scalar:
   - char {c_var}
   f_arg_decl:
   - 'character(kind=C_CHAR), value, intent(IN) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   f_module:
     iso_c_binding:
     - C_CHAR
@@ -1053,6 +1090,8 @@ c_in_native_**:
   - '{cxx_type} **{cxx_var}'
   f_arg_decl:
   - 'type(C_PTR), intent(IN), value :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   f_module:
     iso_c_binding:
     - C_PTR
@@ -1086,6 +1125,8 @@ c_in_native_*_cfi:
   cxx_local_var: pointer
   f_arg_decl:
   - '{f_type}, intent({f_intent}) :: {c_var}{f_c_dimension}'
+  f_c_arg_names:
+  - '{c_var}'
   f_module_line: iso_c_binding:{f_kind}
   iface_header:
   - ISO_Fortran_binding.h
@@ -1102,6 +1143,8 @@ c_in_shadow:
   cxx_local_var: pointer
   f_arg_decl:
   - 'type({f_capsule_data_type}), intent({f_intent}) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   f_module_line: '{f_c_module_line}'
   intent: in/inout
   name: c_in_shadow
@@ -1149,6 +1192,8 @@ c_in_string_&_cfi:
   cxx_local_var: scalar
   f_arg_decl:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   iface_header:
   - ISO_Fortran_binding.h
   intent: in
@@ -1203,6 +1248,8 @@ c_in_string_*_cfi:
   cxx_local_var: scalar
   f_arg_decl:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   iface_header:
   - ISO_Fortran_binding.h
   intent: in
@@ -1223,6 +1270,8 @@ c_in_string_scalar:
   - char *{c_var}
   f_arg_decl:
   - 'character(kind=C_CHAR), intent(IN) :: {c_var}(*)'
+  f_c_arg_names:
+  - '{c_var}'
   f_module:
     iso_c_binding:
     - C_CHAR
@@ -1267,6 +1316,8 @@ c_in_string_scalar_cfi:
   cxx_local_var: scalar
   f_arg_decl:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   iface_header:
   - ISO_Fortran_binding.h
   intent: in
@@ -1356,6 +1407,8 @@ c_in_void_**:
   - void **{c_var}
   f_arg_decl:
   - 'type(C_PTR), intent(IN) :: {c_var}{f_c_dimension}'
+  f_c_arg_names:
+  - '{c_var}'
   f_module:
     iso_c_binding:
     - C_PTR
@@ -1418,6 +1471,8 @@ c_inout_char_*_cfi:
   cxx_local_var: pointer
   f_arg_decl:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   iface_header:
   - ISO_Fortran_binding.h
   intent: inout
@@ -1458,6 +1513,8 @@ c_inout_shadow:
   cxx_local_var: pointer
   f_arg_decl:
   - 'type({f_capsule_data_type}), intent({f_intent}) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   f_module_line: '{f_c_module_line}'
   intent: in/inout
   name: c_inout_shadow
@@ -1511,6 +1568,8 @@ c_inout_string_&_cfi:
   cxx_local_var: scalar
   f_arg_decl:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   iface_header:
   - ISO_Fortran_binding.h
   intent: inout
@@ -1574,6 +1633,8 @@ c_inout_string_*_cfi:
   cxx_local_var: scalar
   f_arg_decl:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   iface_header:
   - ISO_Fortran_binding.h
   intent: inout
@@ -1715,6 +1776,8 @@ c_mixin_arg_character_cfi:
   cxx_local_var: pointer
   f_arg_decl:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   iface_header:
   - ISO_Fortran_binding.h
   intent: mixin
@@ -1731,6 +1794,8 @@ c_mixin_function_buf:
   - '{C_array_type} *{c_var_cdesc}'
   f_arg_decl:
   - 'type({F_array_type}), intent(OUT) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   f_import:
   - '{F_array_type}'
   intent: mixin
@@ -1746,6 +1811,8 @@ c_mixin_function_character:
   - CFI_cdesc_t *{c_var_cfi}
   f_arg_decl:
   - 'XXX-unused character(len=*), intent({f_intent}) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   iface_header:
   - ISO_Fortran_binding.h
   intent: mixin
@@ -1839,6 +1906,10 @@ c_mixin_inout_array_buf:
   temps:
   - size
   - cdesc
+c_mixin_noargs:
+  intent: mixin
+  name: c_mixin_noargs
+  owner: library
 c_mixin_out_array_buf:
   buf_args:
   - arg_decl
@@ -1863,6 +1934,8 @@ c_mixin_out_character_buf:
   - '{C_array_type} *{c_var_cdesc}'
   f_arg_decl:
   - 'type({F_array_type}), intent(OUT) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   f_import:
   - '{F_array_type}'
   intent: mixin
@@ -1877,6 +1950,8 @@ c_mixin_shadow:
   - '{c_type} * {c_var}'
   f_arg_decl:
   - 'type({f_capsule_data_type}), intent({f_intent}) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   f_module_line: '{f_c_module_line}'
   intent: mixin
   name: c_mixin_shadow
@@ -1914,6 +1989,8 @@ c_out_char_*_cfi:
   cxx_local_var: pointer
   f_arg_decl:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   iface_header:
   - ISO_Fortran_binding.h
   intent: out
@@ -2049,6 +2126,8 @@ c_out_string_&_cfi:
   cxx_local_var: scalar
   f_arg_decl:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   iface_header:
   - ISO_Fortran_binding.h
   intent: out
@@ -2109,6 +2188,8 @@ c_out_string_*_cfi:
   cxx_local_var: scalar
   f_arg_decl:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
+  f_c_arg_names:
+  - '{c_var}'
   iface_header:
   - ISO_Fortran_binding.h
   intent: out

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -151,6 +151,7 @@ root
         *
           cdesc -- c_in/out/inout_void_*_cdesc
     setter -- c_setter
+      arg -- c_setter_arg
       native
         scalar -- c_setter_native_scalar
       string
@@ -2126,9 +2127,10 @@ c_setter:
   - // skip call c_setter
   name: c_setter
   owner: library
+c_setter_arg:
+  name: c_setter_arg
+  owner: library
 c_setter_native_scalar:
-  call:
-  - // skip call c_setter
   name: c_setter_native_scalar
   owner: library
   post_call:
@@ -2139,8 +2141,6 @@ c_setter_string_scalar_buf:
   c_arg_decl:
   - char *{c_var}
   - int {c_var_len}
-  call:
-  - // skip call c_setter
   f_arg_decl:
   - 'character(kind=C_CHAR), intent({f_intent}) :: {c_var}(*)'
   - 'integer(C_INT), value, intent(IN) :: {c_var_len}'

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -3,7 +3,7 @@ root
   c
     ctor -- c_ctor
     dtor -- c_dtor
-    function
+    function -- c_function
       char
         * -- c_function_char_*
           buf -- c_function_char_*_buf
@@ -162,7 +162,7 @@ root
       string
         scalar -- f_XXXin_string_scalar
     ctor -- f_ctor
-    function
+    function -- f_function
       bool -- f_function_bool
       char
         *
@@ -344,6 +344,9 @@ c_dtor:
   name: c_dtor
   owner: library
   return_type: void
+c_function:
+  name: c_function
+  owner: library
 c_function_char_*:
   name: c_function_char_*
   owner: library
@@ -2173,6 +2176,8 @@ f_ctor:
   - '{f_var}%{F_derived_member}'
   name: f_ctor
   need_wrapper: true
+f_function:
+  name: f_function
 f_function_bool:
   name: f_function_bool
   need_wrapper: true

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -164,6 +164,7 @@ root
       string
         scalar -- f_XXXin_string_scalar
     ctor -- f_ctor
+    dtor -- f_dtor
     function -- f_function
       bool -- f_function_bool
       char
@@ -317,6 +318,7 @@ root
           cdesc -- f_in/out/inout_void_*_cdesc
         ** -- f_out_void_**
     setter -- f_setter
+      native -- f_setter_native
       string
         scalar
           buf -- f_setter_string_scalar_buf
@@ -2363,6 +2365,9 @@ f_ctor:
   intent: ctor
   name: f_ctor
   need_wrapper: true
+f_dtor:
+  intent: dtor
+  name: f_dtor
 f_function:
   intent: function
   name: f_function
@@ -3319,6 +3324,11 @@ f_out_void_*_cdesc:
 f_setter:
   intent: setter
   name: f_setter
+f_setter_native:
+  arg_c_call:
+  - '{c_var}'
+  intent: setter
+  name: f_setter_native
 f_setter_string_scalar_buf:
   arg_c_call:
   - '{f_var}'

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -333,6 +333,7 @@ c_ctor:
   f_arg_decl:
   - 'type({f_capsule_data_type}), intent({f_intent}) :: {c_var}'
   f_module_line: '{f_c_module_line}'
+  intent: ctor
   name: c_ctor
   owner: caller
   return_type: void
@@ -342,13 +343,16 @@ c_dtor:
   - '{C_this}->addr = {nullptr};'
   impl_header:
   - <cstddef>
+  intent: dtor
   name: c_dtor
   owner: library
   return_type: void
 c_function:
+  intent: function
   name: c_function
   owner: library
 c_function_char_*:
+  intent: function
   name: c_function_char_*
   owner: library
   return_cptr: true
@@ -370,6 +374,7 @@ c_function_char_*_buf:
     iso_c_binding:
     - C_CHAR
     - C_INT
+  intent: function
   name: c_function_char_*_buf
   owner: library
   post_call:
@@ -387,6 +392,7 @@ c_function_char_*_buf_allocatable:
   - 'type({F_array_type}), intent(OUT) :: {c_var}'
   f_import:
   - '{F_array_type}'
+  intent: function
   name: c_function_char_*_buf_allocatable
   owner: library
   post_call:
@@ -411,6 +417,7 @@ c_function_char_*_cfi:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
   iface_header:
   - ISO_Fortran_binding.h
+  intent: function
   name: c_function_char_*_cfi
   owner: library
   post_call:
@@ -430,6 +437,7 @@ c_function_char_*_cfi_allocatable:
   - '{c_var}'
   iface_header:
   - ISO_Fortran_binding.h
+  intent: function
   name: c_function_char_*_cfi_allocatable
   owner: library
   post_call:
@@ -449,6 +457,7 @@ c_function_char_scalar:
     - C_CHAR
   f_result_decl:
   - 'character(kind=C_CHAR) :: {c_var}'
+  intent: function
   name: c_function_char_scalar
   owner: library
 c_function_char_scalar_cfi:
@@ -462,6 +471,7 @@ c_function_char_scalar_cfi:
   - ISO_Fortran_binding.h
   impl_header:
   - <cstring>
+  intent: function
   name: c_function_char_scalar_cfi
   owner: library
   post_call:
@@ -476,6 +486,7 @@ c_function_native_&:
     - C_PTR
   f_result_decl:
   - type(C_PTR) {c_var}
+  intent: function
   name: c_function_native_&
   owner: library
 c_function_native_*:
@@ -484,6 +495,7 @@ c_function_native_*:
     - C_PTR
   f_result_decl:
   - type(C_PTR) {c_var}
+  intent: function
   name: c_function_native_*
   owner: library
 c_function_native_**:
@@ -492,6 +504,7 @@ c_function_native_**:
     - C_PTR
   f_result_decl:
   - type(C_PTR) {c_var}
+  intent: function
   name: c_function_native_**
   owner: library
 c_function_native_*_buf:
@@ -504,6 +517,7 @@ c_function_native_*_buf:
   - 'type({F_array_type}), intent(OUT) :: {c_var}'
   f_import:
   - '{F_array_type}'
+  intent: function
   name: c_function_native_*_buf
   owner: library
   post_call:
@@ -522,6 +536,7 @@ c_function_native_*_scalar:
   f_module_line: iso_c_binding:{f_kind}
   f_result_decl:
   - '{f_type} :: {c_var}'
+  intent: function
   name: c_function_native_*_scalar
   owner: library
 c_function_shadow:
@@ -533,6 +548,7 @@ c_function_shadow:
   f_arg_decl:
   - 'type({f_capsule_data_type}), intent({f_intent}) :: {c_var}'
   f_module_line: '{f_c_module_line}'
+  intent: function
   name: c_function_shadow
   owner: library
   post_call:
@@ -549,6 +565,7 @@ c_function_shadow_scalar:
   f_arg_decl:
   - 'type({f_capsule_data_type}), intent({f_intent}) :: {c_var}'
   f_module_line: '{f_c_module_line}'
+  intent: function
   name: c_function_shadow_scalar
   owner: caller
   post_call:
@@ -558,6 +575,7 @@ c_function_shadow_scalar:
   - '{cxx_type} * {cxx_var} = new {cxx_type};'
   return_type: void
 c_function_string_&:
+  intent: function
   name: c_function_string_&
   owner: library
   ret:
@@ -580,6 +598,7 @@ c_function_string_&_buf:
     iso_c_binding:
     - C_CHAR
     - C_INT
+  intent: function
   name: c_function_string_&_buf
   owner: library
   post_call:
@@ -601,6 +620,7 @@ c_function_string_&_buf_allocatable:
   - 'type({F_array_type}), intent(OUT) :: {c_var}'
   f_import:
   - '{F_array_type}'
+  intent: function
   name: c_function_string_&_buf_allocatable
   owner: library
   post_call:
@@ -618,6 +638,7 @@ c_function_string_&_cfi:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
   iface_header:
   - ISO_Fortran_binding.h
+  intent: function
   name: c_function_string_&_cfi
   owner: library
   post_call:
@@ -644,6 +665,7 @@ c_function_string_&_cfi_allocatable:
   - ISO_Fortran_binding.h
   impl_header:
   - <cstring>
+  intent: function
   name: c_function_string_&_cfi_allocatable
   owner: library
   post_call:
@@ -656,6 +678,7 @@ c_function_string_&_cfi_allocatable:
   temps:
   - cfi
 c_function_string_*:
+  intent: function
   name: c_function_string_*
   owner: library
   ret:
@@ -678,6 +701,7 @@ c_function_string_*_buf:
     iso_c_binding:
     - C_CHAR
     - C_INT
+  intent: function
   name: c_function_string_*_buf
   owner: library
   post_call:
@@ -699,6 +723,7 @@ c_function_string_*_buf_allocatable:
   - 'type({F_array_type}), intent(OUT) :: {c_var}'
   f_import:
   - '{F_array_type}'
+  intent: function
   name: c_function_string_*_buf_allocatable
   owner: library
   post_call:
@@ -716,6 +741,7 @@ c_function_string_*_cfi:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
   iface_header:
   - ISO_Fortran_binding.h
+  intent: function
   name: c_function_string_*_cfi
   owner: library
   post_call:
@@ -742,6 +768,7 @@ c_function_string_*_cfi_allocatable:
   - ISO_Fortran_binding.h
   impl_header:
   - <cstring>
+  intent: function
   name: c_function_string_*_cfi_allocatable
   owner: library
   post_call:
@@ -754,6 +781,7 @@ c_function_string_*_cfi_allocatable:
   temps:
   - cfi
 c_function_string_scalar:
+  intent: function
   name: c_function_string_scalar
   owner: library
   ret:
@@ -776,6 +804,7 @@ c_function_string_scalar_buf:
     iso_c_binding:
     - C_CHAR
     - C_INT
+  intent: function
   name: c_function_string_scalar_buf
   owner: library
   post_call:
@@ -799,6 +828,7 @@ c_function_string_scalar_buf_allocatable:
   - 'type({F_array_type}), intent(OUT) :: {c_var}'
   f_import:
   - '{F_array_type}'
+  intent: function
   name: c_function_string_scalar_buf_allocatable
   owner: library
   post_call:
@@ -818,6 +848,7 @@ c_function_string_scalar_cfi:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
   iface_header:
   - ISO_Fortran_binding.h
+  intent: function
   name: c_function_string_scalar_cfi
   owner: library
   post_call:
@@ -843,6 +874,7 @@ c_function_string_scalar_cfi_allocatable:
   - '{c_var}'
   iface_header:
   - ISO_Fortran_binding.h
+  intent: function
   name: c_function_string_scalar_cfi_allocatable
   owner: library
   post_call:
@@ -856,6 +888,7 @@ c_function_string_scalar_cfi_allocatable:
   - cfi
 c_function_struct:
   c_local_var: pointer
+  intent: function
   name: c_function_struct
   owner: library
   post_call:
@@ -868,6 +901,7 @@ c_function_struct_*:
     - C_PTR
   f_result_decl:
   - type(C_PTR) {c_var}
+  intent: function
   name: c_function_struct_*
   owner: library
   post_call:
@@ -885,6 +919,7 @@ c_function_vector_buf:
   - 'type({F_array_type}), intent(OUT) :: {c_var}'
   f_import:
   - '{F_array_type}'
+  intent: function
   name: c_function_vector_buf
   owner: library
   post_call:
@@ -904,11 +939,13 @@ c_function_vector_buf:
 c_getter:
   call:
   - // skip call c_getter
+  intent: getter
   name: c_getter
   owner: library
 c_getter_native_scalar:
   call:
   - // skip call c_getter
+  intent: getter
   name: c_getter_native_scalar
   owner: library
   ret:
@@ -924,6 +961,7 @@ c_getter_string_scalar_buf:
   - 'type({F_array_type}), intent(OUT) :: {c_var}'
   f_import:
   - '{F_array_type}'
+  intent: getter
   name: c_getter_string_scalar_buf
   owner: library
   post_call:
@@ -944,6 +982,7 @@ c_in_char_**:
   f_module:
     iso_c_binding:
     - C_PTR
+  intent: in
   name: c_in_char_**
   owner: library
 c_in_char_**_buf:
@@ -964,6 +1003,7 @@ c_in_char_**_buf:
   - '{c_var_size}'
   - '{c_var_len}'
   f_module_line: iso_c_binding:C_CHAR,C_SIZE_T,C_INT
+  intent: in
   name: c_in_char_**_buf
   owner: library
   post_call:
@@ -983,6 +1023,7 @@ c_in_char_*_cfi:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
   iface_header:
   - ISO_Fortran_binding.h
+  intent: in
   name: c_in_char_*_cfi
   owner: library
   post_call:
@@ -1002,6 +1043,7 @@ c_in_char_scalar:
   f_module:
     iso_c_binding:
     - C_CHAR
+  intent: in
   name: c_in_char_scalar
   owner: library
 c_in_native_**:
@@ -1014,6 +1056,7 @@ c_in_native_**:
   f_module:
     iso_c_binding:
     - C_PTR
+  intent: in
   name: c_in_native_**
   owner: library
 c_in_native_*_cdesc:
@@ -1028,6 +1071,7 @@ c_in_native_*_cdesc:
   - '{c_var_cdesc}'
   f_import:
   - '{F_array_type}'
+  intent: in/out/inout
   name: c_in_native_*_cdesc
   owner: library
   pre_call:
@@ -1045,6 +1089,7 @@ c_in_native_*_cfi:
   f_module_line: iso_c_binding:{f_kind}
   iface_header:
   - ISO_Fortran_binding.h
+  intent: in
   name: c_in_native_*_cfi
   owner: library
   pre_call:
@@ -1058,12 +1103,14 @@ c_in_shadow:
   f_arg_decl:
   - 'type({f_capsule_data_type}), intent({f_intent}) :: {c_var}'
   f_module_line: '{f_c_module_line}'
+  intent: in/inout
   name: c_in_shadow
   owner: library
   pre_call:
   - "{c_const}{cxx_type} * {cxx_var} =\t {cast_static}{c_const}{cxx_type} *{cast1}{c_var}->addr{cast2};"
 c_in_string_&:
   cxx_local_var: scalar
+  intent: in
   name: c_in_string_&
   owner: library
   pre_call:
@@ -1086,6 +1133,7 @@ c_in_string_&_buf:
     iso_c_binding:
     - C_CHAR
     - C_INT
+  intent: in
   name: c_in_string_&_buf
   owner: library
   pre_call:
@@ -1103,6 +1151,7 @@ c_in_string_&_cfi:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
   iface_header:
   - ISO_Fortran_binding.h
+  intent: in
   local:
   - trim
   name: c_in_string_&_cfi
@@ -1115,6 +1164,7 @@ c_in_string_&_cfi:
   - cfi
 c_in_string_*:
   cxx_local_var: scalar
+  intent: in
   name: c_in_string_*
   owner: library
   pre_call:
@@ -1137,6 +1187,7 @@ c_in_string_*_buf:
     iso_c_binding:
     - C_CHAR
     - C_INT
+  intent: in
   name: c_in_string_*_buf
   owner: library
   pre_call:
@@ -1154,6 +1205,7 @@ c_in_string_*_cfi:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
   iface_header:
   - ISO_Fortran_binding.h
+  intent: in
   local:
   - trim
   name: c_in_string_*_cfi
@@ -1174,6 +1226,7 @@ c_in_string_scalar:
   f_module:
     iso_c_binding:
     - C_CHAR
+  intent: in
   name: c_in_string_scalar
   owner: library
 c_in_string_scalar_buf:
@@ -1195,6 +1248,7 @@ c_in_string_scalar_buf:
     iso_c_binding:
     - C_CHAR
     - C_INT
+  intent: in
   local:
   - trim
   name: c_in_string_scalar_buf
@@ -1215,6 +1269,7 @@ c_in_string_scalar_cfi:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
   iface_header:
   - ISO_Fortran_binding.h
+  intent: in
   local:
   - trim
   name: c_in_string_scalar_cfi
@@ -1227,6 +1282,7 @@ c_in_string_scalar_cfi:
   - cfi
 c_in_struct:
   cxx_local_var: pointer
+  intent: in/out/inout
   name: c_in_struct
   owner: library
   pre_call:
@@ -1246,6 +1302,7 @@ c_in_vector_buf:
   - '{c_var}'
   - '{c_var_size}'
   f_module_line: iso_c_binding:{f_kind},C_SIZE_T
+  intent: in
   name: c_in_vector_buf
   owner: library
   pre_call:
@@ -1270,6 +1327,7 @@ c_in_vector_buf_string:
   - '{c_var_size}'
   - '{c_var_len}'
   f_module_line: iso_c_binding:C_CHAR,C_SIZE_T,C_INT
+  intent: in
   local:
   - i
   - n
@@ -1301,6 +1359,7 @@ c_in_void_**:
   f_module:
     iso_c_binding:
     - C_PTR
+  intent: in
   name: c_in_void_**
   owner: library
 c_in_void_*_cdesc:
@@ -1315,6 +1374,7 @@ c_in_void_*_cdesc:
   - '{c_var_cdesc}'
   f_import:
   - '{F_array_type}'
+  intent: in/out/inout
   name: c_in_void_*_cdesc
   owner: library
   pre_call:
@@ -1339,6 +1399,7 @@ c_inout_char_*_buf:
     iso_c_binding:
     - C_CHAR
     - C_INT
+  intent: inout
   name: c_inout_char_*_buf
   owner: library
   post_call:
@@ -1359,6 +1420,7 @@ c_inout_char_*_cfi:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
   iface_header:
   - ISO_Fortran_binding.h
+  intent: inout
   name: c_inout_char_*_cfi
   owner: library
   post_call:
@@ -1381,6 +1443,7 @@ c_inout_native_*_cdesc:
   - '{c_var_cdesc}'
   f_import:
   - '{F_array_type}'
+  intent: in/out/inout
   name: c_inout_native_*_cdesc
   owner: library
   pre_call:
@@ -1396,6 +1459,7 @@ c_inout_shadow:
   f_arg_decl:
   - 'type({f_capsule_data_type}), intent({f_intent}) :: {c_var}'
   f_module_line: '{f_c_module_line}'
+  intent: in/inout
   name: c_inout_shadow
   owner: library
   pre_call:
@@ -1404,6 +1468,7 @@ c_inout_string_&:
   cxx_local_var: scalar
   impl_header:
   - <cstring>
+  intent: inout
   name: c_inout_string_&
   owner: library
   post_call:
@@ -1428,6 +1493,7 @@ c_inout_string_&_buf:
     iso_c_binding:
     - C_CHAR
     - C_INT
+  intent: inout
   name: c_inout_string_&_buf
   owner: library
   post_call:
@@ -1447,6 +1513,7 @@ c_inout_string_&_cfi:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
   iface_header:
   - ISO_Fortran_binding.h
+  intent: inout
   local:
   - trim
   name: c_inout_string_&_cfi
@@ -1464,6 +1531,7 @@ c_inout_string_*:
   cxx_local_var: scalar
   impl_header:
   - <cstring>
+  intent: inout
   name: c_inout_string_*
   owner: library
   post_call:
@@ -1488,6 +1556,7 @@ c_inout_string_*_buf:
     iso_c_binding:
     - C_CHAR
     - C_INT
+  intent: inout
   name: c_inout_string_*_buf
   owner: library
   post_call:
@@ -1507,6 +1576,7 @@ c_inout_string_*_cfi:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
   iface_header:
   - ISO_Fortran_binding.h
+  intent: inout
   local:
   - trim
   name: c_inout_string_*_cfi
@@ -1522,6 +1592,7 @@ c_inout_string_*_cfi:
   - cfi
 c_inout_struct:
   cxx_local_var: pointer
+  intent: in/out/inout
   name: c_inout_struct
   owner: library
   pre_call:
@@ -1548,6 +1619,7 @@ c_inout_vector_buf:
   f_import:
   - '{F_array_type}'
   f_module_line: iso_c_binding:{f_kind},C_SIZE_T
+  intent: inout
   name: c_inout_vector_buf
   owner: library
   post_call:
@@ -1582,6 +1654,7 @@ c_inout_vector_buf_string:
   - '{c_var_size}'
   - '{c_var_len}'
   f_module_line: iso_c_binding:C_CHAR,C_SIZE_T,C_INT
+  intent: inout
   local:
   - i
   - n
@@ -1627,6 +1700,7 @@ c_inout_void_*_cdesc:
   - '{c_var_cdesc}'
   f_import:
   - '{F_array_type}'
+  intent: in/out/inout
   name: c_inout_void_*_cdesc
   owner: library
   pre_call:
@@ -1643,6 +1717,7 @@ c_mixin_arg_character_cfi:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
   iface_header:
   - ISO_Fortran_binding.h
+  intent: mixin
   name: c_mixin_arg_character_cfi
   owner: library
   pre_call:
@@ -1658,6 +1733,7 @@ c_mixin_function_buf:
   - 'type({F_array_type}), intent(OUT) :: {c_var}'
   f_import:
   - '{F_array_type}'
+  intent: mixin
   name: c_mixin_function_buf
   owner: library
   return_type: void
@@ -1672,6 +1748,7 @@ c_mixin_function_character:
   - 'XXX-unused character(len=*), intent({f_intent}) :: {c_var}'
   iface_header:
   - ISO_Fortran_binding.h
+  intent: mixin
   name: c_mixin_function_character
   owner: library
   temps:
@@ -1689,6 +1766,7 @@ c_mixin_in_array_buf:
   - '{c_var}'
   - '{c_var_size}'
   f_module_line: iso_c_binding:{f_kind},C_SIZE_T
+  intent: mixin
   name: c_mixin_in_array_buf
   owner: library
   temps:
@@ -1709,6 +1787,7 @@ c_mixin_in_character_buf:
     iso_c_binding:
     - C_CHAR
     - C_INT
+  intent: mixin
   name: c_mixin_in_character_buf
   owner: library
   temps:
@@ -1729,6 +1808,7 @@ c_mixin_in_string_array_buf:
   - '{c_var_size}'
   - '{c_var_len}'
   f_module_line: iso_c_binding:C_CHAR,C_SIZE_T,C_INT
+  intent: mixin
   name: c_mixin_in_string_array_buf
   owner: library
   temps:
@@ -1753,6 +1833,7 @@ c_mixin_inout_array_buf:
   f_import:
   - '{F_array_type}'
   f_module_line: iso_c_binding:{f_kind},C_SIZE_T
+  intent: mixin
   name: c_mixin_inout_array_buf
   owner: library
   temps:
@@ -1770,6 +1851,7 @@ c_mixin_out_array_buf:
   - '{c_var_cdesc}'
   f_import:
   - '{F_array_type}'
+  intent: mixin
   name: c_mixin_out_array_buf
   owner: library
   temps:
@@ -1783,6 +1865,7 @@ c_mixin_out_character_buf:
   - 'type({F_array_type}), intent(OUT) :: {c_var}'
   f_import:
   - '{F_array_type}'
+  intent: mixin
   name: c_mixin_out_character_buf
   owner: library
   temps:
@@ -1795,6 +1878,7 @@ c_mixin_shadow:
   f_arg_decl:
   - 'type({f_capsule_data_type}), intent({f_intent}) :: {c_var}'
   f_module_line: '{f_c_module_line}'
+  intent: mixin
   name: c_mixin_shadow
   owner: library
 c_out_char_*_buf:
@@ -1814,6 +1898,7 @@ c_out_char_*_buf:
     iso_c_binding:
     - C_CHAR
     - C_INT
+  intent: out
   name: c_out_char_*_buf
   owner: library
   post_call:
@@ -1831,6 +1916,7 @@ c_out_char_*_cfi:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
   iface_header:
   - ISO_Fortran_binding.h
+  intent: out
   name: c_out_char_*_cfi
   owner: library
   post_call:
@@ -1853,6 +1939,7 @@ c_out_native_*&_buf:
   - '{c_var_cdesc}'
   f_import:
   - '{F_array_type}'
+  intent: out
   name: c_out_native_*&_buf
   owner: library
   post_call:
@@ -1881,6 +1968,7 @@ c_out_native_**_buf:
   - '{c_var_cdesc}'
   f_import:
   - '{F_array_type}'
+  intent: out
   name: c_out_native_**_buf
   owner: library
   post_call:
@@ -1907,6 +1995,7 @@ c_out_native_*_cdesc:
   - '{c_var_cdesc}'
   f_import:
   - '{F_array_type}'
+  intent: in/out/inout
   name: c_out_native_*_cdesc
   owner: library
   pre_call:
@@ -1917,6 +2006,7 @@ c_out_string_&:
   cxx_local_var: scalar
   impl_header:
   - <cstring>
+  intent: out
   name: c_out_string_&
   owner: library
   post_call:
@@ -1941,6 +2031,7 @@ c_out_string_&_buf:
     iso_c_binding:
     - C_CHAR
     - C_INT
+  intent: out
   name: c_out_string_&_buf
   owner: library
   post_call:
@@ -1960,6 +2051,7 @@ c_out_string_&_cfi:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
   iface_header:
   - ISO_Fortran_binding.h
+  intent: out
   name: c_out_string_&_cfi
   owner: library
   post_call:
@@ -1974,6 +2066,7 @@ c_out_string_*:
   cxx_local_var: scalar
   impl_header:
   - <cstring>
+  intent: out
   name: c_out_string_*
   owner: library
   post_call:
@@ -1998,6 +2091,7 @@ c_out_string_*_buf:
     iso_c_binding:
     - C_CHAR
     - C_INT
+  intent: out
   name: c_out_string_*_buf
   owner: library
   post_call:
@@ -2017,6 +2111,7 @@ c_out_string_*_cfi:
   - 'character(len=*), intent({f_intent}) :: {c_var}'
   iface_header:
   - ISO_Fortran_binding.h
+  intent: out
   name: c_out_string_*_cfi
   owner: library
   post_call:
@@ -2029,6 +2124,7 @@ c_out_string_*_cfi:
   - cfi
 c_out_struct:
   cxx_local_var: pointer
+  intent: in/out/inout
   name: c_out_struct
   owner: library
   pre_call:
@@ -2048,6 +2144,7 @@ c_out_vector_buf:
   - '{c_var_cdesc}'
   f_import:
   - '{F_array_type}'
+  intent: out
   name: c_out_vector_buf
   owner: library
   post_call:
@@ -2081,6 +2178,7 @@ c_out_vector_buf_string:
   - '{c_var_size}'
   - '{c_var_len}'
   f_module_line: iso_c_binding:C_CHAR,C_SIZE_T,C_INT
+  intent: out
   local:
   - i
   - n
@@ -2116,6 +2214,7 @@ c_out_void_*_cdesc:
   - '{c_var_cdesc}'
   f_import:
   - '{F_array_type}'
+  intent: in/out/inout
   name: c_out_void_*_cdesc
   owner: library
   pre_call:
@@ -2125,12 +2224,15 @@ c_out_void_*_cdesc:
 c_setter:
   call:
   - // skip call c_setter
+  intent: setter
   name: c_setter
   owner: library
 c_setter_arg:
+  intent: setter
   name: c_setter_arg
   owner: library
 c_setter_native_scalar:
+  intent: setter
   name: c_setter_native_scalar
   owner: library
   post_call:
@@ -2151,6 +2253,7 @@ c_setter_string_scalar_buf:
     iso_c_binding:
     - C_CHAR
     - C_INT
+  intent: setter
   name: c_setter_string_scalar_buf
   owner: library
   post_call:
@@ -2158,6 +2261,7 @@ c_setter_string_scalar_buf:
   temps:
   - len
 c_subroutine:
+  intent: subroutine
   name: c_subroutine
   owner: library
 f_XXXin_string_scalar:
@@ -2169,16 +2273,20 @@ f_XXXin_string_scalar:
   f_module:
     iso_c_binding:
     - C_INT
+  intent: XXXin
   name: f_XXXin_string_scalar
   need_wrapper: true
 f_ctor:
   arg_c_call:
   - '{f_var}%{F_derived_member}'
+  intent: ctor
   name: f_ctor
   need_wrapper: true
 f_function:
+  intent: function
   name: f_function
 f_function_bool:
+  intent: function
   name: f_function_bool
   need_wrapper: true
 f_function_char_*_buf:
@@ -2188,6 +2296,7 @@ f_function_char_*_buf:
   f_module:
     iso_c_binding:
     - C_INT
+  intent: function
   name: f_function_char_*_buf
   need_wrapper: true
 f_function_char_*_buf_allocatable:
@@ -2199,6 +2308,7 @@ f_function_char_*_buf_allocatable:
   declare:
   - 'type({F_array_type}) :: {c_var_cdesc}'
   f_helper: copy_string array_context
+  intent: function
   name: f_function_char_*_buf_allocatable
   need_wrapper: true
   post_call:
@@ -2209,6 +2319,7 @@ f_function_char_*_buf_allocatable:
 f_function_char_*_cfi:
   arg_c_call:
   - '{f_var}'
+  intent: function
   name: f_function_char_*_cfi
   need_wrapper: true
 f_function_char_*_cfi_allocatable:
@@ -2216,11 +2327,13 @@ f_function_char_*_cfi_allocatable:
   - '{f_var}'
   arg_decl:
   - 'character(len=:), allocatable :: {f_var}'
+  intent: function
   name: f_function_char_*_cfi_allocatable
   need_wrapper: true
 f_function_char_*_raw:
   arg_decl:
   - 'type(C_PTR) :: {f_var}'
+  intent: function
   name: f_function_char_*_raw
 f_function_char_scalar_buf_allocatable:
   arg_c_call:
@@ -2231,6 +2344,7 @@ f_function_char_scalar_buf_allocatable:
   declare:
   - 'type({F_array_type}) :: {c_var_cdesc}'
   f_helper: copy_string array_context
+  intent: function
   name: f_function_char_scalar_buf_allocatable
   need_wrapper: true
   post_call:
@@ -2243,6 +2357,7 @@ f_function_char_scalar_cfi_allocatable:
   - '{f_var}'
   arg_decl:
   - 'character(len=:), allocatable :: {f_var}'
+  intent: function
   name: f_function_char_scalar_cfi_allocatable
   need_wrapper: true
 f_function_native_&:
@@ -2254,6 +2369,7 @@ f_function_native_&:
     iso_c_binding:
     - C_PTR
     - c_f_pointer
+  intent: function
   name: f_function_native_&
   post_call:
   - call c_f_pointer({F_pointer}, {F_result}{f_array_shape})
@@ -2268,12 +2384,14 @@ f_function_native_&_buf_pointer:
     iso_c_binding:
     - C_PTR
     - c_f_pointer
+  intent: function
   name: f_function_native_&_buf_pointer
   post_call:
   - call c_f_pointer({F_pointer}, {F_result}{f_array_shape})
 f_function_native_**:
   arg_decl:
   - 'type(C_PTR) :: {f_var}'
+  intent: function
   name: f_function_native_**
 f_function_native_*_buf_allocatable:
   arg_c_call:
@@ -2284,6 +2402,7 @@ f_function_native_*_buf_allocatable:
   declare:
   - 'type({F_array_type}) :: {c_var_cdesc}'
   f_helper: copy_array_{cxx_type}
+  intent: function
   name: f_function_native_*_buf_allocatable
   need_wrapper: true
   post_call:
@@ -2301,6 +2420,7 @@ f_function_native_*_buf_pointer:
   f_module:
     iso_c_binding:
     - c_f_pointer
+  intent: function
   name: f_function_native_*_buf_pointer
   need_wrapper: true
   post_call:
@@ -2321,6 +2441,7 @@ f_function_native_*_buf_pointer_caller:
   f_module:
     iso_c_binding:
     - c_f_pointer
+  intent: function
   name: f_function_native_*_buf_pointer_caller
   need_wrapper: true
   post_call:
@@ -2337,18 +2458,22 @@ f_function_native_*_pointer:
     iso_c_binding:
     - C_PTR
     - c_f_pointer
+  intent: function
   name: f_function_native_*_pointer
   post_call:
   - call c_f_pointer({F_pointer}, {F_result}{f_array_shape})
 f_function_native_*_raw:
   arg_decl:
   - 'type(C_PTR) :: {f_var}'
+  intent: function
   name: f_function_native_*_raw
 f_function_native_*_scalar:
+  intent: function
   name: f_function_native_*_scalar
 f_function_shadow:
   arg_c_call:
   - '{f_var}%{F_derived_member}'
+  intent: function
   name: f_function_shadow
   need_wrapper: true
 f_function_string_&_buf:
@@ -2358,6 +2483,7 @@ f_function_string_&_buf:
   f_module:
     iso_c_binding:
     - C_INT
+  intent: function
   name: f_function_string_&_buf
   need_wrapper: true
 f_function_string_&_buf_allocatable:
@@ -2369,6 +2495,7 @@ f_function_string_&_buf_allocatable:
   declare:
   - 'type({F_array_type}) :: {c_var_cdesc}'
   f_helper: copy_string array_context
+  intent: function
   name: f_function_string_&_buf_allocatable
   need_wrapper: true
   post_call:
@@ -2379,6 +2506,7 @@ f_function_string_&_buf_allocatable:
 f_function_string_&_cfi:
   arg_c_call:
   - '{f_var}'
+  intent: function
   name: f_function_string_&_cfi
   need_wrapper: true
 f_function_string_&_cfi_allocatable:
@@ -2386,6 +2514,7 @@ f_function_string_&_cfi_allocatable:
   - '{f_var}'
   arg_decl:
   - 'character(len=:), allocatable :: {f_var}'
+  intent: function
   name: f_function_string_&_cfi_allocatable
   need_wrapper: true
 f_function_string_*_buf:
@@ -2395,6 +2524,7 @@ f_function_string_*_buf:
   f_module:
     iso_c_binding:
     - C_INT
+  intent: function
   name: f_function_string_*_buf
   need_wrapper: true
 f_function_string_*_buf_allocatable:
@@ -2406,6 +2536,7 @@ f_function_string_*_buf_allocatable:
   declare:
   - 'type({F_array_type}) :: {c_var_cdesc}'
   f_helper: copy_string array_context
+  intent: function
   name: f_function_string_*_buf_allocatable
   need_wrapper: true
   post_call:
@@ -2416,6 +2547,7 @@ f_function_string_*_buf_allocatable:
 f_function_string_*_cfi:
   arg_c_call:
   - '{f_var}'
+  intent: function
   name: f_function_string_*_cfi
   need_wrapper: true
 f_function_string_*_cfi_allocatable:
@@ -2423,6 +2555,7 @@ f_function_string_*_cfi_allocatable:
   - '{f_var}'
   arg_decl:
   - 'character(len=:), allocatable :: {f_var}'
+  intent: function
   name: f_function_string_*_cfi_allocatable
   need_wrapper: true
 f_function_string_scalar_buf:
@@ -2432,6 +2565,7 @@ f_function_string_scalar_buf:
   f_module:
     iso_c_binding:
     - C_INT
+  intent: function
   name: f_function_string_scalar_buf
   need_wrapper: true
 f_function_string_scalar_buf_allocatable:
@@ -2443,6 +2577,7 @@ f_function_string_scalar_buf_allocatable:
   declare:
   - 'type({F_array_type}) :: {c_var_cdesc}'
   f_helper: copy_string array_context
+  intent: function
   name: f_function_string_scalar_buf_allocatable
   need_wrapper: true
   post_call:
@@ -2453,6 +2588,7 @@ f_function_string_scalar_buf_allocatable:
 f_function_string_scalar_cfi:
   arg_c_call:
   - '{f_var}'
+  intent: function
   name: f_function_string_scalar_cfi
   need_wrapper: true
 f_function_string_scalar_cfi_allocatable:
@@ -2460,6 +2596,7 @@ f_function_string_scalar_cfi_allocatable:
   - '{f_var}'
   arg_decl:
   - 'character(len=:), allocatable :: {f_var}'
+  intent: function
   name: f_function_string_scalar_cfi_allocatable
   need_wrapper: true
 f_function_struct_*:
@@ -2471,6 +2608,7 @@ f_function_struct_*:
     iso_c_binding:
     - C_PTR
     - c_f_pointer
+  intent: function
   name: f_function_struct_*
   post_call:
   - call c_f_pointer({F_pointer}, {F_result}{f_array_shape})
@@ -2485,10 +2623,12 @@ f_function_struct_*_buf_pointer:
     iso_c_binding:
     - C_PTR
     - c_f_pointer
+  intent: function
   name: f_function_struct_*_buf_pointer
   post_call:
   - call c_f_pointer({F_pointer}, {F_result}{f_array_shape})
 f_function_struct_scalar:
+  intent: function
   name: f_function_struct_scalar
 f_function_vector_buf:
   c_helper: copy_array
@@ -2496,6 +2636,7 @@ f_function_vector_buf:
   f_module:
     iso_c_binding:
     - C_SIZE_T
+  intent: function
   name: f_function_vector_buf
   post_call:
   - "call {hnamefunc0}(\t{temp0},\t {f_var},\t size({f_var},kind=C_SIZE_T))"
@@ -2511,6 +2652,7 @@ f_function_vector_buf_allocatable:
   f_module:
     iso_c_binding:
     - C_SIZE_T
+  intent: function
   name: f_function_vector_buf_allocatable
   need_wrapper: true
   post_call:
@@ -2524,8 +2666,10 @@ f_function_void_*:
   f_module:
     iso_c_binding:
     - C_PTR
+  intent: function
   name: f_function_void_*
 f_getter:
+  intent: getter
   name: f_getter
 f_getter_string_scalar_buf_allocatable:
   arg_c_call:
@@ -2536,6 +2680,7 @@ f_getter_string_scalar_buf_allocatable:
   declare:
   - 'type({F_array_type}) :: {c_var_cdesc}'
   f_helper: copy_string array_context
+  intent: getter
   name: f_getter_string_scalar_buf_allocatable
   need_wrapper: true
   post_call:
@@ -2545,6 +2690,7 @@ f_getter_string_scalar_buf_allocatable:
   - cdesc
 f_in_bool:
   c_local_var: true
+  intent: in
   name: f_in_bool
   pre_call:
   - '{c_var} = {f_var}  ! coerce to C_BOOL'
@@ -2557,11 +2703,13 @@ f_in_char_**_buf:
     iso_c_binding:
     - C_SIZE_T
     - C_INT
+  intent: in
   name: f_in_char_**_buf
   need_wrapper: true
 f_in_char_scalar:
   arg_decl:
   - 'character, value, intent(IN) :: {f_var}'
+  intent: in
   name: f_in_char_scalar
 f_in_native_*_cdesc:
   arg_c_call:
@@ -2574,6 +2722,7 @@ f_in_native_*_cdesc:
   f_module:
     iso_c_binding:
     - C_LOC
+  intent: in/out/inout
   name: f_in_native_*_cdesc
   pre_call:
   - '{c_var_cdesc}%base_addr = C_LOC({f_var})'
@@ -2587,6 +2736,7 @@ f_in_native_*_cdesc:
 f_in_shadow:
   arg_c_call:
   - '{f_var}%{F_derived_member}'
+  intent: in
   name: f_in_shadow
   need_wrapper: true
 f_in_string_&_buf:
@@ -2596,6 +2746,7 @@ f_in_string_&_buf:
   f_module:
     iso_c_binding:
     - C_INT
+  intent: in
   name: f_in_string_&_buf
   need_wrapper: true
 f_in_string_*_buf:
@@ -2605,6 +2756,7 @@ f_in_string_*_buf:
   f_module:
     iso_c_binding:
     - C_INT
+  intent: in
   name: f_in_string_*_buf
   need_wrapper: true
 f_in_string_scalar_buf:
@@ -2616,6 +2768,7 @@ f_in_string_scalar_buf:
   f_module:
     iso_c_binding:
     - C_INT
+  intent: in
   name: f_in_string_scalar_buf
   need_wrapper: true
 f_in_vector_buf:
@@ -2625,6 +2778,7 @@ f_in_vector_buf:
   f_module:
     iso_c_binding:
     - C_SIZE_T
+  intent: in
   name: f_in_vector_buf
   need_wrapper: true
 f_in_vector_buf_string:
@@ -2636,6 +2790,7 @@ f_in_vector_buf_string:
     iso_c_binding:
     - C_SIZE_T
     - C_INT
+  intent: in
   name: f_in_vector_buf_string
   need_wrapper: true
 f_in_void_*:
@@ -2644,6 +2799,7 @@ f_in_void_*:
   f_module:
     iso_c_binding:
     - C_PTR
+  intent: in
   name: f_in_void_*
 f_in_void_**:
   arg_decl:
@@ -2651,6 +2807,7 @@ f_in_void_**:
   f_module:
     iso_c_binding:
     - C_PTR
+  intent: in
   name: f_in_void_**
 f_in_void_*_cdesc:
   arg_c_call:
@@ -2663,6 +2820,7 @@ f_in_void_*_cdesc:
   f_module:
     iso_c_binding:
     - C_LOC
+  intent: in/out/inout
   name: f_in_void_*_cdesc
   pre_call:
   - '{c_var_cdesc}%base_addr = C_LOC({f_var})'
@@ -2675,6 +2833,7 @@ f_in_void_*_cdesc:
   - cdesc
 f_inout_bool:
   c_local_var: true
+  intent: inout
   name: f_inout_bool
   post_call:
   - '{f_var} = {c_var}  ! coerce to logical'
@@ -2687,6 +2846,7 @@ f_inout_char_*_buf:
   f_module:
     iso_c_binding:
     - C_INT
+  intent: inout
   name: f_inout_char_*_buf
   need_wrapper: true
 f_inout_native_*_cdesc:
@@ -2700,6 +2860,7 @@ f_inout_native_*_cdesc:
   f_module:
     iso_c_binding:
     - C_LOC
+  intent: in/out/inout
   name: f_inout_native_*_cdesc
   pre_call:
   - '{c_var_cdesc}%base_addr = C_LOC({f_var})'
@@ -2717,6 +2878,7 @@ f_inout_string_&_buf:
   f_module:
     iso_c_binding:
     - C_INT
+  intent: inout
   name: f_inout_string_&_buf
   need_wrapper: true
 f_inout_string_*_buf:
@@ -2726,6 +2888,7 @@ f_inout_string_*_buf:
   f_module:
     iso_c_binding:
     - C_INT
+  intent: inout
   name: f_inout_string_*_buf
   need_wrapper: true
 f_inout_vector_buf:
@@ -2740,6 +2903,7 @@ f_inout_vector_buf:
   f_module:
     iso_c_binding:
     - C_SIZE_T
+  intent: inout
   name: f_inout_vector_buf
   post_call:
   - "call {hnamefunc0}(\t{c_var_cdesc},\t {f_var},\t size({f_var},kind=C_SIZE_T))"
@@ -2757,6 +2921,7 @@ f_inout_vector_buf_allocatable:
   f_module:
     iso_c_binding:
     - C_SIZE_T
+  intent: inout
   name: f_inout_vector_buf_allocatable
   post_call:
   - if (allocated({f_var})) deallocate({f_var})
@@ -2773,6 +2938,7 @@ f_inout_vector_buf_string:
     iso_c_binding:
     - C_SIZE_T
     - C_INT
+  intent: inout
   name: f_inout_vector_buf_string
   need_wrapper: true
 f_inout_void_*_cdesc:
@@ -2786,6 +2952,7 @@ f_inout_void_*_cdesc:
   f_module:
     iso_c_binding:
     - C_LOC
+  intent: in/out/inout
   name: f_inout_void_*_cdesc
   pre_call:
   - '{c_var_cdesc}%base_addr = C_LOC({f_var})'
@@ -2801,6 +2968,7 @@ f_mixin_function_buf:
   - '{c_var_cdesc}'
   declare:
   - 'type({F_array_type}) :: {c_var_cdesc}'
+  intent: mixin
   name: f_mixin_function_buf
   need_wrapper: true
   temps:
@@ -2812,6 +2980,7 @@ f_mixin_in_array_buf:
   f_module:
     iso_c_binding:
     - C_SIZE_T
+  intent: mixin
   name: f_mixin_in_array_buf
   need_wrapper: true
 f_mixin_in_character_buf:
@@ -2821,6 +2990,7 @@ f_mixin_in_character_buf:
   f_module:
     iso_c_binding:
     - C_INT
+  intent: mixin
   name: f_mixin_in_character_buf
   need_wrapper: true
 f_mixin_in_string_array_buf:
@@ -2832,6 +3002,7 @@ f_mixin_in_string_array_buf:
     iso_c_binding:
     - C_SIZE_T
     - C_INT
+  intent: mixin
   name: f_mixin_in_string_array_buf
   need_wrapper: true
 f_mixin_inout_array_buf:
@@ -2845,6 +3016,7 @@ f_mixin_inout_array_buf:
   f_module:
     iso_c_binding:
     - C_SIZE_T
+  intent: mixin
   name: f_mixin_inout_array_buf
   temps:
   - cdesc
@@ -2854,6 +3026,7 @@ f_mixin_out_array_buf:
   declare:
   - 'type({F_array_type}) :: {c_var_cdesc}'
   f_helper: array_context
+  intent: mixin
   name: f_mixin_out_array_buf
   temps:
   - cdesc
@@ -2862,16 +3035,19 @@ f_mixin_out_character_buf:
   - '{c_var_cdesc}'
   declare:
   - 'type({F_array_type}) :: {c_var_cdesc}'
+  intent: mixin
   name: f_mixin_out_character_buf
   temps:
   - cdesc
 f_mixin_shadow:
   arg_c_call:
   - '{f_var}%{F_derived_member}'
+  intent: mixin
   name: f_mixin_shadow
   need_wrapper: true
 f_out_bool:
   c_local_var: true
+  intent: out
   name: f_out_bool
   post_call:
   - '{f_var} = {c_var}  ! coerce to logical'
@@ -2882,6 +3058,7 @@ f_out_char_*_buf:
   f_module:
     iso_c_binding:
     - C_INT
+  intent: out
   name: f_out_char_*_buf
   need_wrapper: true
 f_out_native_*&_buf_pointer:
@@ -2895,6 +3072,7 @@ f_out_native_*&_buf_pointer:
   f_module:
     iso_c_binding:
     - c_f_pointer
+  intent: out
   name: f_out_native_*&_buf_pointer
   post_call:
   - call c_f_pointer({c_var_cdesc}%base_addr, {f_var}{f_array_shape})
@@ -2906,6 +3084,7 @@ f_out_native_**:
   f_module:
     iso_c_binding:
     - c_f_pointer
+  intent: out
   name: f_out_native_**
 f_out_native_**_buf_pointer:
   arg_c_call:
@@ -2918,6 +3097,7 @@ f_out_native_**_buf_pointer:
   f_module:
     iso_c_binding:
     - c_f_pointer
+  intent: out
   name: f_out_native_**_buf_pointer
   post_call:
   - call c_f_pointer({c_var_cdesc}%base_addr, {f_var}{f_array_shape})
@@ -2929,10 +3109,12 @@ f_out_native_**_raw:
   f_module:
     iso_c_binding:
     - C_PTR
+  intent: out
   name: f_out_native_**_raw
 f_out_native_*_allocatable:
   arg_decl:
   - '{f_type}, intent({f_intent}), allocatable :: {f_var}{f_assumed_shape}'
+  intent: out
   name: f_out_native_*_allocatable
   pre_call:
   - allocate({f_var}{f_array_allocate})
@@ -2947,6 +3129,7 @@ f_out_native_*_cdesc:
   f_module:
     iso_c_binding:
     - C_LOC
+  intent: in/out/inout
   name: f_out_native_*_cdesc
   pre_call:
   - '{c_var_cdesc}%base_addr = C_LOC({f_var})'
@@ -2964,6 +3147,7 @@ f_out_string_&_buf:
   f_module:
     iso_c_binding:
     - C_INT
+  intent: out
   name: f_out_string_&_buf
   need_wrapper: true
 f_out_string_*_buf:
@@ -2973,6 +3157,7 @@ f_out_string_*_buf:
   f_module:
     iso_c_binding:
     - C_INT
+  intent: out
   name: f_out_string_*_buf
   need_wrapper: true
 f_out_vector_buf:
@@ -2985,6 +3170,7 @@ f_out_vector_buf:
   f_module:
     iso_c_binding:
     - C_SIZE_T
+  intent: out
   name: f_out_vector_buf
   post_call:
   - "call {hnamefunc0}(\t{c_var_cdesc},\t {f_var},\t size({f_var},kind=C_SIZE_T))"
@@ -3000,6 +3186,7 @@ f_out_vector_buf_allocatable:
   f_module:
     iso_c_binding:
     - C_SIZE_T
+  intent: out
   name: f_out_vector_buf_allocatable
   post_call:
   - allocate({f_var}({c_var_cdesc}%size))
@@ -3015,6 +3202,7 @@ f_out_vector_buf_string:
     iso_c_binding:
     - C_SIZE_T
     - C_INT
+  intent: out
   name: f_out_vector_buf_string
   need_wrapper: true
 f_out_void_**:
@@ -3023,6 +3211,7 @@ f_out_void_**:
   f_module:
     iso_c_binding:
     - C_PTR
+  intent: out
   name: f_out_void_**
 f_out_void_*_cdesc:
   arg_c_call:
@@ -3035,6 +3224,7 @@ f_out_void_*_cdesc:
   f_module:
     iso_c_binding:
     - C_LOC
+  intent: in/out/inout
   name: f_out_void_*_cdesc
   pre_call:
   - '{c_var_cdesc}%base_addr = C_LOC({f_var})'
@@ -3046,6 +3236,7 @@ f_out_void_*_cdesc:
   temps:
   - cdesc
 f_setter:
+  intent: setter
   name: f_setter
 f_setter_string_scalar_buf:
   arg_c_call:
@@ -3054,9 +3245,11 @@ f_setter_string_scalar_buf:
   f_module:
     iso_c_binding:
     - C_INT
+  intent: setter
   name: f_setter_string_scalar_buf
   need_wrapper: true
 f_subroutine:
+  intent: subroutine
   name: f_subroutine
 ***** Python
 root
@@ -3230,6 +3423,7 @@ base_py_ctor_array:
   declare:
   - '{PY_typedef_converter} {value_var} = {PY_value_init};'
   - '{value_var}.name = "{field_name}";'
+  intent: py
   name: base_py_ctor_array
   parse_args:
   - '{hnamefunc0}'
@@ -3242,6 +3436,7 @@ base_py_ctor_array_fill:
   declare:
   - PyObject *{py_var} = {nullptr};
   goto_fail: true
+  intent: py
   name: base_py_ctor_array_fill
   parse_args:
   - '&{py_var}'
@@ -3258,6 +3453,7 @@ py_ctor_char_*:
   declare:
   - '{PY_typedef_converter} {value_var} = {PY_value_init};'
   - '{value_var}.name = "{field_name}";'
+  intent: ctor
   name: py_ctor_char_*
   parse_args:
   - '{hnamefunc0}'
@@ -3271,6 +3467,7 @@ py_ctor_char_**:
   declare:
   - '{PY_typedef_converter} {value_var} = {PY_value_init};'
   - '{value_var}.name = "{field_name}";'
+  intent: ctor
   name: py_ctor_char_**
   parse_args:
   - '{hnamefunc0}'
@@ -3284,6 +3481,7 @@ py_ctor_char_[]:
   declare:
   - PyObject *{py_var} = {nullptr};
   goto_fail: true
+  intent: ctor
   name: py_ctor_char_[]
   parse_args:
   - '&{py_var}'
@@ -3298,6 +3496,7 @@ py_ctor_char_[]:
 py_ctor_native:
   declare:
   - '{c_type} {c_var} = 0;'
+  intent: ctor
   name: py_ctor_native
   post_call:
   - SH_obj->{field_name} = {field_name};
@@ -3306,6 +3505,7 @@ py_ctor_native_*:
   declare:
   - '{PY_typedef_converter} {value_var} = {PY_value_init};'
   - '{value_var}.name = "{field_name}";'
+  intent: ctor
   name: py_ctor_native_*
   parse_args:
   - '{hnamefunc0}'
@@ -3319,6 +3519,7 @@ py_ctor_native_[]:
   declare:
   - PyObject *{py_var} = {nullptr};
   goto_fail: true
+  intent: ctor
   name: py_ctor_native_[]
   parse_args:
   - '&{py_var}'
@@ -3337,6 +3538,7 @@ py_descr_char_*:
   - -}}
   - PyObject * rv = {ctor};
   - return rv;
+  intent: descr
   name: py_descr_char_*
   setter:
   - '{PY_typedef_converter} cvalue;'
@@ -3357,6 +3559,7 @@ py_descr_char_**_list:
   - PyObject *rv = {hnamefunc0}({c_var}, {npy_intp_size});
   - return rv;
   getter_helper: to_PyList_char
+  intent: descr
   name: py_descr_char_**_list
   setter:
   - '{PY_typedef_converter} cvalue;'
@@ -3385,6 +3588,7 @@ py_descr_char_[]:
     // XXX assumes is null terminated
 
     return rv;'
+  intent: descr
   name: py_descr_char_[]
   setter:
   - Py_XDECREF({c_var_obj});
@@ -3398,6 +3602,7 @@ py_descr_native:
   getter:
   - PyObject * rv = {ctor};
   - return rv;
+  intent: descr
   name: py_descr_native
   setter:
   - '{cxx_decl} = {PY_get};'
@@ -3417,6 +3622,7 @@ py_descr_native_*_list:
   - PyObject *rv = {hnamefunc0}({c_var}, {npy_intp_size});
   - return rv;
   getter_helper: to_PyList_{c_type}
+  intent: descr
   name: py_descr_native_*_list
   setter:
   - '{PY_typedef_converter} cvalue;'
@@ -3446,6 +3652,7 @@ py_descr_native_*_numpy:
   - '{c_var_obj} = rv;'
   - -}}
   - return rv;
+  intent: descr
   name: py_descr_native_*_numpy
   need_numpy: true
   setter:
@@ -3465,6 +3672,7 @@ py_descr_native_[]_list:
   - PyObject *rv = {hnamefunc0}({c_var}, {npy_intp_size});
   - return rv;
   getter_helper: to_PyList_{c_type}
+  intent: descr
   name: py_descr_native_[]_list
   need_numpy: true
   setter:
@@ -3485,6 +3693,7 @@ py_descr_native_[]_numpy:
   - -}}
   - Py_INCREF({c_var_obj});
   - return {c_var_obj};
+  intent: descr
   name: py_descr_native_[]_numpy
   need_numpy: true
   setter:
@@ -3501,6 +3710,7 @@ py_function_bool:
   fail:
   - Py_XDECREF({py_var});
   goto_fail: true
+  intent: function
   name: py_function_bool
   object_created: true
   post_call:
@@ -3509,10 +3719,12 @@ py_function_bool:
 py_function_char_*:
   fmtdict:
     ctor_expr: '{c_var}'
+  intent: function
   name: py_function_char_*
 py_function_char_scalar:
   declare:
   - '{PyObject} * {py_var} = {nullptr};'
+  intent: function
   name: py_function_char_scalar
   object_created: true
   post_call:
@@ -3527,6 +3739,7 @@ py_function_native_&_pointer_numpy:
   fail_capsule:
   - Py_XDECREF({py_capsule});
   goto_fail: true
+  intent: function
   name: py_function_native_&_pointer_numpy
   need_numpy: true
   object_created: true
@@ -3551,6 +3764,7 @@ py_function_native_*_allocatable_numpy:
   fail_capsule:
   - Py_XDECREF({py_capsule});
   goto_fail: true
+  intent: function
   name: py_function_native_*_allocatable_numpy
   need_numpy: true
   object_created: true
@@ -3572,6 +3786,7 @@ py_function_native_*_pointer_list:
   fail:
   - Py_XDECREF({py_var});
   goto_fail: true
+  intent: function
   name: py_function_native_*_pointer_list
   object_created: true
   post_call:
@@ -3587,6 +3802,7 @@ py_function_native_*_pointer_numpy:
   fail_capsule:
   - Py_XDECREF({py_capsule});
   goto_fail: true
+  intent: function
   name: py_function_native_*_pointer_numpy
   need_numpy: true
   object_created: true
@@ -3602,12 +3818,14 @@ py_function_native_*_pointer_numpy:
   - "if (PyArray_SetBaseObject(\t{cast_reinterpret}PyArrayObject *{cast1}{py_var}{cast2},\t\
     \ {py_capsule}) < 0)\t goto fail;"
 py_function_shadow_&:
+  intent: function
   name: py_function_shadow_&
   object_created: true
   post_call:
   - "{PyObject} * {py_var} =\t PyObject_New({PyObject}, &{PyTypeObject});"
   - '{py_var}->{PY_type_obj} = {cxx_addr}{cxx_var};'
 py_function_shadow_*:
+  intent: function
   name: py_function_shadow_*
   object_created: true
   post_call:
@@ -3622,6 +3840,7 @@ py_function_shadow_scalar:
   fail:
   - Py_XDECREF({py_var});
   goto_fail: true
+  intent: function
   name: py_function_shadow_scalar
   object_created: true
   post_call:
@@ -3632,14 +3851,17 @@ py_function_shadow_scalar:
 py_function_string_&:
   fmtdict:
     ctor_expr: "{cxx_var}{cxx_member}data(),\t {cxx_var}{cxx_member}size()"
+  intent: function
   name: py_function_string_&
 py_function_string_*:
   fmtdict:
     ctor_expr: "{cxx_var}{cxx_member}data(),\t {cxx_var}{cxx_member}size()"
+  intent: function
   name: py_function_string_*
 py_function_string_scalar:
   fmtdict:
     ctor_expr: "{cxx_var}{cxx_member}data(),\t {cxx_var}{cxx_member}size()"
+  intent: function
   name: py_function_string_scalar
 py_function_struct_class:
   allocate_local_var: true
@@ -3649,6 +3871,7 @@ py_function_struct_class:
   fail:
   - Py_XDECREF({py_var});
   goto_fail: true
+  intent: function
   name: py_function_struct_class
   object_created: true
   post_call:
@@ -3665,6 +3888,7 @@ py_function_struct_numpy:
   fail_capsule:
   - Py_XDECREF({py_capsule});
   goto_fail: true
+  intent: function
   name: py_function_struct_numpy
   need_numpy: true
   object_created: true
@@ -3686,6 +3910,7 @@ py_function_vector_list:
   fail:
   - Py_XDECREF({py_var});
   goto_fail: true
+  intent: function
   name: py_function_vector_list
   object_created: true
   post_call:
@@ -3702,6 +3927,7 @@ py_function_vector_numpy:
   fail_capsule:
   - Py_XDECREF({py_capsule});
   goto_fail: true
+  intent: function
   name: py_function_vector_numpy
   need_numpy: true
   object_created: true
@@ -3720,14 +3946,17 @@ py_function_vector_numpy:
 py_function_void_*:
   fmtdict:
     ctor_expr: '{cxx_var}'
+  intent: function
   name: py_function_void_*
 py_in_bool:
+  intent: in
   name: py_in_bool
   pre_call:
   - '{cxx_var} = PyObject_IsTrue({py_var});'
 py_in_char_*:
   arg_call:
   - '{c_var}'
+  intent: in
   name: py_in_char_*
 py_in_char_**:
   arg_call:
@@ -3743,6 +3972,7 @@ py_in_char_**:
   fail:
   - Py_XDECREF({value_var}.dataobj);
   goto_fail: true
+  intent: in
   name: py_in_char_**
   parse_args:
   - '&{pytmp_var}'
@@ -3758,6 +3988,7 @@ py_in_char_scalar:
   - '{c_var}[0]'
   arg_declare:
   - char *{c_var};
+  intent: in
   name: py_in_char_scalar
   parse_args:
   - '&{c_var}'
@@ -3765,12 +3996,14 @@ py_in_char_scalar:
 py_in_native_&:
   arg_declare:
   - '{c_type} {c_var};'
+  intent: in
   name: py_in_native_&
 py_in_native_*:
   arg_call:
   - '&{c_var}'
   arg_declare:
   - '{c_type} {c_var};'
+  intent: in
   name: py_in_native_*
 py_in_native_*_pointer_list:
   arg_call:
@@ -3788,6 +4021,7 @@ py_in_native_*_pointer_list:
   fail:
   - Py_XDECREF({value_var}.dataobj);
   goto_fail: true
+  intent: in
   name: py_in_native_*_pointer_list
   parse_args:
   - '&{pytmp_var}'
@@ -3808,6 +4042,7 @@ py_in_native_*_pointer_numpy:
   fail:
   - Py_XDECREF({py_var});
   goto_fail: true
+  intent: in
   name: py_in_native_*_pointer_numpy
   need_numpy: true
   parse_args:
@@ -3827,11 +4062,13 @@ py_in_shadow_&:
   arg_call:
   - '*{cxx_var}'
   cxx_local_var: pointer
+  intent: in
   name: py_in_shadow_&
   post_declare:
   - "{c_const}{cxx_type} * {cxx_var} =\t {py_var} ? {py_var}->{PY_type_obj} : {nullptr};"
 py_in_shadow_*:
   cxx_local_var: pointer
+  intent: in
   name: py_in_shadow_*
   post_declare:
   - "{c_const}{cxx_type} * {cxx_var} =\t {py_var} ? {py_var}->{PY_type_obj} : {nullptr};"
@@ -3839,6 +4076,7 @@ py_in_shadow_scalar:
   arg_call:
   - '*{cxx_var}'
   cxx_local_var: pointer
+  intent: in
   name: py_in_shadow_scalar
   post_declare:
   - "{c_const}{cxx_type} * {cxx_var} =\t {py_var} ? {py_var}->{PY_type_obj} : {nullptr};"
@@ -3848,6 +4086,7 @@ py_in_string_&:
   cxx_local_var: scalar
   fmtdict:
     ctor_expr: "{cxx_var}{cxx_member}data(),\t {cxx_var}{cxx_member}size()"
+  intent: in
   name: py_in_string_&
   post_declare:
   - '{c_const}std::string {cxx_var}({c_var});'
@@ -3859,6 +4098,7 @@ py_in_string_*:
   cxx_local_var: scalar
   fmtdict:
     ctor_expr: "{cxx_var}{cxx_member}data(),\t {cxx_var}{cxx_member}size()"
+  intent: in
   name: py_in_string_*
   post_declare:
   - '{c_const}std::string {cxx_var}({c_var});'
@@ -3868,6 +4108,7 @@ py_in_string_scalar:
   cxx_local_var: scalar
   fmtdict:
     ctor_expr: "{cxx_var}{cxx_member}data(),\t {cxx_var}{cxx_member}size()"
+  intent: in
   name: py_in_string_scalar
   post_declare:
   - '{c_const}std::string {cxx_var}({c_var});'
@@ -3875,6 +4116,7 @@ py_in_struct_&_class:
   arg_call:
   - '*{cxx_var}'
   cxx_local_var: pointer
+  intent: in
   name: py_in_struct_&_class
   post_declare:
   - "{c_const}{cxx_type} * {cxx_var} =\t {py_var} ? {py_var}->{PY_type_obj} : {nullptr};"
@@ -3892,6 +4134,7 @@ py_in_struct_&_numpy:
   fail:
   - Py_XDECREF({py_var});
   goto_fail: true
+  intent: in
   name: py_in_struct_&_numpy
   need_numpy: true
   parse_args:
@@ -3910,12 +4153,14 @@ py_in_struct_&_numpy:
   - "{cxx_var} = static_cast<{cxx_type} *>\t(PyArray_DATA({py_var}));"
 py_in_struct_*_class:
   cxx_local_var: pointer
+  intent: in
   name: py_in_struct_*_class
   post_declare:
   - "{c_const}{cxx_type} * {cxx_var} =\t {py_var} ? {py_var}->{PY_type_obj} : {nullptr};"
 py_in_struct_*_list:
   arg_call:
   - '&{cxx_var}'
+  intent: in
   name: py_in_struct_*_list
 py_in_struct_*_numpy:
   arg_declare:
@@ -3929,6 +4174,7 @@ py_in_struct_*_numpy:
   fail:
   - Py_XDECREF({py_var});
   goto_fail: true
+  intent: in
   name: py_in_struct_*_numpy
   need_numpy: true
   parse_args:
@@ -3946,15 +4192,18 @@ py_in_struct_*_numpy:
   pre_call:
   - "{cxx_var} = static_cast<{cxx_type} *>\t(PyArray_DATA({py_var}));"
 py_in_struct_list:
+  intent: in
   name: py_in_struct_list
 py_in_struct_scalar_class:
   arg_call:
   - '*{cxx_var}'
   cxx_local_var: pointer
+  intent: in
   name: py_in_struct_scalar_class
   post_declare:
   - "{c_const}{cxx_type} * {cxx_var} =\t {py_var} ? {py_var}->{PY_type_obj} : {nullptr};"
 py_in_struct_scalar_list:
+  intent: in
   name: py_in_struct_scalar_list
 py_in_struct_scalar_numpy:
   arg_call:
@@ -3970,6 +4219,7 @@ py_in_struct_scalar_numpy:
   fail:
   - Py_XDECREF({py_var});
   goto_fail: true
+  intent: in
   name: py_in_struct_scalar_numpy
   need_numpy: true
   parse_args:
@@ -3992,6 +4242,7 @@ py_in_vector_list:
   declare:
   - PyObject * {pytmp_var};
   goto_fail: true
+  intent: in
   name: py_in_vector_list
   parse_args:
   - '&{pytmp_var}'
@@ -4009,6 +4260,7 @@ py_in_vector_numpy:
   fail:
   - Py_XDECREF({py_var});
   goto_fail: true
+  intent: in
   name: py_in_vector_numpy
   need_numpy: true
   parse_args:
@@ -4034,6 +4286,7 @@ py_in_void_*:
   declare:
   - PyObject *{py_var};
   goto_fail: true
+  intent: in
   name: py_in_void_*
   parse_args:
   - '&{py_var}'
@@ -4048,6 +4301,7 @@ py_inout_bool:
   fail:
   - Py_XDECREF({py_var});
   goto_fail: true
+  intent: inout
   name: py_inout_bool
   object_created: true
   post_call:
@@ -4063,6 +4317,7 @@ py_inout_bool_*:
   fail:
   - Py_XDECREF({py_var});
   goto_fail: true
+  intent: inout
   name: py_inout_bool_*
   object_created: true
   post_call:
@@ -4075,10 +4330,12 @@ py_inout_char_*:
   - '{c_var}'
   fmtdict:
     ctor_expr: '{c_var}'
+  intent: inout
   name: py_inout_char_*
 py_inout_native_&:
   arg_declare:
   - '{c_type} {c_var};'
+  intent: inout
   name: py_inout_native_&
 py_inout_native_*:
   arg_call:
@@ -4087,6 +4344,7 @@ py_inout_native_*:
   - '{c_type} {c_var};'
   fmtdict:
     ctor_expr: '{c_var}'
+  intent: inout
   name: py_inout_native_*
 py_inout_native_*_pointer_list:
   arg_call:
@@ -4105,6 +4363,7 @@ py_inout_native_*_pointer_list:
   fail:
   - Py_XDECREF({value_var}.dataobj);
   goto_fail: true
+  intent: inout
   name: py_inout_native_*_pointer_list
   object_created: true
   parse_args:
@@ -4127,6 +4386,7 @@ py_inout_native_*_pointer_numpy:
   fail:
   - Py_XDECREF({py_var});
   goto_fail: true
+  intent: inout
   name: py_inout_native_*_pointer_numpy
   need_numpy: true
   object_created: true
@@ -4145,6 +4405,7 @@ py_inout_native_*_pointer_numpy:
   - "{cxx_var} = static_cast<{cxx_type} *>\t(PyArray_DATA({py_var}));"
 py_inout_shadow_*:
   cxx_local_var: pointer
+  intent: inout
   name: py_inout_shadow_*
   post_declare:
   - "{c_const}{cxx_type} * {cxx_var} =\t {py_var} ? {py_var}->{PY_type_obj} : {nullptr};"
@@ -4152,6 +4413,7 @@ py_inout_string_&:
   cxx_local_var: scalar
   fmtdict:
     ctor_expr: "{cxx_var}{cxx_member}data(),\t {cxx_var}{cxx_member}size()"
+  intent: inout
   name: py_inout_string_&
   post_declare:
   - '{c_const}std::string {cxx_var}({c_var});'
@@ -4161,6 +4423,7 @@ py_inout_string_*:
   cxx_local_var: scalar
   fmtdict:
     ctor_expr: "{cxx_var}{cxx_member}data(),\t {cxx_var}{cxx_member}size()"
+  intent: inout
   name: py_inout_string_*
   post_declare:
   - '{c_const}std::string {cxx_var}({c_var});'
@@ -4168,6 +4431,7 @@ py_inout_string_scalar:
   cxx_local_var: scalar
   fmtdict:
     ctor_expr: "{cxx_var}{cxx_member}data(),\t {cxx_var}{cxx_member}size()"
+  intent: inout
   name: py_inout_string_scalar
   post_declare:
   - '{c_const}std::string {cxx_var}({c_var});'
@@ -4175,6 +4439,7 @@ py_inout_struct_&_class:
   arg_call:
   - '*{cxx_var}'
   cxx_local_var: pointer
+  intent: inout
   name: py_inout_struct_&_class
   object_created: true
   post_declare:
@@ -4190,6 +4455,7 @@ py_inout_struct_&_numpy:
   fail:
   - Py_XDECREF({py_var});
   goto_fail: true
+  intent: inout
   name: py_inout_struct_&_numpy
   need_numpy: true
   object_created: true
@@ -4209,6 +4475,7 @@ py_inout_struct_&_numpy:
   - "{cxx_var} = static_cast<{cxx_type} *>\t(PyArray_DATA({py_var}));"
 py_inout_struct_*_class:
   cxx_local_var: pointer
+  intent: inout
   name: py_inout_struct_*_class
   object_created: true
   post_declare:
@@ -4216,6 +4483,7 @@ py_inout_struct_*_class:
 py_inout_struct_*_list:
   arg_call:
   - '&{cxx_var}'
+  intent: inout
   name: py_inout_struct_*_list
 py_inout_struct_*_numpy:
   arg_declare:
@@ -4226,6 +4494,7 @@ py_inout_struct_*_numpy:
   fail:
   - Py_XDECREF({py_var});
   goto_fail: true
+  intent: inout
   name: py_inout_struct_*_numpy
   need_numpy: true
   object_created: true
@@ -4244,6 +4513,7 @@ py_inout_struct_*_numpy:
   pre_call:
   - "{cxx_var} = static_cast<{cxx_type} *>\t(PyArray_DATA({py_var}));"
 py_inout_struct_list:
+  intent: inout
   name: py_inout_struct_list
 py_out_bool:
   arg_declare:
@@ -4253,6 +4523,7 @@ py_out_bool:
   fail:
   - Py_XDECREF({py_var});
   goto_fail: true
+  intent: out
   name: py_out_bool
   object_created: true
   post_call:
@@ -4268,6 +4539,7 @@ py_out_bool_*:
   fail:
   - Py_XDECREF({py_var});
   goto_fail: true
+  intent: out
   name: py_out_bool_*
   object_created: true
   post_call:
@@ -4280,10 +4552,12 @@ py_out_char_*_charlen:
   - '{c_const}char {c_var}[{charlen}];  // intent(out)'
   fmtdict:
     ctor_expr: '{c_var}'
+  intent: out
   name: py_out_char_*_charlen
 py_out_native_&:
   arg_declare:
   - '{c_const}{c_type} {c_var};'
+  intent: out
   name: py_out_native_&
 py_out_native_*:
   arg_call:
@@ -4292,6 +4566,7 @@ py_out_native_*:
   - '{c_type} {c_var};'
   fmtdict:
     ctor_expr: '{c_var}'
+  intent: out
   name: py_out_native_*
 py_out_native_*&_pointer_numpy:
   arg_call:
@@ -4307,6 +4582,7 @@ py_out_native_*&_pointer_numpy:
   fail_capsule:
   - Py_XDECREF({py_capsule});
   goto_fail: true
+  intent: out
   name: py_out_native_*&_pointer_numpy
   need_numpy: true
   object_created: true
@@ -4332,6 +4608,7 @@ py_out_native_**_pointer_list:
   fail:
   - Py_XDECREF({py_var});
   goto_fail: true
+  intent: out
   name: py_out_native_**_pointer_list
   object_created: true
   post_call:
@@ -4351,6 +4628,7 @@ py_out_native_**_pointer_numpy:
   fail_capsule:
   - Py_XDECREF({py_capsule});
   goto_fail: true
+  intent: out
   name: py_out_native_**_pointer_numpy
   need_numpy: true
   object_created: true
@@ -4372,6 +4650,7 @@ py_out_native_**_raw:
   - '{c_type} *{c_var};'
   declare:
   - PyObject *{py_var} = {nullptr};
+  intent: out
   name: py_out_native_**_raw
   object_created: true
   post_call:
@@ -4395,6 +4674,7 @@ py_out_native_*_allocatable_list:
   - Py_XDECREF({py_var});
   - "if ({cxx_var} != {nullptr})\t {stdlib}free({cxx_var});"
   goto_fail: true
+  intent: out
   name: py_out_native_*_allocatable_list
   object_created: true
   post_call:
@@ -4414,6 +4694,7 @@ py_out_native_*_allocatable_numpy:
   fail:
   - Py_XDECREF({py_var});
   goto_fail: true
+  intent: out
   name: py_out_native_*_allocatable_numpy
   need_numpy: true
   object_created: true
@@ -4446,6 +4727,7 @@ py_out_native_*_pointer_list:
   - Py_XDECREF({py_var});
   - "if ({cxx_var} != {nullptr})\t {stdlib}free({cxx_var});"
   goto_fail: true
+  intent: out
   name: py_out_native_*_pointer_list
   object_created: true
   post_call:
@@ -4465,6 +4747,7 @@ py_out_native_*_pointer_numpy:
   fail:
   - Py_XDECREF({py_var});
   goto_fail: true
+  intent: out
   name: py_out_native_*_pointer_numpy
   need_numpy: true
   object_created: true
@@ -4484,6 +4767,7 @@ py_out_shadow_*:
   fail:
   - Py_XDECREF({py_var});
   goto_fail: true
+  intent: out
   name: py_out_shadow_*
   object_created: true
   post_call:
@@ -4494,6 +4778,7 @@ py_out_string_&:
   cxx_local_var: scalar
   fmtdict:
     ctor_expr: "{cxx_var}{cxx_member}data(),\t {cxx_var}{cxx_member}size()"
+  intent: out
   name: py_out_string_&
   post_declare:
   - '{c_const}std::string {cxx_var};'
@@ -4503,6 +4788,7 @@ py_out_string_*:
   cxx_local_var: scalar
   fmtdict:
     ctor_expr: "{cxx_var}{cxx_member}data(),\t {cxx_var}{cxx_member}size()"
+  intent: out
   name: py_out_string_*
   post_declare:
   - '{c_const}std::string {cxx_var};'
@@ -4510,6 +4796,7 @@ py_out_string_scalar:
   cxx_local_var: scalar
   fmtdict:
     ctor_expr: "{cxx_var}{cxx_member}data(),\t {cxx_var}{cxx_member}size()"
+  intent: out
   name: py_out_string_scalar
   post_declare:
   - '{c_const}std::string {cxx_var};'
@@ -4524,6 +4811,7 @@ py_out_struct_&_class:
   fail:
   - Py_XDECREF({py_var});
   goto_fail: true
+  intent: out
   name: py_out_struct_&_class
   object_created: true
   post_call:
@@ -4541,6 +4829,7 @@ py_out_struct_&_numpy:
   fail:
   - Py_XDECREF({py_var});
   goto_fail: true
+  intent: out
   name: py_out_struct_&_numpy
   need_numpy: true
   object_created: true
@@ -4564,6 +4853,7 @@ py_out_struct_*_class:
   fail:
   - Py_XDECREF({py_var});
   goto_fail: true
+  intent: out
   name: py_out_struct_*_class
   object_created: true
   post_call:
@@ -4574,6 +4864,7 @@ py_out_struct_*_class:
 py_out_struct_*_list:
   arg_call:
   - '&{cxx_var}'
+  intent: out
   name: py_out_struct_*_list
   post_declare:
   - '{cxx_type} {cxx_var};'
@@ -4585,6 +4876,7 @@ py_out_struct_*_numpy:
   fail:
   - Py_XDECREF({py_var});
   goto_fail: true
+  intent: out
   name: py_out_struct_*_numpy
   need_numpy: true
   object_created: true
@@ -4600,6 +4892,7 @@ py_out_struct_*_numpy:
   pre_call:
   - "{cxx_var} = static_cast<{cxx_type} *>\t(PyArray_DATA({py_var}));"
 py_out_struct_list:
+  intent: out
   name: py_out_struct_list
   post_declare:
   - '{cxx_type} {cxx_var};'
@@ -4611,6 +4904,7 @@ py_out_vector_list:
   fail:
   - Py_XDECREF({py_var});
   goto_fail: true
+  intent: out
   name: py_out_vector_list
   object_created: true
   post_call:
@@ -4632,6 +4926,7 @@ py_out_vector_numpy:
   fail_capsule:
   - Py_XDECREF({py_capsule});
   goto_fail: true
+  intent: out
   name: py_out_vector_numpy
   need_numpy: true
   object_created: true
@@ -4654,6 +4949,7 @@ py_out_void_*&:
   - void *{c_var};
   fmtdict:
     ctor_expr: '{cxx_var}'
+  intent: out
   name: py_out_void_*&
 py_out_void_**:
   arg_call:
@@ -4662,6 +4958,7 @@ py_out_void_**:
   - void *{c_var};
   fmtdict:
     ctor_expr: '{cxx_var}'
+  intent: out
   name: py_out_void_**
 ***** Lua
 root
@@ -4706,79 +5003,96 @@ lua_ctor:
   - luaL_getmetatable(L, "{LUA_metadata}");
   - /* Set the metatable on the userdata. */
   - lua_setmetatable(L, -2);
+  intent: ctor
   name: lua_ctor
 lua_dtor:
   call:
   - delete {LUA_userdata_var}->{LUA_userdata_member};
   - '{LUA_userdata_var}->{LUA_userdata_member} = NULL;'
+  intent: dtor
   name: lua_dtor
 lua_function_bool_scalar:
   call:
   - '{rv_asgn}{LUA_this_call}{function_name}({cxx_call_list});'
+  intent: function
   name: lua_function_bool_scalar
   post_call:
   - '{push_expr};'
 lua_function_native_scalar:
   call:
   - '{rv_asgn}{LUA_this_call}{function_name}({cxx_call_list});'
+  intent: function
   name: lua_function_native_scalar
   post_call:
   - '{push_expr};'
 lua_function_shadow_*:
   call:
   - '{rv_asgn}{LUA_this_call}{function_name}({cxx_call_list});'
+  intent: function
   name: lua_function_shadow_*
   post_call:
   - '{push_expr};'
 lua_function_string_&:
   call:
   - '{rv_asgn}{LUA_this_call}{function_name}({cxx_call_list});'
+  intent: function
   name: lua_function_string_&
   post_call:
   - '{push_expr};'
 lua_function_string_scalar:
   call:
   - '{rv_asgn}{LUA_this_call}{function_name}({cxx_call_list});'
+  intent: function
   name: lua_function_string_scalar
   post_call:
   - '{push_expr};'
 lua_function_void_*:
   call:
   - '{rv_asgn}{LUA_this_call}{function_name}({cxx_call_list});'
+  intent: function
   name: lua_function_void_*
 lua_in_bool_scalar:
+  intent: in
   name: lua_in_bool_scalar
   pre_call:
   - bool {c_var} = {pop_expr};
 lua_in_native_scalar:
+  intent: in
   name: lua_in_native_scalar
   pre_call:
   - "{cxx_type} {cxx_var} =\t {pop_expr};"
 lua_in_shadow_*:
+  intent: in
   name: lua_in_shadow_*
   pre_call:
   - "{cxx_type} * {cxx_var} =\t {pop_expr};"
 lua_in_string_&:
+  intent: in
   name: lua_in_string_&
   pre_call:
   - "const char * {c_var} = \t{pop_expr};"
 lua_in_string_*:
+  intent: in
   name: lua_in_string_*
   pre_call:
   - "const char * {c_var} = \t{pop_expr};"
 lua_inout_native_*:
+  intent: inout
   name: lua_inout_native_*
   pre_call:
   - // lua_native_*_inout;
 lua_mixin_callfunction:
   call:
   - '{rv_asgn}{LUA_this_call}{function_name}({cxx_call_list});'
+  intent: mixin
   name: lua_mixin_callfunction
 lua_mixin_push:
+  intent: mixin
   name: lua_mixin_push
   post_call:
   - '{push_expr};'
 lua_subroutine:
   call:
   - '{LUA_this_call}{function_name}({cxx_call_list});'
+  intent: subroutine
   name: lua_subroutine

--- a/regression/reference/ownership/ownership.json
+++ b/regression/reference/ownership/ownership.json
@@ -54,7 +54,7 @@
                             "c_var": "self",
                             "function_name": "dtor",
                             "stmt0": "f_dtor",
-                            "stmt1": "f_default",
+                            "stmt1": "f_dtor",
                             "stmtc0": "c_dtor",
                             "stmtc1": "c_dtor",
                             "underscore_name": "dtor"

--- a/regression/reference/ownership/ownership.json
+++ b/regression/reference/ownership/ownership.json
@@ -143,9 +143,9 @@
                                 "f_var": "SHT_rv",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "f_function_native_scalar",
-                                "stmt1": "f_default",
+                                "stmt1": "f_function",
                                 "stmtc0": "c_function_native_scalar",
-                                "stmtc1": "c_default"
+                                "stmtc1": "c_function"
                             }
                         }
                     }

--- a/regression/reference/ownership/wrapfownership.f
+++ b/regression/reference/ownership/wrapfownership.f
@@ -486,8 +486,7 @@ contains
     ! ----------------------------------------
     ! Function:  ~Class1
     ! Attrs:     +intent(dtor)
-    ! Requested: f_dtor
-    ! Match:     f_default
+    ! Exact:     f_dtor
     ! Attrs:     +intent(dtor)
     ! Exact:     c_dtor
     subroutine class1_dtor(obj)

--- a/regression/reference/ownership/wrapfownership.f
+++ b/regression/reference/ownership/wrapfownership.f
@@ -502,10 +502,10 @@ contains
     ! Function:  int getFlag
     ! Attrs:     +intent(getter)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(getter)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     function class1_get_flag(obj) &
             result(SHT_rv)
         use iso_c_binding, only : C_INT

--- a/regression/reference/pointers-c/pointers.json
+++ b/regression/reference/pointers-c/pointers.json
@@ -2466,7 +2466,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2478,9 +2478,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -2599,7 +2599,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2611,9 +2611,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -2742,7 +2742,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2911,7 +2911,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2923,9 +2923,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -5374,7 +5374,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -5386,9 +5386,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -5629,7 +5629,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_CPTR",
                         "stmt0": "c_function_void_*",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -5642,7 +5642,7 @@
                         "stmt0": "f_function_void_*",
                         "stmt1": "f_function_void_*",
                         "stmtc0": "c_function_void_*",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -5763,7 +5763,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_CPTR",
                         "stmt0": "c_function_void_*",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -5776,7 +5776,7 @@
                         "stmt0": "f_function_void_*",
                         "stmt1": "f_function_void_*",
                         "stmtc0": "c_function_void_*",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -6009,7 +6009,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -6021,9 +6021,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },

--- a/regression/reference/pointers-c/wrapfpointers.f
+++ b/regression/reference/pointers-c/wrapfpointers.f
@@ -430,7 +430,7 @@ module pointers_mod
     ! Function:  int accumulate
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const int * arr +rank(1)
     ! Attrs:     +intent(in)
@@ -459,7 +459,7 @@ module pointers_mod
     ! Function:  int acceptCharArrayIn
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  char * * names +intent(in)+rank(1)
     ! Attrs:     +intent(in)
@@ -481,7 +481,7 @@ module pointers_mod
     ! Function:  int acceptCharArrayIn
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  char * * names +intent(in)+rank(1)
     ! Attrs:     +api(buf)+intent(in)
@@ -527,7 +527,7 @@ module pointers_mod
     ! Function:  int sumFixedArray
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! start sum_fixed_array
     interface
         function sum_fixed_array() &
@@ -972,7 +972,7 @@ module pointers_mod
     ! Function:  int checkInt2d
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  int * * arg +intent(in)
     ! Attrs:     +intent(in)
@@ -1015,7 +1015,7 @@ module pointers_mod
     ! Function:  void * returnAddress1
     ! Attrs:     +intent(function)
     ! Requested: c_function_void_*
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  int flag +value
     ! Attrs:     +intent(in)
@@ -1038,7 +1038,7 @@ module pointers_mod
     ! Function:  void * returnAddress2
     ! Attrs:     +intent(function)
     ! Requested: c_function_void_*
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  int flag +value
     ! Attrs:     +intent(in)
@@ -1082,7 +1082,7 @@ module pointers_mod
     ! Function:  int VoidPtrArray
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  void * * addr +rank(1)
     ! Attrs:     +intent(in)
@@ -1538,10 +1538,10 @@ contains
     ! Function:  int accumulate
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const int * arr +rank(1)
     ! Attrs:     +intent(in)
@@ -1569,10 +1569,10 @@ contains
     ! Function:  int acceptCharArrayIn
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  char * * names +intent(in)+rank(1)
     ! Attrs:     +intent(in)
@@ -1901,7 +1901,7 @@ contains
     ! Exact:     f_function_void_*
     ! Attrs:     +intent(function)
     ! Requested: c_function_void_*
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  int flag +value
     ! Attrs:     +intent(in)
@@ -1926,10 +1926,10 @@ contains
     ! Function:  int VoidPtrArray
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  void * * addr +rank(1)
     ! Attrs:     +intent(in)

--- a/regression/reference/pointers-c/wrappointers.c
+++ b/regression/reference/pointers-c/wrappointers.c
@@ -67,7 +67,7 @@ static void ShroudStrArrayFree(char **src, int nsrc)
 // Function:  int acceptCharArrayIn
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  char * * names +intent(in)+rank(1)
 // Attrs:     +api(buf)+intent(in)

--- a/regression/reference/pointers-cxx/pointers.json
+++ b/regression/reference/pointers-cxx/pointers.json
@@ -2466,7 +2466,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2478,9 +2478,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -2599,7 +2599,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2611,9 +2611,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -2742,7 +2742,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2911,7 +2911,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2923,9 +2923,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -5374,7 +5374,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -5386,9 +5386,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -5629,7 +5629,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_CPTR",
                         "stmt0": "c_function_void_*",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -5642,7 +5642,7 @@
                         "stmt0": "f_function_void_*",
                         "stmt1": "f_function_void_*",
                         "stmtc0": "c_function_void_*",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -5763,7 +5763,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_CPTR",
                         "stmt0": "c_function_void_*",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -5776,7 +5776,7 @@
                         "stmt0": "f_function_void_*",
                         "stmt1": "f_function_void_*",
                         "stmtc0": "c_function_void_*",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -6009,7 +6009,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -6021,9 +6021,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },

--- a/regression/reference/pointers-cxx/wrapfpointers.f
+++ b/regression/reference/pointers-cxx/wrapfpointers.f
@@ -430,7 +430,7 @@ module pointers_mod
     ! Function:  int accumulate
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const int * arr +rank(1)
     ! Attrs:     +intent(in)
@@ -459,7 +459,7 @@ module pointers_mod
     ! Function:  int acceptCharArrayIn
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  char * * names +intent(in)+rank(1)
     ! Attrs:     +intent(in)
@@ -481,7 +481,7 @@ module pointers_mod
     ! Function:  int acceptCharArrayIn
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  char * * names +intent(in)+rank(1)
     ! Attrs:     +api(buf)+intent(in)
@@ -527,7 +527,7 @@ module pointers_mod
     ! Function:  int sumFixedArray
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! start sum_fixed_array
     interface
         function sum_fixed_array() &
@@ -972,7 +972,7 @@ module pointers_mod
     ! Function:  int checkInt2d
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  int * * arg +intent(in)
     ! Attrs:     +intent(in)
@@ -1015,7 +1015,7 @@ module pointers_mod
     ! Function:  void * returnAddress1
     ! Attrs:     +intent(function)
     ! Requested: c_function_void_*
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  int flag +value
     ! Attrs:     +intent(in)
@@ -1038,7 +1038,7 @@ module pointers_mod
     ! Function:  void * returnAddress2
     ! Attrs:     +intent(function)
     ! Requested: c_function_void_*
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  int flag +value
     ! Attrs:     +intent(in)
@@ -1082,7 +1082,7 @@ module pointers_mod
     ! Function:  int VoidPtrArray
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  void * * addr +rank(1)
     ! Attrs:     +intent(in)
@@ -1538,10 +1538,10 @@ contains
     ! Function:  int accumulate
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const int * arr +rank(1)
     ! Attrs:     +intent(in)
@@ -1569,10 +1569,10 @@ contains
     ! Function:  int acceptCharArrayIn
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  char * * names +intent(in)+rank(1)
     ! Attrs:     +intent(in)
@@ -1901,7 +1901,7 @@ contains
     ! Exact:     f_function_void_*
     ! Attrs:     +intent(function)
     ! Requested: c_function_void_*
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  int flag +value
     ! Attrs:     +intent(in)
@@ -1926,10 +1926,10 @@ contains
     ! Function:  int VoidPtrArray
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  void * * addr +rank(1)
     ! Attrs:     +intent(in)

--- a/regression/reference/pointers-cxx/wrappointers.cpp
+++ b/regression/reference/pointers-cxx/wrappointers.cpp
@@ -427,7 +427,7 @@ void POI_fill_with_zeros(double * x, int x_length)
 // Function:  int accumulate
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  const int * arr +rank(1)
 // Attrs:     +intent(in)
@@ -455,7 +455,7 @@ int POI_accumulate(const int * arr, size_t len)
 // Function:  int acceptCharArrayIn
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  char * * names +intent(in)+rank(1)
 // Attrs:     +intent(in)
@@ -477,7 +477,7 @@ int POI_accept_char_array_in(char **names)
 // Function:  int acceptCharArrayIn
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  char * * names +intent(in)+rank(1)
 // Attrs:     +api(buf)+intent(in)
@@ -521,7 +521,7 @@ void POI_set_global_int(int value)
 // Function:  int sumFixedArray
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // start POI_sum_fixed_array
 int POI_sum_fixed_array(void)
 {
@@ -1011,7 +1011,7 @@ void POI_get_raw_ptr_to_int2d(int * * * arg)
 // Function:  int checkInt2d
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  int * * arg +intent(in)
 // Attrs:     +intent(in)
@@ -1052,7 +1052,7 @@ void POI_dimension_in(const int * arg)
 // Function:  void * returnAddress1
 // Attrs:     +intent(function)
 // Requested: c_function_void_*
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  int flag +value
 // Attrs:     +intent(in)
@@ -1072,7 +1072,7 @@ void * POI_return_address1(int flag)
 // Function:  void * returnAddress2
 // Attrs:     +intent(function)
 // Requested: c_function_void_*
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  int flag +value
 // Attrs:     +intent(in)
@@ -1110,7 +1110,7 @@ void POI_fetch_void_ptr(void * * addr)
 // Function:  int VoidPtrArray
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  void * * addr +rank(1)
 // Attrs:     +intent(in)

--- a/regression/reference/statement/statement.json
+++ b/regression/reference/statement/statement.json
@@ -82,7 +82,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -94,9 +94,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },

--- a/regression/reference/statement/wrapfstatement.f
+++ b/regression/reference/statement/wrapfstatement.f
@@ -26,7 +26,7 @@ module statement_mod
         ! Function:  int GetNameLength +pure
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         pure function get_name_length() &
                 result(SHT_rv) &
                 bind(C, name="STMT_get_name_length")

--- a/regression/reference/statement/wrapstatement.cpp
+++ b/regression/reference/statement/wrapstatement.cpp
@@ -47,7 +47,7 @@ static void ShroudStrCopy(char *dest, int ndest, const char *src, int nsrc)
 // Function:  int GetNameLength +pure
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 int STMT_get_name_length(void)
 {
     // splicer begin function.get_name_length

--- a/regression/reference/strings-cfi/strings.json
+++ b/regression/reference/strings-cfi/strings.json
@@ -316,7 +316,7 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "f_function_char_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_char_scalar",
                         "stmtc1": "c_function_char_scalar"
                     },
@@ -6379,7 +6379,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -6391,9 +6391,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -6529,7 +6529,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -7345,7 +7345,7 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "f_function_char_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_char_scalar",
                         "stmtc1": "c_function_char_scalar"
                     },

--- a/regression/reference/strings-cfi/wrapfstrings.f
+++ b/regression/reference/strings-cfi/wrapfstrings.f
@@ -895,7 +895,7 @@ module strings_mod
     ! Function:  int acceptStringInstance
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  std::string arg1 +value
     ! Attrs:     +intent(in)
@@ -915,7 +915,7 @@ module strings_mod
     ! Function:  int acceptStringInstance
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  std::string arg1 +value
     ! Attrs:     +api(cfi)+intent(in)

--- a/regression/reference/strings-cfi/wrapstrings.cpp
+++ b/regression/reference/strings-cfi/wrapstrings.cpp
@@ -1287,7 +1287,7 @@ void STR_fetch_string_pointer_len_CFI(CFI_cdesc_t *SHT_arg1_cfi,
 // Function:  int acceptStringInstance
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  std::string arg1 +value
 // Attrs:     +intent(in)
@@ -1308,7 +1308,7 @@ int STR_accept_string_instance(char *arg1)
 // Function:  int acceptStringInstance
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  std::string arg1 +value
 // Attrs:     +api(cfi)+intent(in)

--- a/regression/reference/strings/strings.json
+++ b/regression/reference/strings/strings.json
@@ -316,7 +316,7 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "f_function_char_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_char_scalar",
                         "stmtc1": "c_function_char_scalar"
                     },
@@ -6289,7 +6289,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -6301,9 +6301,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -6437,7 +6437,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -7150,7 +7150,7 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_OTHER",
                         "stmt0": "f_function_char_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_char_scalar",
                         "stmtc1": "c_function_char_scalar"
                     },

--- a/regression/reference/strings/wrapfstrings.f
+++ b/regression/reference/strings/wrapfstrings.f
@@ -978,7 +978,7 @@ module strings_mod
     ! Function:  int acceptStringInstance
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  std::string arg1 +value
     ! Attrs:     +intent(in)
@@ -998,7 +998,7 @@ module strings_mod
     ! Function:  int acceptStringInstance
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  std::string arg1 +value
     ! Attrs:     +api(buf)+intent(in)
@@ -1944,10 +1944,10 @@ contains
     ! Function:  int acceptStringInstance
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  std::string arg1 +value
     ! Attrs:     +intent(in)

--- a/regression/reference/strings/wrapstrings.cpp
+++ b/regression/reference/strings/wrapstrings.cpp
@@ -1269,7 +1269,7 @@ void STR_fetch_string_pointer_len_bufferify(char *arg1,
 // Function:  int acceptStringInstance
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  std::string arg1 +value
 // Attrs:     +intent(in)
@@ -1290,7 +1290,7 @@ int STR_accept_string_instance(char *arg1)
 // Function:  int acceptStringInstance
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  std::string arg1 +value
 // Attrs:     +api(buf)+intent(in)

--- a/regression/reference/struct-c/struct.json
+++ b/regression/reference/struct-c/struct.json
@@ -696,9 +696,9 @@
                                 "f_var": "SHT_rv",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "f_function_native_scalar",
-                                "stmt1": "f_default",
+                                "stmt1": "f_function",
                                 "stmtc0": "c_function_native_scalar",
-                                "stmtc1": "c_default"
+                                "stmtc1": "c_function"
                             }
                         }
                     },
@@ -888,9 +888,9 @@
                                 "f_var": "SHT_rv",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "f_function_native_scalar",
-                                "stmt1": "f_default",
+                                "stmt1": "f_function",
                                 "stmtc0": "c_function_native_scalar",
-                                "stmtc1": "c_default"
+                                "stmtc1": "c_function"
                             }
                         }
                     },
@@ -1174,9 +1174,9 @@
                                 "f_var": "SHT_rv",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "f_function_native_scalar",
-                                "stmt1": "f_default",
+                                "stmt1": "f_function",
                                 "stmtc0": "c_function_native_scalar",
-                                "stmtc1": "c_default"
+                                "stmtc1": "c_function"
                             }
                         }
                     },
@@ -1366,9 +1366,9 @@
                                 "f_var": "SHT_rv",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "f_function_native_scalar",
-                                "stmt1": "f_default",
+                                "stmt1": "f_function",
                                 "stmtc0": "c_function_native_scalar",
-                                "stmtc1": "c_default"
+                                "stmtc1": "c_function"
                             }
                         }
                     },
@@ -1558,9 +1558,9 @@
                                 "f_var": "SHT_rv",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "f_function_native_scalar",
-                                "stmt1": "f_default",
+                                "stmt1": "f_function",
                                 "stmtc0": "c_function_native_scalar",
-                                "stmtc1": "c_default"
+                                "stmtc1": "c_function"
                             }
                         }
                     },
@@ -1917,7 +1917,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -1929,9 +1929,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -2049,7 +2049,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2061,9 +2061,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -2220,7 +2220,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2232,9 +2232,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -2404,7 +2404,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2528,7 +2528,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2540,9 +2540,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -4354,7 +4354,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -4366,9 +4366,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },

--- a/regression/reference/struct-c/struct.json
+++ b/regression/reference/struct-c/struct.json
@@ -777,7 +777,7 @@
                                     "f_var": "val",
                                     "sh_type": "SH_TYPE_INT",
                                     "stmt0": "f_setter_native_scalar",
-                                    "stmt1": "f_setter",
+                                    "stmt1": "f_setter_native",
                                     "stmtc0": "c_setter_native_scalar",
                                     "stmtc1": "c_setter_native_scalar"
                                 }
@@ -969,7 +969,7 @@
                                     "f_var": "val",
                                     "sh_type": "SH_TYPE_INT",
                                     "stmt0": "f_setter_native_scalar",
-                                    "stmt1": "f_setter",
+                                    "stmt1": "f_setter_native",
                                     "stmtc0": "c_setter_native_scalar",
                                     "stmtc1": "c_setter_native_scalar"
                                 }
@@ -1255,7 +1255,7 @@
                                     "f_var": "val",
                                     "sh_type": "SH_TYPE_INT",
                                     "stmt0": "f_setter_native_scalar",
-                                    "stmt1": "f_setter",
+                                    "stmt1": "f_setter_native",
                                     "stmtc0": "c_setter_native_scalar",
                                     "stmtc1": "c_setter_native_scalar"
                                 }
@@ -1447,7 +1447,7 @@
                                     "f_var": "val",
                                     "sh_type": "SH_TYPE_INT",
                                     "stmt0": "f_setter_native_scalar",
-                                    "stmt1": "f_setter",
+                                    "stmt1": "f_setter_native",
                                     "stmtc0": "c_setter_native_scalar",
                                     "stmtc1": "c_setter_native_scalar"
                                 }
@@ -1639,7 +1639,7 @@
                                     "f_var": "val",
                                     "sh_type": "SH_TYPE_INT",
                                     "stmt0": "f_setter_native_scalar",
-                                    "stmt1": "f_setter",
+                                    "stmt1": "f_setter_native",
                                     "stmtc0": "c_setter_native_scalar",
                                     "stmtc1": "c_setter_native_scalar"
                                 }

--- a/regression/reference/struct-c/wrapfstruct.f
+++ b/regression/reference/struct-c/wrapfstruct.f
@@ -817,7 +817,7 @@ contains
     ! Argument:  int val +intent(in)+value
     ! Attrs:     +intent(setter)
     ! Requested: f_setter_native_scalar
-    ! Match:     f_setter
+    ! Match:     f_setter_native
     ! Attrs:     +intent(setter)
     ! Exact:     c_setter_native_scalar
     ! start cstruct_as_class_set_x1
@@ -863,7 +863,7 @@ contains
     ! Argument:  int val +intent(in)+value
     ! Attrs:     +intent(setter)
     ! Requested: f_setter_native_scalar
-    ! Match:     f_setter
+    ! Match:     f_setter_native
     ! Attrs:     +intent(setter)
     ! Exact:     c_setter_native_scalar
     ! start cstruct_as_class_set_y1
@@ -912,7 +912,7 @@ contains
     ! Argument:  int val +intent(in)+value
     ! Attrs:     +intent(setter)
     ! Requested: f_setter_native_scalar
-    ! Match:     f_setter
+    ! Match:     f_setter_native
     ! Attrs:     +intent(setter)
     ! Exact:     c_setter_native_scalar
     ! start cstruct_as_subclass_set_x1
@@ -958,7 +958,7 @@ contains
     ! Argument:  int val +intent(in)+value
     ! Attrs:     +intent(setter)
     ! Requested: f_setter_native_scalar
-    ! Match:     f_setter
+    ! Match:     f_setter_native
     ! Attrs:     +intent(setter)
     ! Exact:     c_setter_native_scalar
     ! start cstruct_as_subclass_set_y1
@@ -1004,7 +1004,7 @@ contains
     ! Argument:  int val +intent(in)+value
     ! Attrs:     +intent(setter)
     ! Requested: f_setter_native_scalar
-    ! Match:     f_setter
+    ! Match:     f_setter_native
     ! Attrs:     +intent(setter)
     ! Exact:     c_setter_native_scalar
     ! start cstruct_as_subclass_set_z1

--- a/regression/reference/struct-c/wrapfstruct.f
+++ b/regression/reference/struct-c/wrapfstruct.f
@@ -317,7 +317,7 @@ module struct_mod
     ! Function:  int passStructByValue
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  Cstruct1 arg +value
     ! Attrs:     +intent(in)
@@ -341,7 +341,7 @@ module struct_mod
     ! Function:  int passStruct1
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const Cstruct1 * arg
     ! Attrs:     +intent(in)
@@ -365,7 +365,7 @@ module struct_mod
     ! Function:  int passStruct2
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const Cstruct1 * s1
     ! Attrs:     +intent(in)
@@ -393,7 +393,7 @@ module struct_mod
     ! Function:  int passStruct2
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const Cstruct1 * s1
     ! Attrs:     +intent(in)
@@ -421,7 +421,7 @@ module struct_mod
     ! Function:  int acceptStructInPtr
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  Cstruct1 * arg +intent(in)
     ! Attrs:     +intent(in)
@@ -716,7 +716,7 @@ module struct_mod
     ! Function:  int Cstruct_as_class_sum
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const Cstruct_as_class * point +pass
     ! Attrs:     +intent(in)
@@ -790,10 +790,10 @@ contains
     ! Function:  int getX1
     ! Attrs:     +intent(getter)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(getter)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! start cstruct_as_class_get_x1
     function cstruct_as_class_get_x1(obj) &
             result(SHT_rv)
@@ -836,10 +836,10 @@ contains
     ! Function:  int getY1
     ! Attrs:     +intent(getter)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(getter)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! start cstruct_as_class_get_y1
     function cstruct_as_class_get_y1(obj) &
             result(SHT_rv)
@@ -885,10 +885,10 @@ contains
     ! Function:  int getX1
     ! Attrs:     +intent(getter)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(getter)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! start cstruct_as_subclass_get_x1
     function cstruct_as_subclass_get_x1(obj) &
             result(SHT_rv)
@@ -931,10 +931,10 @@ contains
     ! Function:  int getY1
     ! Attrs:     +intent(getter)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(getter)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! start cstruct_as_subclass_get_y1
     function cstruct_as_subclass_get_y1(obj) &
             result(SHT_rv)
@@ -977,10 +977,10 @@ contains
     ! Function:  int getZ1
     ! Attrs:     +intent(getter)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(getter)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! start cstruct_as_subclass_get_z1
     function cstruct_as_subclass_get_z1(obj) &
             result(SHT_rv)
@@ -1026,10 +1026,10 @@ contains
     ! Function:  int passStruct2
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const Cstruct1 * s1
     ! Attrs:     +intent(in)
@@ -1227,10 +1227,10 @@ contains
     ! Function:  int Cstruct_as_class_sum
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const Cstruct_as_class * point +pass
     ! Attrs:     +intent(in)

--- a/regression/reference/struct-c/wrapstruct.c
+++ b/regression/reference/struct-c/wrapstruct.c
@@ -31,7 +31,7 @@ static void ShroudStrBlankFill(char *dest, int ndest)
 // Function:  int passStruct2
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  const Cstruct1 * s1
 // Attrs:     +intent(in)
@@ -130,7 +130,7 @@ void STR_create__cstruct_as_class_args(STR_Cstruct_as_class * SHC_rv,
 // Function:  int Cstruct_as_class_sum
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  const Cstruct_as_class * point +pass
 // Attrs:     +intent(in)

--- a/regression/reference/struct-cxx/struct.json
+++ b/regression/reference/struct-cxx/struct.json
@@ -696,9 +696,9 @@
                                 "f_var": "SHT_rv",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "f_function_native_scalar",
-                                "stmt1": "f_default",
+                                "stmt1": "f_function",
                                 "stmtc0": "c_function_native_scalar",
-                                "stmtc1": "c_default"
+                                "stmtc1": "c_function"
                             }
                         }
                     },
@@ -888,9 +888,9 @@
                                 "f_var": "SHT_rv",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "f_function_native_scalar",
-                                "stmt1": "f_default",
+                                "stmt1": "f_function",
                                 "stmtc0": "c_function_native_scalar",
-                                "stmtc1": "c_default"
+                                "stmtc1": "c_function"
                             }
                         }
                     },
@@ -1174,9 +1174,9 @@
                                 "f_var": "SHT_rv",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "f_function_native_scalar",
-                                "stmt1": "f_default",
+                                "stmt1": "f_function",
                                 "stmtc0": "c_function_native_scalar",
-                                "stmtc1": "c_default"
+                                "stmtc1": "c_function"
                             }
                         }
                     },
@@ -1366,9 +1366,9 @@
                                 "f_var": "SHT_rv",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "f_function_native_scalar",
-                                "stmt1": "f_default",
+                                "stmt1": "f_function",
                                 "stmtc0": "c_function_native_scalar",
-                                "stmtc1": "c_default"
+                                "stmtc1": "c_function"
                             }
                         }
                     },
@@ -1558,9 +1558,9 @@
                                 "f_var": "SHT_rv",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "f_function_native_scalar",
-                                "stmt1": "f_default",
+                                "stmt1": "f_function",
                                 "stmtc0": "c_function_native_scalar",
-                                "stmtc1": "c_default"
+                                "stmtc1": "c_function"
                             }
                         }
                     },
@@ -1917,7 +1917,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -1929,9 +1929,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -2049,7 +2049,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2061,9 +2061,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -2220,7 +2220,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2232,9 +2232,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -2404,7 +2404,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2528,7 +2528,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2540,9 +2540,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -4354,7 +4354,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -4366,9 +4366,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },

--- a/regression/reference/struct-cxx/struct.json
+++ b/regression/reference/struct-cxx/struct.json
@@ -777,7 +777,7 @@
                                     "f_var": "val",
                                     "sh_type": "SH_TYPE_INT",
                                     "stmt0": "f_setter_native_scalar",
-                                    "stmt1": "f_setter",
+                                    "stmt1": "f_setter_native",
                                     "stmtc0": "c_setter_native_scalar",
                                     "stmtc1": "c_setter_native_scalar"
                                 }
@@ -969,7 +969,7 @@
                                     "f_var": "val",
                                     "sh_type": "SH_TYPE_INT",
                                     "stmt0": "f_setter_native_scalar",
-                                    "stmt1": "f_setter",
+                                    "stmt1": "f_setter_native",
                                     "stmtc0": "c_setter_native_scalar",
                                     "stmtc1": "c_setter_native_scalar"
                                 }
@@ -1255,7 +1255,7 @@
                                     "f_var": "val",
                                     "sh_type": "SH_TYPE_INT",
                                     "stmt0": "f_setter_native_scalar",
-                                    "stmt1": "f_setter",
+                                    "stmt1": "f_setter_native",
                                     "stmtc0": "c_setter_native_scalar",
                                     "stmtc1": "c_setter_native_scalar"
                                 }
@@ -1447,7 +1447,7 @@
                                     "f_var": "val",
                                     "sh_type": "SH_TYPE_INT",
                                     "stmt0": "f_setter_native_scalar",
-                                    "stmt1": "f_setter",
+                                    "stmt1": "f_setter_native",
                                     "stmtc0": "c_setter_native_scalar",
                                     "stmtc1": "c_setter_native_scalar"
                                 }
@@ -1639,7 +1639,7 @@
                                     "f_var": "val",
                                     "sh_type": "SH_TYPE_INT",
                                     "stmt0": "f_setter_native_scalar",
-                                    "stmt1": "f_setter",
+                                    "stmt1": "f_setter_native",
                                     "stmtc0": "c_setter_native_scalar",
                                     "stmtc1": "c_setter_native_scalar"
                                 }

--- a/regression/reference/struct-cxx/wrapfstruct.f
+++ b/regression/reference/struct-cxx/wrapfstruct.f
@@ -297,7 +297,7 @@ module struct_mod
         ! Function:  int passStructByValue
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  Cstruct1 arg +value
         ! Attrs:     +intent(in)
@@ -319,7 +319,7 @@ module struct_mod
         ! Function:  int passStruct1
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  const Cstruct1 * arg
         ! Attrs:     +intent(in)
@@ -341,7 +341,7 @@ module struct_mod
         ! Function:  int passStruct2
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  const Cstruct1 * s1
         ! Attrs:     +intent(in)
@@ -367,7 +367,7 @@ module struct_mod
         ! Function:  int passStruct2
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  const Cstruct1 * s1
         ! Attrs:     +intent(in)
@@ -393,7 +393,7 @@ module struct_mod
         ! Function:  int acceptStructInPtr
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  Cstruct1 * arg +intent(in)
         ! Attrs:     +intent(in)
@@ -664,7 +664,7 @@ module struct_mod
         ! Function:  int Cstruct_as_class_sum
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  const Cstruct_as_class * point +pass
         ! Attrs:     +intent(in)
@@ -733,10 +733,10 @@ contains
     ! Function:  int getX1
     ! Attrs:     +intent(getter)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(getter)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! start cstruct_as_class_get_x1
     function cstruct_as_class_get_x1(obj) &
             result(SHT_rv)
@@ -779,10 +779,10 @@ contains
     ! Function:  int getY1
     ! Attrs:     +intent(getter)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(getter)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! start cstruct_as_class_get_y1
     function cstruct_as_class_get_y1(obj) &
             result(SHT_rv)
@@ -828,10 +828,10 @@ contains
     ! Function:  int getX1
     ! Attrs:     +intent(getter)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(getter)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! start cstruct_as_subclass_get_x1
     function cstruct_as_subclass_get_x1(obj) &
             result(SHT_rv)
@@ -874,10 +874,10 @@ contains
     ! Function:  int getY1
     ! Attrs:     +intent(getter)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(getter)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! start cstruct_as_subclass_get_y1
     function cstruct_as_subclass_get_y1(obj) &
             result(SHT_rv)
@@ -920,10 +920,10 @@ contains
     ! Function:  int getZ1
     ! Attrs:     +intent(getter)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(getter)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! start cstruct_as_subclass_get_z1
     function cstruct_as_subclass_get_z1(obj) &
             result(SHT_rv)
@@ -969,10 +969,10 @@ contains
     ! Function:  int passStruct2
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const Cstruct1 * s1
     ! Attrs:     +intent(in)
@@ -1170,10 +1170,10 @@ contains
     ! Function:  int Cstruct_as_class_sum
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const Cstruct_as_class * point +pass
     ! Attrs:     +intent(in)

--- a/regression/reference/struct-cxx/wrapfstruct.f
+++ b/regression/reference/struct-cxx/wrapfstruct.f
@@ -760,7 +760,7 @@ contains
     ! Argument:  int val +intent(in)+value
     ! Attrs:     +intent(setter)
     ! Requested: f_setter_native_scalar
-    ! Match:     f_setter
+    ! Match:     f_setter_native
     ! Attrs:     +intent(setter)
     ! Exact:     c_setter_native_scalar
     ! start cstruct_as_class_set_x1
@@ -806,7 +806,7 @@ contains
     ! Argument:  int val +intent(in)+value
     ! Attrs:     +intent(setter)
     ! Requested: f_setter_native_scalar
-    ! Match:     f_setter
+    ! Match:     f_setter_native
     ! Attrs:     +intent(setter)
     ! Exact:     c_setter_native_scalar
     ! start cstruct_as_class_set_y1
@@ -855,7 +855,7 @@ contains
     ! Argument:  int val +intent(in)+value
     ! Attrs:     +intent(setter)
     ! Requested: f_setter_native_scalar
-    ! Match:     f_setter
+    ! Match:     f_setter_native
     ! Attrs:     +intent(setter)
     ! Exact:     c_setter_native_scalar
     ! start cstruct_as_subclass_set_x1
@@ -901,7 +901,7 @@ contains
     ! Argument:  int val +intent(in)+value
     ! Attrs:     +intent(setter)
     ! Requested: f_setter_native_scalar
-    ! Match:     f_setter
+    ! Match:     f_setter_native
     ! Attrs:     +intent(setter)
     ! Exact:     c_setter_native_scalar
     ! start cstruct_as_subclass_set_y1
@@ -947,7 +947,7 @@ contains
     ! Argument:  int val +intent(in)+value
     ! Attrs:     +intent(setter)
     ! Requested: f_setter_native_scalar
-    ! Match:     f_setter
+    ! Match:     f_setter_native
     ! Attrs:     +intent(setter)
     ! Exact:     c_setter_native_scalar
     ! start cstruct_as_subclass_set_z1

--- a/regression/reference/struct-cxx/wrapstruct.cpp
+++ b/regression/reference/struct-cxx/wrapstruct.cpp
@@ -33,7 +33,7 @@ static void ShroudStrBlankFill(char *dest, int ndest)
 // Function:  int passStructByValue
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  Cstruct1 arg +value
 // Attrs:     +intent(in)
@@ -55,7 +55,7 @@ int STR_pass_struct_by_value(STR_cstruct1 arg)
 // Function:  int passStruct1
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  const Cstruct1 * arg
 // Attrs:     +intent(in)
@@ -80,7 +80,7 @@ int STR_pass_struct1(const STR_cstruct1 * arg)
 // Function:  int passStruct2
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  const Cstruct1 * s1
 // Attrs:     +intent(in)
@@ -108,7 +108,7 @@ int STR_pass_struct2(const STR_cstruct1 * s1, char * outbuf)
 // Function:  int passStruct2
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  const Cstruct1 * s1
 // Attrs:     +intent(in)
@@ -134,7 +134,7 @@ int STR_pass_struct2_bufferify(const STR_cstruct1 * s1, char *outbuf,
 // Function:  int acceptStructInPtr
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  Cstruct1 * arg +intent(in)
 // Attrs:     +intent(in)
@@ -430,7 +430,7 @@ void STR_create__cstruct_as_class_args(STR_Cstruct_as_class * SHC_rv,
 // Function:  int Cstruct_as_class_sum
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  const Cstruct_as_class * point +pass
 // Attrs:     +intent(in)

--- a/regression/reference/templates/templates.json
+++ b/regression/reference/templates/templates.json
@@ -641,7 +641,7 @@
                                 "idtor": "0",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "c_function_native_scalar",
-                                "stmt1": "c_default"
+                                "stmt1": "c_function"
                             },
                             "fmtf": {
                                 "F_C_var": "SHT_rv",
@@ -653,9 +653,9 @@
                                 "f_var": "SHT_rv",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "f_function_native_scalar",
-                                "stmt1": "f_default",
+                                "stmt1": "f_function",
                                 "stmtc0": "c_function_native_scalar",
-                                "stmtc1": "c_default"
+                                "stmtc1": "c_function"
                             }
                         }
                     },
@@ -905,7 +905,7 @@
                                 "idtor": "0",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "c_function_native_scalar",
-                                "stmt1": "c_default"
+                                "stmt1": "c_function"
                             },
                             "fmtf": {
                                 "F_C_var": "SHT_rv",
@@ -917,9 +917,9 @@
                                 "f_var": "SHT_rv",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "f_function_native_scalar",
-                                "stmt1": "f_default",
+                                "stmt1": "f_function",
                                 "stmtc0": "c_function_native_scalar",
-                                "stmtc1": "c_default"
+                                "stmtc1": "c_function"
                             }
                         }
                     }
@@ -1230,7 +1230,7 @@
                                 "idtor": "0",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "c_function_native_scalar",
-                                "stmt1": "c_default"
+                                "stmt1": "c_function"
                             },
                             "fmtf": {
                                 "F_C_var": "SHT_rv",
@@ -1242,9 +1242,9 @@
                                 "f_var": "SHT_rv",
                                 "sh_type": "SH_TYPE_INT",
                                 "stmt0": "f_function_native_scalar",
-                                "stmt1": "f_default",
+                                "stmt1": "f_function",
                                 "stmtc0": "c_function_native_scalar",
-                                "stmtc1": "c_default"
+                                "stmtc1": "c_function"
                             }
                         }
                     },
@@ -1494,7 +1494,7 @@
                                 "idtor": "0",
                                 "sh_type": "SH_TYPE_DOUBLE",
                                 "stmt0": "c_function_native_scalar",
-                                "stmt1": "c_default"
+                                "stmt1": "c_function"
                             },
                             "fmtf": {
                                 "F_C_var": "SHT_rv",
@@ -1506,9 +1506,9 @@
                                 "f_var": "SHT_rv",
                                 "sh_type": "SH_TYPE_DOUBLE",
                                 "stmt0": "f_function_native_scalar",
-                                "stmt1": "f_default",
+                                "stmt1": "f_function",
                                 "stmtc0": "c_function_native_scalar",
-                                "stmtc1": "c_default"
+                                "stmtc1": "c_function"
                             }
                         }
                     }
@@ -2429,7 +2429,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2441,9 +2441,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -2567,7 +2567,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2579,9 +2579,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",

--- a/regression/reference/templates/templates.json
+++ b/regression/reference/templates/templates.json
@@ -2763,7 +2763,7 @@
                                     "c_var": "self",
                                     "function_name": "dtor",
                                     "stmt0": "f_dtor",
-                                    "stmt1": "f_default",
+                                    "stmt1": "f_dtor",
                                     "stmtc0": "c_dtor",
                                     "stmtc1": "c_dtor",
                                     "underscore_name": "dtor"
@@ -3530,7 +3530,7 @@
                                     "c_var": "self",
                                     "function_name": "dtor",
                                     "stmt0": "f_dtor",
-                                    "stmt1": "f_default",
+                                    "stmt1": "f_dtor",
                                     "stmtc0": "c_dtor",
                                     "stmtc1": "c_dtor",
                                     "underscore_name": "dtor"

--- a/regression/reference/templates/wrapftemplates.f
+++ b/regression/reference/templates/wrapftemplates.f
@@ -165,7 +165,7 @@ module templates_mod
         ! Function:  int get_npts
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         function c_structasclass_int_get_npts(self) &
                 result(SHT_rv) &
                 bind(C, name="TEM_structAsClass_int_get_npts")
@@ -199,7 +199,7 @@ module templates_mod
         ! Function:  int get_value
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         function c_structasclass_int_get_value(self) &
                 result(SHT_rv) &
                 bind(C, name="TEM_structAsClass_int_get_value")
@@ -247,7 +247,7 @@ module templates_mod
         ! Function:  int get_npts
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         function c_structasclass_double_get_npts(self) &
                 result(SHT_rv) &
                 bind(C, name="TEM_structAsClass_double_get_npts")
@@ -281,7 +281,7 @@ module templates_mod
         ! Function:  double get_value
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         function c_structasclass_double_get_value(self) &
                 result(SHT_rv) &
                 bind(C, name="TEM_structAsClass_double_get_value")
@@ -356,7 +356,7 @@ module templates_mod
         ! Function:  int UseImplWorker
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         function c_use_impl_worker_internal_implworker1() &
                 result(SHT_rv) &
                 bind(C, name="TEM_use_impl_worker_internal_ImplWorker1")
@@ -369,7 +369,7 @@ module templates_mod
         ! Function:  int UseImplWorker
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         function c_use_impl_worker_internal_implworker2() &
                 result(SHT_rv) &
                 bind(C, name="TEM_use_impl_worker_internal_ImplWorker2")
@@ -523,10 +523,10 @@ contains
     ! Function:  int get_npts
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     function structasclass_int_get_npts(obj) &
             result(SHT_rv)
         use iso_c_binding, only : C_INT
@@ -566,10 +566,10 @@ contains
     ! Function:  int get_value
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     function structasclass_int_get_value(obj) &
             result(SHT_rv)
         use iso_c_binding, only : C_INT
@@ -647,10 +647,10 @@ contains
     ! Function:  int get_npts
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     function structasclass_double_get_npts(obj) &
             result(SHT_rv)
         use iso_c_binding, only : C_INT
@@ -690,10 +690,10 @@ contains
     ! Function:  double get_value
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     function structasclass_double_get_value(obj) &
             result(SHT_rv)
         use iso_c_binding, only : C_DOUBLE
@@ -822,10 +822,10 @@ contains
     ! Function:  int UseImplWorker
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     !>
     !! \brief Function which uses a templated T in the implemetation.
     !!
@@ -844,10 +844,10 @@ contains
     ! Function:  int UseImplWorker
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     !>
     !! \brief Function which uses a templated T in the implemetation.
     !!

--- a/regression/reference/templates/wrapftemplates_std.f
+++ b/regression/reference/templates/wrapftemplates_std.f
@@ -274,8 +274,7 @@ contains
     ! ----------------------------------------
     ! Function:  ~vector
     ! Attrs:     +intent(dtor)
-    ! Requested: f_dtor
-    ! Match:     f_default
+    ! Exact:     f_dtor
     ! Attrs:     +intent(dtor)
     ! Exact:     c_dtor
     subroutine vector_int_dtor(obj)
@@ -381,8 +380,7 @@ contains
     ! ----------------------------------------
     ! Function:  ~vector
     ! Attrs:     +intent(dtor)
-    ! Requested: f_dtor
-    ! Match:     f_default
+    ! Exact:     f_dtor
     ! Attrs:     +intent(dtor)
     ! Exact:     c_dtor
     subroutine vector_double_dtor(obj)

--- a/regression/reference/templates/wrapstructAsClass_double.cpp
+++ b/regression/reference/templates/wrapstructAsClass_double.cpp
@@ -56,7 +56,7 @@ void TEM_structAsClass_double_set_npts(TEM_structAsClass_double * self,
 // Function:  int get_npts
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 int TEM_structAsClass_double_get_npts(TEM_structAsClass_double * self)
 {
     structAsClass<double> *SH_this =
@@ -90,7 +90,7 @@ void TEM_structAsClass_double_set_value(TEM_structAsClass_double * self,
 // Function:  double get_value
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 double TEM_structAsClass_double_get_value(
     TEM_structAsClass_double * self)
 {

--- a/regression/reference/templates/wrapstructAsClass_int.cpp
+++ b/regression/reference/templates/wrapstructAsClass_int.cpp
@@ -55,7 +55,7 @@ void TEM_structAsClass_int_set_npts(TEM_structAsClass_int * self, int n)
 // Function:  int get_npts
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 int TEM_structAsClass_int_get_npts(TEM_structAsClass_int * self)
 {
     structAsClass<int> *SH_this = static_cast<structAsClass<int> *>
@@ -89,7 +89,7 @@ void TEM_structAsClass_int_set_value(TEM_structAsClass_int * self,
 // Function:  int get_value
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 int TEM_structAsClass_int_get_value(TEM_structAsClass_int * self)
 {
     structAsClass<int> *SH_this = static_cast<structAsClass<int> *>

--- a/regression/reference/templates/wraptemplates.cpp
+++ b/regression/reference/templates/wraptemplates.cpp
@@ -94,7 +94,7 @@ void TEM_function_tu_1(float arg1, double arg2)
 // Function:  int UseImplWorker
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 int TEM_use_impl_worker_internal_ImplWorker1(void)
 {
     // splicer begin function.use_impl_worker_internal_ImplWorker1
@@ -111,7 +111,7 @@ int TEM_use_impl_worker_internal_ImplWorker1(void)
 // Function:  int UseImplWorker
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 int TEM_use_impl_worker_internal_ImplWorker2(void)
 {
     // splicer begin function.use_impl_worker_internal_ImplWorker2

--- a/regression/reference/tutorial/tutorial.json
+++ b/regression/reference/tutorial/tutorial.json
@@ -365,7 +365,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -377,9 +377,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtl": {
                         "c_var": "SHCXX_rv",
@@ -866,7 +866,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -878,9 +878,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -1009,7 +1009,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -1021,9 +1021,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -1281,7 +1281,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -1293,9 +1293,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtl": {
                         "c_var": "SHCXX_rv",
@@ -2302,7 +2302,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2314,9 +2314,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -2420,7 +2420,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2432,9 +2432,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_DOUBLE",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -3369,7 +3369,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -3381,9 +3381,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -3559,7 +3559,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -3571,9 +3571,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -3909,7 +3909,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -3921,9 +3921,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtl": {
                         "c_var": "SHCXX_rv",
@@ -4120,7 +4120,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -4132,9 +4132,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -4354,7 +4354,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -4366,9 +4366,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -4779,7 +4779,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -4791,9 +4791,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtl": {
                         "c_var": "SHCXX_rv",
@@ -4973,7 +4973,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -4985,9 +4985,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtl": {
                         "c_var": "SHCXX_rv",
@@ -5173,7 +5173,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -5185,9 +5185,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtl": {
                         "c_var": "static_cast<int>(SHCXX_rv)",
@@ -5373,7 +5373,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -5385,9 +5385,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtl": {
                         "c_var": "static_cast<int>(SHCXX_rv)",
@@ -5803,7 +5803,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -5815,9 +5815,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },

--- a/regression/reference/tutorial/wrapTutorial.cpp
+++ b/regression/reference/tutorial/wrapTutorial.cpp
@@ -93,7 +93,7 @@ void TUT_no_return_no_arguments(void)
 // Function:  double PassByValue
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  double arg1 +value
 // Attrs:     +intent(in)
@@ -146,7 +146,7 @@ void TUT_concatenate_strings_bufferify(TUT_SHROUD_array *SHT_rv_cdesc,
 // Function:  double UseDefaultArguments
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // start TUT_use_default_arguments
 double TUT_use_default_arguments(void)
 {
@@ -161,7 +161,7 @@ double TUT_use_default_arguments(void)
 // Function:  double UseDefaultArguments
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  double arg1=3.1415 +value
 // Attrs:     +intent(in)
@@ -181,7 +181,7 @@ double TUT_use_default_arguments_arg1(double arg1)
 // Function:  double UseDefaultArguments
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  double arg1=3.1415 +value
 // Attrs:     +intent(in)
@@ -288,7 +288,7 @@ void TUT_template_argument_double(double arg)
 // Function:  int TemplateReturn
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 int TUT_template_return_int(void)
 {
     // splicer begin function.template_return_int
@@ -301,7 +301,7 @@ int TUT_template_return_int(void)
 // Function:  double TemplateReturn
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 double TUT_template_return_double(void)
 {
     // splicer begin function.template_return_double
@@ -392,7 +392,7 @@ void TUT_fortran_generic_overloaded_1_double_bufferify(char *name,
 // Function:  int UseDefaultOverload
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  int num +value
 // Attrs:     +intent(in)
@@ -410,7 +410,7 @@ int TUT_use_default_overload_num(int num)
 // Function:  int UseDefaultOverload
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  int num +value
 // Attrs:     +intent(in)
@@ -433,7 +433,7 @@ int TUT_use_default_overload_num_offset(int num, int offset)
 // Function:  int UseDefaultOverload
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  int num +value
 // Attrs:     +intent(in)
@@ -462,7 +462,7 @@ int TUT_use_default_overload_num_offset_stride(int num, int offset,
 // Function:  int UseDefaultOverload
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  double type +value
 // Attrs:     +intent(in)
@@ -485,7 +485,7 @@ int TUT_use_default_overload_3(double type, int num)
 // Function:  int UseDefaultOverload
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  double type +value
 // Attrs:     +intent(in)
@@ -513,7 +513,7 @@ int TUT_use_default_overload_4(double type, int num, int offset)
 // Function:  int UseDefaultOverload
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  double type +value
 // Attrs:     +intent(in)
@@ -548,7 +548,7 @@ int TUT_use_default_overload_5(double type, int num, int offset,
 // Function:  TypeID typefunc
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  TypeID arg +value
 // Attrs:     +intent(in)
@@ -566,7 +566,7 @@ int TUT_typefunc(int arg)
 // Function:  EnumTypeID enumfunc
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  EnumTypeID arg +value
 // Attrs:     +intent(in)
@@ -587,7 +587,7 @@ int TUT_enumfunc(int arg)
 // Function:  Color colorfunc
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  Color arg +value
 // Attrs:     +intent(in)
@@ -638,7 +638,7 @@ void TUT_get_min_max(int * min, int * max)
 // Function:  int callback1
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  int in +value
 // Attrs:     +intent(in)

--- a/regression/reference/tutorial/wrapftutorial.f
+++ b/regression/reference/tutorial/wrapftutorial.f
@@ -82,7 +82,7 @@ module tutorial_mod
     ! Function:  double PassByValue
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  double arg1 +value
     ! Attrs:     +intent(in)
@@ -136,7 +136,7 @@ module tutorial_mod
     ! Function:  double UseDefaultArguments
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! start c_use_default_arguments
     interface
         function c_use_default_arguments() &
@@ -153,7 +153,7 @@ module tutorial_mod
     ! Function:  double UseDefaultArguments
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  double arg1=3.1415 +value
     ! Attrs:     +intent(in)
@@ -176,7 +176,7 @@ module tutorial_mod
     ! Function:  double UseDefaultArguments
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  double arg1=3.1415 +value
     ! Attrs:     +intent(in)
@@ -300,7 +300,7 @@ module tutorial_mod
     ! Function:  int TemplateReturn
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     interface
         function c_template_return_int() &
                 result(SHT_rv) &
@@ -315,7 +315,7 @@ module tutorial_mod
     ! Function:  double TemplateReturn
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     interface
         function c_template_return_double() &
                 result(SHT_rv) &
@@ -418,7 +418,7 @@ module tutorial_mod
     ! Function:  int UseDefaultOverload
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  int num +value
     ! Attrs:     +intent(in)
@@ -439,7 +439,7 @@ module tutorial_mod
     ! Function:  int UseDefaultOverload
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  int num +value
     ! Attrs:     +intent(in)
@@ -466,7 +466,7 @@ module tutorial_mod
     ! Function:  int UseDefaultOverload
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  int num +value
     ! Attrs:     +intent(in)
@@ -500,7 +500,7 @@ module tutorial_mod
     ! Function:  int UseDefaultOverload
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  double type +value
     ! Attrs:     +intent(in)
@@ -527,7 +527,7 @@ module tutorial_mod
     ! Function:  int UseDefaultOverload
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  double type +value
     ! Attrs:     +intent(in)
@@ -560,7 +560,7 @@ module tutorial_mod
     ! Function:  int UseDefaultOverload
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  double type +value
     ! Attrs:     +intent(in)
@@ -599,7 +599,7 @@ module tutorial_mod
     ! Function:  TypeID typefunc
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  TypeID arg +value
     ! Attrs:     +intent(in)
@@ -620,7 +620,7 @@ module tutorial_mod
     ! Function:  EnumTypeID enumfunc
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  EnumTypeID arg +value
     ! Attrs:     +intent(in)
@@ -641,7 +641,7 @@ module tutorial_mod
     ! Function:  Color colorfunc
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  Color arg +value
     ! Attrs:     +intent(in)
@@ -689,7 +689,7 @@ module tutorial_mod
     ! Function:  int callback1
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  int in +value
     ! Attrs:     +intent(in)
@@ -846,10 +846,10 @@ contains
     ! Function:  double UseDefaultArguments
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! start use_default_arguments
     function use_default_arguments() &
             result(SHT_rv)
@@ -866,10 +866,10 @@ contains
     ! Function:  double UseDefaultArguments
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  double arg1=3.1415 +value
     ! Attrs:     +intent(in)
@@ -894,10 +894,10 @@ contains
     ! Function:  double UseDefaultArguments
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  double arg1=3.1415 +value
     ! Attrs:     +intent(in)
@@ -1024,10 +1024,10 @@ contains
     ! Function:  int TemplateReturn
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     function template_return_int() &
             result(SHT_rv)
         use iso_c_binding, only : C_INT
@@ -1042,10 +1042,10 @@ contains
     ! Function:  double TemplateReturn
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     function template_return_double() &
             result(SHT_rv)
         use iso_c_binding, only : C_DOUBLE
@@ -1134,10 +1134,10 @@ contains
     ! Function:  int UseDefaultOverload
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  int num +value
     ! Attrs:     +intent(in)
@@ -1161,10 +1161,10 @@ contains
     ! Function:  int UseDefaultOverload
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  int num +value
     ! Attrs:     +intent(in)
@@ -1196,10 +1196,10 @@ contains
     ! Function:  int UseDefaultOverload
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  int num +value
     ! Attrs:     +intent(in)
@@ -1242,10 +1242,10 @@ contains
     ! Function:  int UseDefaultOverload
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  double type +value
     ! Attrs:     +intent(in)
@@ -1278,10 +1278,10 @@ contains
     ! Function:  int UseDefaultOverload
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  double type +value
     ! Attrs:     +intent(in)
@@ -1322,10 +1322,10 @@ contains
     ! Function:  int UseDefaultOverload
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  double type +value
     ! Attrs:     +intent(in)

--- a/regression/reference/types/types.json
+++ b/regression/reference/types/types.json
@@ -145,7 +145,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_SHORT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -157,9 +157,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_SHORT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -312,7 +312,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -324,9 +324,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -479,7 +479,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_LONG",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -491,9 +491,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_LONG",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -648,7 +648,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_LONG_LONG",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -660,9 +660,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_LONG_LONG",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "PY_build_format": "L",
@@ -819,7 +819,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_SHORT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -831,9 +831,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_SHORT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -988,7 +988,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_LONG",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -1000,9 +1000,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_LONG",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -1159,7 +1159,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_LONG_LONG",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -1171,9 +1171,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_LONG_LONG",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "PY_build_format": "L",
@@ -1328,7 +1328,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_UNSIGNED_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -1340,9 +1340,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_UNSIGNED_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -1497,7 +1497,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_UNSIGNED_SHORT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -1509,9 +1509,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_UNSIGNED_SHORT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -1666,7 +1666,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_UNSIGNED_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -1678,9 +1678,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_UNSIGNED_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -1835,7 +1835,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_UNSIGNED_LONG",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -1847,9 +1847,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_UNSIGNED_LONG",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -2006,7 +2006,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_UNSIGNED_LONG_LONG",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2018,9 +2018,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_UNSIGNED_LONG_LONG",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "PY_build_format": "L",
@@ -2179,7 +2179,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_UNSIGNED_LONG",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2191,9 +2191,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_UNSIGNED_LONG",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -2346,7 +2346,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT8_T",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2358,9 +2358,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT8_T",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -2513,7 +2513,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT16_T",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2525,9 +2525,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT16_T",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -2680,7 +2680,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT32_T",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2692,9 +2692,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT32_T",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -2847,7 +2847,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT64_T",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -2859,9 +2859,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT64_T",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -3014,7 +3014,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_UINT8_T",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -3026,9 +3026,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_UINT8_T",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -3181,7 +3181,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_UINT16_T",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -3193,9 +3193,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_UINT16_T",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -3348,7 +3348,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_UINT32_T",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -3360,9 +3360,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_UINT32_T",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -3515,7 +3515,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_UINT64_T",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -3527,9 +3527,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_UINT64_T",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -3682,7 +3682,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_SIZE_T",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -3694,9 +3694,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_SIZE_T",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "c_deref": "",
@@ -3851,7 +3851,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_BOOL",
                         "stmt0": "c_function_bool_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -3865,7 +3865,7 @@
                         "stmt0": "f_function_bool_scalar",
                         "stmt1": "f_function_bool",
                         "stmtc0": "c_function_bool_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "PyTypeObject": "PyBool_Type",
@@ -4028,7 +4028,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_BOOL",
                         "stmt0": "c_function_bool_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -4042,7 +4042,7 @@
                         "stmt0": "f_function_bool_scalar",
                         "stmt1": "f_function_bool",
                         "stmtc0": "c_function_bool_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     },
                     "fmtpy": {
                         "PyTypeObject": "PyBool_Type",

--- a/regression/reference/types/wrapftypes.f
+++ b/regression/reference/types/wrapftypes.f
@@ -26,7 +26,7 @@ module types_mod
         ! Function:  short short_func
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  short arg1 +value
         ! Attrs:     +intent(in)
@@ -45,7 +45,7 @@ module types_mod
         ! Function:  int int_func
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  int arg1 +value
         ! Attrs:     +intent(in)
@@ -64,7 +64,7 @@ module types_mod
         ! Function:  long long_func
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  long arg1 +value
         ! Attrs:     +intent(in)
@@ -83,7 +83,7 @@ module types_mod
         ! Function:  long long long_long_func
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  long long arg1 +value
         ! Attrs:     +intent(in)
@@ -102,7 +102,7 @@ module types_mod
         ! Function:  short int short_int_func
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  short int arg1 +value
         ! Attrs:     +intent(in)
@@ -121,7 +121,7 @@ module types_mod
         ! Function:  long int long_int_func
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  long int arg1 +value
         ! Attrs:     +intent(in)
@@ -140,7 +140,7 @@ module types_mod
         ! Function:  long long int long_long_int_func
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  long long int arg1 +value
         ! Attrs:     +intent(in)
@@ -159,7 +159,7 @@ module types_mod
         ! Function:  unsigned unsigned_func
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  unsigned arg1 +value
         ! Attrs:     +intent(in)
@@ -178,7 +178,7 @@ module types_mod
         ! Function:  unsigned short ushort_func
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  unsigned short arg1 +value
         ! Attrs:     +intent(in)
@@ -197,7 +197,7 @@ module types_mod
         ! Function:  unsigned int uint_func
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  unsigned int arg1 +value
         ! Attrs:     +intent(in)
@@ -216,7 +216,7 @@ module types_mod
         ! Function:  unsigned long ulong_func
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  unsigned long arg1 +value
         ! Attrs:     +intent(in)
@@ -235,7 +235,7 @@ module types_mod
         ! Function:  unsigned long long ulong_long_func
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  unsigned long long arg1 +value
         ! Attrs:     +intent(in)
@@ -254,7 +254,7 @@ module types_mod
         ! Function:  unsigned long int ulong_int_func
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  unsigned long int arg1 +value
         ! Attrs:     +intent(in)
@@ -273,7 +273,7 @@ module types_mod
         ! Function:  int8_t int8_func
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  int8_t arg1 +value
         ! Attrs:     +intent(in)
@@ -292,7 +292,7 @@ module types_mod
         ! Function:  int16_t int16_func
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  int16_t arg1 +value
         ! Attrs:     +intent(in)
@@ -311,7 +311,7 @@ module types_mod
         ! Function:  int32_t int32_func
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  int32_t arg1 +value
         ! Attrs:     +intent(in)
@@ -330,7 +330,7 @@ module types_mod
         ! Function:  int64_t int64_func
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  int64_t arg1 +value
         ! Attrs:     +intent(in)
@@ -349,7 +349,7 @@ module types_mod
         ! Function:  uint8_t uint8_func
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  uint8_t arg1 +value
         ! Attrs:     +intent(in)
@@ -368,7 +368,7 @@ module types_mod
         ! Function:  uint16_t uint16_func
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  uint16_t arg1 +value
         ! Attrs:     +intent(in)
@@ -387,7 +387,7 @@ module types_mod
         ! Function:  uint32_t uint32_func
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  uint32_t arg1 +value
         ! Attrs:     +intent(in)
@@ -406,7 +406,7 @@ module types_mod
         ! Function:  uint64_t uint64_func
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  uint64_t arg1 +value
         ! Attrs:     +intent(in)
@@ -425,7 +425,7 @@ module types_mod
         ! Function:  size_t size_func
         ! Attrs:     +intent(function)
         ! Requested: c_function_native_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  size_t arg1 +value
         ! Attrs:     +intent(in)
@@ -444,7 +444,7 @@ module types_mod
         ! Function:  bool bool_func
         ! Attrs:     +intent(function)
         ! Requested: c_function_bool_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  bool arg +value
         ! Attrs:     +intent(in)
@@ -463,7 +463,7 @@ module types_mod
         ! Function:  bool returnBoolAndOthers
         ! Attrs:     +intent(function)
         ! Requested: c_function_bool_scalar
-        ! Match:     c_default
+        ! Match:     c_function
         ! ----------------------------------------
         ! Argument:  int * flag +intent(out)
         ! Attrs:     +intent(out)
@@ -491,7 +491,7 @@ contains
     ! Match:     f_function_bool
     ! Attrs:     +intent(function)
     ! Requested: c_function_bool_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  bool arg +value
     ! Attrs:     +intent(in)
@@ -519,7 +519,7 @@ contains
     ! Match:     f_function_bool
     ! Attrs:     +intent(function)
     ! Requested: c_function_bool_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  int * flag +intent(out)
     ! Attrs:     +intent(out)

--- a/regression/reference/types/wraptypes.cpp
+++ b/regression/reference/types/wraptypes.cpp
@@ -23,7 +23,7 @@ extern "C" {
 // Function:  short short_func
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  short arg1 +value
 // Attrs:     +intent(in)
@@ -41,7 +41,7 @@ short TYP_short_func(short arg1)
 // Function:  int int_func
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  int arg1 +value
 // Attrs:     +intent(in)
@@ -59,7 +59,7 @@ int TYP_int_func(int arg1)
 // Function:  long long_func
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  long arg1 +value
 // Attrs:     +intent(in)
@@ -77,7 +77,7 @@ long TYP_long_func(long arg1)
 // Function:  long long long_long_func
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  long long arg1 +value
 // Attrs:     +intent(in)
@@ -95,7 +95,7 @@ long long TYP_long_long_func(long long arg1)
 // Function:  short int short_int_func
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  short int arg1 +value
 // Attrs:     +intent(in)
@@ -113,7 +113,7 @@ short TYP_short_int_func(short arg1)
 // Function:  long int long_int_func
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  long int arg1 +value
 // Attrs:     +intent(in)
@@ -131,7 +131,7 @@ long TYP_long_int_func(long arg1)
 // Function:  long long int long_long_int_func
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  long long int arg1 +value
 // Attrs:     +intent(in)
@@ -149,7 +149,7 @@ long long TYP_long_long_int_func(long long arg1)
 // Function:  unsigned unsigned_func
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  unsigned arg1 +value
 // Attrs:     +intent(in)
@@ -167,7 +167,7 @@ unsigned int TYP_unsigned_func(unsigned int arg1)
 // Function:  unsigned short ushort_func
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  unsigned short arg1 +value
 // Attrs:     +intent(in)
@@ -185,7 +185,7 @@ unsigned short TYP_ushort_func(unsigned short arg1)
 // Function:  unsigned int uint_func
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  unsigned int arg1 +value
 // Attrs:     +intent(in)
@@ -203,7 +203,7 @@ unsigned int TYP_uint_func(unsigned int arg1)
 // Function:  unsigned long ulong_func
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  unsigned long arg1 +value
 // Attrs:     +intent(in)
@@ -221,7 +221,7 @@ unsigned long TYP_ulong_func(unsigned long arg1)
 // Function:  unsigned long long ulong_long_func
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  unsigned long long arg1 +value
 // Attrs:     +intent(in)
@@ -239,7 +239,7 @@ unsigned long long TYP_ulong_long_func(unsigned long long arg1)
 // Function:  unsigned long int ulong_int_func
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  unsigned long int arg1 +value
 // Attrs:     +intent(in)
@@ -257,7 +257,7 @@ unsigned long TYP_ulong_int_func(unsigned long arg1)
 // Function:  int8_t int8_func
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  int8_t arg1 +value
 // Attrs:     +intent(in)
@@ -275,7 +275,7 @@ int8_t TYP_int8_func(int8_t arg1)
 // Function:  int16_t int16_func
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  int16_t arg1 +value
 // Attrs:     +intent(in)
@@ -293,7 +293,7 @@ int16_t TYP_int16_func(int16_t arg1)
 // Function:  int32_t int32_func
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  int32_t arg1 +value
 // Attrs:     +intent(in)
@@ -311,7 +311,7 @@ int32_t TYP_int32_func(int32_t arg1)
 // Function:  int64_t int64_func
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  int64_t arg1 +value
 // Attrs:     +intent(in)
@@ -329,7 +329,7 @@ int64_t TYP_int64_func(int64_t arg1)
 // Function:  uint8_t uint8_func
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  uint8_t arg1 +value
 // Attrs:     +intent(in)
@@ -347,7 +347,7 @@ uint8_t TYP_uint8_func(uint8_t arg1)
 // Function:  uint16_t uint16_func
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  uint16_t arg1 +value
 // Attrs:     +intent(in)
@@ -365,7 +365,7 @@ uint16_t TYP_uint16_func(uint16_t arg1)
 // Function:  uint32_t uint32_func
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  uint32_t arg1 +value
 // Attrs:     +intent(in)
@@ -383,7 +383,7 @@ uint32_t TYP_uint32_func(uint32_t arg1)
 // Function:  uint64_t uint64_func
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  uint64_t arg1 +value
 // Attrs:     +intent(in)
@@ -401,7 +401,7 @@ uint64_t TYP_uint64_func(uint64_t arg1)
 // Function:  size_t size_func
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  size_t arg1 +value
 // Attrs:     +intent(in)
@@ -419,7 +419,7 @@ size_t TYP_size_func(size_t arg1)
 // Function:  bool bool_func
 // Attrs:     +intent(function)
 // Requested: c_function_bool_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  bool arg +value
 // Attrs:     +intent(in)
@@ -447,7 +447,7 @@ bool TYP_bool_func(bool arg)
 // Function:  bool returnBoolAndOthers
 // Attrs:     +intent(function)
 // Requested: c_function_bool_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  int * flag +intent(out)
 // Attrs:     +intent(out)

--- a/regression/reference/vectors/vectors.json
+++ b/regression/reference/vectors/vectors.json
@@ -94,9 +94,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -229,7 +229,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",
@@ -1823,9 +1823,9 @@
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "f_function_native_scalar",
-                        "stmt1": "f_default",
+                        "stmt1": "f_function",
                         "stmtc0": "c_function_native_scalar",
-                        "stmtc1": "c_default"
+                        "stmtc1": "c_function"
                     }
                 }
             },
@@ -1970,7 +1970,7 @@
                         "idtor": "0",
                         "sh_type": "SH_TYPE_INT",
                         "stmt0": "c_function_native_scalar",
-                        "stmt1": "c_default"
+                        "stmt1": "c_function"
                     },
                     "fmtf": {
                         "F_C_var": "SHT_rv",

--- a/regression/reference/vectors/wrapfvectors.f
+++ b/regression/reference/vectors/wrapfvectors.f
@@ -52,7 +52,7 @@ module vectors_mod
     ! Function:  int vector_sum
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const std::vector<int> & arg +rank(1)
     ! Attrs:     +api(buf)+intent(in)
@@ -230,7 +230,7 @@ module vectors_mod
     ! Function:  int vector_string_count
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const std::vector<std::string> & arg +rank(1)
     ! Attrs:     +api(buf)+intent(in)
@@ -309,10 +309,10 @@ contains
     ! Function:  int vector_sum
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const std::vector<int> & arg +rank(1)
     ! Attrs:     +intent(in)
@@ -570,10 +570,10 @@ contains
     ! Function:  int vector_string_count
     ! Attrs:     +intent(function)
     ! Requested: f_function_native_scalar
-    ! Match:     f_default
+    ! Match:     f_function
     ! Attrs:     +intent(function)
     ! Requested: c_function_native_scalar
-    ! Match:     c_default
+    ! Match:     c_function
     ! ----------------------------------------
     ! Argument:  const std::vector<std::string> & arg +rank(1)
     ! Attrs:     +intent(in)

--- a/regression/reference/vectors/wrapvectors.cpp
+++ b/regression/reference/vectors/wrapvectors.cpp
@@ -41,7 +41,7 @@ static int ShroudLenTrim(const char *src, int nsrc) {
 // Function:  int vector_sum
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  const std::vector<int> & arg +rank(1)
 // Attrs:     +api(buf)+intent(in)
@@ -289,7 +289,7 @@ void VEC_vector_iota_out_d_bufferify(VEC_SHROUD_array *SHT_arg_cdesc)
 // Function:  int vector_string_count
 // Attrs:     +intent(function)
 // Requested: c_function_native_scalar
-// Match:     c_default
+// Match:     c_function
 // ----------------------------------------
 // Argument:  const std::vector<std::string> & arg +rank(1)
 // Attrs:     +api(buf)+intent(in)

--- a/shroud/statements.py
+++ b/shroud/statements.py
@@ -443,7 +443,7 @@ CStmts = util.Scope(
     destructor_name=None,
     owner="library",
     return_type=None, return_cptr=False,
-    c_arg_decl=[],
+    c_arg_decl=None,
     f_c_arg_names=None,
     f_arg_decl=[],
     f_result_decl=None,
@@ -502,6 +502,7 @@ default_stmts = dict(
 fc_statements = [
     dict(
         name="c_subroutine",
+        c_arg_decl=[],
     ),
     dict(
         name="f_subroutine",
@@ -509,6 +510,7 @@ fc_statements = [
 
     dict(
         name="c_function",
+        c_arg_decl=[],
     ),
     dict(
         name="f_function",
@@ -1903,6 +1905,7 @@ fc_statements = [
         name="c_dtor",
         c_impl_header=["<stddef.h>"],
         cxx_impl_header=["<cstddef>"],
+        c_arg_decl=[],
         call=[
             "delete {CXX_this};",
             "{C_this}->addr = {nullptr};",
@@ -1961,6 +1964,7 @@ fc_statements = [
     dict(
         # Base for all getters to avoid calling function.
         name="c_getter",
+        c_arg_decl=[],
         call=[
             "// skip call c_getter",
         ],
@@ -1969,6 +1973,7 @@ fc_statements = [
         # Not actually calling a subroutine.
         # Work is done by arg's setter.
         name="c_setter",
+        c_arg_decl=[],
         call=[
             "// skip call c_setter",
         ],

--- a/shroud/statements.py
+++ b/shroud/statements.py
@@ -501,6 +501,13 @@ fc_statements = [
         name="f_subroutine",
     ),
 
+    dict(
+        name="c_function",
+    ),
+    dict(
+        name="f_function",
+    ),
+
     ########## mixin ##########
     dict(
         name="c_mixin_function_buf",

--- a/shroud/statements.py
+++ b/shroud/statements.py
@@ -443,9 +443,10 @@ def lookup_stmts_tree(tree, path):
 #  arg_call    - List of arguments passed to C function.
 #
 #  Used with buf_args = "arg_decl".
-#  c_arg_decl  - Add C declaration to C wrapper with buf_args=arg_decl
-#  f_arg_decl  - Add Fortran declaration to Fortran wrapper interface block
-#                with buf_args=arg_decl.
+#  c_arg_decl  - Add C declaration to C wrapper.
+#                Empty list is no arguments, None is default argument.
+#  f_arg_decl  - Add Fortran declaration to Fortran wrapper interface block.
+#                Empty list is no arguments, None is default argument.
 #  f_c_arg_names - 
 #  f_result_decl - Declaration for function result.
 #                  Can be an empty list to override default.

--- a/shroud/statements.py
+++ b/shroud/statements.py
@@ -221,7 +221,7 @@ def add_statement_to_tree(tree, nodes, node_stmts, node, steps):
     scope.name = name
     nodes[name] = scope
     node_stmts[name] = node
-    
+    return scope
         
 def update_stmt_tree(stmts, nodes, tree, defaults):
     """Update tree by adding stmts.  Each key in stmts is split by
@@ -296,7 +296,8 @@ def update_stmt_tree(stmts, nodes, tree, defaults):
             if name in nodes:
                 raise RuntimeError("Duplicate key in statements: {}".
                                    format(name))
-            add_statement_to_tree(tree, nodes, node_stmts, node, namelst)
+            stmt = add_statement_to_tree(tree, nodes, node_stmts, node, namelst)
+            stmt.intent = steps[1]
 
 
 def write_cf_tree(fp):
@@ -414,6 +415,7 @@ def lookup_stmts_tree(tree, path):
 
 
 # C Statements.
+#  intent      - Set from name.
 #  arg_call    - List of arguments passed to C function.
 #
 #  Used with buf_args = "arg_decl".
@@ -423,8 +425,10 @@ def lookup_stmts_tree(tree, path):
 #  f_result_decl - Declaration for function result.
 #                  Can be an empty list to override default.
 #  f_module    - Add module info to interface block.
-CStmts = util.Scope(None,
+CStmts = util.Scope(
+    None,
     name="c_default",
+    intent=None,
     buf_args=[],
     iface_header=[],
     impl_header=[],
@@ -451,8 +455,10 @@ CStmts = util.Scope(None,
 )
 
 # Fortran Statements.
-FStmts = util.Scope(None,
+FStmts = util.Scope(
+    None,
     name="f_default",
+    intent=None,
     c_helper="",
     c_local_var=None,
     f_helper="",

--- a/shroud/statements.py
+++ b/shroud/statements.py
@@ -541,6 +541,7 @@ fc_statements = [
     ),
     dict(
         name="f_subroutine",
+        arg_c_call=[],
     ),
 
     dict(
@@ -1927,6 +1928,10 @@ fc_statements = [
         mixin=["f_mixin_shadow"],
     ),
     dict(
+        name="f_dtor",
+        arg_c_call=[],
+    ),
+    dict(
         name="c_ctor",
         mixin=["c_mixin_shadow"],
         cxx_local_var="pointer",
@@ -1940,7 +1945,7 @@ fc_statements = [
     ),
     dict(
         name="f_ctor",
-        base="f_function_shadow",
+        mixin=["f_mixin_shadow"],
     ),
     dict(
         # NULL in stddef.h
@@ -2029,6 +2034,7 @@ fc_statements = [
     ),
     dict(
         name="f_setter",
+        arg_c_call=[],
     ),
 
     dict(
@@ -2037,6 +2043,11 @@ fc_statements = [
         ret=[
             "return {CXX_this}->{field_name};",
         ],
+    ),
+    dict(
+        name="f_setter_native",
+        arg_c_call=["{c_var}"],
+        # f_setter is intended for the function, this is for an argument.
     ),
     dict(
         name="c_setter_native_scalar",

--- a/shroud/statements.py
+++ b/shroud/statements.py
@@ -1968,6 +1968,10 @@ fc_statements = [
         ],
     ),
     dict(
+        # Argument to setter.
+        name="c_setter_arg",
+    ),
+    dict(
         name="f_getter",
     ),
     dict(
@@ -1983,7 +1987,7 @@ fc_statements = [
     ),
     dict(
         name="c_setter_native_scalar",
-        base="c_setter",
+        base="c_setter_arg",
         post_call=[
             "{CXX_this}->{field_name} = val;",
         ],
@@ -2005,7 +2009,7 @@ fc_statements = [
     dict(
         # Create std::string from Fortran meta data.
         name="c_setter_string_scalar_buf",
-        base="c_setter",
+        base="c_setter_arg",
         mixin=["c_mixin_in_character_buf"],
         post_call=[
             "{CXX_this}->{field_name} = std::string({c_var},\t {c_var_len});",

--- a/shroud/wrapc.py
+++ b/shroud/wrapc.py
@@ -663,17 +663,17 @@ class Wrapc(util.WrapperMixin):
         A wrapper will be needed if there is meta data.
         i.e. No wrapper if the C function can be called directly.
         """
-        attrs = ast.attrs
-        for buf_arg in buf_args:
-            if buf_arg == "arg":
-                # vector<int> -> int *
-                proto_list.append(ast.gen_arg_as_c(continuation=True))
-                continue
-            elif buf_arg == "arg_decl":
-                for arg in intent_blk.c_arg_decl:
-                    append_format(proto_list, arg, fmt)
-                continue
-
+        if not buf_args:
+            return
+        assert len(buf_args) == 1
+        buf_arg = buf_args[0]
+        if buf_arg == "arg":
+            # vector<int> -> int *
+            proto_list.append(ast.gen_arg_as_c(continuation=True))
+        elif buf_arg == "arg_decl":
+            for arg in intent_blk.c_arg_decl:
+                append_format(proto_list, arg, fmt)
+        else:
             raise RuntimeError(
                 "wrap_function: unhandled case {}".format(buf_arg)
             )

--- a/shroud/wrapl.py
+++ b/shroud/wrapl.py
@@ -933,8 +933,10 @@ def write_stmts_tree(fp):
 def lookup_stmts(path):
     return statements.lookup_stmts_tree(lua_tree, path)
 
-LuaStmts = util.Scope(None,
+LuaStmts = util.Scope(
+    None,
     name="lua_default",
+    intent=None,
     pre_call=[],
     call=[],
     post_call=[],

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -3568,8 +3568,10 @@ def write_stmts_tree(fp):
 def lookup_stmts(path):
     return statements.lookup_stmts_tree(py_tree, path)
 
-PyStmts = util.Scope(None,
+PyStmts = util.Scope(
+    None,
     name="py_default",
+    intent=None,
     arg_declare=None,   # Empty list indicates no declaration.
     post_declare=[],
     fmtdict=None,


### PR DESCRIPTION
Remove ``Stmts.buf_args``. This was intended as a short cut to add 'bufferify' arguments to wrappers. All of this is now done via *c_arg_decl* and *f_arg_decl* to be more explicit.  Eventually this will allow users to create their own wrapping schemes for custom types without relying on too much 'magic'.