### PR TITLE
Add a splicer into the types file

### DIFF
--- a/regression/input/typemap.yaml
+++ b/regression/input/typemap.yaml
@@ -65,20 +65,21 @@ splicer_code:
       integer, parameter :: FLOATTYPE = C_FLOAT
       #endif
   c:
-    C_declarations: |
-      #ifndef __cplusplus
-      #if defined(USE_64BIT_INDEXTYPE)
-      typedef int64_t IndexType;
-      #else
-      typedef int32_t IndexType;
-      #endif
+    types:
+      C_declarations: |
+        #ifndef __cplusplus
+        #if defined(USE_64BIT_INDEXTYPE)
+        typedef int64_t IndexType;
+        #else
+        typedef int32_t IndexType;
+        #endif
 
-      #if defined(USE_64BIT_FLOAT)
-      typedef double FloatType;
-      #else
-      typedef float FloatType;
-      #endif
-      #endif
+        #if defined(USE_64BIT_FLOAT)
+        typedef double FloatType;
+        #else
+        typedef float FloatType;
+        #endif
+        #endif
 
 # Add code which will be integrated with other include and use statements
 # added by typemaps and statements.

--- a/regression/input/typemap.yaml
+++ b/regression/input/typemap.yaml
@@ -27,8 +27,27 @@ declarations:
 #- decl: IndexType i1
 
 - decl: bool passIndex(IndexType i1, IndexType *i2+intent(out))
+# XXX - This does not act the same as passIndex2.
+#   It does the type coercision in C++ instead of using a fortran intrinsic.
+  fortran_generic:
+  - decl: (int32_t i1)
+    function_suffix: _32
+  - decl: (int64_t i1)
+    function_suffix: _64
+
+- decl: void passIndex2(IndexType i1)
+  fortran_generic:
+  - decl: (int32_t i1)
+    function_suffix: _32
+  - decl: (int64_t i1)
+    function_suffix: _64
 
 - decl: void passFloat(FloatType f1);
+  fortran_generic:
+  - decl: (float f1)
+    function_suffix: _float
+  - decl: (double f1)
+    function_suffix: _double
 
 ######################################################################
 splicer_code:

--- a/regression/reference/arrayclass/typesarrayclass.h
+++ b/regression/reference/arrayclass/typesarrayclass.h
@@ -14,10 +14,15 @@
 // shroud
 #include <stddef.h>
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// splicer begin types.C_declarations
+// splicer end types.C_declarations
 
 /* helper ShroudTypeDefines */
 /* Shroud type defines */

--- a/regression/reference/ccomplex/typesccomplex.h
+++ b/regression/reference/ccomplex/typesccomplex.h
@@ -11,6 +11,9 @@
 #ifndef TYPESCCOMPLEX_H
 #define TYPESCCOMPLEX_H
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
+
 // helper capsule_data_helper
 struct s_CCO_SHROUD_capsule_data {
     void *addr;     /* address of C++ memory */

--- a/regression/reference/cdesc/typescdesc.h
+++ b/regression/reference/cdesc/typescdesc.h
@@ -14,10 +14,15 @@
 // shroud
 #include <stddef.h>
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// splicer begin types.C_declarations
+// splicer end types.C_declarations
 
 // helper capsule_data_helper
 struct s_CDE_SHROUD_capsule_data {

--- a/regression/reference/classes/typesclasses.h
+++ b/regression/reference/classes/typesclasses.h
@@ -14,10 +14,15 @@
 // shroud
 #include <stddef.h>
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// splicer begin types.C_declarations
+// splicer end types.C_declarations
 
 // helper capsule_data_helper
 struct s_CLA_SHROUD_capsule_data {

--- a/regression/reference/clibrary/typesClibrary.h
+++ b/regression/reference/clibrary/typesClibrary.h
@@ -11,6 +11,9 @@
 #ifndef TYPESCLIBRARY_H
 #define TYPESCLIBRARY_H
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
+
 // helper capsule_data_helper
 struct s_CLI_SHROUD_capsule_data {
     void *addr;     /* address of C++ memory */

--- a/regression/reference/cxxlibrary/typescxxlibrary.h
+++ b/regression/reference/cxxlibrary/typescxxlibrary.h
@@ -11,10 +11,15 @@
 #ifndef TYPESCXXLIBRARY_H
 #define TYPESCXXLIBRARY_H
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// splicer begin types.C_declarations
+// splicer end types.C_declarations
 
 // helper capsule_data_helper
 struct s_CXX_SHROUD_capsule_data {

--- a/regression/reference/debugfalse/typesTutorial.h
+++ b/regression/reference/debugfalse/typesTutorial.h
@@ -13,10 +13,15 @@
 
 #include <stddef.h>
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// splicer begin types.C_declarations
+// splicer end types.C_declarations
 
 // helper capsule_data_helper
 struct s_TUT_SHROUD_capsule_data {

--- a/regression/reference/enum-c/typesenum.h
+++ b/regression/reference/enum-c/typesenum.h
@@ -11,6 +11,9 @@
 #ifndef TYPESENUM_H
 #define TYPESENUM_H
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
+
 // helper capsule_data_helper
 struct s_ENU_SHROUD_capsule_data {
     void *addr;     /* address of C++ memory */

--- a/regression/reference/enum-cxx/typesenum.h
+++ b/regression/reference/enum-cxx/typesenum.h
@@ -11,10 +11,15 @@
 #ifndef TYPESENUM_H
 #define TYPESENUM_H
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// splicer begin types.C_declarations
+// splicer end types.C_declarations
 
 // helper capsule_data_helper
 struct s_ENU_SHROUD_capsule_data {

--- a/regression/reference/example/typesUserLibrary.h
+++ b/regression/reference/example/typesUserLibrary.h
@@ -14,10 +14,15 @@
 // shroud
 #include <stddef.h>
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// splicer begin types.C_declarations
+// splicer end types.C_declarations
 
 // helper capsule_data_helper
 struct s_AA_SHROUD_capsule_data {

--- a/regression/reference/forward/typesforward.h
+++ b/regression/reference/forward/typesforward.h
@@ -11,10 +11,15 @@
 #ifndef TYPESFORWARD_H
 #define TYPESFORWARD_H
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// splicer begin types.C_declarations
+// splicer end types.C_declarations
 
 // helper capsule_FOR_Class2
 struct s_FOR_Class2 {

--- a/regression/reference/generic-cfi/typesgeneric.h
+++ b/regression/reference/generic-cfi/typesgeneric.h
@@ -11,6 +11,9 @@
 #ifndef TYPESGENERIC_H
 #define TYPESGENERIC_H
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
+
 /* helper ShroudTypeDefines */
 /* Shroud type defines */
 #define SH_TYPE_SIGNED_CHAR 1

--- a/regression/reference/generic/typesgeneric.h
+++ b/regression/reference/generic/typesgeneric.h
@@ -14,6 +14,9 @@
 // shroud
 #include <stddef.h>
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
+
 /* helper ShroudTypeDefines */
 /* Shroud type defines */
 #define SH_TYPE_SIGNED_CHAR 1

--- a/regression/reference/include/typeslibrary.h
+++ b/regression/reference/include/typeslibrary.h
@@ -16,6 +16,7 @@
 extern "C" {
 #endif
 
+
 // helper capsule_LIB_Class2
 struct s_LIB_Class2 {
     void *addr;     /* address of C++ memory */

--- a/regression/reference/interface/typesInterface.h
+++ b/regression/reference/interface/typesInterface.h
@@ -11,6 +11,9 @@
 #ifndef TYPESINTERFACE_H
 #define TYPESINTERFACE_H
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
+
 // helper capsule_data_helper
 struct s_INT_SHROUD_capsule_data {
     void *addr;     /* address of C++ memory */

--- a/regression/reference/memdoc/typesmemdoc.h
+++ b/regression/reference/memdoc/typesmemdoc.h
@@ -14,10 +14,15 @@
 // shroud
 #include <stddef.h>
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// splicer begin types.C_declarations
+// splicer end types.C_declarations
 
 // helper capsule_data_helper
 struct s_STR_SHROUD_capsule_data {

--- a/regression/reference/names/typestestnames.hh
+++ b/regression/reference/names/typestestnames.hh
@@ -11,10 +11,15 @@
 #ifndef TYPESTESTNAMES_HH
 #define TYPESTESTNAMES_HH
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// splicer begin types.C_declarations
+// splicer end types.C_declarations
 
 // helper capsule_TES_Cstruct_as_class
 struct s_TES_Cstruct_as_class {

--- a/regression/reference/names2/typesNames.h
+++ b/regression/reference/names2/typesNames.h
@@ -11,10 +11,15 @@
 #ifndef TYPESNAMES_H
 #define TYPESNAMES_H
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// splicer begin types.C_declarations
+// splicer end types.C_declarations
 
 // helper capsule_data_helper
 struct s_NAM_SHROUD_capsule_data {

--- a/regression/reference/namespace/typesns.h
+++ b/regression/reference/namespace/typesns.h
@@ -14,10 +14,15 @@
 // shroud
 #include <stddef.h>
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// splicer begin types.C_declarations
+// splicer end types.C_declarations
 
 // helper capsule_data_helper
 struct s_NS_SHROUD_capsule_data {

--- a/regression/reference/namespacedoc/typeswrapped.h
+++ b/regression/reference/namespacedoc/typeswrapped.h
@@ -11,10 +11,15 @@
 #ifndef TYPESWRAPPED_H
 #define TYPESWRAPPED_H
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// splicer begin types.C_declarations
+// splicer end types.C_declarations
 
 // helper capsule_data_helper
 struct s_WWW_SHROUD_capsule_data {

--- a/regression/reference/none/typeslibrary.h
+++ b/regression/reference/none/typeslibrary.h
@@ -11,10 +11,15 @@
 #ifndef TYPESLIBRARY_H
 #define TYPESLIBRARY_H
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// splicer begin types.C_declarations
+// splicer end types.C_declarations
 
 // helper capsule_data_helper
 struct s_LIB_SHROUD_capsule_data {

--- a/regression/reference/ownership/typesownership.h
+++ b/regression/reference/ownership/typesownership.h
@@ -14,10 +14,15 @@
 // shroud
 #include <stddef.h>
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// splicer begin types.C_declarations
+// splicer end types.C_declarations
 
 /* helper ShroudTypeDefines */
 /* Shroud type defines */

--- a/regression/reference/pointers-c/typespointers.h
+++ b/regression/reference/pointers-c/typespointers.h
@@ -14,6 +14,9 @@
 // shroud
 #include <stddef.h>
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
+
 /* helper ShroudTypeDefines */
 /* Shroud type defines */
 #define SH_TYPE_SIGNED_CHAR 1

--- a/regression/reference/pointers-cfi/typespointers.h
+++ b/regression/reference/pointers-cfi/typespointers.h
@@ -11,10 +11,15 @@
 #ifndef TYPESPOINTERS_H
 #define TYPESPOINTERS_H
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// splicer begin types.C_declarations
+// splicer end types.C_declarations
 
 // helper capsule_data_helper
 struct s_POI_SHROUD_capsule_data {

--- a/regression/reference/pointers-cxx/typespointers.h
+++ b/regression/reference/pointers-cxx/typespointers.h
@@ -14,10 +14,15 @@
 // shroud
 #include <stddef.h>
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// splicer begin types.C_declarations
+// splicer end types.C_declarations
 
 /* helper ShroudTypeDefines */
 /* Shroud type defines */

--- a/regression/reference/preprocess/typespreprocess.h
+++ b/regression/reference/preprocess/typespreprocess.h
@@ -11,10 +11,15 @@
 #ifndef TYPESPREPROCESS_H
 #define TYPESPREPROCESS_H
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// splicer begin types.C_declarations
+// splicer end types.C_declarations
 
 // helper capsule_PRE_User1
 struct s_PRE_User1 {

--- a/regression/reference/scope/typesscope.h
+++ b/regression/reference/scope/typesscope.h
@@ -14,10 +14,15 @@
 // shroud
 #include <stddef.h>
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// splicer begin types.C_declarations
+// splicer end types.C_declarations
 
 /* helper ShroudTypeDefines */
 /* Shroud type defines */

--- a/regression/reference/statement/typesstatement.h
+++ b/regression/reference/statement/typesstatement.h
@@ -11,10 +11,15 @@
 #ifndef TYPESSTATEMENT_H
 #define TYPESSTATEMENT_H
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// splicer begin types.C_declarations
+// splicer end types.C_declarations
 
 // helper capsule_data_helper
 struct s_STMT_SHROUD_capsule_data {

--- a/regression/reference/strings-cfi/typesstrings.h
+++ b/regression/reference/strings-cfi/typesstrings.h
@@ -11,10 +11,15 @@
 #ifndef TYPESSTRINGS_H
 #define TYPESSTRINGS_H
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// splicer begin types.C_declarations
+// splicer end types.C_declarations
 
 // helper capsule_data_helper
 struct s_STR_SHROUD_capsule_data {

--- a/regression/reference/strings/typesstrings.h
+++ b/regression/reference/strings/typesstrings.h
@@ -14,10 +14,15 @@
 // shroud
 #include <stddef.h>
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// splicer begin types.C_declarations
+// splicer end types.C_declarations
 
 // helper capsule_data_helper
 struct s_STR_SHROUD_capsule_data {

--- a/regression/reference/struct-c/typesstruct.h
+++ b/regression/reference/struct-c/typesstruct.h
@@ -14,6 +14,9 @@
 // shroud
 #include <stddef.h>
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
+
 /* helper ShroudTypeDefines */
 /* Shroud type defines */
 #define SH_TYPE_SIGNED_CHAR 1

--- a/regression/reference/struct-cxx/typesstruct.h
+++ b/regression/reference/struct-cxx/typesstruct.h
@@ -14,10 +14,15 @@
 // shroud
 #include <stddef.h>
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// splicer begin types.C_declarations
+// splicer end types.C_declarations
 
 /* helper ShroudTypeDefines */
 /* Shroud type defines */

--- a/regression/reference/templates/typestemplates.h
+++ b/regression/reference/templates/typestemplates.h
@@ -11,10 +11,15 @@
 #ifndef TYPESTEMPLATES_H
 #define TYPESTEMPLATES_H
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// splicer begin types.C_declarations
+// splicer end types.C_declarations
 
 // helper capsule_TEM_Worker
 struct s_TEM_Worker {

--- a/regression/reference/tutorial/typesTutorial.h
+++ b/regression/reference/tutorial/typesTutorial.h
@@ -14,10 +14,15 @@
 // shroud
 #include <stddef.h>
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// splicer begin types.C_declarations
+// splicer end types.C_declarations
 
 // helper capsule_data_helper
 struct s_TUT_SHROUD_capsule_data {

--- a/regression/reference/typemap/typemap.json
+++ b/regression/reference/typemap/typemap.json
@@ -15,6 +15,7 @@
         "functions": [
             {
                 "<FUNCTION>": "0 ****************************************",
+                "_overloaded": true,
                 "ast": {
                     "declarator": {
                         "name": "passIndex",
@@ -68,11 +69,95 @@
                 },
                 "decl": "bool passIndex(IndexType i1, IndexType *i2+intent(out))",
                 "declgen": "bool passIndex(IndexType i1 +value, IndexType * i2 +intent(out))",
+                "fortran_generic": [
+                    {
+                        "decls": [
+                            {
+                                "attrs": {
+                                    "value": true
+                                },
+                                "declarator": {
+                                    "name": "i1",
+                                    "pointer": []
+                                },
+                                "metaattrs": {
+                                    "intent": "in"
+                                },
+                                "specifier": [
+                                    "int32_t"
+                                ],
+                                "typemap_name": "int32_t"
+                            },
+                            {
+                                "attrs": {
+                                    "intent": "out"
+                                },
+                                "declarator": {
+                                    "name": "i2",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ]
+                                },
+                                "metaattrs": {
+                                    "intent": "out"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
+                            }
+                        ],
+                        "function_suffix": "_32",
+                        "generic": "(int32_t i1)"
+                    },
+                    {
+                        "decls": [
+                            {
+                                "attrs": {
+                                    "value": true
+                                },
+                                "declarator": {
+                                    "name": "i1",
+                                    "pointer": []
+                                },
+                                "metaattrs": {
+                                    "intent": "in"
+                                },
+                                "specifier": [
+                                    "int64_t"
+                                ],
+                                "typemap_name": "int64_t"
+                            },
+                            {
+                                "attrs": {
+                                    "intent": "out"
+                                },
+                                "declarator": {
+                                    "name": "i2",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ]
+                                },
+                                "metaattrs": {
+                                    "intent": "out"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
+                            }
+                        ],
+                        "function_suffix": "_64",
+                        "generic": "(int64_t i1)"
+                    }
+                ],
                 "options": {},
                 "wrap": {
-                    "c": true,
-                    "f_c": true,
-                    "fortran": true
+                    "c": true
                 },
                 "zz_fmtargs": {
                     "i1": {
@@ -102,7 +187,176 @@
                             "f_kind": "INDEXTYPE",
                             "f_type": "integer(INDEXTYPE)",
                             "f_var": "i1",
+                            "sh_type": "SH_TYPE_OTHER"
+                        }
+                    },
+                    "i2": {
+                        "fmtc": {
+                            "c_addr": "",
+                            "c_const": "",
+                            "c_deref": "*",
+                            "c_member": "->",
+                            "c_type": "IndexType",
+                            "c_var": "i2",
+                            "cfi_type": "CFI_type_other",
+                            "cxx_addr": "",
+                            "cxx_member": "->",
+                            "cxx_nonconst_ptr": "i2",
+                            "cxx_type": "IndexType",
+                            "cxx_var": "i2",
+                            "idtor": "0",
                             "sh_type": "SH_TYPE_OTHER",
+                            "stmt0": "c_out_native_*",
+                            "stmt1": "c_default"
+                        },
+                        "fmtf": {
+                            "F_C_var": "i2",
+                            "c_var": "i2",
+                            "f_c_module_line": "typemap_mod:INDEXTYPE",
+                            "f_intent": "OUT",
+                            "f_kind": "INDEXTYPE",
+                            "f_type": "integer(INDEXTYPE)",
+                            "f_var": "i2",
+                            "sh_type": "SH_TYPE_OTHER"
+                        }
+                    }
+                },
+                "zz_fmtdict": {
+                    "C_call_list": "i1,\t i2",
+                    "C_name": "TYP_pass_index",
+                    "C_prototype": "IndexType i1,\t IndexType * i2",
+                    "C_return_type": "bool",
+                    "F_C_arguments": "i1,\t i2",
+                    "F_C_name": "c_pass_index",
+                    "F_C_result_clause": "\fresult(SHT_rv)",
+                    "F_C_subprogram": "function",
+                    "cxx_rv_decl": "bool SHC_rv",
+                    "function_name": "passIndex",
+                    "underscore_name": "pass_index"
+                },
+                "zz_fmtresult": {
+                    "fmtc": {
+                        "c_const": "",
+                        "c_get_value": "",
+                        "c_type": "bool",
+                        "c_var": "SHC_rv",
+                        "cfi_type": "CFI_type_Bool",
+                        "cxx_addr": "&",
+                        "cxx_member": ".",
+                        "cxx_nonconst_ptr": "&SHC_rv",
+                        "cxx_type": "bool",
+                        "cxx_var": "SHC_rv",
+                        "idtor": "0",
+                        "sh_type": "SH_TYPE_BOOL",
+                        "stmt0": "c_function_bool_scalar",
+                        "stmt1": "c_function"
+                    },
+                    "fmtf": {
+                        "F_C_var": "SHT_rv",
+                        "c_var": "SHT_rv",
+                        "f_intent": "OUT",
+                        "f_kind": "C_BOOL",
+                        "f_type": "logical",
+                        "f_var": "SHT_rv",
+                        "sh_type": "SH_TYPE_BOOL"
+                    }
+                }
+            },
+            {
+                "<FUNCTION>": "3 ****************************************",
+                "C_force_wrapper": "True",
+                "C_generated_path": [
+                    "fortran_generic"
+                ],
+                "_generated": "fortran_generic",
+                "_overloaded": true,
+                "ast": {
+                    "declarator": {
+                        "name": "passIndex",
+                        "pointer": []
+                    },
+                    "metaattrs": {
+                        "intent": "function"
+                    },
+                    "params": [
+                        {
+                            "attrs": {
+                                "value": true
+                            },
+                            "declarator": {
+                                "name": "i1",
+                                "pointer": []
+                            },
+                            "metaattrs": {
+                                "intent": "in"
+                            },
+                            "specifier": [
+                                "int32_t"
+                            ],
+                            "typemap_name": "int32_t"
+                        },
+                        {
+                            "attrs": {
+                                "intent": "out"
+                            },
+                            "declarator": {
+                                "name": "i2",
+                                "pointer": [
+                                    {
+                                        "ptr": "*"
+                                    }
+                                ]
+                            },
+                            "metaattrs": {
+                                "intent": "out"
+                            },
+                            "specifier": [
+                                "IndexType"
+                            ],
+                            "typemap_name": "IndexType"
+                        }
+                    ],
+                    "specifier": [
+                        "bool"
+                    ],
+                    "typemap_name": "bool"
+                },
+                "decl": "bool passIndex(IndexType i1, IndexType *i2+intent(out))",
+                "declgen": "bool passIndex(int32_t i1 +value, IndexType * i2 +intent(out))",
+                "options": {},
+                "wrap": {
+                    "c": true,
+                    "f_c": true,
+                    "fortran": true
+                },
+                "zz_fmtargs": {
+                    "i1": {
+                        "fmtc": {
+                            "c_addr": "&",
+                            "c_const": "",
+                            "c_deref": "",
+                            "c_member": ".",
+                            "c_type": "int32_t",
+                            "c_var": "i1",
+                            "cfi_type": "CFI_type_int32_t",
+                            "cxx_addr": "&",
+                            "cxx_member": ".",
+                            "cxx_nonconst_ptr": "&i1",
+                            "cxx_type": "int32_t",
+                            "cxx_var": "i1",
+                            "idtor": "0",
+                            "sh_type": "SH_TYPE_INT32_T",
+                            "stmt0": "c_in_native_scalar",
+                            "stmt1": "c_default"
+                        },
+                        "fmtf": {
+                            "F_C_var": "i1",
+                            "c_var": "i1",
+                            "f_intent": "IN",
+                            "f_kind": "C_INT32_T",
+                            "f_type": "integer(C_INT32_T)",
+                            "f_var": "i1",
+                            "sh_type": "SH_TYPE_INT32_T",
                             "stmt0": "f_in_native_scalar",
                             "stmt1": "f_default",
                             "stmtc0": "c_in_native_scalar",
@@ -146,23 +400,215 @@
                 },
                 "zz_fmtdict": {
                     "C_call_list": "i1,\t i2",
-                    "C_name": "TYP_pass_index",
-                    "C_prototype": "IndexType i1,\t IndexType * i2",
+                    "C_name": "TYP_pass_index_32",
+                    "C_prototype": "int32_t i1,\t IndexType * i2",
                     "C_return_type": "bool",
                     "F_C_arguments": "i1,\t i2",
-                    "F_C_call": "c_pass_index",
-                    "F_C_name": "c_pass_index",
+                    "F_C_call": "c_pass_index_32",
+                    "F_C_name": "c_pass_index_32",
                     "F_C_result_clause": "\fresult(SHT_rv)",
                     "F_C_subprogram": "function",
                     "F_arg_c_call": "i1,\t i2",
                     "F_arguments": "i1,\t i2",
-                    "F_name_function": "pass_index",
+                    "F_name_function": "pass_index_32",
                     "F_name_generic": "pass_index",
-                    "F_name_impl": "pass_index",
+                    "F_name_impl": "pass_index_32",
                     "F_result_clause": "\fresult(SHT_rv)",
                     "F_subprogram": "function",
                     "cxx_rv_decl": "bool SHC_rv",
                     "function_name": "passIndex",
+                    "function_suffix": "_32",
+                    "underscore_name": "pass_index"
+                },
+                "zz_fmtresult": {
+                    "fmtc": {
+                        "c_const": "",
+                        "c_get_value": "",
+                        "c_type": "bool",
+                        "c_var": "SHC_rv",
+                        "cfi_type": "CFI_type_Bool",
+                        "cxx_addr": "&",
+                        "cxx_member": ".",
+                        "cxx_nonconst_ptr": "&SHC_rv",
+                        "cxx_type": "bool",
+                        "cxx_var": "SHC_rv",
+                        "idtor": "0",
+                        "sh_type": "SH_TYPE_BOOL",
+                        "stmt0": "c_function_bool_scalar",
+                        "stmt1": "c_function"
+                    },
+                    "fmtf": {
+                        "F_C_var": "SHT_rv",
+                        "c_var": "SHT_rv",
+                        "cxx_type": "bool",
+                        "f_intent": "OUT",
+                        "f_kind": "C_BOOL",
+                        "f_type": "logical",
+                        "f_var": "SHT_rv",
+                        "sh_type": "SH_TYPE_BOOL",
+                        "stmt0": "f_function_bool_scalar",
+                        "stmt1": "f_function_bool",
+                        "stmtc0": "c_function_bool_scalar",
+                        "stmtc1": "c_function"
+                    }
+                }
+            },
+            {
+                "<FUNCTION>": "4 ****************************************",
+                "C_force_wrapper": "True",
+                "C_generated_path": [
+                    "fortran_generic"
+                ],
+                "_generated": "fortran_generic",
+                "_overloaded": true,
+                "ast": {
+                    "declarator": {
+                        "name": "passIndex",
+                        "pointer": []
+                    },
+                    "metaattrs": {
+                        "intent": "function"
+                    },
+                    "params": [
+                        {
+                            "attrs": {
+                                "value": true
+                            },
+                            "declarator": {
+                                "name": "i1",
+                                "pointer": []
+                            },
+                            "metaattrs": {
+                                "intent": "in"
+                            },
+                            "specifier": [
+                                "int64_t"
+                            ],
+                            "typemap_name": "int64_t"
+                        },
+                        {
+                            "attrs": {
+                                "intent": "out"
+                            },
+                            "declarator": {
+                                "name": "i2",
+                                "pointer": [
+                                    {
+                                        "ptr": "*"
+                                    }
+                                ]
+                            },
+                            "metaattrs": {
+                                "intent": "out"
+                            },
+                            "specifier": [
+                                "IndexType"
+                            ],
+                            "typemap_name": "IndexType"
+                        }
+                    ],
+                    "specifier": [
+                        "bool"
+                    ],
+                    "typemap_name": "bool"
+                },
+                "decl": "bool passIndex(IndexType i1, IndexType *i2+intent(out))",
+                "declgen": "bool passIndex(int64_t i1 +value, IndexType * i2 +intent(out))",
+                "options": {},
+                "wrap": {
+                    "c": true,
+                    "f_c": true,
+                    "fortran": true
+                },
+                "zz_fmtargs": {
+                    "i1": {
+                        "fmtc": {
+                            "c_addr": "&",
+                            "c_const": "",
+                            "c_deref": "",
+                            "c_member": ".",
+                            "c_type": "int64_t",
+                            "c_var": "i1",
+                            "cfi_type": "CFI_type_int64_t",
+                            "cxx_addr": "&",
+                            "cxx_member": ".",
+                            "cxx_nonconst_ptr": "&i1",
+                            "cxx_type": "int64_t",
+                            "cxx_var": "i1",
+                            "idtor": "0",
+                            "sh_type": "SH_TYPE_INT64_T",
+                            "stmt0": "c_in_native_scalar",
+                            "stmt1": "c_default"
+                        },
+                        "fmtf": {
+                            "F_C_var": "i1",
+                            "c_var": "i1",
+                            "f_intent": "IN",
+                            "f_kind": "C_INT64_T",
+                            "f_type": "integer(C_INT64_T)",
+                            "f_var": "i1",
+                            "sh_type": "SH_TYPE_INT64_T",
+                            "stmt0": "f_in_native_scalar",
+                            "stmt1": "f_default",
+                            "stmtc0": "c_in_native_scalar",
+                            "stmtc1": "c_default"
+                        }
+                    },
+                    "i2": {
+                        "fmtc": {
+                            "c_addr": "",
+                            "c_const": "",
+                            "c_deref": "*",
+                            "c_member": "->",
+                            "c_type": "IndexType",
+                            "c_var": "i2",
+                            "cfi_type": "CFI_type_other",
+                            "cxx_addr": "",
+                            "cxx_member": "->",
+                            "cxx_nonconst_ptr": "i2",
+                            "cxx_type": "IndexType",
+                            "cxx_var": "i2",
+                            "idtor": "0",
+                            "sh_type": "SH_TYPE_OTHER",
+                            "stmt0": "c_out_native_*",
+                            "stmt1": "c_default"
+                        },
+                        "fmtf": {
+                            "F_C_var": "i2",
+                            "c_var": "i2",
+                            "f_c_module_line": "typemap_mod:INDEXTYPE",
+                            "f_intent": "OUT",
+                            "f_kind": "INDEXTYPE",
+                            "f_type": "integer(INDEXTYPE)",
+                            "f_var": "i2",
+                            "sh_type": "SH_TYPE_OTHER",
+                            "stmt0": "f_out_native_*",
+                            "stmt1": "f_out_native_*",
+                            "stmtc0": "c_out_native_*",
+                            "stmtc1": "c_default"
+                        }
+                    }
+                },
+                "zz_fmtdict": {
+                    "C_call_list": "i1,\t i2",
+                    "C_name": "TYP_pass_index_64",
+                    "C_prototype": "int64_t i1,\t IndexType * i2",
+                    "C_return_type": "bool",
+                    "F_C_arguments": "i1,\t i2",
+                    "F_C_call": "c_pass_index_64",
+                    "F_C_name": "c_pass_index_64",
+                    "F_C_result_clause": "\fresult(SHT_rv)",
+                    "F_C_subprogram": "function",
+                    "F_arg_c_call": "i1,\t i2",
+                    "F_arguments": "i1,\t i2",
+                    "F_name_function": "pass_index_64",
+                    "F_name_generic": "pass_index",
+                    "F_name_impl": "pass_index_64",
+                    "F_result_clause": "\fresult(SHT_rv)",
+                    "F_subprogram": "function",
+                    "cxx_rv_decl": "bool SHC_rv",
+                    "function_name": "passIndex",
+                    "function_suffix": "_64",
                     "underscore_name": "pass_index"
                 },
                 "zz_fmtresult": {
@@ -200,6 +646,268 @@
             },
             {
                 "<FUNCTION>": "1 ****************************************",
+                "_overloaded": true,
+                "ast": {
+                    "declarator": {
+                        "name": "passIndex2",
+                        "pointer": []
+                    },
+                    "metaattrs": {
+                        "intent": "subroutine"
+                    },
+                    "params": [
+                        {
+                            "attrs": {
+                                "value": true
+                            },
+                            "declarator": {
+                                "name": "i1",
+                                "pointer": []
+                            },
+                            "metaattrs": {
+                                "intent": "in"
+                            },
+                            "specifier": [
+                                "IndexType"
+                            ],
+                            "typemap_name": "IndexType"
+                        }
+                    ],
+                    "specifier": [
+                        "void"
+                    ],
+                    "typemap_name": "void"
+                },
+                "decl": "void passIndex2(IndexType i1)",
+                "declgen": "void passIndex2(IndexType i1 +value)",
+                "fortran_generic": [
+                    {
+                        "decls": [
+                            {
+                                "attrs": {
+                                    "value": true
+                                },
+                                "declarator": {
+                                    "name": "i1",
+                                    "pointer": []
+                                },
+                                "metaattrs": {
+                                    "intent": "in"
+                                },
+                                "specifier": [
+                                    "int32_t"
+                                ],
+                                "typemap_name": "int32_t"
+                            }
+                        ],
+                        "function_suffix": "_32",
+                        "generic": "(int32_t i1)"
+                    },
+                    {
+                        "decls": [
+                            {
+                                "attrs": {
+                                    "value": true
+                                },
+                                "declarator": {
+                                    "name": "i1",
+                                    "pointer": []
+                                },
+                                "metaattrs": {
+                                    "intent": "in"
+                                },
+                                "specifier": [
+                                    "int64_t"
+                                ],
+                                "typemap_name": "int64_t"
+                            }
+                        ],
+                        "function_suffix": "_64",
+                        "generic": "(int64_t i1)"
+                    }
+                ],
+                "options": {},
+                "wrap": {
+                    "c": true,
+                    "f_c": true
+                },
+                "zz_fmtargs": {
+                    "i1": {
+                        "fmtc": {
+                            "c_addr": "&",
+                            "c_const": "",
+                            "c_deref": "",
+                            "c_member": ".",
+                            "c_type": "IndexType",
+                            "c_var": "i1",
+                            "cfi_type": "CFI_type_other",
+                            "cxx_addr": "&",
+                            "cxx_member": ".",
+                            "cxx_nonconst_ptr": "&i1",
+                            "cxx_type": "IndexType",
+                            "cxx_var": "i1",
+                            "idtor": "0",
+                            "sh_type": "SH_TYPE_OTHER",
+                            "stmt0": "c_in_native_scalar",
+                            "stmt1": "c_default"
+                        },
+                        "fmtf": {
+                            "F_C_var": "i1",
+                            "c_var": "i1",
+                            "f_c_module_line": "typemap_mod:INDEXTYPE",
+                            "f_intent": "IN",
+                            "f_kind": "INDEXTYPE",
+                            "f_type": "integer(INDEXTYPE)",
+                            "f_var": "i1",
+                            "sh_type": "SH_TYPE_OTHER",
+                            "stmt0": "f_in_native_scalar",
+                            "stmt1": "f_default",
+                            "stmtc0": "c_in_native_scalar",
+                            "stmtc1": "c_default"
+                        }
+                    }
+                },
+                "zz_fmtdict": {
+                    "C_call_list": "i1",
+                    "C_name": "TYP_pass_index2",
+                    "C_prototype": "IndexType i1",
+                    "C_return_type": "void",
+                    "F_C_arguments": "i1",
+                    "F_C_name": "c_pass_index2",
+                    "F_C_subprogram": "subroutine",
+                    "function_name": "passIndex2",
+                    "stmt0": "c_subroutine",
+                    "stmt1": "c_subroutine",
+                    "underscore_name": "pass_index2"
+                }
+            },
+            {
+                "<FUNCTION>": "5 ****************************************",
+                "C_generated_path": [
+                    "fortran_generic"
+                ],
+                "_PTR_F_C_index": "1",
+                "_generated": "fortran_generic",
+                "_overloaded": true,
+                "ast": {
+                    "declarator": {
+                        "name": "passIndex2",
+                        "pointer": []
+                    },
+                    "metaattrs": {
+                        "intent": "subroutine"
+                    },
+                    "params": [
+                        {
+                            "attrs": {
+                                "value": true
+                            },
+                            "declarator": {
+                                "name": "i1",
+                                "pointer": []
+                            },
+                            "metaattrs": {
+                                "intent": "in"
+                            },
+                            "specifier": [
+                                "int32_t"
+                            ],
+                            "typemap_name": "int32_t"
+                        }
+                    ],
+                    "specifier": [
+                        "void"
+                    ],
+                    "typemap_name": "void"
+                },
+                "decl": "void passIndex2(IndexType i1)",
+                "declgen": "void passIndex2(int32_t i1 +value)",
+                "options": {},
+                "wrap": {
+                    "fortran": true
+                },
+                "zz_fmtdict": {
+                    "F_C_call": "c_pass_index2",
+                    "F_arg_c_call": "int(i1, INDEXTYPE)",
+                    "F_arguments": "i1",
+                    "F_name_function": "pass_index2_32",
+                    "F_name_generic": "pass_index2",
+                    "F_name_impl": "pass_index2_32",
+                    "F_subprogram": "subroutine",
+                    "function_name": "passIndex2",
+                    "function_suffix": "_32",
+                    "stmt0": "f_subroutine",
+                    "stmt1": "f_subroutine",
+                    "stmtc0": "c_subroutine",
+                    "stmtc1": "c_subroutine",
+                    "underscore_name": "pass_index2"
+                }
+            },
+            {
+                "<FUNCTION>": "6 ****************************************",
+                "C_generated_path": [
+                    "fortran_generic"
+                ],
+                "_PTR_F_C_index": "1",
+                "_generated": "fortran_generic",
+                "_overloaded": true,
+                "ast": {
+                    "declarator": {
+                        "name": "passIndex2",
+                        "pointer": []
+                    },
+                    "metaattrs": {
+                        "intent": "subroutine"
+                    },
+                    "params": [
+                        {
+                            "attrs": {
+                                "value": true
+                            },
+                            "declarator": {
+                                "name": "i1",
+                                "pointer": []
+                            },
+                            "metaattrs": {
+                                "intent": "in"
+                            },
+                            "specifier": [
+                                "int64_t"
+                            ],
+                            "typemap_name": "int64_t"
+                        }
+                    ],
+                    "specifier": [
+                        "void"
+                    ],
+                    "typemap_name": "void"
+                },
+                "decl": "void passIndex2(IndexType i1)",
+                "declgen": "void passIndex2(int64_t i1 +value)",
+                "options": {},
+                "wrap": {
+                    "fortran": true
+                },
+                "zz_fmtdict": {
+                    "F_C_call": "c_pass_index2",
+                    "F_arg_c_call": "int(i1, INDEXTYPE)",
+                    "F_arguments": "i1",
+                    "F_name_function": "pass_index2_64",
+                    "F_name_generic": "pass_index2",
+                    "F_name_impl": "pass_index2_64",
+                    "F_subprogram": "subroutine",
+                    "function_name": "passIndex2",
+                    "function_suffix": "_64",
+                    "stmt0": "f_subroutine",
+                    "stmt1": "f_subroutine",
+                    "stmtc0": "c_subroutine",
+                    "stmtc1": "c_subroutine",
+                    "underscore_name": "pass_index2"
+                }
+            },
+            {
+                "<FUNCTION>": "2 ****************************************",
+                "_overloaded": true,
                 "ast": {
                     "declarator": {
                         "name": "passFloat",
@@ -233,11 +941,56 @@
                 },
                 "decl": "void passFloat(FloatType f1);",
                 "declgen": "void passFloat(FloatType f1 +value)",
+                "fortran_generic": [
+                    {
+                        "decls": [
+                            {
+                                "attrs": {
+                                    "value": true
+                                },
+                                "declarator": {
+                                    "name": "f1",
+                                    "pointer": []
+                                },
+                                "metaattrs": {
+                                    "intent": "in"
+                                },
+                                "specifier": [
+                                    "float"
+                                ],
+                                "typemap_name": "float"
+                            }
+                        ],
+                        "function_suffix": "_float",
+                        "generic": "(float f1)"
+                    },
+                    {
+                        "decls": [
+                            {
+                                "attrs": {
+                                    "value": true
+                                },
+                                "declarator": {
+                                    "name": "f1",
+                                    "pointer": []
+                                },
+                                "metaattrs": {
+                                    "intent": "in"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "function_suffix": "_double",
+                        "generic": "(double f1)"
+                    }
+                ],
                 "options": {},
                 "wrap": {
                     "c": true,
-                    "f_c": true,
-                    "fortran": true
+                    "f_c": true
                 },
                 "zz_fmtargs": {
                     "f1": {
@@ -281,16 +1034,131 @@
                     "C_prototype": "FloatType f1",
                     "C_return_type": "void",
                     "F_C_arguments": "f1",
-                    "F_C_call": "c_pass_float",
-                    "F_C_name": "pass_float",
+                    "F_C_name": "c_pass_float",
                     "F_C_subprogram": "subroutine",
-                    "F_arg_c_call": "f1",
+                    "function_name": "passFloat",
+                    "stmt0": "c_subroutine",
+                    "stmt1": "c_subroutine",
+                    "underscore_name": "pass_float"
+                }
+            },
+            {
+                "<FUNCTION>": "7 ****************************************",
+                "C_generated_path": [
+                    "fortran_generic"
+                ],
+                "_PTR_F_C_index": "2",
+                "_generated": "fortran_generic",
+                "_overloaded": true,
+                "ast": {
+                    "declarator": {
+                        "name": "passFloat",
+                        "pointer": []
+                    },
+                    "metaattrs": {
+                        "intent": "subroutine"
+                    },
+                    "params": [
+                        {
+                            "attrs": {
+                                "value": true
+                            },
+                            "declarator": {
+                                "name": "f1",
+                                "pointer": []
+                            },
+                            "metaattrs": {
+                                "intent": "in"
+                            },
+                            "specifier": [
+                                "float"
+                            ],
+                            "typemap_name": "float"
+                        }
+                    ],
+                    "specifier": [
+                        "void"
+                    ],
+                    "typemap_name": "void"
+                },
+                "decl": "void passFloat(FloatType f1);",
+                "declgen": "void passFloat(float f1 +value)",
+                "options": {},
+                "wrap": {
+                    "fortran": true
+                },
+                "zz_fmtdict": {
+                    "F_C_call": "c_pass_float",
+                    "F_arg_c_call": "real(f1, FLOATTYPE)",
                     "F_arguments": "f1",
-                    "F_name_function": "pass_float",
+                    "F_name_function": "pass_float_float",
                     "F_name_generic": "pass_float",
-                    "F_name_impl": "pass_float",
+                    "F_name_impl": "pass_float_float",
                     "F_subprogram": "subroutine",
                     "function_name": "passFloat",
+                    "function_suffix": "_float",
+                    "stmt0": "f_subroutine",
+                    "stmt1": "f_subroutine",
+                    "stmtc0": "c_subroutine",
+                    "stmtc1": "c_subroutine",
+                    "underscore_name": "pass_float"
+                }
+            },
+            {
+                "<FUNCTION>": "8 ****************************************",
+                "C_generated_path": [
+                    "fortran_generic"
+                ],
+                "_PTR_F_C_index": "2",
+                "_generated": "fortran_generic",
+                "_overloaded": true,
+                "ast": {
+                    "declarator": {
+                        "name": "passFloat",
+                        "pointer": []
+                    },
+                    "metaattrs": {
+                        "intent": "subroutine"
+                    },
+                    "params": [
+                        {
+                            "attrs": {
+                                "value": true
+                            },
+                            "declarator": {
+                                "name": "f1",
+                                "pointer": []
+                            },
+                            "metaattrs": {
+                                "intent": "in"
+                            },
+                            "specifier": [
+                                "double"
+                            ],
+                            "typemap_name": "double"
+                        }
+                    ],
+                    "specifier": [
+                        "void"
+                    ],
+                    "typemap_name": "void"
+                },
+                "decl": "void passFloat(FloatType f1);",
+                "declgen": "void passFloat(double f1 +value)",
+                "options": {},
+                "wrap": {
+                    "fortran": true
+                },
+                "zz_fmtdict": {
+                    "F_C_call": "c_pass_float",
+                    "F_arg_c_call": "real(f1, FLOATTYPE)",
+                    "F_arguments": "f1",
+                    "F_name_function": "pass_float_double",
+                    "F_name_generic": "pass_float",
+                    "F_name_impl": "pass_float_double",
+                    "F_subprogram": "subroutine",
+                    "function_name": "passFloat",
+                    "function_suffix": "_double",
                     "stmt0": "f_subroutine",
                     "stmt1": "f_subroutine",
                     "stmtc0": "c_subroutine",

--- a/regression/reference/typemap/typemap.log
+++ b/regression/reference/typemap/typemap.log
@@ -1,12 +1,22 @@
 Read yaml typemap.yaml
 Close typemap_types.yaml
 C bool passIndex(IndexType i1 +value, IndexType * i2 +intent(out))  +intent(function)
+C bool passIndex(int32_t i1 +value, IndexType * i2 +intent(out))  +intent(function)
+C bool passIndex(int64_t i1 +value, IndexType * i2 +intent(out))  +intent(function)
+C void passIndex2(IndexType i1 +value)  +intent(subroutine)
 C void passFloat(FloatType f1 +value)  +intent(subroutine)
 Close wraptypemap.h
 Close wraptypemap.cpp
-Fortran bool passIndex(IndexType i1 +value, IndexType * i2 +intent(out))  +intent(function)
-Fortran void passFloat(FloatType f1 +value)  +intent(subroutine)
+Fortran bool passIndex(int32_t i1 +value, IndexType * i2 +intent(out))  +intent(function)
+Fortran bool passIndex(int64_t i1 +value, IndexType * i2 +intent(out))  +intent(function)
+Fortran void passIndex2(int32_t i1 +value)  +intent(subroutine)
+Fortran void passIndex2(int64_t i1 +value)  +intent(subroutine)
+Fortran void passFloat(float f1 +value)  +intent(subroutine)
+Fortran void passFloat(double f1 +value)  +intent(subroutine)
 C-interface bool passIndex(IndexType i1 +value, IndexType * i2 +intent(out))  +intent(function)
+C-interface bool passIndex(int32_t i1 +value, IndexType * i2 +intent(out))  +intent(function)
+C-interface bool passIndex(int64_t i1 +value, IndexType * i2 +intent(out))  +intent(function)
+C-interface void passIndex2(IndexType i1 +value)  +intent(subroutine)
 C-interface void passFloat(FloatType f1 +value)  +intent(subroutine)
 Close wrapftypemap.f
 Close utiltypemap.cpp

--- a/regression/reference/typemap/typestypemap.h
+++ b/regression/reference/typemap/typestypemap.h
@@ -11,10 +11,28 @@
 #ifndef TYPESTYPEMAP_H
 #define TYPESTYPEMAP_H
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// splicer begin types.C_declarations
+#ifndef __cplusplus
+#if defined(USE_64BIT_INDEXTYPE)
+typedef int64_t IndexType;
+#else
+typedef int32_t IndexType;
+#endif
+
+#if defined(USE_64BIT_FLOAT)
+typedef double FloatType;
+#else
+typedef float FloatType;
+#endif
+#endif
+// splicer end types.C_declarations
 
 // helper capsule_data_helper
 struct s_TYP_SHROUD_capsule_data {

--- a/regression/reference/typemap/wrapftypemap.f
+++ b/regression/reference/typemap/wrapftypemap.f
@@ -45,29 +45,116 @@ module typemap_mod
             logical(C_BOOL) :: SHT_rv
         end function c_pass_index
 
-        subroutine pass_float(f1) &
+        function c_pass_index_32(i1, i2) &
+                result(SHT_rv) &
+                bind(C, name="TYP_pass_index_32")
+            use iso_c_binding, only : C_BOOL, C_INT32_T
+            import :: INDEXTYPE
+            implicit none
+            integer(C_INT32_T), value, intent(IN) :: i1
+            integer(INDEXTYPE), intent(OUT) :: i2
+            logical(C_BOOL) :: SHT_rv
+        end function c_pass_index_32
+
+        function c_pass_index_64(i1, i2) &
+                result(SHT_rv) &
+                bind(C, name="TYP_pass_index_64")
+            use iso_c_binding, only : C_BOOL, C_INT64_T
+            import :: INDEXTYPE
+            implicit none
+            integer(C_INT64_T), value, intent(IN) :: i1
+            integer(INDEXTYPE), intent(OUT) :: i2
+            logical(C_BOOL) :: SHT_rv
+        end function c_pass_index_64
+
+        subroutine c_pass_index2(i1) &
+                bind(C, name="TYP_pass_index2")
+            import :: INDEXTYPE
+            implicit none
+            integer(INDEXTYPE), value, intent(IN) :: i1
+        end subroutine c_pass_index2
+
+        subroutine c_pass_float(f1) &
                 bind(C, name="TYP_pass_float")
             import :: FLOATTYPE
             implicit none
             real(FLOATTYPE), value, intent(IN) :: f1
-        end subroutine pass_float
+        end subroutine c_pass_float
 
         ! splicer begin additional_interfaces
         ! splicer end additional_interfaces
     end interface
 
+    interface pass_float
+        module procedure pass_float_float
+        module procedure pass_float_double
+    end interface pass_float
+
+    interface pass_index
+        module procedure pass_index_32
+        module procedure pass_index_64
+    end interface pass_index
+
+    interface pass_index2
+        module procedure pass_index2_32
+        module procedure pass_index2_64
+    end interface pass_index2
+
 contains
 
-    function pass_index(i1, i2) &
+    function pass_index_32(i1, i2) &
             result(SHT_rv)
-        use iso_c_binding, only : C_BOOL
-        integer(INDEXTYPE), value, intent(IN) :: i1
+        use iso_c_binding, only : C_BOOL, C_INT32_T
+        integer(C_INT32_T), value, intent(IN) :: i1
         integer(INDEXTYPE), intent(OUT) :: i2
         logical :: SHT_rv
-        ! splicer begin function.pass_index
-        SHT_rv = c_pass_index(i1, i2)
-        ! splicer end function.pass_index
-    end function pass_index
+        ! splicer begin function.pass_index_32
+        SHT_rv = c_pass_index_32(i1, i2)
+        ! splicer end function.pass_index_32
+    end function pass_index_32
+
+    function pass_index_64(i1, i2) &
+            result(SHT_rv)
+        use iso_c_binding, only : C_BOOL, C_INT64_T
+        integer(C_INT64_T), value, intent(IN) :: i1
+        integer(INDEXTYPE), intent(OUT) :: i2
+        logical :: SHT_rv
+        ! splicer begin function.pass_index_64
+        SHT_rv = c_pass_index_64(i1, i2)
+        ! splicer end function.pass_index_64
+    end function pass_index_64
+
+    subroutine pass_index2_32(i1)
+        use iso_c_binding, only : C_INT32_T
+        integer(C_INT32_T), value, intent(IN) :: i1
+        ! splicer begin function.pass_index2_32
+        call c_pass_index2(int(i1, INDEXTYPE))
+        ! splicer end function.pass_index2_32
+    end subroutine pass_index2_32
+
+    subroutine pass_index2_64(i1)
+        use iso_c_binding, only : C_INT64_T
+        integer(C_INT64_T), value, intent(IN) :: i1
+        ! splicer begin function.pass_index2_64
+        call c_pass_index2(int(i1, INDEXTYPE))
+        ! splicer end function.pass_index2_64
+    end subroutine pass_index2_64
+
+    subroutine pass_float_float(f1)
+        use iso_c_binding, only : C_FLOAT
+        real(C_FLOAT), value, intent(IN) :: f1
+        ! splicer begin function.pass_float_float
+        call c_pass_float(real(f1, FLOATTYPE))
+        ! splicer end function.pass_float_float
+    end subroutine pass_float_float
+
+    subroutine pass_float_double(f1)
+        use iso_c_binding, only : C_DOUBLE
+        real(C_DOUBLE), value, intent(IN) :: f1
+        ! splicer begin function.pass_float_double
+        call c_pass_float(real(f1, FLOATTYPE))
+        ! splicer end function.pass_float_double
+    end subroutine pass_float_double
 
     ! splicer begin additional_functions
     ! splicer end additional_functions

--- a/regression/reference/typemap/wraptypemap.cpp
+++ b/regression/reference/typemap/wraptypemap.cpp
@@ -26,6 +26,29 @@ bool TYP_pass_index(IndexType i1, IndexType * i2)
     // splicer end function.pass_index
 }
 
+bool TYP_pass_index_32(int32_t i1, IndexType * i2)
+{
+    // splicer begin function.pass_index_32
+    bool SHC_rv = passIndex(i1, i2);
+    return SHC_rv;
+    // splicer end function.pass_index_32
+}
+
+bool TYP_pass_index_64(int64_t i1, IndexType * i2)
+{
+    // splicer begin function.pass_index_64
+    bool SHC_rv = passIndex(i1, i2);
+    return SHC_rv;
+    // splicer end function.pass_index_64
+}
+
+void TYP_pass_index2(IndexType i1)
+{
+    // splicer begin function.pass_index2
+    passIndex2(i1);
+    // splicer end function.pass_index2
+}
+
 void TYP_pass_float(FloatType f1)
 {
     // splicer begin function.pass_float

--- a/regression/reference/typemap/wraptypemap.h
+++ b/regression/reference/typemap/wraptypemap.h
@@ -34,19 +34,6 @@ extern "C" {
 #endif
 
 // splicer begin C_declarations
-#ifndef __cplusplus
-#if defined(USE_64BIT_INDEXTYPE)
-typedef int64_t IndexType;
-#else
-typedef int32_t IndexType;
-#endif
-
-#if defined(USE_64BIT_FLOAT)
-typedef double FloatType;
-#else
-typedef float FloatType;
-#endif
-#endif
 // splicer end C_declarations
 
 bool TYP_pass_index(IndexType i1, IndexType * i2);

--- a/regression/reference/typemap/wraptypemap.h
+++ b/regression/reference/typemap/wraptypemap.h
@@ -20,7 +20,8 @@
 #else
 #include <stdint.h>
 #endif
-#ifndef __cplusplus
+#ifdef __cplusplus
+#else
 #include <stdbool.h>
 #endif
 #include "typestypemap.h"
@@ -49,6 +50,12 @@ typedef float FloatType;
 // splicer end C_declarations
 
 bool TYP_pass_index(IndexType i1, IndexType * i2);
+
+bool TYP_pass_index_32(int32_t i1, IndexType * i2);
+
+bool TYP_pass_index_64(int64_t i1, IndexType * i2);
+
+void TYP_pass_index2(IndexType i1);
 
 void TYP_pass_float(FloatType f1);
 

--- a/regression/reference/types/typestypes.h
+++ b/regression/reference/types/typestypes.h
@@ -11,10 +11,15 @@
 #ifndef TYPESTYPES_H
 #define TYPESTYPES_H
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// splicer begin types.C_declarations
+// splicer end types.C_declarations
 
 // helper capsule_data_helper
 struct s_TYP_SHROUD_capsule_data {

--- a/regression/reference/vectors/typesvectors.h
+++ b/regression/reference/vectors/typesvectors.h
@@ -14,10 +14,15 @@
 // shroud
 #include <stddef.h>
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// splicer begin types.C_declarations
+// splicer end types.C_declarations
 
 /* helper ShroudTypeDefines */
 /* Shroud type defines */

--- a/regression/reference/wrap/typeswrap.h
+++ b/regression/reference/wrap/typeswrap.h
@@ -11,10 +11,15 @@
 #ifndef TYPESWRAP_H
 #define TYPESWRAP_H
 
+// splicer begin types.CXX_declarations
+// splicer end types.CXX_declarations
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// splicer begin types.C_declarations
+// splicer end types.C_declarations
 
 // helper capsule_data_helper
 struct s_WRA_SHROUD_capsule_data {

--- a/regression/run/typemap/typemap.cpp
+++ b/regression/run/typemap/typemap.cpp
@@ -21,6 +21,10 @@ bool passIndex(IndexType i1, IndexType *i2)
 #endif
 }
 
+void passIndex2(IndexType i1)
+{
+}
+
 void passFloat(FloatType f1)
 {
 }

--- a/regression/run/typemap/typemap.hpp
+++ b/regression/run/typemap/typemap.hpp
@@ -15,6 +15,7 @@ using IndexType = std::int32_t;
 #endif
 
 bool passIndex(IndexType i1, IndexType *i2);
+void passIndex2(IndexType i1);
 
 #if defined(USE_64BIT_FLOAT)
 using FloatType = double;

--- a/shroud/typemap.py
+++ b/shroud/typemap.py
@@ -921,6 +921,12 @@ def create_native_typemap_from_fields(cxx_name, fields, library):
     return ntypemap
 
 
+# Map base type to fortran intrinsic function.
+base_cast = dict(
+    integer='int',
+    real='real',
+)
+
 def fill_native_typemap_defaults(ntypemap, fmt):
     """Add some defaults to integer or real typemap.
     When dumping typemaps to a file, only a subset is written
@@ -937,7 +943,7 @@ def fill_native_typemap_defaults(ntypemap, fmt):
     if ntypemap.f_type is None:
         ntypemap.f_type = "{}({})".format(ntypemap.base, ntypemap.f_kind)
     if ntypemap.f_cast is None:
-        ntypemap.f_cast = "{}({{f_var}}, {})".format(ntypemap.base, ntypemap.f_kind)
+        ntypemap.f_cast = "{}({{f_var}}, {})".format(base_cast[ntypemap.base], ntypemap.f_kind)
     if ntypemap.f_module is None:
         ntypemap.f_module = {ntypemap.f_module_name: [ntypemap.f_kind]}
 

--- a/shroud/wrapc.py
+++ b/shroud/wrapc.py
@@ -345,11 +345,14 @@ class Wrapc(util.WrapperMixin):
         headers.add_shroud_dict(self.helper_include["cwrap_include"])
         headers.write_headers(output)
 
+        output.append("")
+        self._push_splicer("types")
+        self._create_splicer('CXX_declarations', output)
+        
         if self.language == "cxx":
-            output.append("")
-            #            if self._create_splicer('CXX_declarations', output):
-            #                write_file = True
             output.extend(["", "#ifdef __cplusplus", 'extern "C" {', "#endif"])
+            output.append("")
+            self._create_splicer('C_declarations', output)
 
         output.extend(self.helper_source["cwrap_include"])
 
@@ -360,6 +363,7 @@ class Wrapc(util.WrapperMixin):
             output.extend(["", "#ifdef __cplusplus", "}", "#endif"])
 
         output.extend(["", "#endif  // " + guard])
+        self._pop_splicer("util")
 
         self.config.cfiles.append(
             os.path.join(self.config.c_fortran_dir, fname)


### PR DESCRIPTION
This is a convient place to define types which are needed for all wrapper files.  Perhaps a C typedef for a C++ typedef which is in some nested scope.

Named types.C_declarations and types.CXX_declarations.
