### PR TITLE
Typemap test

### DIFF
--- a/regression/input/typemap.yaml
+++ b/regression/input/typemap.yaml
@@ -47,6 +47,7 @@ splicer_code:
       #endif
   c:
     C_declarations: |
+      #ifndef __cplusplus
       #if defined(USE_64BIT_INDEXTYPE)
       typedef int64_t IndexType;
       #else
@@ -57,6 +58,7 @@ splicer_code:
       typedef double FloatType;
       #else
       typedef float FloatType;
+      #endif
       #endif
 
 # Add code which will be integrated with other include and use statements

--- a/regression/reference/arrayclass/wrapArrayWrapper.cpp
+++ b/regression/reference/arrayclass/wrapArrayWrapper.cpp
@@ -6,10 +6,11 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapArrayWrapper.h"
 
 // cxx_header
 #include "arrayclass.hpp"
+// shroud
+#include "wrapArrayWrapper.h"
 
 // splicer begin class.ArrayWrapper.CXX_definitions
 // splicer end class.ArrayWrapper.CXX_definitions

--- a/regression/reference/cdesc/wrapcdesc.cpp
+++ b/regression/reference/cdesc/wrapcdesc.cpp
@@ -6,12 +6,13 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapcdesc.h"
 
 // cxx_header
 #include "cdesc.hpp"
 // typemap
 #include <string>
+// shroud
+#include "wrapcdesc.h"
 
 // splicer begin CXX_definitions
 // splicer end CXX_definitions

--- a/regression/reference/classes/wrapCircle.cpp
+++ b/regression/reference/classes/wrapCircle.cpp
@@ -6,10 +6,11 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapCircle.h"
 
 // cxx_header
 #include "classes.hpp"
+// shroud
+#include "wrapCircle.h"
 
 // splicer begin class.Circle.CXX_definitions
 // splicer end class.Circle.CXX_definitions

--- a/regression/reference/classes/wrapClass1.cpp
+++ b/regression/reference/classes/wrapClass1.cpp
@@ -6,7 +6,6 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapClass1.h"
 
 // cxx_header
 #include "classes.hpp"
@@ -15,6 +14,7 @@
 // shroud
 #include <cstddef>
 #include <cstring>
+#include "wrapClass1.h"
 
 // splicer begin class.Class1.CXX_definitions
 // splicer end class.Class1.CXX_definitions

--- a/regression/reference/classes/wrapClass2.cpp
+++ b/regression/reference/classes/wrapClass2.cpp
@@ -6,7 +6,6 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapClass2.h"
 
 // cxx_header
 #include "classes.hpp"
@@ -15,6 +14,7 @@
 // shroud
 #include <cstddef>
 #include <cstring>
+#include "wrapClass2.h"
 
 // splicer begin class.Class2.CXX_definitions
 // splicer end class.Class2.CXX_definitions

--- a/regression/reference/classes/wrapShape.cpp
+++ b/regression/reference/classes/wrapShape.cpp
@@ -6,10 +6,11 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapShape.h"
 
 // cxx_header
 #include "classes.hpp"
+// shroud
+#include "wrapShape.h"
 
 // splicer begin class.Shape.CXX_definitions
 // splicer end class.Shape.CXX_definitions

--- a/regression/reference/classes/wrapSingleton.cpp
+++ b/regression/reference/classes/wrapSingleton.cpp
@@ -6,10 +6,11 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapSingleton.h"
 
 // cxx_header
 #include "classes.hpp"
+// shroud
+#include "wrapSingleton.h"
 
 // splicer begin class.Singleton.CXX_definitions
 // splicer end class.Singleton.CXX_definitions

--- a/regression/reference/classes/wrapclasses.cpp
+++ b/regression/reference/classes/wrapclasses.cpp
@@ -6,7 +6,6 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapclasses.h"
 
 // cxx_header
 #include "classes.hpp"
@@ -14,6 +13,7 @@
 #include <string>
 // shroud
 #include <cstring>
+#include "wrapclasses.h"
 
 // splicer begin CXX_definitions
 // splicer end CXX_definitions

--- a/regression/reference/clibrary/wrapClibrary.c
+++ b/regression/reference/clibrary/wrapClibrary.c
@@ -6,7 +6,6 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapClibrary.h"
 
 // cxx_header
 #include "clibrary.h"
@@ -14,6 +13,7 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
+#include "wrapClibrary.h"
 
 
 // helper ShroudLenTrim

--- a/regression/reference/cxxlibrary/wrapcxxlibrary.cpp
+++ b/regression/reference/cxxlibrary/wrapcxxlibrary.cpp
@@ -6,10 +6,11 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapcxxlibrary.h"
 
 // cxx_header
 #include "cxxlibrary.hpp"
+// shroud
+#include "wrapcxxlibrary.h"
 
 // splicer begin CXX_definitions
 // splicer end CXX_definitions

--- a/regression/reference/cxxlibrary/wrapcxxlibrary_structns.cpp
+++ b/regression/reference/cxxlibrary/wrapcxxlibrary_structns.cpp
@@ -6,10 +6,11 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapcxxlibrary_structns.h"
 
 // cxx_header
 #include "cxxlibrary.hpp"
+// shroud
+#include "wrapcxxlibrary_structns.h"
 
 // splicer begin namespace.structns.CXX_definitions
 // splicer end namespace.structns.CXX_definitions

--- a/regression/reference/debugfalse/wrapTutorial.cpp
+++ b/regression/reference/debugfalse/wrapTutorial.cpp
@@ -6,12 +6,12 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapTutorial.h"
 
 #include "tutorial.hpp"
 #include <string>
 #include <cstddef>
 #include <cstring>
+#include "wrapTutorial.h"
 
 // splicer begin CXX_definitions
 // splicer end CXX_definitions

--- a/regression/reference/example/wrapUserLibrary_example_nested.cpp
+++ b/regression/reference/example/wrapUserLibrary_example_nested.cpp
@@ -6,10 +6,11 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapUserLibrary_example_nested.h"
 
 // typemap
 #include <string>
+// shroud
+#include "wrapUserLibrary_example_nested.h"
 
 // splicer begin namespace.example::nested.CXX_definitions
 // splicer end namespace.example::nested.CXX_definitions

--- a/regression/reference/example/wrapexample_nested_ExClass1.cpp
+++ b/regression/reference/example/wrapexample_nested_ExClass1.cpp
@@ -6,7 +6,6 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapexample_nested_ExClass1.h"
 
 // cxx_header
 #include "ExClass1.hpp"
@@ -15,6 +14,7 @@
 // shroud
 #include <cstddef>
 #include <cstring>
+#include "wrapexample_nested_ExClass1.h"
 
 // splicer begin namespace.example::nested.class.ExClass1.CXX_definitions
 //   namespace.example::nested.class.ExClass1.CXX_definitions

--- a/regression/reference/example/wrapexample_nested_ExClass2.cpp
+++ b/regression/reference/example/wrapexample_nested_ExClass2.cpp
@@ -6,7 +6,6 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapexample_nested_ExClass2.h"
 
 // cxx_header
 #include "ExClass2.hpp"
@@ -16,6 +15,7 @@
 // shroud
 #include <cstddef>
 #include <cstring>
+#include "wrapexample_nested_ExClass2.h"
 
 // splicer begin namespace.example::nested.class.ExClass2.CXX_definitions
 //   namespace.example::nested.class.ExClass2.CXX_definitions

--- a/regression/reference/forward/wrapClass2.cpp
+++ b/regression/reference/forward/wrapClass2.cpp
@@ -6,7 +6,6 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapClass2.h"
 
 // cxx_header
 #include "forward.hpp"
@@ -15,6 +14,7 @@
 #include "header2.hpp"
 // shroud
 #include <cstddef>
+#include "wrapClass2.h"
 
 // splicer begin class.Class2.CXX_definitions
 // splicer end class.Class2.CXX_definitions

--- a/regression/reference/forward/wrapforward.cpp
+++ b/regression/reference/forward/wrapforward.cpp
@@ -6,10 +6,11 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapforward.h"
 
 // cxx_header
 #include "forward.hpp"
+// shroud
+#include "wrapforward.h"
 
 // splicer begin CXX_definitions
 // splicer end CXX_definitions

--- a/regression/reference/generic-cfi/wrapgeneric.c
+++ b/regression/reference/generic-cfi/wrapgeneric.c
@@ -6,11 +6,12 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapgeneric.h"
 
 // cxx_header
 #include "generic.h"
 #include "helper.h"
+// shroud
+#include "wrapgeneric.h"
 
 // splicer begin C_definitions
 // splicer end C_definitions

--- a/regression/reference/generic/wrapgeneric.c
+++ b/regression/reference/generic/wrapgeneric.c
@@ -6,11 +6,12 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapgeneric.h"
 
 // cxx_header
 #include "generic.h"
 #include "helper.h"
+// shroud
+#include "wrapgeneric.h"
 
 // splicer begin C_definitions
 // splicer end C_definitions

--- a/regression/reference/include/wrapClass2.cpp
+++ b/regression/reference/include/wrapClass2.cpp
@@ -6,13 +6,14 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapClass2.h"
 
 // cxx_header
 #include "zzheader.hpp"
 #include "global_header.hpp"
 // typemap
 #include "class_header.hpp"
+// shroud
+#include "wrapClass2.h"
 
 
 extern "C" {

--- a/regression/reference/include/wraplibrary_one_two.cpp
+++ b/regression/reference/include/wraplibrary_one_two.cpp
@@ -6,11 +6,12 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wraplibrary_one_two.h"
 
 // cxx_header
 #include "zzheader.hpp"
 #include "global_header.hpp"
+// shroud
+#include "wraplibrary_one_two.h"
 
 
 extern "C" {

--- a/regression/reference/include/wraplibrary_outer1.cpp
+++ b/regression/reference/include/wraplibrary_outer1.cpp
@@ -6,10 +6,11 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wraplibrary_outer1.h"
 
 // cxx_header
 #include "outer1.hpp"
+// shroud
+#include "wraplibrary_outer1.h"
 
 
 extern "C" {

--- a/regression/reference/include/wraplibrary_outer2.cpp
+++ b/regression/reference/include/wraplibrary_outer2.cpp
@@ -6,10 +6,11 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wraplibrary_outer2.h"
 
 // cxx_header
 #include "outer2.hpp"
+// shroud
+#include "wraplibrary_outer2.h"
 
 
 extern "C" {

--- a/regression/reference/include/wrapouter1_class0.cpp
+++ b/regression/reference/include/wrapouter1_class0.cpp
@@ -6,10 +6,11 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapouter1_class0.h"
 
 // cxx_header
 #include "outer1.hpp"
+// shroud
+#include "wrapouter1_class0.h"
 
 
 extern "C" {

--- a/regression/reference/include/wrapouter2_class0.cpp
+++ b/regression/reference/include/wrapouter2_class0.cpp
@@ -6,11 +6,12 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapouter2_class0.h"
 
 // cxx_header
 #include "classA.hpp"
 #include "classAb.hpp"
+// shroud
+#include "wrapouter2_class0.h"
 
 
 extern "C" {

--- a/regression/reference/include/wrapthree_Class1.cpp
+++ b/regression/reference/include/wrapthree_Class1.cpp
@@ -6,10 +6,11 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapthree_Class1.h"
 
 // cxx_header
 #include "class_header.hpp"
+// shroud
+#include "wrapthree_Class1.h"
 
 
 extern "C" {

--- a/regression/reference/memdoc/wrapmemdoc.cpp
+++ b/regression/reference/memdoc/wrapmemdoc.cpp
@@ -6,13 +6,13 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapmemdoc.h"
 
 // typemap
 #include <string>
 // shroud
 #include <cstddef>
 #include <cstring>
+#include "wrapmemdoc.h"
 
 // splicer begin CXX_definitions
 // splicer end CXX_definitions

--- a/regression/reference/names/foo.cpp
+++ b/regression/reference/names/foo.cpp
@@ -6,6 +6,8 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
+
+// shroud
 #include "foo.h"
 
 // splicer begin namespace.ns0.class.Names.CXX_definitions

--- a/regression/reference/names/top.cpp
+++ b/regression/reference/names/top.cpp
@@ -6,13 +6,13 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "top.h"
 
 // typemap
 #include <string>
 // shroud
 #include <cstring>
 #include <cstdlib>
+#include "top.h"
 
 // splicer begin CXX_definitions
 // Add some text from splicer

--- a/regression/reference/names/wrapCAPI_Class1.cc
+++ b/regression/reference/names/wrapCAPI_Class1.cc
@@ -6,6 +6,8 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
+
+// shroud
 #include "wrapCAPI_Class1.hh"
 
 // splicer begin namespace.CAPI.class.Class1.CXX_definitions

--- a/regression/reference/names/wraptestnames_CAPI.cc
+++ b/regression/reference/names/wraptestnames_CAPI.cc
@@ -6,6 +6,8 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
+
+// shroud
 #include "wraptestnames_CAPI.hh"
 
 // splicer begin namespace.CAPI.CXX_definitions

--- a/regression/reference/names/wraptestnames_ns1.cc
+++ b/regression/reference/names/wraptestnames_ns1.cc
@@ -6,6 +6,8 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
+
+// shroud
 #include "wraptestnames_ns1.hh"
 
 // splicer begin namespace.ns1.CXX_definitions

--- a/regression/reference/names2/wrapNames.cpp
+++ b/regression/reference/names2/wrapNames.cpp
@@ -6,6 +6,8 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
+
+// shroud
 #include "wrapNames.h"
 
 // splicer begin CXX_definitions

--- a/regression/reference/namespace/wrapns.cpp
+++ b/regression/reference/namespace/wrapns.cpp
@@ -6,7 +6,6 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapns.h"
 
 // cxx_header
 #include "namespace.hpp"
@@ -15,6 +14,7 @@
 // shroud
 #include <cstddef>
 #include <cstring>
+#include "wrapns.h"
 
 // splicer begin CXX_definitions
 // splicer end CXX_definitions

--- a/regression/reference/namespace/wrapns_outer.cpp
+++ b/regression/reference/namespace/wrapns_outer.cpp
@@ -6,10 +6,11 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapns_outer.h"
 
 // cxx_header
 #include "namespace.hpp"
+// shroud
+#include "wrapns_outer.h"
 
 // splicer begin namespace.outer.CXX_definitions
 // splicer end namespace.outer.CXX_definitions

--- a/regression/reference/namespacedoc/wrapwrapped.cpp
+++ b/regression/reference/namespacedoc/wrapwrapped.cpp
@@ -6,6 +6,8 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
+
+// shroud
 #include "wrapwrapped.h"
 
 // splicer begin CXX_definitions

--- a/regression/reference/namespacedoc/wrapwrapped_inner1.cpp
+++ b/regression/reference/namespacedoc/wrapwrapped_inner1.cpp
@@ -6,6 +6,8 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
+
+// shroud
 #include "wrapwrapped_inner1.h"
 
 // splicer begin namespace.inner1.CXX_definitions

--- a/regression/reference/namespacedoc/wrapwrapped_inner2.cpp
+++ b/regression/reference/namespacedoc/wrapwrapped_inner2.cpp
@@ -6,6 +6,8 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
+
+// shroud
 #include "wrapwrapped_inner2.h"
 
 // splicer begin namespace.inner2.CXX_definitions

--- a/regression/reference/namespacedoc/wrapwrapped_inner4.cpp
+++ b/regression/reference/namespacedoc/wrapwrapped_inner4.cpp
@@ -6,6 +6,8 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
+
+// shroud
 #include "wrapwrapped_inner4.h"
 
 // splicer begin namespace.inner4.CXX_definitions

--- a/regression/reference/ownership/wrapClass1.cpp
+++ b/regression/reference/ownership/wrapClass1.cpp
@@ -6,12 +6,12 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapClass1.h"
 
 // cxx_header
 #include "ownership.hpp"
 // shroud
 #include <cstddef>
+#include "wrapClass1.h"
 
 // splicer begin class.Class1.CXX_definitions
 // splicer end class.Class1.CXX_definitions

--- a/regression/reference/ownership/wrapownership.cpp
+++ b/regression/reference/ownership/wrapownership.cpp
@@ -6,10 +6,11 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapownership.h"
 
 // cxx_header
 #include "ownership.hpp"
+// shroud
+#include "wrapownership.h"
 
 // splicer begin CXX_definitions
 // splicer end CXX_definitions

--- a/regression/reference/pointers-c/wrappointers.c
+++ b/regression/reference/pointers-c/wrappointers.c
@@ -6,13 +6,13 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrappointers.h"
 
 // cxx_header
 #include "pointers.h"
 // shroud
 #include <stdlib.h>
 #include <string.h>
+#include "wrappointers.h"
 
 
 // helper ShroudLenTrim

--- a/regression/reference/pointers-cfi/wrappointers.cpp
+++ b/regression/reference/pointers-cfi/wrappointers.cpp
@@ -6,13 +6,13 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrappointers.h"
 
 // cxx_header
 #include "pointers.h"
 // shroud
 #include <cstdlib>
 #include <cstring>
+#include "wrappointers.h"
 
 // splicer begin CXX_definitions
 // splicer end CXX_definitions

--- a/regression/reference/pointers-cxx/wrappointers.cpp
+++ b/regression/reference/pointers-cxx/wrappointers.cpp
@@ -6,13 +6,13 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrappointers.h"
 
 // cxx_header
 #include "pointers.h"
 // shroud
 #include <cstdlib>
 #include <cstring>
+#include "wrappointers.h"
 
 // splicer begin CXX_definitions
 // splicer end CXX_definitions

--- a/regression/reference/preprocess/wrapUser1.cpp
+++ b/regression/reference/preprocess/wrapUser1.cpp
@@ -6,10 +6,11 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapUser1.h"
 
 // cxx_header
 #include "preprocess.hpp"
+// shroud
+#include "wrapUser1.h"
 
 // splicer begin class.User1.CXX_definitions
 // splicer end class.User1.CXX_definitions

--- a/regression/reference/preprocess/wrapUser2.cpp
+++ b/regression/reference/preprocess/wrapUser2.cpp
@@ -7,10 +7,11 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
 #ifdef USE_USER2
-#include "wrapUser2.h"
 
 // cxx_header
 #include "User2.hpp"
+// shroud
+#include "wrapUser2.h"
 
 // splicer begin class.User2.CXX_definitions
 // splicer end class.User2.CXX_definitions

--- a/regression/reference/statement/wrapstatement.cpp
+++ b/regression/reference/statement/wrapstatement.cpp
@@ -6,7 +6,6 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapstatement.h"
 
 // cxx_header
 #include "statement.hpp"
@@ -14,6 +13,7 @@
 #include <string>
 // shroud
 #include <cstring>
+#include "wrapstatement.h"
 
 // splicer begin CXX_definitions
 // splicer end CXX_definitions

--- a/regression/reference/strings-cfi/wrapstrings.cpp
+++ b/regression/reference/strings-cfi/wrapstrings.cpp
@@ -6,7 +6,6 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapstrings.h"
 
 // cxx_header
 #include "strings.hpp"
@@ -16,6 +15,7 @@
 // shroud
 #include <cstring>
 #include <cstdlib>
+#include "wrapstrings.h"
 
 // splicer begin CXX_definitions
 // splicer end CXX_definitions

--- a/regression/reference/strings/wrapstrings.cpp
+++ b/regression/reference/strings/wrapstrings.cpp
@@ -6,7 +6,6 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapstrings.h"
 
 // cxx_header
 #include "strings.hpp"
@@ -17,6 +16,7 @@
 #include <cstring>
 #include <cstddef>
 #include <cstdlib>
+#include "wrapstrings.h"
 
 // splicer begin CXX_definitions
 // splicer end CXX_definitions

--- a/regression/reference/struct-c/wrapCstruct_as_class.c
+++ b/regression/reference/struct-c/wrapCstruct_as_class.c
@@ -6,10 +6,11 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapCstruct_as_class.h"
 
 // cxx_header
 #include "struct.h"
+// shroud
+#include "wrapCstruct_as_class.h"
 
 // splicer begin class.Cstruct_as_class.C_definitions
 // splicer end class.Cstruct_as_class.C_definitions

--- a/regression/reference/struct-c/wrapCstruct_as_subclass.c
+++ b/regression/reference/struct-c/wrapCstruct_as_subclass.c
@@ -6,10 +6,11 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapCstruct_as_subclass.h"
 
 // cxx_header
 #include "struct.h"
+// shroud
+#include "wrapCstruct_as_subclass.h"
 
 // splicer begin class.Cstruct_as_subclass.C_definitions
 // splicer end class.Cstruct_as_subclass.C_definitions

--- a/regression/reference/struct-c/wrapstruct.c
+++ b/regression/reference/struct-c/wrapstruct.c
@@ -6,12 +6,12 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapstruct.h"
 
 // cxx_header
 #include "struct.h"
 // shroud
 #include <string.h>
+#include "wrapstruct.h"
 
 
 // helper ShroudStrBlankFill

--- a/regression/reference/struct-cxx/wrapCstruct_as_class.cpp
+++ b/regression/reference/struct-cxx/wrapCstruct_as_class.cpp
@@ -6,10 +6,11 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapCstruct_as_class.h"
 
 // cxx_header
 #include "struct.h"
+// shroud
+#include "wrapCstruct_as_class.h"
 
 // splicer begin class.Cstruct_as_class.CXX_definitions
 // splicer end class.Cstruct_as_class.CXX_definitions

--- a/regression/reference/struct-cxx/wrapCstruct_as_subclass.cpp
+++ b/regression/reference/struct-cxx/wrapCstruct_as_subclass.cpp
@@ -6,10 +6,11 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapCstruct_as_subclass.h"
 
 // cxx_header
 #include "struct.h"
+// shroud
+#include "wrapCstruct_as_subclass.h"
 
 // splicer begin class.Cstruct_as_subclass.CXX_definitions
 // splicer end class.Cstruct_as_subclass.CXX_definitions

--- a/regression/reference/struct-cxx/wrapstruct.cpp
+++ b/regression/reference/struct-cxx/wrapstruct.cpp
@@ -6,12 +6,12 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapstruct.h"
 
 // cxx_header
 #include "struct.h"
 // shroud
 #include <cstring>
+#include "wrapstruct.h"
 
 // splicer begin CXX_definitions
 // splicer end CXX_definitions

--- a/regression/reference/templates/wrapstd_vector_double.cpp
+++ b/regression/reference/templates/wrapstd_vector_double.cpp
@@ -6,12 +6,12 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapstd_vector_double.h"
 
 // cxx_header
 #include <vector>
 // shroud
 #include <cstddef>
+#include "wrapstd_vector_double.h"
 
 // splicer begin namespace.std.class.vector.CXX_definitions
 // splicer end namespace.std.class.vector.CXX_definitions

--- a/regression/reference/templates/wrapstructAsClass_double.cpp
+++ b/regression/reference/templates/wrapstructAsClass_double.cpp
@@ -6,10 +6,11 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapstructAsClass_double.h"
 
 // cxx_header
 #include "templates.hpp"
+// shroud
+#include "wrapstructAsClass_double.h"
 
 // splicer begin class.structAsClass.CXX_definitions
 // splicer end class.structAsClass.CXX_definitions

--- a/regression/reference/templates/wrapstructAsClass_int.cpp
+++ b/regression/reference/templates/wrapstructAsClass_int.cpp
@@ -6,10 +6,11 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapstructAsClass_int.h"
 
 // cxx_header
 #include "templates.hpp"
+// shroud
+#include "wrapstructAsClass_int.h"
 
 // splicer begin class.structAsClass.CXX_definitions
 // splicer end class.structAsClass.CXX_definitions

--- a/regression/reference/templates/wraptemplates.cpp
+++ b/regression/reference/templates/wraptemplates.cpp
@@ -6,13 +6,14 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wraptemplates.h"
 
 // cxx_header
 #include "templates.hpp"
 // typemap
 #include "implworker1.hpp"
 #include "implworker2.hpp"
+// shroud
+#include "wraptemplates.h"
 
 // splicer begin CXX_definitions
 // splicer end CXX_definitions

--- a/regression/reference/templates/wrapuser_int.cpp
+++ b/regression/reference/templates/wrapuser_int.cpp
@@ -6,10 +6,11 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapuser_int.h"
 
 // cxx_header
 #include "templates.hpp"
+// shroud
+#include "wrapuser_int.h"
 
 // splicer begin class.user.CXX_definitions
 // splicer end class.user.CXX_definitions

--- a/regression/reference/templates/wrapvectorforint.cpp
+++ b/regression/reference/templates/wrapvectorforint.cpp
@@ -6,12 +6,12 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapstd_vector_int.h"
 
 // cxx_header
 #include <vector>
 // shroud
 #include <cstddef>
+#include "wrapstd_vector_int.h"
 
 // splicer begin namespace.std.class.vector.CXX_definitions
 // splicer end namespace.std.class.vector.CXX_definitions

--- a/regression/reference/tutorial/wrapTutorial.cpp
+++ b/regression/reference/tutorial/wrapTutorial.cpp
@@ -6,7 +6,6 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapTutorial.h"
 
 // cxx_header
 #include "tutorial.hpp"
@@ -15,6 +14,7 @@
 // shroud
 #include <cstddef>
 #include <cstring>
+#include "wrapTutorial.h"
 
 // splicer begin CXX_definitions
 // splicer end CXX_definitions

--- a/regression/reference/typemap/wraptypemap.cpp
+++ b/regression/reference/typemap/wraptypemap.cpp
@@ -6,9 +6,9 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wraptypemap.h"
 
 #include "typemap.hpp"
+#include "wraptypemap.h"
 
 // splicer begin CXX_definitions
 // splicer end CXX_definitions

--- a/regression/reference/typemap/wraptypemap.h
+++ b/regression/reference/typemap/wraptypemap.h
@@ -33,6 +33,7 @@ extern "C" {
 #endif
 
 // splicer begin C_declarations
+#ifndef __cplusplus
 #if defined(USE_64BIT_INDEXTYPE)
 typedef int64_t IndexType;
 #else
@@ -43,6 +44,7 @@ typedef int32_t IndexType;
 typedef double FloatType;
 #else
 typedef float FloatType;
+#endif
 #endif
 // splicer end C_declarations
 

--- a/regression/reference/types/wraptypes.cpp
+++ b/regression/reference/types/wraptypes.cpp
@@ -6,10 +6,11 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wraptypes.h"
 
 // cxx_header
 #include "types.hpp"
+// shroud
+#include "wraptypes.h"
 
 // splicer begin CXX_definitions
 // splicer end CXX_definitions

--- a/regression/reference/vectors/wrapvectors.cpp
+++ b/regression/reference/vectors/wrapvectors.cpp
@@ -6,12 +6,13 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //
-#include "wrapvectors.h"
 
 // cxx_header
 #include "vectors.hpp"
 // typemap
 #include <vector>
+// shroud
+#include "wrapvectors.h"
 
 // splicer begin CXX_definitions
 // splicer end CXX_definitions

--- a/regression/run/Makefile
+++ b/regression/run/Makefile
@@ -271,6 +271,13 @@ test-struct : \
   test-python-struct-class-c \
   test-python-struct-class-cxx
 
+.PHONY : test-typemap
+test-typemap : \
+  test-c-typemap32 \
+  test-c-typemap64 \
+  test-fortran-typemap32 \
+  test-fortran-typemap64 \
+
 test-clean-testdir :
 	rm -rf $(relrunpath)
 .PHONY : test-clean-testdir

--- a/regression/run/Makefile
+++ b/regression/run/Makefile
@@ -117,6 +117,8 @@ test-cfi : $(fortran-test-list-cfi)
 
 c-test-list = \
   test-c-types \
+  test-c-typemap32 \
+  test-c-typemap64 \
   test-c-classes \
   test-c-enum-c \
   test-c-namespace \

--- a/regression/run/typemap/testc.c
+++ b/regression/run/typemap/testc.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2017-2021, Lawrence Livermore National Security, LLC and
+ * other Shroud Project Developers.
+ * See the top-level COPYRIGHT file for details.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ *
+ * Test C API generated from types.yaml.
+ */
+
+#include <math.h>
+#include <wraptypemap.h>
+
+#include <assert.h>
+
+void test_pass_index(void)
+{
+    IndexType indx;
+
+#if defined(USE_64BIT_INDEXTYPE)
+    int64_t indx64 = pow(2,34);
+    assert(sizeof(IndexType) == sizeof(int64_t) && "TYPEMAP_size64");
+    assert(! TYP_pass_index(indx64 - 1, &indx));
+    assert(  TYP_pass_index(indx64, &indx));
+    assert(  indx == indx64);
+#else
+    int32_t indx32 = 2;
+    assert(sizeof(IndexType) == sizeof(int32_t) && "TYPEMAP_size32");
+    assert(! TYP_pass_index(indx32 - 1, &indx));
+    assert(  TYP_pass_index(indx32, &indx));
+    assert(  indx == indx32);
+#endif
+}
+
+int main(int argc, char *argv[])
+{
+  test_pass_index();
+
+  return 0;
+}
+

--- a/shroud/wrapc.py
+++ b/shroud/wrapc.py
@@ -474,13 +474,12 @@ class Wrapc(util.WrapperMixin):
         if cls and cls.cpp_if:
             output.append("#" + node.cpp_if)
 
-        if hname:
-            output.append('#include "%s"' % hname)
-
         # Use headers from implementation
         self.header_impl.add_cxx_header(node)
         self.header_impl.add_shroud_dict(self.helper_include["file"])
         self.header_impl.add_typemaps_xxx(self.impl_typedef_nodes, "impl_header")
+        if hname:
+            self.header_impl.add_shroud_file(hname)
         self.header_impl.write_headers(output)
 
         if self.language == "cxx":


### PR DESCRIPTION
Change order of include files in C wrapper. This was prompted by the `typemap.yaml` test which creates a typedef for C users in a header file. However, the C wrapper, compiled by C++, uses types defined in typemap.hpp.