### PR TITLE
 test with multiple compilers

### DIFF
--- a/regression/run/Makefile
+++ b/regression/run/Makefile
@@ -19,6 +19,14 @@ relrunpath = $(tempdir)/run/$(testdir)
 
 include $(top)/regression/run/defaults.mk
 
+# ( directory, command )
+# Save output to file and record PASS/FAIL
+ifeq ($(LOGOUTPUT),1)
+run-command = cd $1 && rm -f PASS FAIL ; { $2 >| out 2>&1; } && touch PASS || touch FAIL
+else
+run-command = cd $1 && $2
+endif
+
 ######################################################################
 # Compile a Fortran test
 fortran-% : $(relrunpath)/%/.. phony_explicit
@@ -29,7 +37,7 @@ fortran-% : $(relrunpath)/%/.. phony_explicit
 
 # Run a Fortran test
 test-fortran-% : fortran-%
-	$(relrunpath)/$*/$*
+	$(call run-command, $(relrunpath)/$*, ./$*)
 
 # Run the Fortran tests
 test-fortran : \
@@ -74,7 +82,7 @@ c-% : $(relrunpath)/%/.. phony_explicit
 
 # Run the C tests
 test-c-% : c-%
-	$(relrunpath)/$*/testc
+	$(call run-command, $(relrunpath)/$*, ./testc)
 
 # Compile C tests
 test-c : \
@@ -112,7 +120,7 @@ cpp-% : $(relrunpath)/%/.. phony_explicit
 
 # Run a C++ test
 test-cpp-% : cpp-%
-	$(relrunpath)/$*/maincpp
+	$(call run-command, $(relrunpath)/$*, ./maincpp)
 
 test-cpp : \
   cpp-tutorial \
@@ -130,7 +138,8 @@ pymod-% : $(relrunpath)/%/python/.. phony_explicit
 # Run the Python tests
 test-python-% : pymod-%
 	export PYTHONPATH=$(top)/$(relrunpath)/$*/python; \
-	$(python.exe) $(top)/regression/run/$*/python/test.py
+	$(call run-command, $(relrunpath)/$*/python, \
+	$(python.exe) $(top)/regression/run/$*/python/test.py)
 
 test-python : \
   test-python-tutorial \
@@ -171,8 +180,8 @@ compile-lua-% : $(relrunpath)/%/lua/.. phony_explicit
 # Run the Lua test
 test-lua-% : compile-lua-%
 #	export LUA_PATH=$(top)/$(relrunpath)/tutorial/lua;
-	cd $(top)/$(relrunpath)/$*/lua; \
-	$(LUA_BIN) $(top)/regression/run/$*/lua/test.lua
+	$(call run-command, $(relrunpath)/$*/lua, \
+	$(LUA_BIN) $(top)/regression/run/$*/lua/test.lua)
 
 test-lua : \
     test-lua-tutorial \

--- a/regression/run/Makefile
+++ b/regression/run/Makefile
@@ -28,19 +28,7 @@ run-command = cd $1 && $2
 endif
 
 ######################################################################
-# Compile a Fortran test
-fortran-% : $(relrunpath)/%/.. phony_explicit
-	$(MAKE) \
-	    -C $(relrunpath)/$* \
-	    -f $(top)/regression/run/$*/Makefile \
-	    top=$(top) $*
-
-# Run a Fortran test
-test-fortran-% : fortran-%
-	$(call run-command, $(relrunpath)/$*, ./$*)
-
-# Run the Fortran tests
-test-fortran : \
+fortran-test-list = \
   test-fortran-tutorial \
   test-fortran-types \
   test-fortran-classes \
@@ -64,28 +52,33 @@ test-fortran : \
   test-fortran-statement \
   test-fortran-templates
 
+# Compile a Fortran test
+fortran-% : $(relrunpath)/%/..
+	$(MAKE) \
+	    -C $(relrunpath)/$* \
+	    -f $(top)/regression/run/$*/Makefile \
+	    top=$(top) $*
+
+# Run a Fortran test
+.PHONY : $(fortran-test-list)
+$(fortran-test-list) : test-fortran-% : fortran-%
+	$(call run-command, $(relrunpath)/$*, ./$*)
+
+# Run the Fortran tests
+.PHONY : test-fortran
+test-fortran : $(fortran-test-list)
+
 # Futher Interoperability with C
 # gfortran 9.1
 # intel 16.0.3
+.PHONY : test-cfi
 test-cfi : \
   test-fortran-strings-cfi \
   test-fortran-generic-cfi
 
 ######################################################################
-# Compile a C test
-c-% : $(relrunpath)/%/.. phony_explicit
-	$(MAKE) \
-	    -C $(relrunpath)/$* \
-	    -f $(top)/regression/run/$*/Makefile \
-	    top=$(top) testc
 
-
-# Run the C tests
-test-c-% : c-%
-	$(call run-command, $(relrunpath)/$*, ./testc)
-
-# Compile C tests
-test-c : \
+c-test-list = \
   test-c-types \
   test-c-classes \
   test-c-enum-c \
@@ -94,6 +87,21 @@ test-c : \
   test-c-statement \
   test-c-templates
 
+# Compile a C test
+c-% : $(relrunpath)/%/..
+	$(MAKE) \
+	    -C $(relrunpath)/$* \
+	    -f $(top)/regression/run/$*/Makefile \
+	    top=$(top) testc
+
+# Run the C tests
+.PHONY : $(c-test-list)
+$(c-test-list) : test-c-% : c-%
+	$(call run-command, $(relrunpath)/$*, ./testc)
+
+# Compile C tests
+.PHONY : test-c
+test-c : $(c-test-list)
 
 ##  test-c-tutorial 
 ##  test-c-types 
@@ -111,37 +119,30 @@ test-c : \
 
 
 ######################################################################
+
+cpp-test-list = \
+  test-cpp-tutorial \
+  test-cpp-templates \
+  test-cpp-scope
+
 # Compile a C++ test
-cpp-% : $(relrunpath)/%/.. phony_explicit
+cpp-% : $(relrunpath)/%/..
 	$(MAKE) \
 	    -C $(relrunpath)/$* \
 	    -f $(top)/regression/run/$*/Makefile \
 	    top=$(top) maincpp
 
 # Run a C++ test
-test-cpp-% : cpp-%
+.PHONY : $(cpp-test-list)
+$(cpp-test-list) : test-cpp-% : cpp-%
 	$(call run-command, $(relrunpath)/$*, ./maincpp)
 
-test-cpp : \
-  cpp-tutorial \
-  cpp-templates \
-  test-cpp-scope
+.PHONY : test-cpp
+test-cpp : $(cpp-test-list)
 
 ######################################################################
-# Compile the generated Python wrapper
-pymod-% : $(relrunpath)/%/python/.. phony_explicit
-	$(MAKE) \
-	    -C $(relrunpath)/$*/python \
-	    -f $(top)/regression/run/$*/python/Makefile \
-	    PYTHON=$(PYTHON) top=$(top) all
 
-# Run the Python tests
-test-python-% : pymod-%
-	export PYTHONPATH=$(top)/$(relrunpath)/$*/python; \
-	$(call run-command, $(relrunpath)/$*/python, \
-	$(python.exe) $(top)/regression/run/$*/python/test.py)
-
-test-python : \
+python-test-list = \
   test-python-tutorial \
   test-python-types \
   test-python-classes \
@@ -167,30 +168,54 @@ test-python : \
   test-python-ownership \
   test-python-templates
 
+# Compile the generated Python wrapper
+pymod-% : $(relrunpath)/%/python/..
+	$(MAKE) \
+	    -C $(relrunpath)/$*/python \
+	    -f $(top)/regression/run/$*/python/Makefile \
+	    PYTHON=$(PYTHON) top=$(top) all
+
+# Run the Python tests
+.PHONY : $(python-test-list)
+$(python-test-list) : test-python-% : pymod-%
+	export PYTHONPATH=$(top)/$(relrunpath)/$*/python; \
+	$(call run-command, $(relrunpath)/$*/python, \
+	$(python.exe) $(top)/regression/run/$*/python/test.py)
+
+.PHONY : test-python
+test-python : $(python-test-list)
+
 # test-python-templates
 
 ######################################################################
+
+lua-test-list = \
+    test-lua-tutorial \
+    test-lua-classes
+
 # Compile the generated Lua wrapper
-compile-lua-% : $(relrunpath)/%/lua/.. phony_explicit
+compile-lua-% : $(relrunpath)/%/lua/..
 	$(MAKE) \
 	    -C $(relrunpath)/$*/lua \
 	    -f $(top)/regression/run/$*/lua/Makefile \
 	    LUA=$(LUA) top=$(top) all
 
 # Run the Lua test
-test-lua-% : compile-lua-%
+.PHONY : $(lua-test-list)
+$(lua-test-list) : test-lua-% : compile-lua-%
 #	export LUA_PATH=$(top)/$(relrunpath)/tutorial/lua;
 	$(call run-command, $(relrunpath)/$*/lua, \
 	$(LUA_BIN) $(top)/regression/run/$*/lua/test.lua)
 
-test-lua : \
-    test-lua-tutorial \
-    test-lua-classes
+.PHONY : test-lua
+test-lua : $(lua-test-list)
 
 ######################################################################
+.PHONY : test-all
 test-all : test-c test-fortran test-python test-lua
 
 # test specific yaml files
+.PHONY : test-pointers
 test-pointers : \
   test-fortran-pointers-c \
   test-fortran-pointers-cxx \
@@ -199,6 +224,7 @@ test-pointers : \
   test-python-pointers-list-c \
   test-python-pointers-list-cxx
 
+.PHONY : test-struct
 test-struct : \
   test-c-struct-cxx \
   test-fortran-struct-c \
@@ -207,16 +233,6 @@ test-struct : \
   test-python-struct-numpy-cxx \
   test-python-struct-class-c \
   test-python-struct-class-cxx
-
-.PHONY : test-c
-.PHONY : test-fortran
-.PHONY : test-python
-.PHONY : test-lua
-.PHONY : test-all
-.PHONY : test-struct
-
-.PHONY: phony_explicit
-phony_explicit: 
 
 # Avoid deleting directories created to run tests.
 # They are created via pattern rules.

--- a/regression/run/Makefile
+++ b/regression/run/Makefile
@@ -11,19 +11,25 @@
 compiler = gcc
 export compiler
 
+# build/temp-
+#             run/$(testdir)/prob
+# relrunpath- relative directory, allow multiple compiler builds
+testdir = .
+relrunpath = $(tempdir)/run/$(testdir)
+
 include $(top)/regression/run/defaults.mk
 
 ######################################################################
 # Compile a Fortran test
-fortran-% : $(tempdir)/run/%/.. phony_explicit
+fortran-% : $(relrunpath)/%/.. phony_explicit
 	$(MAKE) \
-	    -C $(tempdir)/run/$* \
+	    -C $(relrunpath)/$* \
 	    -f $(top)/regression/run/$*/Makefile \
 	    top=$(top) $*
 
 # Run a Fortran test
 test-fortran-% : fortran-%
-	$(tempdir)/run/$*/$*
+	$(relrunpath)/$*/$*
 
 # Run the Fortran tests
 test-fortran : \
@@ -59,16 +65,16 @@ test-cfi : \
 
 ######################################################################
 # Compile a C test
-c-% : $(tempdir)/run/%/.. phony_explicit
+c-% : $(relrunpath)/%/.. phony_explicit
 	$(MAKE) \
-	    -C $(tempdir)/run/$* \
+	    -C $(relrunpath)/$* \
 	    -f $(top)/regression/run/$*/Makefile \
 	    top=$(top) testc
 
 
 # Run the C tests
 test-c-% : c-%
-	$(tempdir)/run/$*/testc
+	$(relrunpath)/$*/testc
 
 # Compile C tests
 test-c : \
@@ -98,15 +104,15 @@ test-c : \
 
 ######################################################################
 # Compile a C++ test
-cpp-% : $(tempdir)/run/%/.. phony_explicit
+cpp-% : $(relrunpath)/%/.. phony_explicit
 	$(MAKE) \
-	    -C $(tempdir)/run/$* \
+	    -C $(relrunpath)/$* \
 	    -f $(top)/regression/run/$*/Makefile \
 	    top=$(top) maincpp
 
 # Run a C++ test
 test-cpp-% : cpp-%
-	$(tempdir)/run/$*/maincpp
+	$(relrunpath)/$*/maincpp
 
 test-cpp : \
   cpp-tutorial \
@@ -115,15 +121,15 @@ test-cpp : \
 
 ######################################################################
 # Compile the generated Python wrapper
-pymod-% : $(tempdir)/run/%/python/.. phony_explicit
+pymod-% : $(relrunpath)/%/python/.. phony_explicit
 	$(MAKE) \
-	    -C $(tempdir)/run/$(subst pymod-,,$@)/python \
-	    -f $(top)/regression/run/$(subst pymod-,,$@)/python/Makefile \
+	    -C $(relrunpath)/$*/python \
+	    -f $(top)/regression/run/$*/python/Makefile \
 	    PYTHON=$(PYTHON) top=$(top) all
 
 # Run the Python tests
 test-python-% : pymod-%
-	export PYTHONPATH=$(top)/$(tempdir)/run/$*/python; \
+	export PYTHONPATH=$(top)/$(relrunpath)/$*/python; \
 	$(python.exe) $(top)/regression/run/$*/python/test.py
 
 test-python : \
@@ -156,16 +162,16 @@ test-python : \
 
 ######################################################################
 # Compile the generated Lua wrapper
-compile-lua-% : $(tempdir)/run/%/lua/.. phony_explicit
+compile-lua-% : $(relrunpath)/%/lua/.. phony_explicit
 	$(MAKE) \
-	    -C $(tempdir)/run/$*/lua \
+	    -C $(relrunpath)/$*/lua \
 	    -f $(top)/regression/run/$*/lua/Makefile \
 	    LUA=$(LUA) top=$(top) all
 
 # Run the Lua test
 test-lua-% : compile-lua-%
-#	export LUA_PATH=$(top)/$(tempdir)/run/tutorial/lua;
-	cd $(top)/$(tempdir)/run/$*/lua; \
+#	export LUA_PATH=$(top)/$(relrunpath)/tutorial/lua;
+	cd $(top)/$(relrunpath)/$*/lua; \
 	$(LUA_BIN) $(top)/regression/run/$*/lua/test.lua
 
 test-lua : \
@@ -206,59 +212,62 @@ phony_explicit:
 # Avoid deleting directories created to run tests.
 # They are created via pattern rules.
 .SECONDARY: \
-    $(tempdir)/run/ccomplex/.. \
-    $(tempdir)/run/ccomplex/python/.. \
-    $(tempdir)/run/cdesc/.. \
-    $(tempdir)/run/classes/.. \
-    $(tempdir)/run/classes/lua/.. \
-    $(tempdir)/run/classes/python/.. \
-    $(tempdir)/run/clibrary/.. \
-    $(tempdir)/run/clibrary/python/.. \
-    $(tempdir)/run/cxxlibrary/.. \
-    $(tempdir)/run/cxxlibrary/python/.. \
-    $(tempdir)/run/enum-c/.. \
-    $(tempdir)/run/enum-c/python/.. \
-    $(tempdir)/run/forward/.. \
-    $(tempdir)/run/generic/.. \
-    $(tempdir)/run/generic-cfi/.. \
-    $(tempdir)/run/namespace/.. \
-    $(tempdir)/run/namespace/python/.. \
-    $(tempdir)/run/ownership/.. \
-    $(tempdir)/run/ownership/python/.. \
-    $(tempdir)/run/pointers-c/..\
-    $(tempdir)/run/pointers-cxx/..\
-    $(tempdir)/run/pointers-numpy-cxx/python/.. \
-    $(tempdir)/run/pointers-list-cxx/python/.. \
-    $(tempdir)/run/pointers-numpy-c/python/.. \
-    $(tempdir)/run/pointers-list-c/python/.. \
-    $(tempdir)/run/preprocess/..\
-    $(tempdir)/run/preprocess/python/.. \
-    $(tempdir)/run/preprocess/.. \
-    $(tempdir)/run/arrayclass/.. \
-    $(tempdir)/run/arrayclass/python/.. \
-    $(tempdir)/run/scope/.. \
-    $(tempdir)/run/statement/.. \
-    $(tempdir)/run/strings/.. \
-    $(tempdir)/run/strings/python/.. \
-    $(tempdir)/run/strings-cfi/.. \
-    $(tempdir)/run/struct-c/.. \
-    $(tempdir)/run/struct-cxx/.. \
-    $(tempdir)/run/struct-numpy-c/python/.. \
-    $(tempdir)/run/struct-numpy-cxx/python/.. \
-    $(tempdir)/run/struct-class-c/python/.. \
-    $(tempdir)/run/struct-class-cxx/python/.. \
-    $(tempdir)/run/struct-list-c/python/.. \
-    $(tempdir)/run/structlist/python/.. \
-    $(tempdir)/run/struct-py-c/python/.. \
-    $(tempdir)/run/struct-py-cxx/python/.. \
-    $(tempdir)/run/templates/.. \
-    $(tempdir)/run/templates/python/.. \
-    $(tempdir)/run/tutorial/..\
-    $(tempdir)/run/tutorial/lua/.. \
-    $(tempdir)/run/tutorial/python/.. \
-    $(tempdir)/run/types/..\
-    $(tempdir)/run/types/python/..\
-    $(tempdir)/run/vectors/..\
-    $(tempdir)/run/vectors-list/python/.. \
-    $(tempdir)/run/vectors-numpy/python/..
+    $(relrunpath)/ccomplex/.. \
+    $(relrunpath)/ccomplex/python/.. \
+    $(relrunpath)/cdesc/.. \
+    $(relrunpath)/classes/.. \
+    $(relrunpath)/classes/lua/.. \
+    $(relrunpath)/classes/python/.. \
+    $(relrunpath)/clibrary/.. \
+    $(relrunpath)/clibrary/python/.. \
+    $(relrunpath)/cxxlibrary/.. \
+    $(relrunpath)/cxxlibrary/python/.. \
+    $(relrunpath)/enum-c/.. \
+    $(relrunpath)/enum-c/python/.. \
+    $(relrunpath)/forward/.. \
+    $(relrunpath)/generic/.. \
+    $(relrunpath)/generic-cfi/.. \
+    $(relrunpath)/namespace/.. \
+    $(relrunpath)/namespace/python/.. \
+    $(relrunpath)/ownership/.. \
+    $(relrunpath)/ownership/python/.. \
+    $(relrunpath)/pointers-c/..\
+    $(relrunpath)/pointers-cxx/..\
+    $(relrunpath)/pointers-numpy-cxx/python/.. \
+    $(relrunpath)/pointers-list-cxx/python/.. \
+    $(relrunpath)/pointers-numpy-c/python/.. \
+    $(relrunpath)/pointers-list-c/python/.. \
+    $(relrunpath)/preprocess/..\
+    $(relrunpath)/preprocess/python/.. \
+    $(relrunpath)/preprocess/.. \
+    $(relrunpath)/arrayclass/.. \
+    $(relrunpath)/arrayclass/python/.. \
+    $(relrunpath)/scope/.. \
+    $(relrunpath)/statement/.. \
+    $(relrunpath)/strings/.. \
+    $(relrunpath)/strings/python/.. \
+    $(relrunpath)/strings-cfi/.. \
+    $(relrunpath)/struct-c/.. \
+    $(relrunpath)/struct-cxx/.. \
+    $(relrunpath)/struct-numpy-c/python/.. \
+    $(relrunpath)/struct-numpy-cxx/python/.. \
+    $(relrunpath)/struct-class-c/python/.. \
+    $(relrunpath)/struct-class-cxx/python/.. \
+    $(relrunpath)/struct-list-c/python/.. \
+    $(relrunpath)/structlist/python/.. \
+    $(relrunpath)/struct-py-c/python/.. \
+    $(relrunpath)/struct-py-cxx/python/.. \
+    $(relrunpath)/templates/.. \
+    $(relrunpath)/templates/python/.. \
+    $(relrunpath)/tutorial/..\
+    $(relrunpath)/tutorial/lua/.. \
+    $(relrunpath)/tutorial/python/.. \
+    $(relrunpath)/types/..\
+    $(relrunpath)/types/python/..\
+    $(relrunpath)/vectors/..\
+    $(relrunpath)/vectors-list/python/.. \
+    $(relrunpath)/vectors-numpy/python/..
 
+test-clean-testdir :
+	rm -rf $(relrunpath)
+.PHONY : test-clean-testdir

--- a/regression/run/Makefile
+++ b/regression/run/Makefile
@@ -34,6 +34,28 @@ run-command = cd $1 && $2
 endif
 
 ######################################################################
+#
+# Several tests compile the test code with both C and C++.
+# Copy the .c suffix to a .cpp suffix file to compile as C++.
+# Done as an order-only dependency since the referrence file will not
+# change during the compilation test.
+#
+c-to-cxx = \
+  regression/run/struct/struct.c
+
+
+.PHONY : sync-cxx
+sync-cxx : \
+  $(relrunpath)/cxx/pointers.cpp \
+  $(relrunpath)/cxx/struct.cpp
+
+$(relrunpath)/cxx/struct.cpp : regression/run/struct/struct.c | $(relrunpath)/cxx/..
+	cp $< $@
+$(relrunpath)/cxx/pointers.cpp : regression/run/pointers/pointers.c | $(relrunpath)/cxx/..
+	cp $< $@
+
+
+######################################################################
 fortran-test-list = \
   test-fortran-tutorial \
   test-fortran-types \
@@ -59,7 +81,7 @@ fortran-test-list = \
   test-fortran-templates
 
 # Compile a Fortran test
-fortran-% : | $(relrunpath)/%/..
+fortran-% : | $(relrunpath)/%/.. sync-cxx
 	$(MAKE) \
 	    -C $(relrunpath)/$* \
 	    -f $(top)/regression/run/$*/Makefile \
@@ -94,7 +116,7 @@ c-test-list = \
   test-c-templates
 
 # Compile a C test
-c-% : | $(relrunpath)/%/..
+c-% : | $(relrunpath)/%/.. sync-cxx
 	$(MAKE) \
 	    -C $(relrunpath)/$* \
 	    -f $(top)/regression/run/$*/Makefile \
@@ -175,7 +197,7 @@ python-test-list = \
   test-python-templates
 
 # Compile the generated Python wrapper
-pymod-% : | $(relrunpath)/%/python/..
+pymod-% : | $(relrunpath)/%/python/.. sync-cxx
 	$(MAKE) \
 	    -C $(relrunpath)/$*/python \
 	    -f $(top)/regression/run/$*/python/Makefile \

--- a/regression/run/Makefile
+++ b/regression/run/Makefile
@@ -8,6 +8,12 @@
 #
 #  Compile and test generated wrappers.
 #
+# Initialization
+# 3.80 for order-only dependency.
+need := 3.80
+ok := $(filter $(need),$(firstword $(sort $(MAKE_VERSION) $(need))))
+$(if $(ok),,$(error version $(need) of gmake or greater is required))
+
 compiler = gcc
 export compiler
 
@@ -53,7 +59,7 @@ fortran-test-list = \
   test-fortran-templates
 
 # Compile a Fortran test
-fortran-% : $(relrunpath)/%/..
+fortran-% : | $(relrunpath)/%/..
 	$(MAKE) \
 	    -C $(relrunpath)/$* \
 	    -f $(top)/regression/run/$*/Makefile \
@@ -61,7 +67,7 @@ fortran-% : $(relrunpath)/%/..
 
 # Run a Fortran test
 .PHONY : $(fortran-test-list)
-$(fortran-test-list) : test-fortran-% : fortran-%
+$(fortran-test-list) : test-fortran-% : fortran-% | $(relrunpath)/%/..
 	$(call run-command, $(relrunpath)/$*, ./$*)
 
 # Run the Fortran tests
@@ -88,7 +94,7 @@ c-test-list = \
   test-c-templates
 
 # Compile a C test
-c-% : $(relrunpath)/%/..
+c-% : | $(relrunpath)/%/..
 	$(MAKE) \
 	    -C $(relrunpath)/$* \
 	    -f $(top)/regression/run/$*/Makefile \
@@ -96,7 +102,7 @@ c-% : $(relrunpath)/%/..
 
 # Run the C tests
 .PHONY : $(c-test-list)
-$(c-test-list) : test-c-% : c-%
+$(c-test-list) : test-c-% : c-% | $(relrunpath)/%/..
 	$(call run-command, $(relrunpath)/$*, ./testc)
 
 # Compile C tests
@@ -126,7 +132,7 @@ cpp-test-list = \
   test-cpp-scope
 
 # Compile a C++ test
-cpp-% : $(relrunpath)/%/..
+cpp-% : | $(relrunpath)/%/..
 	$(MAKE) \
 	    -C $(relrunpath)/$* \
 	    -f $(top)/regression/run/$*/Makefile \
@@ -134,7 +140,7 @@ cpp-% : $(relrunpath)/%/..
 
 # Run a C++ test
 .PHONY : $(cpp-test-list)
-$(cpp-test-list) : test-cpp-% : cpp-%
+$(cpp-test-list) : test-cpp-% : cpp-% | $(relrunpath)/%/..
 	$(call run-command, $(relrunpath)/$*, ./maincpp)
 
 .PHONY : test-cpp
@@ -169,7 +175,7 @@ python-test-list = \
   test-python-templates
 
 # Compile the generated Python wrapper
-pymod-% : $(relrunpath)/%/python/..
+pymod-% : | $(relrunpath)/%/python/..
 	$(MAKE) \
 	    -C $(relrunpath)/$*/python \
 	    -f $(top)/regression/run/$*/python/Makefile \
@@ -177,7 +183,7 @@ pymod-% : $(relrunpath)/%/python/..
 
 # Run the Python tests
 .PHONY : $(python-test-list)
-$(python-test-list) : test-python-% : pymod-%
+$(python-test-list) : test-python-% : pymod-% | $(relrunpath)/%/python/..
 	export PYTHONPATH=$(top)/$(relrunpath)/$*/python; \
 	$(call run-command, $(relrunpath)/$*/python, \
 	$(python.exe) $(top)/regression/run/$*/python/test.py)
@@ -194,7 +200,7 @@ lua-test-list = \
     test-lua-classes
 
 # Compile the generated Lua wrapper
-compile-lua-% : $(relrunpath)/%/lua/..
+compile-lua-% : | $(relrunpath)/%/lua/..
 	$(MAKE) \
 	    -C $(relrunpath)/$*/lua \
 	    -f $(top)/regression/run/$*/lua/Makefile \
@@ -202,7 +208,7 @@ compile-lua-% : $(relrunpath)/%/lua/..
 
 # Run the Lua test
 .PHONY : $(lua-test-list)
-$(lua-test-list) : test-lua-% : compile-lua-%
+$(lua-test-list) : test-lua-% : compile-lua-% | $(relrunpath)/%/lua/..
 #	export LUA_PATH=$(top)/$(relrunpath)/tutorial/lua;
 	$(call run-command, $(relrunpath)/$*/lua, \
 	$(LUA_BIN) $(top)/regression/run/$*/lua/test.lua)
@@ -233,65 +239,6 @@ test-struct : \
   test-python-struct-numpy-cxx \
   test-python-struct-class-c \
   test-python-struct-class-cxx
-
-# Avoid deleting directories created to run tests.
-# They are created via pattern rules.
-.SECONDARY: \
-    $(relrunpath)/ccomplex/.. \
-    $(relrunpath)/ccomplex/python/.. \
-    $(relrunpath)/cdesc/.. \
-    $(relrunpath)/classes/.. \
-    $(relrunpath)/classes/lua/.. \
-    $(relrunpath)/classes/python/.. \
-    $(relrunpath)/clibrary/.. \
-    $(relrunpath)/clibrary/python/.. \
-    $(relrunpath)/cxxlibrary/.. \
-    $(relrunpath)/cxxlibrary/python/.. \
-    $(relrunpath)/enum-c/.. \
-    $(relrunpath)/enum-c/python/.. \
-    $(relrunpath)/forward/.. \
-    $(relrunpath)/generic/.. \
-    $(relrunpath)/generic-cfi/.. \
-    $(relrunpath)/namespace/.. \
-    $(relrunpath)/namespace/python/.. \
-    $(relrunpath)/ownership/.. \
-    $(relrunpath)/ownership/python/.. \
-    $(relrunpath)/pointers-c/..\
-    $(relrunpath)/pointers-cxx/..\
-    $(relrunpath)/pointers-numpy-cxx/python/.. \
-    $(relrunpath)/pointers-list-cxx/python/.. \
-    $(relrunpath)/pointers-numpy-c/python/.. \
-    $(relrunpath)/pointers-list-c/python/.. \
-    $(relrunpath)/preprocess/..\
-    $(relrunpath)/preprocess/python/.. \
-    $(relrunpath)/preprocess/.. \
-    $(relrunpath)/arrayclass/.. \
-    $(relrunpath)/arrayclass/python/.. \
-    $(relrunpath)/scope/.. \
-    $(relrunpath)/statement/.. \
-    $(relrunpath)/strings/.. \
-    $(relrunpath)/strings/python/.. \
-    $(relrunpath)/strings-cfi/.. \
-    $(relrunpath)/struct-c/.. \
-    $(relrunpath)/struct-cxx/.. \
-    $(relrunpath)/struct-numpy-c/python/.. \
-    $(relrunpath)/struct-numpy-cxx/python/.. \
-    $(relrunpath)/struct-class-c/python/.. \
-    $(relrunpath)/struct-class-cxx/python/.. \
-    $(relrunpath)/struct-list-c/python/.. \
-    $(relrunpath)/structlist/python/.. \
-    $(relrunpath)/struct-py-c/python/.. \
-    $(relrunpath)/struct-py-cxx/python/.. \
-    $(relrunpath)/templates/.. \
-    $(relrunpath)/templates/python/.. \
-    $(relrunpath)/tutorial/..\
-    $(relrunpath)/tutorial/lua/.. \
-    $(relrunpath)/tutorial/python/.. \
-    $(relrunpath)/types/..\
-    $(relrunpath)/types/python/..\
-    $(relrunpath)/vectors/..\
-    $(relrunpath)/vectors-list/python/.. \
-    $(relrunpath)/vectors-numpy/python/..
 
 test-clean-testdir :
 	rm -rf $(relrunpath)

--- a/regression/run/Makefile
+++ b/regression/run/Makefile
@@ -25,12 +25,12 @@ relrunpath = $(tempdir)/run/$(testdir)
 
 include $(top)/regression/run/defaults.mk
 
-# ( directory, command )
+# ( prefix, directory, command )
 # Save output to file and record PASS/FAIL
 ifeq ($(LOGOUTPUT),1)
-run-command = cd $1 && rm -f PASS FAIL ; { $2 >| out 2>&1; } && touch PASS || touch FAIL
+run-command = cd $2 && rm -f $1.PASS $1.FAIL ; { $3 >| $1.out 2>&1; } && touch $1.PASS || touch $1.FAIL
 else
-run-command = cd $1 && $2
+run-command = cd $2 && $3
 endif
 
 ######################################################################
@@ -82,15 +82,13 @@ fortran-test-list = \
 
 # Compile a Fortran test
 fortran-% : | $(relrunpath)/%/.. sync-cxx
-	$(MAKE) \
-	    -C $(relrunpath)/$* \
-	    -f $(top)/regression/run/$*/Makefile \
-	    top=$(top) $*
+	$(call run-command,build,$(relrunpath)/$*,\
+	$(MAKE) -f $(top)/regression/run/$*/Makefile top=$(top) $*)
 
 # Run a Fortran test
 .PHONY : $(fortran-test-list)
 $(fortran-test-list) : test-fortran-% : fortran-% | $(relrunpath)/%/..
-	$(call run-command, $(relrunpath)/$*, ./$*)
+	$(call run-command,test,$(relrunpath)/$*,./$*)
 
 # Run the Fortran tests
 .PHONY : test-fortran
@@ -117,15 +115,13 @@ c-test-list = \
 
 # Compile a C test
 c-% : | $(relrunpath)/%/.. sync-cxx
-	$(MAKE) \
-	    -C $(relrunpath)/$* \
-	    -f $(top)/regression/run/$*/Makefile \
-	    top=$(top) testc
+	$(call run-command,build,$(relrunpath)/$*,\
+	$(MAKE) -f $(top)/regression/run/$*/Makefile top=$(top) testc)
 
 # Run the C tests
 .PHONY : $(c-test-list)
 $(c-test-list) : test-c-% : c-% | $(relrunpath)/%/..
-	$(call run-command, $(relrunpath)/$*, ./testc)
+	$(call run-command,test,$(relrunpath)/$*,./testc)
 
 # Compile C tests
 .PHONY : test-c
@@ -155,15 +151,13 @@ cpp-test-list = \
 
 # Compile a C++ test
 cpp-% : | $(relrunpath)/%/..
-	$(MAKE) \
-	    -C $(relrunpath)/$* \
-	    -f $(top)/regression/run/$*/Makefile \
-	    top=$(top) maincpp
+	$(call run-command,build,$(relrunpath)/$*,\
+	$(MAKE) -f $(top)/regression/run/$*/Makefile top=$(top) maincpp)
 
 # Run a C++ test
 .PHONY : $(cpp-test-list)
 $(cpp-test-list) : test-cpp-% : cpp-% | $(relrunpath)/%/..
-	$(call run-command, $(relrunpath)/$*, ./maincpp)
+	$(call run-command,test,$(relrunpath)/$*,./maincpp)
 
 .PHONY : test-cpp
 test-cpp : $(cpp-test-list)
@@ -198,16 +192,15 @@ python-test-list = \
 
 # Compile the generated Python wrapper
 pymod-% : | $(relrunpath)/%/python/.. sync-cxx
-	$(MAKE) \
-	    -C $(relrunpath)/$*/python \
-	    -f $(top)/regression/run/$*/python/Makefile \
-	    PYTHON=$(PYTHON) top=$(top) all
+	$(call run-command,build,$(relrunpath)/$*/python,\
+	$(MAKE) -f $(top)/regression/run/$*/python/Makefile \
+	    PYTHON=$(PYTHON) top=$(top) all)
 
 # Run the Python tests
 .PHONY : $(python-test-list)
 $(python-test-list) : test-python-% : pymod-% | $(relrunpath)/%/python/..
 	export PYTHONPATH=$(top)/$(relrunpath)/$*/python; \
-	$(call run-command, $(relrunpath)/$*/python, \
+	$(call run-command,test,$(relrunpath)/$*/python, \
 	$(python.exe) $(top)/regression/run/$*/python/test.py)
 
 .PHONY : test-python
@@ -223,16 +216,15 @@ lua-test-list = \
 
 # Compile the generated Lua wrapper
 compile-lua-% : | $(relrunpath)/%/lua/..
-	$(MAKE) \
-	    -C $(relrunpath)/$*/lua \
-	    -f $(top)/regression/run/$*/lua/Makefile \
-	    LUA=$(LUA) top=$(top) all
+	$(call run-command,build,$(relrunpath)/$*/lua,\
+	$(MAKE) -f $(top)/regression/run/$*/lua/Makefile \
+	    LUA=$(LUA) top=$(top) all)
 
 # Run the Lua test
 .PHONY : $(lua-test-list)
 $(lua-test-list) : test-lua-% : compile-lua-% | $(relrunpath)/%/lua/..
 #	export LUA_PATH=$(top)/$(relrunpath)/tutorial/lua;
-	$(call run-command, $(relrunpath)/$*/lua, \
+	$(call run-command,test,$(relrunpath)/$*/lua, \
 	$(LUA_BIN) $(top)/regression/run/$*/lua/test.lua)
 
 .PHONY : test-lua

--- a/regression/run/arrayclass/Makefile
+++ b/regression/run/arrayclass/Makefile
@@ -33,4 +33,4 @@ arrayclass : $(OBJS)
 clean :
 	rm -f $(OBJS) *.mod arrayclass
 
-main.o : wrapfarrayclass.o
+main.o : fruit.o wrapfarrayclass.o

--- a/regression/run/arrayclass/python/Makefile
+++ b/regression/run/arrayclass/python/Makefile
@@ -25,7 +25,7 @@ OBJS = \
     pyarrayclassutil.o \
     pyArrayWrappertype.o
 
-CXXFLAGS += $(SHARED)
+LOCAL_CXXFLAGS += $(SHARED)
 
 all : arrayclass.so
 

--- a/regression/run/ccomplex/Makefile
+++ b/regression/run/ccomplex/Makefile
@@ -31,4 +31,4 @@ ccomplex : $(OBJS)
 clean :
 	rm -f $(OBJS) *.mod ccomplex
 
-main.o : wrapfccomplex.o
+main.o : fruit.o wrapfccomplex.o

--- a/regression/run/ccomplex/python/Makefile
+++ b/regression/run/ccomplex/python/Makefile
@@ -22,7 +22,7 @@ OBJS = \
     ccomplex.o \
     pyccomplexmodule.o
 
-CFLAGS += $(SHARED)
+LOCAL_CFLAGS += $(SHARED)
 
 all : ccomplex.so simple
 

--- a/regression/run/cdesc/Makefile
+++ b/regression/run/cdesc/Makefile
@@ -40,7 +40,7 @@ clean :
 
 cdesc.o : cdesc.hpp
 wrapcdesc.o : wrapcdesc.h cdesc.hpp
-main.o : wrapfcdesc.o
+main.o : fruit.o wrapfcdesc.o
 
 # useful to isolate load error with just C++ code
 maincpp : maincpp.o wrapcdesc.o cdesc.o

--- a/regression/run/classes/Makefile
+++ b/regression/run/classes/Makefile
@@ -48,7 +48,7 @@ wrapClasses.o : wrapClasses.h classes.hpp
 wrapClass1.o : wrapClass1.h classes.hpp
 wrapClass2.o : wrapClass2.h classes.hpp
 wrapSingleton.o : wrapSingleton.h classes.hpp
-main.o : wrapfclasses.o
+main.o : fruit.o wrapfclasses.o
 
 # useful to isolate load error with just C++ code
 maincpp : maincpp.o wrapclasses.o wrapClass1.o wrapSingleton.o classes.o

--- a/regression/run/classes/python/Makefile
+++ b/regression/run/classes/python/Makefile
@@ -30,7 +30,7 @@ OBJS = \
     pyCircletype.o \
     pyclassesutil.o
 
-CXXFLAGS += $(SHARED)
+LOCAL_CXXFLAGS += $(SHARED)
 
 all : classes.so simple
 

--- a/regression/run/clibrary/Makefile
+++ b/regression/run/clibrary/Makefile
@@ -31,4 +31,4 @@ clibrary : $(OBJS)
 clean :
 	rm -f $(OBJS) *.mod clibrary
 
-main.o : wrapfclibrary.o
+main.o : fruit.o wrapfclibrary.o

--- a/regression/run/clibrary/python/Makefile
+++ b/regression/run/clibrary/python/Makefile
@@ -22,7 +22,7 @@ OBJS = \
     clibrary.o \
     pyClibrarymodule.o
 
-CFLAGS += $(SHARED)
+LOCAL_CFLAGS += $(SHARED)
 
 all : clibrary.so simple
 

--- a/regression/run/cxxlibrary/Makefile
+++ b/regression/run/cxxlibrary/Makefile
@@ -38,4 +38,4 @@ clean :
 
 cxxlibrary.o : cxxlibrary.hpp
 wrapcxxlibrary.o : wrapcxxlibrary.h cxxlibrary.hpp
-main.o : wrapfcxxlibrary.o
+main.o : fruit.o wrapfcxxlibrary.o

--- a/regression/run/cxxlibrary/python/Makefile
+++ b/regression/run/cxxlibrary/python/Makefile
@@ -26,7 +26,7 @@ OBJS = \
     pycxxlibrary_structnsmodule.o \
     pycxxlibraryutil.o
 
-CXXFLAGS += $(SHARED)
+LOCAL_CXXFLAGS += $(SHARED)
 
 all : cxxlibrary.so
 

--- a/regression/run/defaults.mk
+++ b/regression/run/defaults.mk
@@ -26,14 +26,14 @@ CC = gcc
 # -Wextra
 # -O3 generates additional warnings
 CXXWARNINGS = -O3
-CFLAGS = -g -Wall -Wstrict-prototypes -fno-strict-aliasing -std=c99
+LOCAL_CFLAGS = -g -Wall -Wstrict-prototypes -fno-strict-aliasing -std=c99
 # silence warning in enum.yaml test
-CFLAGS += -Wno-enum-compare
+LOCAL_CFLAGS += -Wno-enum-compare
 CLIBS = -lstdc++
 CXX = g++
-CXXFLAGS = -g $(CXXWARNINGS) -Wall -std=c++11 -fno-strict-aliasing
+LOCAL_CXXFLAGS = -g $(CXXWARNINGS) -Wall -std=c++11 -fno-strict-aliasing
 FC = gfortran
-FFLAGS = -g -cpp -Wall -ffree-form -fbounds-check
+LOCAL_FFLAGS = -g -cpp -Wall -ffree-form -fbounds-check
 #FFLAGS += -std=f2003
 FLIBS = -lstdc++
 SHARED = -fPIC
@@ -42,12 +42,13 @@ endif
 
 ifeq ($(compiler),intel)
 CC = icc
-CFLAGS = -g -std=c99
+LOCAL_CFLAGS = -g -std=c99
 CLIBS = -lstdc++
 CXX = icpc
-CXXFLAGS = -g -std=c++11
+LOCAL_CXXFLAGS = -g -std=c++11
+#LOCAL_CXXFLAGS += 
 FC = ifort
-FFLAGS = -g -fpp -free -check all
+LOCAL_FFLAGS = -g -fpp -free -check all
 FLIBS = -lstdc++
 SHARED = -fPIC
 LD_SHARED = -shared
@@ -55,12 +56,12 @@ endif
 
 ifeq ($(compiler),pgi)
 CC = pgcc
-CFLAGS = -g
+LOCAL_CFLAGS = -g
 CLIBS = -lstdc++
 CXX = pgc++
-CXXFLAGS = -g -std=c++11
+LOCAL_CXXFLAGS = -g -std=c++11
 FC = pgf90
-FFLAGS = -g -Mfree -Mstandard -cpp
+LOCAL_FFLAGS = -g -Mfree -Mstandard -cpp
 FLIBS = -lstdc++
 SHARED = -fPIC
 LD_SHARED = -shared
@@ -71,12 +72,12 @@ ifeq ($(compiler),ibm)
 TCE = /usr/tce/packages/xl/xl-2019.08.20/
 TCE = /usr/tce/packages/xl/xl-2020.11.12/
 CC = xlc
-CFLAGS = -g
+LOCAL_CFLAGS = -g
 CLIBS = -lstdc++
 CXX = xlC
-CXXFLAGS = -g -std=c++0x 
+LOCAL_CXXFLAGS = -g -std=c++0x 
 FC = xlf2003
-FFLAGS = -g -qfree=f90 -qsuffix=cpp=f
+LOCAL_FFLAGS = -g -qfree=f90 -qsuffix=cpp=f
 # -qlanglvl=2003std
 FLIBS = -lstdc++ -L$(TCE)/alllibs -libmc++ -lstdc++
 SHARED = -fPIC
@@ -86,11 +87,11 @@ endif
 # BG/Q with clang and xlf
 ifeq ($(compiler),bgq)
 CC = /collab/usr/gapps/opnsrc/gnu/dev/lnx-2.12-ppc/bgclang/r284961-stable/llnl/bin/mpiclang
-CFLAGS = -g
+LOCAL_CFLAGS = -g
 CXX = /collab/usr/gapps/opnsrc/gnu/dev/lnx-2.12-ppc/bgclang/r284961-stable/llnl/bin/mpiclang++
-CXXFLAGS = -g -std=c++0x 
+LOCAL_CXXFLAGS = -g -std=c++0x 
 FC = /opt/ibmcmp/xlf/bg/14.1/bin/bgxlf2003
-FFLAGS = -g -qfree=f90
+LOCAL_FFLAGS = -g -qfree=f90
 FLIBS = \
   -L/usr/apps/gnu/bgclang/r284961-stable/libc++/lib \
   -L/collab/usr/gapps/opnsrc/gnu/dev/lnx-2.12-ppc/bgclang/toolchain-4.7.2-fixup/lib \
@@ -99,6 +100,11 @@ FLIBS = \
 SHARED = -fPIC
 LD_SHARED = -shared
 endif
+
+# Prefix local flags to user flags.
+LOCAL_CFLAGS += $(CFLAGS)
+LOCAL_CXXFLAGS += $(CXXFLAGS)
+LOCAL_FFLAGS += $(FFLAGS)
 
 ifdef PYTHON
 # Simple string functions, to reduce the clutter below.
@@ -142,13 +148,13 @@ LUA_LIB = -L$(LUA_PREFIX)/lib -llua -ldl
 endif
 
 %.o : %.c
-	$(CC) $(CFLAGS) $(INCLUDE) -c -o $*.o $<
+	$(CC) $(LOCAL_CFLAGS) $(INCLUDE) -c -o $*.o $<
 
 %.o : %.cpp
-	$(CXX) $(CXXFLAGS) $(INCLUDE) -c -o $*.o $<
+	$(CXX) $(LOCAL_CXXFLAGS) $(INCLUDE) -c -o $*.o $<
 
 %.o %.mod  : %.f
-	$(FC) $(FFLAGS) $(INCLUDE) -c -o $*.o $<
+	$(FC) $(LOCAL_FFLAGS) $(INCLUDE) -c -o $*.o $<
 
 %.o %.mod  : %.f90
-	$(FC) $(FFLAGS) $(INCLUDE) -c -o $*.o $<
+	$(FC) $(LOCAL_FFLAGS) $(INCLUDE) -c -o $*.o $<

--- a/regression/run/defaults.mk
+++ b/regression/run/defaults.mk
@@ -116,6 +116,8 @@ python.libpl   = $(eval python.libpl := $$(call shell,$(python.exe) \
   -c $(call sf_01,LIBPL) 2>&1))$(python.libpl)
 python.libs    = $(eval python.libs := $$(call shell,$(python.exe) \
   -c $(call sf_01,LIBS) 2>&1))$(python.libs)
+python.ldflags = $(eval python.ldflags := $$(call shell,$(python.exe) \
+  -c $(call sf_01,LDFLAGS) 2>&1))$(python.ldflags)
 python.bldlibrary  = $(eval python.bldlibrary := $$(call shell,$(python.exe) \
   -c $(call sf_01,BLDLIBRARY) 2>&1))$(python.bldlibrary)
 python.incdir   = $(eval python.incdir := $$(call shell,$(python.exe) \
@@ -137,7 +139,7 @@ PYTHON_PREFIX := $(shell $(PYTHON) -c "import sys;sys.stdout.write(sys.exec_pref
 PYTHON_NUMPY := $(shell $(PYTHON) -c "import sys, numpy;sys.stdout.write(numpy.get_include())")
 
 PYTHON_INC := -I$(python.incdir) -I$(PYTHON_NUMPY)
-PYTHON_LIB := -L$(python.libpl) $(python.bldlibrary) $(python.libs)
+PYTHON_LIB := -L$(python.libpl) $(python.ldflags) $(python.bldlibrary) $(python.libs)
 endif
 
 ifdef LUA

--- a/regression/run/enum-c/Makefile
+++ b/regression/run/enum-c/Makefile
@@ -35,7 +35,7 @@ enum-c : $(C_OBJS) $(F_OBJS)
 clean :
 	rm -f $(OBJS) *.mod enum-c
 
-main.o : wrapfenum.o
+main.o : fruit.o wrapfenum.o
 
 # useful to isolate load error with just C++ code
 maincpp : maincpp.o 

--- a/regression/run/enum-c/python/Makefile
+++ b/regression/run/enum-c/python/Makefile
@@ -22,7 +22,7 @@ VPATH = \
 OBJS = \
     pyenummodule.o
 
-CFLAGS += $(SHARED)
+LOCAL_CFLAGS += $(SHARED)
 
 all : cenum.so
 

--- a/regression/run/forward/Makefile
+++ b/regression/run/forward/Makefile
@@ -46,7 +46,7 @@ wrapforward.o : wrapforward.h
 wrapfforward.o : struct_mod.o tutorial_mod.o
 forward.o : forward.hpp
 wrapClass1.o : wrapClass2.h forward.hpp
-main.o : wrapfforward.o struct_mod.o
+main.o : fruit.o wrapfforward.o struct_mod.o
 
 # useful to isolate load error with just C++ code
 maincpp : maincpp.o wrapClass2.o forward.o

--- a/regression/run/generic-cfi/Makefile
+++ b/regression/run/generic-cfi/Makefile
@@ -36,6 +36,6 @@ clean :
 helper.o : generic.h typesgeneric.h
 generic.o : generic.h
 wrapgeneric.o : generic.h
-main.o : wrapfgeneric.o
+main.o : fruit.o wrapfgeneric.o
 
 

--- a/regression/run/generic/Makefile
+++ b/regression/run/generic/Makefile
@@ -35,6 +35,6 @@ clean :
 helper.o : generic.h typesgeneric.h
 generic.o : generic.h
 wrapgeneric.o : generic.h
-main.o : wrapfgeneric.o
+main.o : fruit.o wrapfgeneric.o
 
 

--- a/regression/run/namespace/Makefile
+++ b/regression/run/namespace/Makefile
@@ -30,7 +30,7 @@ C_OBJS = \
     wrapns.o \
     wrapns_outer.o
 F_OBJS= \
-    wrapfns.f \
+    wrapfns.o \
     fruit.o \
     main.o
 

--- a/regression/run/namespace/Makefile
+++ b/regression/run/namespace/Makefile
@@ -43,7 +43,7 @@ clean :
 namespace.o : namespace.hpp
 wrapns.o : namespace.hpp
 wrapns_outer.o : namespace.hpp
-main.o : wrapfns.o wrapfns_outer.o
+main.o : fruit.o wrapfns.o wrapfns_outer.o
 
 testc.o : testc.c wrapns.h wrapns_outer.h
 testc : testc.o $(C_OBJS)

--- a/regression/run/namespace/python/Makefile
+++ b/regression/run/namespace/python/Makefile
@@ -25,7 +25,7 @@ OBJS = \
     pyns_nsworkmodule.o \
     pynsutil.o
 
-CXXFLAGS += $(SHARED)
+LOCAL_CXXFLAGS += $(SHARED)
 
 all : ns.so
 

--- a/regression/run/ownership/Makefile
+++ b/regression/run/ownership/Makefile
@@ -41,7 +41,7 @@ clean :
 
 ownership.o : ownership.hpp
 wrapOwnership.o : wrapownership.h ownership.hpp
-main.o : wrapfownership.o
+main.o : fruit.o wrapfownership.o
 
 # useful to isolate load error with just C++ code
 maincpp : maincpp.o ownership.o

--- a/regression/run/ownership/python/Makefile
+++ b/regression/run/ownership/python/Makefile
@@ -30,7 +30,7 @@ OBJS = \
     pyownershipmodule.o \
     pyownershiputil.o
 
-CXXFLAGS += $(SHARED)
+LOCAL_CXXFLAGS += $(SHARED)
 
 all : ownership.so simple
 

--- a/regression/run/pointers-c/Makefile
+++ b/regression/run/pointers-c/Makefile
@@ -32,4 +32,4 @@ pointers-c : $(OBJS)
 clean :
 	rm -f $(OBJS) *.mod pointers
 
-main.o : wrapfpointers.o
+main.o : fruit.o wrapfpointers.o

--- a/regression/run/pointers-cxx/Makefile
+++ b/regression/run/pointers-cxx/Makefile
@@ -16,6 +16,8 @@ INCLUDE = \
 
 VPATH = \
     $(top)/regression/reference/pointers-cxx \
+    ../cxx \
+    $(top)/regression/run/pointers \
     $(top)/regression/run/fruit
 
 OBJS = \
@@ -28,14 +30,9 @@ OBJS = \
 pointers-cxx : $(OBJS)
 	$(FC) $(FFLAGS) $^ -o $@ $(CLIBS)
 
-# Copy all source files from run/pointers, need to avoid VPATH.
-# Convert C file to C++
-pointers.cpp : $(top)/regression/run/pointers/pointers.c
-	cp $^ $@
-main.f : $(top)/regression/run/pointers/main.f
-	cp $< $@
 main.o : main.f fruit.o wrapfpointers.o
-pointers.o : pointers.cpp
+pointers.o : pointers.cpp pointers.h
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c -o $*.o $<
 
 clean :
 	rm -f $(OBJS) *.mod pointers main.f pointers.cpp

--- a/regression/run/pointers-cxx/Makefile
+++ b/regression/run/pointers-cxx/Makefile
@@ -34,7 +34,7 @@ pointers.cpp : $(top)/regression/run/pointers/pointers.c
 	cp $^ $@
 main.f : $(top)/regression/run/pointers/main.f
 	cp $< $@
-main.o : main.f
+main.o : main.f fruit.o wrapfpointers.o
 pointers.o : pointers.cpp
 
 clean :

--- a/regression/run/pointers-list-c/python/Makefile
+++ b/regression/run/pointers-list-c/python/Makefile
@@ -24,7 +24,7 @@ OBJS = \
     pointers.o \
     pypointersmodule.o
 
-CFLAGS += $(SHARED)
+LOCAL_CFLAGS += $(SHARED)
 
 all : pointers.so
 

--- a/regression/run/pointers-list-cxx/python/Makefile
+++ b/regression/run/pointers-list-cxx/python/Makefile
@@ -17,7 +17,8 @@ INCLUDE = \
 
 VPATH = \
     $(top)/regression/reference/pointers-list-cxx \
-    $(top)/regression/run/pointers/python
+    $(top)/regression/run/pointers \
+    ../../cxx
 
 OBJS = \
     pointers.o \
@@ -28,10 +29,8 @@ CXXFLAGS += $(SHARED)
 all : pointers.so
 # simple
 
-# Convert C file to C++
-pointers.cpp : $(top)/regression/run/pointers/pointers.c
-	cp $^ $@
-pointers.o : pointers.cpp
+pointers.o : pointers.cpp pointers.h
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c -o $*.o $<
 
 pointers.so : $(OBJS)
 	$(CXX) $(LD_SHARED) $^ -o $@ $(LIBS)

--- a/regression/run/pointers-list-cxx/python/Makefile
+++ b/regression/run/pointers-list-cxx/python/Makefile
@@ -30,7 +30,7 @@ all : pointers.so
 # simple
 
 pointers.o : pointers.cpp pointers.h
-	$(CXX) $(CXXFLAGS) $(INCLUDE) -c -o $*.o $<
+	$(CXX) $(LOCAL_CXXFLAGS) $(INCLUDE) -c -o $*.o $<
 
 pointers.so : $(OBJS)
 	$(CXX) $(LD_SHARED) $^ -o $@ $(LIBS)

--- a/regression/run/pointers-list-cxx/python/Makefile
+++ b/regression/run/pointers-list-cxx/python/Makefile
@@ -24,7 +24,7 @@ OBJS = \
     pointers.o \
     pypointersmodule.o
 
-CXXFLAGS += $(SHARED)
+LOCAL_CXXFLAGS += $(SHARED)
 
 all : pointers.so
 # simple

--- a/regression/run/pointers-numpy-c/python/Makefile
+++ b/regression/run/pointers-numpy-c/python/Makefile
@@ -24,7 +24,7 @@ OBJS = \
     pointers.o \
     pypointersmodule.o
 
-CFLAGS += $(SHARED)
+LOCAL_CFLAGS += $(SHARED)
 
 all : pointers.so
 

--- a/regression/run/pointers-numpy-cxx/python/Makefile
+++ b/regression/run/pointers-numpy-cxx/python/Makefile
@@ -17,7 +17,9 @@ INCLUDE = \
 
 VPATH = \
     $(top)/regression/reference/pointers-numpy-cxx \
-    $(top)/regression/run/pointers/python
+    $(top)/regression/run/pointers/python \
+    $(top)/regression/run/pointers \
+    ../../cxx
 
 OBJS = \
     pointers.o \
@@ -27,10 +29,8 @@ CXXFLAGS += $(SHARED)
 
 all : pointers.so simple
 
-# Convert C file to C++
-pointers.cpp : $(top)/regression/run/pointers/pointers.c
-	cp $^ $@
-pointers.o : pointers.cpp
+pointers.o : pointers.cpp pointers.h
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c -o $*.o $<
 
 pointers.so : $(OBJS)
 	$(CXX) $(LD_SHARED) $^ -o $@ $(LIBS)

--- a/regression/run/pointers-numpy-cxx/python/Makefile
+++ b/regression/run/pointers-numpy-cxx/python/Makefile
@@ -30,7 +30,7 @@ LOCAL_CXXFLAGS += $(SHARED)
 all : pointers.so simple
 
 pointers.o : pointers.cpp pointers.h
-	$(CXX) $(CXXFLAGS) $(INCLUDE) -c -o $*.o $<
+	$(CXX) $(LOCAL_CXXFLAGS) $(INCLUDE) -c -o $*.o $<
 
 pointers.so : $(OBJS)
 	$(CXX) $(LD_SHARED) $^ -o $@ $(LIBS)

--- a/regression/run/pointers-numpy-cxx/python/Makefile
+++ b/regression/run/pointers-numpy-cxx/python/Makefile
@@ -25,7 +25,7 @@ OBJS = \
     pointers.o \
     pypointersmodule.o
 
-CXXFLAGS += $(SHARED)
+LOCAL_CXXFLAGS += $(SHARED)
 
 all : pointers.so simple
 

--- a/regression/run/preprocess/Makefile
+++ b/regression/run/preprocess/Makefile
@@ -36,4 +36,4 @@ clean :
 
 wrappreprocess.o : preprocess.hpp
 wrapUser1.o : wrapUser1.h preprocess.hpp wrapUser1.h
-main.o : wrapfpreprocess.o wrappreprocess.o
+main.o : fruit.o wrapfpreprocess.o wrappreprocess.o

--- a/regression/run/preprocess/python/Makefile
+++ b/regression/run/preprocess/python/Makefile
@@ -26,7 +26,7 @@ OBJS = \
     pyUser1type.o \
     pyUser2type.o
 
-CXXFLAGS += $(SHARED)
+LOCAL_CXXFLAGS += $(SHARED)
 
 all : preprocess.so
 

--- a/regression/run/scope/Makefile
+++ b/regression/run/scope/Makefile
@@ -39,7 +39,7 @@ clean :
 
 scope.o : scope.hpp
 wrapScope.o : wrapscope.h scope.hpp
-main.o : wrapfscope.o
+main.o : fruit.o wrapfscope.o
 
 # useful to isolate load error with just C++ code
 maincpp : maincpp.o wrapscope.o

--- a/regression/run/statement/Makefile
+++ b/regression/run/statement/Makefile
@@ -39,7 +39,7 @@ clean :
 
 statement.o : statement.hpp
 wrapstatement.o : wrapstatement.h statement.hpp
-main.o : wrapfstatement.o
+main.o : fruit.o wrapfstatement.o
 
 # useful to isolate load error with just C++ code
 maincpp : maincpp.o wrapStatement.o wrapClass1.o wrapSingleton.o statement.o

--- a/regression/run/strings-cfi/Makefile
+++ b/regression/run/strings-cfi/Makefile
@@ -34,4 +34,4 @@ strings-cfi : $(OBJS)
 clean :
 	rm -f $(OBJS) *.mod strings
 
-main.o : wrapfstrings.o
+main.o : fruit.o wrapfstrings.o

--- a/regression/run/strings/Makefile
+++ b/regression/run/strings/Makefile
@@ -34,4 +34,4 @@ strings : $(OBJS)
 clean :
 	rm -f $(OBJS) *.mod strings
 
-main.o : wrapfstrings.o
+main.o : fruit.o wrapfstrings.o

--- a/regression/run/strings/python/Makefile
+++ b/regression/run/strings/python/Makefile
@@ -24,7 +24,7 @@ OBJS = \
     strings.o \
     pystringsmodule.o
 
-CXXFLAGS += $(SHARED)
+LOCAL_CXXFLAGS += $(SHARED)
 
 all : strings.so simple
 

--- a/regression/run/struct-c/Makefile
+++ b/regression/run/struct-c/Makefile
@@ -37,4 +37,4 @@ clean :
 
 struct.o : struct.h
 wrapstruct.o : wrapstruct.h struct.h
-main.o : wrapfstruct.o
+main.o : fruit.o wrapfstruct.o

--- a/regression/run/struct-class-c/python/Makefile
+++ b/regression/run/struct-class-c/python/Makefile
@@ -29,7 +29,7 @@ OBJS = \
     pyCstruct_numpytype.o \
     pyArrays1type.o
 
-CFLAGS += $(SHARED)
+LOCAL_CFLAGS += $(SHARED)
 
 all : cstruct.so
 

--- a/regression/run/struct-class-cxx/python/Makefile
+++ b/regression/run/struct-class-cxx/python/Makefile
@@ -38,7 +38,7 @@ cstruct.so : $(OBJS)
 	$(CXX) $(LD_SHARED) -o $@ $^ $(LIBS)
 
 struct.o : struct.cpp struct.h
-	$(CXX) $(CXXFLAGS) $(INCLUDE) -c -o $*.o $<
+	$(CXX) $(LOCAL_CXXFLAGS) $(INCLUDE) -c -o $*.o $<
 
 clean :
 	rm -f *.so *.o

--- a/regression/run/struct-class-cxx/python/Makefile
+++ b/regression/run/struct-class-cxx/python/Makefile
@@ -16,7 +16,9 @@ INCLUDE = \
     $(PYTHON_INC)
 
 VPATH = \
-    $(top)/regression/reference/struct-class-cxx
+    $(top)/regression/reference/struct-class-cxx \
+    $(top)/regression/run/struct \
+    ../../cxx
 
 OBJS = \
     struct.o \
@@ -32,14 +34,11 @@ CXXFLAGS += $(SHARED)
 
 all : cstruct.so
 
-# Convert C++ file to C
-struct.cpp : $(top)/regression/run/struct/struct.c
-	cp $^ $@
-
 cstruct.so : $(OBJS)
 	$(CXX) $(LD_SHARED) -o $@ $^ $(LIBS)
 
-struct.o : struct.cpp
+struct.o : struct.cpp struct.h
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c -o $*.o $<
 
 clean :
 	rm -f *.so *.o

--- a/regression/run/struct-class-cxx/python/Makefile
+++ b/regression/run/struct-class-cxx/python/Makefile
@@ -30,7 +30,7 @@ OBJS = \
     pyCstruct_numpytype.o \
     pyArrays1type.o
 
-CXXFLAGS += $(SHARED)
+LOCAL_CXXFLAGS += $(SHARED)
 
 all : cstruct.so
 

--- a/regression/run/struct-cxx/Makefile
+++ b/regression/run/struct-cxx/Makefile
@@ -17,7 +17,9 @@ INCLUDE = \
 
 VPATH = \
     $(top)/regression/reference/struct-cxx \
+    ../cxx \
     $(top)/regression/run/struct-cxx \
+    $(top)/regression/run/struct \
     $(top)/regression/run/fruit
 
 C_OBJS = \
@@ -30,22 +32,14 @@ F_OBJS = \
     fruit.o \
     main.o
 
-struct-cxx : main.f struct.h struct.cpp $(C_OBJS) $(F_OBJS)
+struct-cxx : $(C_OBJS) $(F_OBJS)
 	$(FC) $(FFLAGS) $(C_OBJS) $(F_OBJS) -o $@ $(FLIBS)
-
-# Copy all source files from run/struct, need to avoid VPATH.
-# "convert" to c++
-struct.cpp : $(top)/regression/run/struct/struct.c
-	cp $< $@
-struct.h : $(top)/regression/run/struct/struct.h
-	cp $< $@
-main.f : $(top)/regression/run/struct/main.f
-	cp $< $@
 
 clean :
 	rm -f $(OBJS) *.mod struct-cxx
 
-struct.o : struct.h
+struct.o : struct.cpp struct.h
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c -o $*.o $<
 wrapstruct.o : wrapstruct.h struct.h
 main.o : fruit.o wrapfstruct.o
 

--- a/regression/run/struct-cxx/Makefile
+++ b/regression/run/struct-cxx/Makefile
@@ -47,7 +47,7 @@ clean :
 
 struct.o : struct.h
 wrapstruct.o : wrapstruct.h struct.h
-main.o : wrapfstruct.o
+main.o : fruit.o wrapfstruct.o
 
 testc.o : testc.c wrapstruct.h struct.h
 testc : testc.o $(C_OBJS)

--- a/regression/run/struct-numpy-c/python/Makefile
+++ b/regression/run/struct-numpy-c/python/Makefile
@@ -24,7 +24,7 @@ OBJS = \
     pystructmodule.o \
     pystructutil.o
 
-CFLAGS += $(SHARED)
+LOCAL_CFLAGS += $(SHARED)
 
 all : cstruct.so
 

--- a/regression/run/struct-numpy-cxx/python/Makefile
+++ b/regression/run/struct-numpy-cxx/python/Makefile
@@ -25,7 +25,7 @@ OBJS = \
     pystructmodule.o \
     pystructutil.o
 
-CXXFLAGS += $(SHARED)
+LOCAL_CXXFLAGS += $(SHARED)
 
 all : cstruct.so
 

--- a/regression/run/struct-numpy-cxx/python/Makefile
+++ b/regression/run/struct-numpy-cxx/python/Makefile
@@ -33,7 +33,7 @@ cstruct.so : $(OBJS)
 	$(CXX) $(LD_SHARED) -o $@ $^ $(LIBS)
 
 struct.o : struct.cpp struct.h
-	$(CXX) $(CXXFLAGS) $(INCLUDE) -c -o $*.o $<
+	$(CXX) $(LOCAL_CXXFLAGS) $(INCLUDE) -c -o $*.o $<
 
 clean :
 	rm -f *.so *.o

--- a/regression/run/struct-numpy-cxx/python/Makefile
+++ b/regression/run/struct-numpy-cxx/python/Makefile
@@ -16,7 +16,9 @@ INCLUDE = \
     $(PYTHON_INC)
 
 VPATH = \
-    $(top)/regression/reference/struct-numpy-cxx
+    $(top)/regression/reference/struct-numpy-cxx \
+    $(top)/regression/run/struct \
+    ../../cxx
 
 OBJS = \
     struct.o \
@@ -27,14 +29,11 @@ CXXFLAGS += $(SHARED)
 
 all : cstruct.so
 
-# Convert C++ file to C
-struct.cpp : $(top)/regression/run/struct/struct.c
-	cp $^ $@
-
 cstruct.so : $(OBJS)
 	$(CXX) $(LD_SHARED) -o $@ $^ $(LIBS)
 
-struct.o : struct.cpp
+struct.o : struct.cpp struct.h
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c -o $*.o $<
 
 clean :
 	rm -f *.so *.o

--- a/regression/run/struct-py-c/python/Makefile
+++ b/regression/run/struct-py-c/python/Makefile
@@ -25,7 +25,7 @@ OBJS = \
     pyCstruct_as_classtype.o \
     pystructutil.o
 
-CFLAGS += $(SHARED)
+LOCAL_CFLAGS += $(SHARED)
 
 all : cstruct.so
 

--- a/regression/run/struct-py-cxx/python/Makefile
+++ b/regression/run/struct-py-cxx/python/Makefile
@@ -34,7 +34,7 @@ cstruct.so : $(OBJS)
 	$(CXX) $(LD_SHARED) -o $@ $^ $(LIBS)
 
 struct.o : struct.cpp struct.h
-	$(CXX) $(CXXFLAGS) $(INCLUDE) -c -o $*.o $<
+	$(CXX) $(LOCAL_CXXFLAGS) $(INCLUDE) -c -o $*.o $<
 
 clean :
 	rm -f *.so *.o

--- a/regression/run/struct-py-cxx/python/Makefile
+++ b/regression/run/struct-py-cxx/python/Makefile
@@ -16,7 +16,9 @@ INCLUDE = \
     $(PYTHON_INC)
 
 VPATH = \
-    $(top)/regression/reference/struct-py-cxx
+    $(top)/regression/reference/struct-py-cxx \
+    $(top)/regression/run/struct \
+    ../../cxx
 
 OBJS = \
     struct.o \
@@ -28,14 +30,11 @@ CXXFLAGS += $(SHARED)
 
 all : cstruct.so
 
-# Convert C++ file to C
-struct.cpp : $(top)/regression/run/struct/struct.c
-	cp $^ $@
-
 cstruct.so : $(OBJS)
 	$(CXX) $(LD_SHARED) -o $@ $^ $(LIBS)
 
-struct.o : struct.cpp
+struct.o : struct.cpp struct.h
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c -o $*.o $<
 
 clean :
 	rm -f *.so *.o

--- a/regression/run/struct-py-cxx/python/Makefile
+++ b/regression/run/struct-py-cxx/python/Makefile
@@ -26,7 +26,7 @@ OBJS = \
     pyCstruct_as_classtype.o \
     pystructutil.o
 
-CXXFLAGS += $(SHARED)
+LOCAL_CXXFLAGS += $(SHARED)
 
 all : cstruct.so
 

--- a/regression/run/structlist/python/Makefile
+++ b/regression/run/structlist/python/Makefile
@@ -25,7 +25,7 @@ OBJS = \
     pystructutil.o \
     pyArrays1type.o
 
-CFLAGS += $(SHARED)
+LOCAL_CFLAGS += $(SHARED)
 
 all : cstruct.so
 

--- a/regression/run/templates/Makefile
+++ b/regression/run/templates/Makefile
@@ -49,7 +49,7 @@ wrapuser_int.o : wrapuser_int.cpp wrapuser_int.h typestemplates.h templates.hpp
 wraptemplates.o : wraptemplates.cpp wraptemplates.h typestemplates.h templates.hpp
 wrapstructAsClass_int.o : wrapstructAsClass_int.h
 wrapstructAsClass_double.o : wrapstructAsClass_double.h
-main.o : main.f wrapftemplates.o
+main.o : main.f fruit.o wrapftemplates.o
 maincpp.o : maincpp.cpp templates.hpp
 
 # useful to isolate load error with just C++ code

--- a/regression/run/templates/python/Makefile
+++ b/regression/run/templates/python/Makefile
@@ -34,7 +34,7 @@ OBJS = \
     pystd_vector_inttype.o
 
 
-CXXFLAGS += $(SHARED)
+LOCAL_CXXFLAGS += $(SHARED)
 
 all : templates.so simple
 

--- a/regression/run/tr29113/Makefile
+++ b/regression/run/tr29113/Makefile
@@ -44,7 +44,7 @@ clean :
 
 tr29113.o : tr29113.hpp
 wrapTr29113.o : wraptr29113.h tr29113.hpp
-main.o : wrapftr29113.o
+main.o : fruit.o wrapftr29113.o
 
 # useful to isolate load error with just C++ code
 maincpp : maincpp.o wrapTr29113.o tr29113.o

--- a/regression/run/tutorial/Makefile
+++ b/regression/run/tutorial/Makefile
@@ -40,7 +40,7 @@ clean :
 
 tutorial.o : tutorial.hpp
 wrapTutorial.o : wrapTutorial.h tutorial.hpp
-main.o : wrapftutorial.o
+main.o : fruit.o wrapftutorial.o
 
 # useful to isolate load error with just C++ code
 maincpp : maincpp.o wrapTutorial.o tutorial.o

--- a/regression/run/tutorial/python/Makefile
+++ b/regression/run/tutorial/python/Makefile
@@ -24,7 +24,7 @@ OBJS = \
     tutorial.o \
     pyTutorialmodule.o
 
-CXXFLAGS += $(SHARED)
+LOCAL_CXXFLAGS += $(SHARED)
 
 all : tutorial.so simple
 

--- a/regression/run/types/Makefile
+++ b/regression/run/types/Makefile
@@ -35,7 +35,7 @@ clean :
 
 types.o : types.hpp
 wraptypes.o : wraptypes.h types.hpp
-main.o : wrapftypes.o types.o
+main.o : fruit.o wrapftypes.o types.o
 
 # useful to isolate load error with just C++ code
 maincpp : maincpp.o wraptypes.o types.o

--- a/regression/run/types/python/Makefile
+++ b/regression/run/types/python/Makefile
@@ -23,7 +23,7 @@ OBJS = \
     types.o \
     pytypesmodule.o
 
-CXXFLAGS += $(SHARED)
+LOCAL_CXXFLAGS += $(SHARED)
 
 all : shtypes.so #simple
 

--- a/regression/run/vectors-list/python/Makefile
+++ b/regression/run/vectors-list/python/Makefile
@@ -24,7 +24,7 @@ OBJS = \
     vectors.o \
     pyvectorsmodule.o
 
-CXXFLAGS += $(SHARED)
+LOCAL_CXXFLAGS += $(SHARED)
 
 all : vectors.so #simple
 

--- a/regression/run/vectors-numpy/python/Makefile
+++ b/regression/run/vectors-numpy/python/Makefile
@@ -25,7 +25,7 @@ OBJS = \
     pyvectorsmodule.o \
     pyvectorsutil.o
 
-CXXFLAGS += $(SHARED)
+LOCAL_CXXFLAGS += $(SHARED)
 
 all : vectors.so #simple
 

--- a/regression/run/vectors/Makefile
+++ b/regression/run/vectors/Makefile
@@ -36,7 +36,7 @@ clean :
 
 vectors.o : vectors.hpp
 wrapvectors.o : wrapvectors.h vectors.hpp
-main.o : wrapfvectors.o
+main.o : fruit.o wrapfvectors.o
 
 # useful to isolate load error with just C++ code
 maincpp : maincpp.o wrapvectors.o vectors.o

--- a/scripts/lc.mk
+++ b/scripts/lc.mk
@@ -1,0 +1,64 @@
+#
+# Test with various compilers at Livermore Computing
+#
+# LC installs compilers in a consistent pattern which allows gmake
+# pattern rules to be used.
+
+gccdir = /usr/tce/packages/gcc
+inteldir = /usr/tce/packages/intel
+pgidir = /usr/tce/packages/pgi
+
+target = test-fortran-tutorial
+
+all : gcc intel pgi
+.PHONY : all
+
+clean :
+	$(MAKE) test-clean
+.PHONY : clean
+
+gcc : \
+  gcc-4.9.3 \
+  gcc-6.1.0 \
+  gcc-7.3.0 \
+  gcc-8.3.1 \
+  gcc-9.3.1 \
+  gcc-10.2.1
+.PHONY : gcc
+
+gcc-% :
+	$(MAKE) $(target) testdir=$@ compiler=gcc \
+	CC=$(gccdir)/$@/bin/gcc \
+	CXX=$(gccdir)/$@/bin/g++ \
+	FC=$(gccdir)/$@/bin/gfortran
+#.PHONY : gcc-9.3.1
+
+intel : \
+  intel-14.0.3 \
+  intel-15.0.6 \
+  intel-16.0.4 \
+  intel-17.0.2 \
+  intel-18.0.2 \
+  intel-19.1.2 \
+  intel-2021.2
+
+intel-% :
+	$(MAKE) $(target) testdir=$@ compiler=intel \
+	CC=$(inteldir)/$@/bin/icc \
+	CXX=$(inteldir)/$@/bin/icpc \
+	FC=$(inteldir)/$@/bin/ifort
+
+#  pgi-16.9  missing -cpp flag
+pgi : \
+ pgi-17.10 \
+ pgi-18.5 \
+ pgi-19.7 \
+ pgi-20.1 \
+ pgi-21.1 \
+
+pgi-% :
+	$(MAKE) $(target) testdir=$@ compiler=pgi \
+	CC=$(pgidir)/$@/bin/pgcc \
+	CXX=$(pgidir)/$@/bin/pgc++ \
+	FC=$(pgidir)/$@/bin/pgf90
+

--- a/scripts/lc.mk
+++ b/scripts/lc.mk
@@ -20,23 +20,26 @@ clean :
 	$(MAKE) test-clean
 .PHONY : clean
 
-gcc : \
+gcc-list = \
   gcc-4.9.3 \
   gcc-6.1.0 \
   gcc-7.3.0 \
   gcc-8.3.1 \
   gcc-9.3.1 \
   gcc-10.2.1
-.PHONY : gcc
 
-gcc-% :
+.PHONY : gcc
+gcc : $(gcc-list)
+
+.PHONY : $(gcc-list)
+$(gcc-list) : gcc-% :
 	$(MAKE) $(makeargs) testdir=$@ compiler=gcc \
 	CC=$(gccdir)/$@/bin/gcc \
 	CXX=$(gccdir)/$@/bin/g++ \
 	FC=$(gccdir)/$@/bin/gfortran
 #.PHONY : gcc-9.3.1
 
-intel : \
+intel-list = \
   intel-14.0.3 \
   intel-15.0.6 \
   intel-16.0.4 \
@@ -45,21 +48,29 @@ intel : \
   intel-19.1.2 \
   intel-2021.2
 
-intel-% :
+.PHONY : intel
+intel : $(intel-list)
+
+.PHONY : $(intel-list)
+$(intel-list) : intel-% :
 	$(MAKE) $(makeargs) testdir=$@ compiler=intel \
 	CC=$(inteldir)/$@/bin/icc \
 	CXX=$(inteldir)/$@/bin/icpc \
 	FC=$(inteldir)/$@/bin/ifort
 
 #  pgi-16.9  missing -cpp flag
-pgi : \
+pgi-list = \
  pgi-17.10 \
  pgi-18.5 \
  pgi-19.7 \
  pgi-20.1 \
  pgi-21.1 \
 
-pgi-% :
+.PHONY : pgi
+pgi : $(pgi-list)
+
+.PHONY : $(pgi-list)
+$(pgi-list) : pgi-% :
 	$(MAKE) $(makeargs) testdir=$@ compiler=pgi \
 	CC=$(pgidir)/$@/bin/pgcc \
 	CXX=$(pgidir)/$@/bin/pgc++ \

--- a/scripts/lc.mk
+++ b/scripts/lc.mk
@@ -16,6 +16,9 @@ target = test-fortran-strings
 makeargs = LOGOUTPUT=1 $(target)
 # Keep going if a test fails.
 makeargs += --ignore-errors
+# Run each compiler serially to avoid too many tasks
+# and to keep output in the same order.
+makeargs += -j 1
 
 all : gcc intel pgi
 .PHONY : all

--- a/scripts/lc.mk
+++ b/scripts/lc.mk
@@ -8,7 +8,10 @@ gccdir = /usr/tce/packages/gcc
 inteldir = /usr/tce/packages/intel
 pgidir = /usr/tce/packages/pgi
 
-target = test-fortran-tutorial
+target = test-fortran-strings
+#target = test-all
+# Flags for all uses of $(MAKE)
+makeargs = LOGOUTPUT=1 $(target)
 
 all : gcc intel pgi
 .PHONY : all
@@ -27,7 +30,7 @@ gcc : \
 .PHONY : gcc
 
 gcc-% :
-	$(MAKE) $(target) testdir=$@ compiler=gcc \
+	$(MAKE) $(makeargs) testdir=$@ compiler=gcc \
 	CC=$(gccdir)/$@/bin/gcc \
 	CXX=$(gccdir)/$@/bin/g++ \
 	FC=$(gccdir)/$@/bin/gfortran
@@ -43,7 +46,7 @@ intel : \
   intel-2021.2
 
 intel-% :
-	$(MAKE) $(target) testdir=$@ compiler=intel \
+	$(MAKE) $(makeargs) testdir=$@ compiler=intel \
 	CC=$(inteldir)/$@/bin/icc \
 	CXX=$(inteldir)/$@/bin/icpc \
 	FC=$(inteldir)/$@/bin/ifort
@@ -57,7 +60,7 @@ pgi : \
  pgi-21.1 \
 
 pgi-% :
-	$(MAKE) $(target) testdir=$@ compiler=pgi \
+	$(MAKE) $(makeargs) testdir=$@ compiler=pgi \
 	CC=$(pgidir)/$@/bin/pgcc \
 	CXX=$(pgidir)/$@/bin/pgc++ \
 	FC=$(pgidir)/$@/bin/pgf90

--- a/scripts/lc.mk
+++ b/scripts/lc.mk
@@ -9,23 +9,30 @@
 gccdir = /usr/tce/packages/gcc
 inteldir = /usr/tce/packages/intel
 pgidir = /usr/tce/packages/pgi
+pythondir = /usr/tce/packages/python
+
+tempdir = build/regression
 
 target = test-fortran-strings
 #target = test-all
 # Flags for all uses of $(MAKE)
-makeargs = LOGOUTPUT=1 $(target)
+makeargs = LOGOUTPUT=1
+# Location of build directory.
+makeargs += tempdir=$(tempdir)
 # Keep going if a test fails.
 makeargs += --ignore-errors
 # Run each compiler serially to avoid too many tasks
 # and to keep output in the same order.
 makeargs += -j 1
+makeargs += $(target)
 
-all : gcc intel pgi
+
 .PHONY : all
+all : gcc intel pgi
 
-clean :
-	$(MAKE) test-clean
 .PHONY : clean
+clean :
+	rm -rf $(tempdir)
 
 ######################################################################
 gcc-list = \
@@ -104,3 +111,30 @@ $(pgi-list) : pgi-% :
 	CXX=$(pgidir)/$@/bin/pgc++ \
 	FC=$(pgidir)/$@/bin/pgf90
 
+######################################################################
+
+python-list = \
+  python-2.7.16 \
+  python-3.5.1 \
+  python-3.6.4 \
+  python-3.7.2 \
+  python-3.8.2
+
+python-compiler = \
+  compiler=gcc \
+  CC=$(gccdir)/gcc-8.3.1/bin/gcc \
+  CXX=$(gccdir)/gcc-8.3.1/bin/g++
+
+python-exe-2.7.16 = $(pythondir)/python-2.7.16/bin/python2
+python-exe-3.5.1  = $(pythondir)/python-3.5.1/bin/python3
+python-exe-3.6.4  = $(pythondir)/python-3.6.4/bin/python3
+python-exe-3.7.2  = $(pythondir)/python-3.7.2/bin/python3
+python-exe-3.8.2  = $(pythondir)/python-3.8.2/bin/python3
+
+.PHONY : python
+python : $(python-list)
+
+.PHONY : $(python-list)
+$(python-list) : python-% :
+	$(MAKE) $(makeargs) testdir=$@ \
+	PYTHON=$(python-exe-$*) $(python-compiler)

--- a/scripts/lc.mk
+++ b/scripts/lc.mk
@@ -3,6 +3,8 @@
 #
 # LC installs compilers in a consistent pattern which allows gmake
 # pattern rules to be used.
+#
+# Usage:  srun make -f scripts/lc.mk target=test-all -j
 
 gccdir = /usr/tce/packages/gcc
 inteldir = /usr/tce/packages/intel
@@ -12,6 +14,8 @@ target = test-fortran-strings
 #target = test-all
 # Flags for all uses of $(MAKE)
 makeargs = LOGOUTPUT=1 $(target)
+# Keep going if a test fails.
+makeargs += --ignore-errors
 
 all : gcc intel pgi
 .PHONY : all
@@ -20,6 +24,7 @@ clean :
 	$(MAKE) test-clean
 .PHONY : clean
 
+######################################################################
 gcc-list = \
   gcc-4.9.3 \
   gcc-6.1.0 \
@@ -37,16 +42,32 @@ $(gcc-list) : gcc-% :
 	CC=$(gccdir)/$@/bin/gcc \
 	CXX=$(gccdir)/$@/bin/g++ \
 	FC=$(gccdir)/$@/bin/gfortran
-#.PHONY : gcc-9.3.1
+
+######################################################################
+#  intel-14.0.3
 
 intel-list = \
-  intel-14.0.3 \
   intel-15.0.6 \
   intel-16.0.4 \
   intel-17.0.2 \
   intel-18.0.2 \
   intel-19.1.2 \
   intel-2021.2
+
+
+# Match up gcc stdlib with intel compiler.
+gccbin-14.0.3 = $(gccdir)/gcc-4.9.3/bin
+gccbin-15.0.6 = $(gccdir)/gcc-4.9.3/bin
+gccbin-16.0.4 = $(gccdir)/gcc-4.9.3/bin
+gccbin-17.0.2 = $(gccdir)/gcc-4.9.3/bin
+gccbin-18.0.2 = $(gccdir)/gcc-8.3.1/bin
+gccbin-19.1.2 = $(gccdir)/gcc-8.3.1/bin
+gccbin-2021.2 = $(gccdir)/gcc-8.3.1/bin
+
+#intel-14.0.3-cxxflags = -std=gnu++98 -Dnullptr=NULL
+
+# Add F2003 feature.
+intel-15.0.6-fflags = -assume realloc_lhs
 
 .PHONY : intel
 intel : $(intel-list)
@@ -56,8 +77,12 @@ $(intel-list) : intel-% :
 	$(MAKE) $(makeargs) testdir=$@ compiler=intel \
 	CC=$(inteldir)/$@/bin/icc \
 	CXX=$(inteldir)/$@/bin/icpc \
-	FC=$(inteldir)/$@/bin/ifort
+	FC=$(inteldir)/$@/bin/ifort \
+	CFLAGS=-gcc-name=$(gccbin-$*)/gcc \
+	CXXFLAGS=-gxx-name=$(gccbin-$*)/g++ \
+	FFLAGS="-gcc-name=$(gccbin-$*)/gcc $($@-fflags)"
 
+######################################################################
 #  pgi-16.9  missing -cpp flag
 pgi-list = \
  pgi-17.10 \

--- a/scripts/summary.py
+++ b/scripts/summary.py
@@ -1,0 +1,59 @@
+#!/bin/env python3
+
+"""
+Create a summary of regression test coverage created by lc.mk.
+
+$tempdir
+  gcc-4.9.3
+    tutorial
+      build.out
+      build.PASS | build.FAIL
+      test.out
+      test.PASS | test.FAIL
+  python-3.8.3
+    tutorial
+      python
+      build.out
+      build.PASS | build.FAIL
+      test.out
+      test.PASS | test.FAIL
+"""
+
+import os
+import sys
+
+RED   = "\033[1;31m"  
+BLUE  = "\033[1;34m"
+CYAN  = "\033[1;36m"
+GREEN = "\033[0;32m"
+RESET = "\033[0;0m"
+BOLD    = "\033[;1m"
+REVERSE = "\033[;7m"
+
+FAIL = RED + "FAIL" + RESET
+PASS = GREEN + "PASS" + RESET
+ 
+
+def print_pass_fail(rootDir):
+    os.chdir(rootDir)
+    for dirName, subdirList, fileList in os.walk('.'):
+        dirName = dirName[2:]  # Remove leading ./
+        if 'build.FAIL' in fileList:
+            print(f'build {FAIL} {dirName}')
+        elif 'build.PASS' in fileList:
+            if 'test.FAIL' in fileList:
+                print(f'test {FAIL} {dirName}')
+            elif 'test.PASS' in fileList:
+                print(f'test {PASS} {dirName}')
+            else:
+                print(f'missing PASS/FAIL {dirName}')
+
+
+if __name__ == "__main__":
+    print("HERE", sys.argv)
+    if len(sys.argv) < 2:
+        print("usage: {} directory".format(sys.argv[0]))
+        raise SystemExit
+    print_pass_fail(sys.argv[1])
+
+    

--- a/scripts/test-lc.sh
+++ b/scripts/test-lc.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+#
+# Run from home directory
+# scripts/test-lc.sh
+
+date
+
+# Compile Fortran tests with multiple compilers.
+make -f scripts/lc.mk clean
+
+srun make -f scripts/lc.mk target=test-fortran all -j
+
+# Compile Python tests with gcc
+srun make -f scripts/lc.mk target=test-python python -j
+
+date
+
+# Create summary
+

--- a/scripts/test-lc.sh
+++ b/scripts/test-lc.sh
@@ -13,6 +13,8 @@ srun make -f scripts/lc.mk target=test-fortran all -j
 # Compile Python tests with gcc
 srun make -f scripts/lc.mk target=test-python python -j
 
+scripts/summary.py build/regression/run
+
 date
 
 # Create summary

--- a/shroud/generate.py
+++ b/shroud/generate.py
@@ -488,30 +488,28 @@ class VerifyAttrs(object):
             if charlen is True:
                 raise RuntimeError("charlen attribute must have a value")
 
-        const_char_in = (
-            intent == "in" and
+        char_ptr_in = (
             is_ptr == 1 and
+            intent == "in" and
             arg_typemap.name == "char")
             
         blanknull = attrs["blanknull"]
         if blanknull is not None:
-            if not const_char_in:
+            if not char_ptr_in:
                 raise RuntimeError(
                     "blanknull attribute can only be "
                     "used on intent(in) 'char *'"
                 )
             else:
                 arg.blanknull = blanknull
-        elif const_char_in:
+        elif char_ptr_in:
             arg.blanknull = options.F_blanknull
 
         if meta["api"]:  # User set
             pass
         elif (
             options.F_CFI is False and
-            intent == "in" and
-            is_ptr == 1 and
-            arg_typemap.name == "char" and
+            char_ptr_in and
             arg.blanknull is False
         ):
             # const char *arg


### PR DESCRIPTION
* Add a script and Makefile to run current regression test using multiple compilers and python versions.
* Allow CFLAGS, CXXFLAGS, and FFLAGS to be set as Makefile arguments.
* Update dependencies to build in parallel (Make -j)