### PR TITLE
cleanup tags in typemaps

### DIFF
--- a/regression/reference/arrayclass/arrayclass.json
+++ b/regression/reference/arrayclass/arrayclass.json
@@ -3558,6 +3558,9 @@
             "python": true
         }
     },
+    "symtab": {
+        "ArrayWrapper": "ArrayWrapper"
+    },
     "types": {
         "ArrayWrapper": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",

--- a/regression/reference/classes/classes.json
+++ b/regression/reference/classes/classes.json
@@ -5963,6 +5963,16 @@
             "python": true
         }
     },
+    "symtab": {
+        "classes": {
+            "Circle": "classes::Circle",
+            "Class1": "classes::Class1",
+            "Class2": "classes::Class2",
+            "Data": "classes::Data",
+            "Shape": "classes::Shape",
+            "Singleton": "classes::Singleton"
+        }
+    },
     "types": {
         "classes::Circle": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",

--- a/regression/reference/classes/classes.json
+++ b/regression/reference/classes/classes.json
@@ -78,7 +78,7 @@
                         "decl": "enum DIRECTION { UP = 2, DOWN, LEFT= 100, RIGHT };",
                         "name": "DIRECTION",
                         "options": {},
-                        "typemap_name": "enum-classes::Class1::DIRECTION",
+                        "typemap_name": "classes::Class1::DIRECTION",
                         "wrap": {
                             "c": true,
                             "fortran": true,
@@ -1617,13 +1617,13 @@
                                     "specifier": [
                                         "DIRECTION"
                                     ],
-                                    "typemap_name": "enum-classes::Class1::DIRECTION"
+                                    "typemap_name": "classes::Class1::DIRECTION"
                                 }
                             ],
                             "specifier": [
                                 "DIRECTION"
                             ],
-                            "typemap_name": "enum-classes::Class1::DIRECTION"
+                            "typemap_name": "classes::Class1::DIRECTION"
                         },
                         "decl": "DIRECTION directionFunc(DIRECTION arg);",
                         "declgen": "DIRECTION directionFunc(DIRECTION arg +value)",
@@ -4304,13 +4304,13 @@
                             "specifier": [
                                 "Class1::DIRECTION"
                             ],
-                            "typemap_name": "enum-classes::Class1::DIRECTION"
+                            "typemap_name": "classes::Class1::DIRECTION"
                         }
                     ],
                     "specifier": [
                         "Class1::DIRECTION"
                     ],
-                    "typemap_name": "enum-classes::Class1::DIRECTION"
+                    "typemap_name": "classes::Class1::DIRECTION"
                 },
                 "decl": "Class1::DIRECTION directionFunc(Class1::DIRECTION arg);",
                 "declgen": "Class1::DIRECTION directionFunc(Class1::DIRECTION arg +value)",
@@ -6050,6 +6050,31 @@
                 "typesclasses.h"
             ]
         },
+        "classes::Class1::DIRECTION": {
+            "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
+            "LUA_push": "lua_pushinteger({LUA_state_var}, {push_arg})",
+            "LUA_type": "LUA_TNUMBER",
+            "PYN_typenum": "NPY_INT",
+            "PY_ctor": "PyInt_FromLong({ctor_expr})",
+            "PY_format": "i",
+            "PY_get": "PyInt_AsLong({py_var})",
+            "c_to_cxx": "static_cast<classes::Class1::DIRECTION>({c_var})",
+            "c_type": "int",
+            "cfi_type": "CFI_type_int",
+            "cxx_to_c": "static_cast<int>({cxx_var})",
+            "cxx_type": "classes::Class1::DIRECTION",
+            "f_cast": "int({f_var}, C_INT)",
+            "f_kind": "C_INT",
+            "f_module": {
+                "iso_c_binding": [
+                    "C_INT"
+                ]
+            },
+            "f_type": "integer(C_INT)",
+            "flat_name": "int",
+            "sgroup": "native",
+            "sh_type": "SH_TYPE_INT"
+        },
         "classes::Class2": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",
             "LUA_type": "LUA_TUSERDATA",
@@ -6214,31 +6239,6 @@
             "wrap_header": [
                 "typesclasses.h"
             ]
-        },
-        "enum-classes::Class1::DIRECTION": {
-            "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
-            "LUA_push": "lua_pushinteger({LUA_state_var}, {push_arg})",
-            "LUA_type": "LUA_TNUMBER",
-            "PYN_typenum": "NPY_INT",
-            "PY_ctor": "PyInt_FromLong({ctor_expr})",
-            "PY_format": "i",
-            "PY_get": "PyInt_AsLong({py_var})",
-            "c_to_cxx": "static_cast<classes::Class1::DIRECTION>({c_var})",
-            "c_type": "int",
-            "cfi_type": "CFI_type_int",
-            "cxx_to_c": "static_cast<int>({cxx_var})",
-            "cxx_type": "classes::Class1::DIRECTION",
-            "f_cast": "int({f_var}, C_INT)",
-            "f_kind": "C_INT",
-            "f_module": {
-                "iso_c_binding": [
-                    "C_INT"
-                ]
-            },
-            "f_type": "integer(C_INT)",
-            "flat_name": "int",
-            "sgroup": "native",
-            "sh_type": "SH_TYPE_INT"
         }
     }
 }

--- a/regression/reference/clibrary/clibrary.json
+++ b/regression/reference/clibrary/clibrary.json
@@ -6071,7 +6071,8 @@
         }
     },
     "symtab": {
-        "array_info": "array_info"
+        "array_info": "struct-array_info",
+        "struct-array_info": "array_info"
     },
     "types": {
         "array_info": {

--- a/regression/reference/clibrary/clibrary.json
+++ b/regression/reference/clibrary/clibrary.json
@@ -6070,6 +6070,9 @@
             "python": true
         }
     },
+    "symtab": {
+        "array_info": "array_info"
+    },
     "types": {
         "array_info": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",

--- a/regression/reference/cxxlibrary/cxxlibrary.json
+++ b/regression/reference/cxxlibrary/cxxlibrary.json
@@ -2795,6 +2795,12 @@
             "python": true
         }
     },
+    "symtab": {
+        "Cstruct1_cls": "Cstruct1_cls",
+        "structns": {
+            "Cstruct1": "structns::Cstruct1"
+        }
+    },
     "types": {
         "Cstruct1_cls": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",

--- a/regression/reference/cxxlibrary/cxxlibrary.json
+++ b/regression/reference/cxxlibrary/cxxlibrary.json
@@ -2796,9 +2796,11 @@
         }
     },
     "symtab": {
-        "Cstruct1_cls": "Cstruct1_cls",
+        "Cstruct1_cls": "struct-Cstruct1_cls",
+        "struct-Cstruct1_cls": "Cstruct1_cls",
         "structns": {
-            "Cstruct1": "structns::Cstruct1"
+            "Cstruct1": "struct-Cstruct1",
+            "struct-Cstruct1": "structns::Cstruct1"
         }
     },
     "types": {

--- a/regression/reference/debugfalse/tutorial.json
+++ b/regression/reference/debugfalse/tutorial.json
@@ -60,7 +60,7 @@
                 "options": {
                     "bar": 4
                 },
-                "typemap_name": "enum-tutorial::Color",
+                "typemap_name": "tutorial::Color",
                 "wrap": {
                     "c": true,
                     "fortran": true,
@@ -5222,13 +5222,13 @@
                             "specifier": [
                                 "Color"
                             ],
-                            "typemap_name": "enum-tutorial::Color"
+                            "typemap_name": "tutorial::Color"
                         }
                     ],
                     "specifier": [
                         "Color"
                     ],
-                    "typemap_name": "enum-tutorial::Color"
+                    "typemap_name": "tutorial::Color"
                 },
                 "decl": "Color colorfunc(Color arg);",
                 "declgen": "Color colorfunc(Color arg +value)",
@@ -6127,7 +6127,7 @@
         }
     },
     "types": {
-        "enum-tutorial::Color": {
+        "tutorial::Color": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
             "LUA_push": "lua_pushinteger({LUA_state_var}, {push_arg})",
             "LUA_type": "LUA_TNUMBER",

--- a/regression/reference/debugfalse/tutorial.json
+++ b/regression/reference/debugfalse/tutorial.json
@@ -6128,7 +6128,8 @@
     },
     "symtab": {
         "tutorial": {
-            "Color": "tutorial::Color"
+            "Color": "enum-Color",
+            "enum-Color": "tutorial::Color"
         }
     },
     "types": {

--- a/regression/reference/debugfalse/tutorial.json
+++ b/regression/reference/debugfalse/tutorial.json
@@ -6126,6 +6126,11 @@
             "python": true
         }
     },
+    "symtab": {
+        "tutorial": {
+            "Color": "tutorial::Color"
+        }
+    },
     "types": {
         "tutorial::Color": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",

--- a/regression/reference/enum-c/enum.json
+++ b/regression/reference/enum-c/enum.json
@@ -391,6 +391,10 @@
             "python": true
         }
     },
+    "symtab": {
+        "Color": "Color",
+        "val": "val"
+    },
     "types": {
         "Color": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",

--- a/regression/reference/enum-c/enum.json
+++ b/regression/reference/enum-c/enum.json
@@ -392,8 +392,10 @@
         }
     },
     "symtab": {
-        "Color": "Color",
-        "val": "val"
+        "Color": "enum-Color",
+        "enum-Color": "Color",
+        "enum-val": "val",
+        "val": "enum-val"
     },
     "types": {
         "Color": {

--- a/regression/reference/enum-c/enum.json
+++ b/regression/reference/enum-c/enum.json
@@ -62,7 +62,7 @@
                 "decl": "enum Color {\n  RED = 10,\n  BLUE,\n  WHITE\n};\n",
                 "name": "Color",
                 "options": {},
-                "typemap_name": "enum-Color",
+                "typemap_name": "Color",
                 "wrap": {
                     "c": true,
                     "fortran": true,
@@ -197,7 +197,7 @@
                 "decl": "enum val {\n  a1,\n  b1 = 3,\n  c1,\n  d1 = b1 - a1,\n  e1 = d1,\n  f1,\n  g1,\n  h1 = 100,\n};\n",
                 "name": "val",
                 "options": {},
-                "typemap_name": "enum-val",
+                "typemap_name": "val",
                 "wrap": {
                     "c": true,
                     "fortran": true,
@@ -235,7 +235,7 @@
                             "specifier": [
                                 "enum Color"
                             ],
-                            "typemap_name": "enum-Color"
+                            "typemap_name": "Color"
                         }
                     ],
                     "specifier": [
@@ -392,7 +392,7 @@
         }
     },
     "types": {
-        "enum-Color": {
+        "Color": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
             "LUA_push": "lua_pushinteger({LUA_state_var}, {push_arg})",
             "LUA_type": "LUA_TNUMBER",
@@ -417,7 +417,7 @@
             "sgroup": "native",
             "sh_type": "SH_TYPE_INT"
         },
-        "enum-val": {
+        "val": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
             "LUA_push": "lua_pushinteger({LUA_state_var}, {push_arg})",
             "LUA_type": "LUA_TNUMBER",

--- a/regression/reference/enum-cxx/enum.json
+++ b/regression/reference/enum-cxx/enum.json
@@ -394,8 +394,10 @@
         }
     },
     "symtab": {
-        "Color": "Color",
-        "val": "val"
+        "Color": "enum-Color",
+        "enum-Color": "Color",
+        "enum-val": "val",
+        "val": "enum-val"
     },
     "types": {
         "Color": {

--- a/regression/reference/enum-cxx/enum.json
+++ b/regression/reference/enum-cxx/enum.json
@@ -62,7 +62,7 @@
                 "decl": "enum Color {\n  RED = 10,\n  BLUE,\n  WHITE\n};\n",
                 "name": "Color",
                 "options": {},
-                "typemap_name": "enum-Color",
+                "typemap_name": "Color",
                 "wrap": {
                     "c": true,
                     "fortran": true,
@@ -197,7 +197,7 @@
                 "decl": "enum val {\n  a1,\n  b1 = 3,\n  c1,\n  d1 = b1 - a1,\n  e1 = d1,\n  f1,\n  g1,\n  h1 = 100,\n};\n",
                 "name": "val",
                 "options": {},
-                "typemap_name": "enum-val",
+                "typemap_name": "val",
                 "wrap": {
                     "c": true,
                     "fortran": true,
@@ -235,7 +235,7 @@
                             "specifier": [
                                 "enum Color"
                             ],
-                            "typemap_name": "enum-Color"
+                            "typemap_name": "Color"
                         }
                     ],
                     "specifier": [
@@ -394,7 +394,7 @@
         }
     },
     "types": {
-        "enum-Color": {
+        "Color": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
             "LUA_push": "lua_pushinteger({LUA_state_var}, {push_arg})",
             "LUA_type": "LUA_TNUMBER",
@@ -419,7 +419,7 @@
             "sgroup": "native",
             "sh_type": "SH_TYPE_INT"
         },
-        "enum-val": {
+        "val": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
             "LUA_push": "lua_pushinteger({LUA_state_var}, {push_arg})",
             "LUA_type": "LUA_TNUMBER",

--- a/regression/reference/enum-cxx/enum.json
+++ b/regression/reference/enum-cxx/enum.json
@@ -393,6 +393,10 @@
             "python": true
         }
     },
+    "symtab": {
+        "Color": "Color",
+        "val": "val"
+    },
     "types": {
         "Color": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",

--- a/regression/reference/example/example.json
+++ b/regression/reference/example/example.json
@@ -11210,6 +11210,14 @@
             "python": true
         }
     },
+    "symtab": {
+        "example": {
+            "nested": {
+                "ExClass1": "example::nested::ExClass1",
+                "ExClass2": "example::nested::ExClass2"
+            }
+        }
+    },
     "types": {
         "example::nested::ExClass1": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",

--- a/regression/reference/forward/forward.json
+++ b/regression/reference/forward/forward.json
@@ -750,6 +750,16 @@
             "python": true
         }
     },
+    "symtab": {
+        "Cstruct1": "Cstruct1",
+        "forward": {
+            "Class2": "forward::Class2",
+            "Class3": "forward::Class3"
+        },
+        "tutorial": {
+            "Class1": "tutorial::Class1"
+        }
+    },
     "types": {
         "Cstruct1": {
             "base": "struct",

--- a/regression/reference/generic-cfi/generic.json
+++ b/regression/reference/generic-cfi/generic.json
@@ -6698,7 +6698,8 @@
         }
     },
     "symtab": {
-        "StructAsClass": "StructAsClass"
+        "StructAsClass": "struct-StructAsClass",
+        "struct-StructAsClass": "StructAsClass"
     },
     "types": {
         "StructAsClass": {

--- a/regression/reference/generic-cfi/generic.json
+++ b/regression/reference/generic-cfi/generic.json
@@ -6697,6 +6697,9 @@
             "fortran": true
         }
     },
+    "symtab": {
+        "StructAsClass": "StructAsClass"
+    },
     "types": {
         "StructAsClass": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",

--- a/regression/reference/generic/generic.json
+++ b/regression/reference/generic/generic.json
@@ -6533,7 +6533,8 @@
         }
     },
     "symtab": {
-        "StructAsClass": "StructAsClass"
+        "StructAsClass": "struct-StructAsClass",
+        "struct-StructAsClass": "StructAsClass"
     },
     "types": {
         "StructAsClass": {

--- a/regression/reference/generic/generic.json
+++ b/regression/reference/generic/generic.json
@@ -6532,6 +6532,9 @@
             "fortran": true
         }
     },
+    "symtab": {
+        "StructAsClass": "StructAsClass"
+    },
     "types": {
         "StructAsClass": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",

--- a/regression/reference/include/include.json
+++ b/regression/reference/include/include.json
@@ -879,6 +879,18 @@
             "fortran": true
         }
     },
+    "symtab": {
+        "Class2": "Class2",
+        "outer1": {
+            "class0": "outer1::class0"
+        },
+        "outer2": {
+            "class0": "outer2::class0"
+        },
+        "three": {
+            "Class1": "three::Class1"
+        }
+    },
     "types": {
         "Class2": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",

--- a/regression/reference/names/names.json
+++ b/regression/reference/names/names.json
@@ -4122,6 +4122,25 @@
             "python": true
         }
     },
+    "symtab": {
+        "CAPI": {
+            "Class1": "CAPI::Class1"
+        },
+        "Color": "Color",
+        "Cstruct_as_class": "Cstruct_as_class",
+        "Cstruct_as_subclass": "Cstruct_as_subclass",
+        "Names2": "Names2",
+        "internal": {
+            "ImplWorker1": "internal::ImplWorker1"
+        },
+        "ns0": {
+            "Names": "ns0::Names"
+        },
+        "std": {
+            "vector": "std::vector"
+        },
+        "twoTs": "twoTs"
+    },
     "types": {
         "CAPI::Class1": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",

--- a/regression/reference/names/names.json
+++ b/regression/reference/names/names.json
@@ -4126,10 +4126,11 @@
         "CAPI": {
             "Class1": "CAPI::Class1"
         },
-        "Color": "Color",
-        "Cstruct_as_class": "Cstruct_as_class",
-        "Cstruct_as_subclass": "Cstruct_as_subclass",
+        "Color": "enum-Color",
+        "Cstruct_as_class": "struct-Cstruct_as_class",
+        "Cstruct_as_subclass": "struct-Cstruct_as_subclass",
         "Names2": "Names2",
+        "enum-Color": "Color",
         "internal": {
             "ImplWorker1": "internal::ImplWorker1"
         },
@@ -4139,6 +4140,8 @@
         "std": {
             "vector": "std::vector"
         },
+        "struct-Cstruct_as_class": "Cstruct_as_class",
+        "struct-Cstruct_as_subclass": "Cstruct_as_subclass",
         "twoTs": "twoTs"
     },
     "types": {

--- a/regression/reference/names/names.json
+++ b/regression/reference/names/names.json
@@ -353,7 +353,7 @@
                 "options": {
                     "bar": 4
                 },
-                "typemap_name": "enum-Color",
+                "typemap_name": "Color",
                 "wrap": {
                     "c": true,
                     "fortran": true,
@@ -4158,6 +4158,31 @@
                 "typestestnames.hh"
             ]
         },
+        "Color": {
+            "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
+            "LUA_push": "lua_pushinteger({LUA_state_var}, {push_arg})",
+            "LUA_type": "LUA_TNUMBER",
+            "PYN_typenum": "NPY_INT",
+            "PY_ctor": "PyInt_FromLong({ctor_expr})",
+            "PY_format": "i",
+            "PY_get": "PyInt_AsLong({py_var})",
+            "c_to_cxx": "static_cast<Color>({c_var})",
+            "c_type": "int",
+            "cfi_type": "CFI_type_int",
+            "cxx_to_c": "static_cast<int>({cxx_var})",
+            "cxx_type": "Color",
+            "f_cast": "int({f_var}, C_INT)",
+            "f_kind": "C_INT",
+            "f_module": {
+                "iso_c_binding": [
+                    "C_INT"
+                ]
+            },
+            "f_type": "integer(C_INT)",
+            "flat_name": "int",
+            "sgroup": "native",
+            "sh_type": "SH_TYPE_INT"
+        },
         "Cstruct_as_class": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",
             "LUA_type": "LUA_TUSERDATA",
@@ -4277,31 +4302,6 @@
             "wrap_header": [
                 "typestestnames.hh"
             ]
-        },
-        "enum-Color": {
-            "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
-            "LUA_push": "lua_pushinteger({LUA_state_var}, {push_arg})",
-            "LUA_type": "LUA_TNUMBER",
-            "PYN_typenum": "NPY_INT",
-            "PY_ctor": "PyInt_FromLong({ctor_expr})",
-            "PY_format": "i",
-            "PY_get": "PyInt_AsLong({py_var})",
-            "c_to_cxx": "static_cast<Color>({c_var})",
-            "c_type": "int",
-            "cfi_type": "CFI_type_int",
-            "cxx_to_c": "static_cast<int>({cxx_var})",
-            "cxx_type": "Color",
-            "f_cast": "int({f_var}, C_INT)",
-            "f_kind": "C_INT",
-            "f_module": {
-                "iso_c_binding": [
-                    "C_INT"
-                ]
-            },
-            "f_type": "integer(C_INT)",
-            "flat_name": "int",
-            "sgroup": "native",
-            "sh_type": "SH_TYPE_INT"
         },
         "internal::ImplWorker1": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",

--- a/regression/reference/namespace/namespace.json
+++ b/regression/reference/namespace/namespace.json
@@ -734,6 +734,17 @@
             "python": true
         }
     },
+    "symtab": {
+        "nswork": {
+            "ClassWork": "nswork::ClassWork"
+        },
+        "outer": {
+            "Cstruct1": "outer::Cstruct1"
+        },
+        "upper": {
+            "Color": "upper::Color"
+        }
+    },
     "types": {
         "nswork::ClassWork": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",

--- a/regression/reference/namespace/namespace.json
+++ b/regression/reference/namespace/namespace.json
@@ -288,7 +288,7 @@
                         "decl": "enum Color {\n  ERROR,\n  WARN,\n};\n",
                         "name": "Color",
                         "options": {},
-                        "typemap_name": "enum-upper::Color",
+                        "typemap_name": "upper::Color",
                         "wrap": {
                             "c": true,
                             "fortran": true
@@ -735,31 +735,6 @@
         }
     },
     "types": {
-        "enum-upper::Color": {
-            "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
-            "LUA_push": "lua_pushinteger({LUA_state_var}, {push_arg})",
-            "LUA_type": "LUA_TNUMBER",
-            "PYN_typenum": "NPY_INT",
-            "PY_ctor": "PyInt_FromLong({ctor_expr})",
-            "PY_format": "i",
-            "PY_get": "PyInt_AsLong({py_var})",
-            "c_to_cxx": "static_cast<upper::Color>({c_var})",
-            "c_type": "int",
-            "cfi_type": "CFI_type_int",
-            "cxx_to_c": "static_cast<int>({cxx_var})",
-            "cxx_type": "upper::Color",
-            "f_cast": "int({f_var}, C_INT)",
-            "f_kind": "C_INT",
-            "f_module": {
-                "iso_c_binding": [
-                    "C_INT"
-                ]
-            },
-            "f_type": "integer(C_INT)",
-            "flat_name": "int",
-            "sgroup": "native",
-            "sh_type": "SH_TYPE_INT"
-        },
         "nswork::ClassWork": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",
             "LUA_type": "LUA_TUSERDATA",
@@ -831,6 +806,31 @@
             "flat_name": "outer_Cstruct1",
             "sgroup": "struct",
             "sh_type": "SH_TYPE_STRUCT"
+        },
+        "upper::Color": {
+            "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
+            "LUA_push": "lua_pushinteger({LUA_state_var}, {push_arg})",
+            "LUA_type": "LUA_TNUMBER",
+            "PYN_typenum": "NPY_INT",
+            "PY_ctor": "PyInt_FromLong({ctor_expr})",
+            "PY_format": "i",
+            "PY_get": "PyInt_AsLong({py_var})",
+            "c_to_cxx": "static_cast<upper::Color>({c_var})",
+            "c_type": "int",
+            "cfi_type": "CFI_type_int",
+            "cxx_to_c": "static_cast<int>({cxx_var})",
+            "cxx_type": "upper::Color",
+            "f_cast": "int({f_var}, C_INT)",
+            "f_kind": "C_INT",
+            "f_module": {
+                "iso_c_binding": [
+                    "C_INT"
+                ]
+            },
+            "f_type": "integer(C_INT)",
+            "flat_name": "int",
+            "sgroup": "native",
+            "sh_type": "SH_TYPE_INT"
         }
     }
 }

--- a/regression/reference/namespace/namespace.json
+++ b/regression/reference/namespace/namespace.json
@@ -739,10 +739,12 @@
             "ClassWork": "nswork::ClassWork"
         },
         "outer": {
-            "Cstruct1": "outer::Cstruct1"
+            "Cstruct1": "struct-Cstruct1",
+            "struct-Cstruct1": "outer::Cstruct1"
         },
         "upper": {
-            "Color": "upper::Color"
+            "Color": "enum-Color",
+            "enum-Color": "upper::Color"
         }
     },
     "types": {

--- a/regression/reference/ownership/ownership.json
+++ b/regression/reference/ownership/ownership.json
@@ -3896,6 +3896,9 @@
             "python": true
         }
     },
+    "symtab": {
+        "Class1": "Class1"
+    },
     "types": {
         "Class1": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",

--- a/regression/reference/preprocess/preprocess.json
+++ b/regression/reference/preprocess/preprocess.json
@@ -576,6 +576,10 @@
             "python": true
         }
     },
+    "symtab": {
+        "User1": "User1",
+        "User2": "User2"
+    },
     "types": {
         "User1": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",

--- a/regression/reference/python-only/tutorial.json
+++ b/regression/reference/python-only/tutorial.json
@@ -2308,6 +2308,11 @@
             "python": true
         }
     },
+    "symtab": {
+        "tutorial": {
+            "Color": "tutorial::Color"
+        }
+    },
     "types": {
         "tutorial::Color": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",

--- a/regression/reference/python-only/tutorial.json
+++ b/regression/reference/python-only/tutorial.json
@@ -60,7 +60,7 @@
                 "options": {
                     "bar": 4
                 },
-                "typemap_name": "enum-tutorial::Color",
+                "typemap_name": "tutorial::Color",
                 "wrap": {
                     "python": true
                 },
@@ -1876,13 +1876,13 @@
                             "specifier": [
                                 "Color"
                             ],
-                            "typemap_name": "enum-tutorial::Color"
+                            "typemap_name": "tutorial::Color"
                         }
                     ],
                     "specifier": [
                         "Color"
                     ],
-                    "typemap_name": "enum-tutorial::Color"
+                    "typemap_name": "tutorial::Color"
                 },
                 "decl": "Color colorfunc(Color arg);",
                 "declgen": "Color colorfunc(Color arg +value)",
@@ -2309,7 +2309,7 @@
         }
     },
     "types": {
-        "enum-tutorial::Color": {
+        "tutorial::Color": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
             "LUA_push": "lua_pushinteger({LUA_state_var}, {push_arg})",
             "LUA_type": "LUA_TNUMBER",

--- a/regression/reference/python-only/tutorial.json
+++ b/regression/reference/python-only/tutorial.json
@@ -2310,7 +2310,8 @@
     },
     "symtab": {
         "tutorial": {
-            "Color": "tutorial::Color"
+            "Color": "enum-Color",
+            "enum-Color": "tutorial::Color"
         }
     },
     "types": {

--- a/regression/reference/scope/scope.json
+++ b/regression/reference/scope/scope.json
@@ -159,7 +159,7 @@
                         "decl": "enum Color {\n  RED = 40,\n  BLUE,\n  WHITE\n};\n",
                         "name": "Color",
                         "options": {},
-                        "typemap_name": "enum-Class1::Color",
+                        "typemap_name": "Class1::Color",
                         "wrap": {
                             "c": true,
                             "fortran": true
@@ -251,7 +251,7 @@
                         "decl": "enum Color {\n  RED = 50,\n  BLUE,\n  WHITE\n};\n",
                         "name": "Color",
                         "options": {},
-                        "typemap_name": "enum-Class2::Color",
+                        "typemap_name": "Class2::Color",
                         "wrap": {
                             "c": true,
                             "fortran": true
@@ -349,7 +349,7 @@
                 "decl": "enum Color {\n  RED = 10,\n  BLUE,\n  WHITE\n};\n",
                 "name": "Color",
                 "options": {},
-                "typemap_name": "enum-Color",
+                "typemap_name": "Color",
                 "wrap": {
                     "c": true,
                     "fortran": true
@@ -410,7 +410,7 @@
                 "decl": "enum Color {\n  RED = 70,\n  BLUE,\n  WHITE\n};\n",
                 "name": "Color",
                 "options": {},
-                "typemap_name": "enum-ns3::Color",
+                "typemap_name": "ns3::Color",
                 "wrap": {
                     "c": true,
                     "fortran": true
@@ -478,7 +478,7 @@
                 "decl": "enum class ColorEnum {\n  RED = 60,\n  BLUE,\n  WHITE,\n};\n",
                 "name": "ColorEnum",
                 "options": {},
-                "typemap_name": "enum-ColorEnum",
+                "typemap_name": "ColorEnum",
                 "wrap": {
                     "c": true,
                     "fortran": true
@@ -1054,7 +1054,7 @@
                         "decl": "enum Color {\n  RED = 20,\n  BLUE,\n  WHITE\n};\n",
                         "name": "Color",
                         "options": {},
-                        "typemap_name": "enum-ns1::Color",
+                        "typemap_name": "ns1::Color",
                         "wrap": {
                             "c": true,
                             "fortran": true
@@ -1656,7 +1656,7 @@
                         "decl": "enum Color {\n  RED = 30,\n  BLUE,\n  WHITE\n};\n",
                         "name": "Color",
                         "options": {},
-                        "typemap_name": "enum-ns2::Color",
+                        "typemap_name": "ns2::Color",
                         "wrap": {
                             "c": true,
                             "fortran": true
@@ -2152,6 +2152,31 @@
                 "typesscope.h"
             ]
         },
+        "Class1::Color": {
+            "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
+            "LUA_push": "lua_pushinteger({LUA_state_var}, {push_arg})",
+            "LUA_type": "LUA_TNUMBER",
+            "PYN_typenum": "NPY_INT",
+            "PY_ctor": "PyInt_FromLong({ctor_expr})",
+            "PY_format": "i",
+            "PY_get": "PyInt_AsLong({py_var})",
+            "c_to_cxx": "static_cast<Class1::Color>({c_var})",
+            "c_type": "int",
+            "cfi_type": "CFI_type_int",
+            "cxx_to_c": "static_cast<int>({cxx_var})",
+            "cxx_type": "Class1::Color",
+            "f_cast": "int({f_var}, C_INT)",
+            "f_kind": "C_INT",
+            "f_module": {
+                "iso_c_binding": [
+                    "C_INT"
+                ]
+            },
+            "f_type": "integer(C_INT)",
+            "flat_name": "int",
+            "sgroup": "native",
+            "sh_type": "SH_TYPE_INT"
+        },
         "Class2": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",
             "LUA_type": "LUA_TUSERDATA",
@@ -2187,32 +2212,7 @@
                 "typesscope.h"
             ]
         },
-        "enum-Class1::Color": {
-            "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
-            "LUA_push": "lua_pushinteger({LUA_state_var}, {push_arg})",
-            "LUA_type": "LUA_TNUMBER",
-            "PYN_typenum": "NPY_INT",
-            "PY_ctor": "PyInt_FromLong({ctor_expr})",
-            "PY_format": "i",
-            "PY_get": "PyInt_AsLong({py_var})",
-            "c_to_cxx": "static_cast<Class1::Color>({c_var})",
-            "c_type": "int",
-            "cfi_type": "CFI_type_int",
-            "cxx_to_c": "static_cast<int>({cxx_var})",
-            "cxx_type": "Class1::Color",
-            "f_cast": "int({f_var}, C_INT)",
-            "f_kind": "C_INT",
-            "f_module": {
-                "iso_c_binding": [
-                    "C_INT"
-                ]
-            },
-            "f_type": "integer(C_INT)",
-            "flat_name": "int",
-            "sgroup": "native",
-            "sh_type": "SH_TYPE_INT"
-        },
-        "enum-Class2::Color": {
+        "Class2::Color": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
             "LUA_push": "lua_pushinteger({LUA_state_var}, {push_arg})",
             "LUA_type": "LUA_TNUMBER",
@@ -2237,7 +2237,7 @@
             "sgroup": "native",
             "sh_type": "SH_TYPE_INT"
         },
-        "enum-Color": {
+        "Color": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
             "LUA_push": "lua_pushinteger({LUA_state_var}, {push_arg})",
             "LUA_type": "LUA_TNUMBER",
@@ -2262,7 +2262,7 @@
             "sgroup": "native",
             "sh_type": "SH_TYPE_INT"
         },
-        "enum-ColorEnum": {
+        "ColorEnum": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
             "LUA_push": "lua_pushinteger({LUA_state_var}, {push_arg})",
             "LUA_type": "LUA_TNUMBER",
@@ -2287,7 +2287,7 @@
             "sgroup": "native",
             "sh_type": "SH_TYPE_INT"
         },
-        "enum-ns1::Color": {
+        "ns1::Color": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
             "LUA_push": "lua_pushinteger({LUA_state_var}, {push_arg})",
             "LUA_type": "LUA_TNUMBER",
@@ -2300,56 +2300,6 @@
             "cfi_type": "CFI_type_int",
             "cxx_to_c": "static_cast<int>({cxx_var})",
             "cxx_type": "ns1::Color",
-            "f_cast": "int({f_var}, C_INT)",
-            "f_kind": "C_INT",
-            "f_module": {
-                "iso_c_binding": [
-                    "C_INT"
-                ]
-            },
-            "f_type": "integer(C_INT)",
-            "flat_name": "int",
-            "sgroup": "native",
-            "sh_type": "SH_TYPE_INT"
-        },
-        "enum-ns2::Color": {
-            "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
-            "LUA_push": "lua_pushinteger({LUA_state_var}, {push_arg})",
-            "LUA_type": "LUA_TNUMBER",
-            "PYN_typenum": "NPY_INT",
-            "PY_ctor": "PyInt_FromLong({ctor_expr})",
-            "PY_format": "i",
-            "PY_get": "PyInt_AsLong({py_var})",
-            "c_to_cxx": "static_cast<ns2::Color>({c_var})",
-            "c_type": "int",
-            "cfi_type": "CFI_type_int",
-            "cxx_to_c": "static_cast<int>({cxx_var})",
-            "cxx_type": "ns2::Color",
-            "f_cast": "int({f_var}, C_INT)",
-            "f_kind": "C_INT",
-            "f_module": {
-                "iso_c_binding": [
-                    "C_INT"
-                ]
-            },
-            "f_type": "integer(C_INT)",
-            "flat_name": "int",
-            "sgroup": "native",
-            "sh_type": "SH_TYPE_INT"
-        },
-        "enum-ns3::Color": {
-            "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
-            "LUA_push": "lua_pushinteger({LUA_state_var}, {push_arg})",
-            "LUA_type": "LUA_TNUMBER",
-            "PYN_typenum": "NPY_INT",
-            "PY_ctor": "PyInt_FromLong({ctor_expr})",
-            "PY_format": "i",
-            "PY_get": "PyInt_AsLong({py_var})",
-            "c_to_cxx": "static_cast<ns3::Color>({c_var})",
-            "c_type": "int",
-            "cfi_type": "CFI_type_int",
-            "cxx_to_c": "static_cast<int>({cxx_var})",
-            "cxx_type": "ns3::Color",
             "f_cast": "int({f_var}, C_INT)",
             "f_kind": "C_INT",
             "f_module": {
@@ -2387,6 +2337,31 @@
             "sgroup": "struct",
             "sh_type": "SH_TYPE_STRUCT"
         },
+        "ns2::Color": {
+            "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
+            "LUA_push": "lua_pushinteger({LUA_state_var}, {push_arg})",
+            "LUA_type": "LUA_TNUMBER",
+            "PYN_typenum": "NPY_INT",
+            "PY_ctor": "PyInt_FromLong({ctor_expr})",
+            "PY_format": "i",
+            "PY_get": "PyInt_AsLong({py_var})",
+            "c_to_cxx": "static_cast<ns2::Color>({c_var})",
+            "c_type": "int",
+            "cfi_type": "CFI_type_int",
+            "cxx_to_c": "static_cast<int>({cxx_var})",
+            "cxx_type": "ns2::Color",
+            "f_cast": "int({f_var}, C_INT)",
+            "f_kind": "C_INT",
+            "f_module": {
+                "iso_c_binding": [
+                    "C_INT"
+                ]
+            },
+            "f_type": "integer(C_INT)",
+            "flat_name": "int",
+            "sgroup": "native",
+            "sh_type": "SH_TYPE_INT"
+        },
         "ns2::DataPointer": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",
             "LUA_type": "LUA_TUSERDATA",
@@ -2411,6 +2386,31 @@
             "flat_name": "ns2_DataPointer",
             "sgroup": "struct",
             "sh_type": "SH_TYPE_STRUCT"
+        },
+        "ns3::Color": {
+            "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
+            "LUA_push": "lua_pushinteger({LUA_state_var}, {push_arg})",
+            "LUA_type": "LUA_TNUMBER",
+            "PYN_typenum": "NPY_INT",
+            "PY_ctor": "PyInt_FromLong({ctor_expr})",
+            "PY_format": "i",
+            "PY_get": "PyInt_AsLong({py_var})",
+            "c_to_cxx": "static_cast<ns3::Color>({c_var})",
+            "c_type": "int",
+            "cfi_type": "CFI_type_int",
+            "cxx_to_c": "static_cast<int>({cxx_var})",
+            "cxx_type": "ns3::Color",
+            "f_cast": "int({f_var}, C_INT)",
+            "f_kind": "C_INT",
+            "f_module": {
+                "iso_c_binding": [
+                    "C_INT"
+                ]
+            },
+            "f_type": "integer(C_INT)",
+            "flat_name": "int",
+            "sgroup": "native",
+            "sh_type": "SH_TYPE_INT"
         },
         "ns3::DataPointer": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",

--- a/regression/reference/scope/scope.json
+++ b/regression/reference/scope/scope.json
@@ -2119,19 +2119,27 @@
     "symtab": {
         "Class1": "Class1",
         "Class2": "Class2",
-        "Color": "Color",
-        "ColorEnum": "ColorEnum",
+        "Color": "enum-Color",
+        "ColorEnum": "enum-ColorEnum",
+        "enum-Color": "Color",
+        "enum-ColorEnum": "ColorEnum",
         "ns1": {
-            "Color": "ns1::Color",
-            "DataPointer": "ns1::DataPointer"
+            "Color": "enum-Color",
+            "DataPointer": "struct-DataPointer",
+            "enum-Color": "ns1::Color",
+            "struct-DataPointer": "ns1::DataPointer"
         },
         "ns2": {
-            "Color": "ns2::Color",
-            "DataPointer": "ns2::DataPointer"
+            "Color": "enum-Color",
+            "DataPointer": "struct-DataPointer",
+            "enum-Color": "ns2::Color",
+            "struct-DataPointer": "ns2::DataPointer"
         },
         "ns3": {
-            "Color": "ns3::Color",
-            "DataPointer": "ns3::DataPointer"
+            "Color": "enum-Color",
+            "DataPointer": "struct-DataPointer",
+            "enum-Color": "ns3::Color",
+            "struct-DataPointer": "ns3::DataPointer"
         }
     },
     "types": {

--- a/regression/reference/scope/scope.json
+++ b/regression/reference/scope/scope.json
@@ -2116,6 +2116,24 @@
             "fortran": true
         }
     },
+    "symtab": {
+        "Class1": "Class1",
+        "Class2": "Class2",
+        "Color": "Color",
+        "ColorEnum": "ColorEnum",
+        "ns1": {
+            "Color": "ns1::Color",
+            "DataPointer": "ns1::DataPointer"
+        },
+        "ns2": {
+            "Color": "ns2::Color",
+            "DataPointer": "ns2::DataPointer"
+        },
+        "ns3": {
+            "Color": "ns3::Color",
+            "DataPointer": "ns3::DataPointer"
+        }
+    },
     "types": {
         "Class1": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",

--- a/regression/reference/struct-c/struct.json
+++ b/regression/reference/struct-c/struct.json
@@ -5912,13 +5912,20 @@
         }
     },
     "symtab": {
-        "Arrays1": "Arrays1",
-        "Cstruct1": "Cstruct1",
-        "Cstruct_as_class": "Cstruct_as_class",
-        "Cstruct_as_subclass": "Cstruct_as_subclass",
-        "Cstruct_list": "Cstruct_list",
-        "Cstruct_numpy": "Cstruct_numpy",
-        "Cstruct_ptr": "Cstruct_ptr"
+        "Arrays1": "struct-Arrays1",
+        "Cstruct1": "struct-Cstruct1",
+        "Cstruct_as_class": "struct-Cstruct_as_class",
+        "Cstruct_as_subclass": "struct-Cstruct_as_subclass",
+        "Cstruct_list": "struct-Cstruct_list",
+        "Cstruct_numpy": "struct-Cstruct_numpy",
+        "Cstruct_ptr": "struct-Cstruct_ptr",
+        "struct-Arrays1": "Arrays1",
+        "struct-Cstruct1": "Cstruct1",
+        "struct-Cstruct_as_class": "Cstruct_as_class",
+        "struct-Cstruct_as_subclass": "Cstruct_as_subclass",
+        "struct-Cstruct_list": "Cstruct_list",
+        "struct-Cstruct_numpy": "Cstruct_numpy",
+        "struct-Cstruct_ptr": "Cstruct_ptr"
     },
     "types": {
         "Arrays1": {

--- a/regression/reference/struct-c/struct.json
+++ b/regression/reference/struct-c/struct.json
@@ -5911,6 +5911,15 @@
             "fortran": true
         }
     },
+    "symtab": {
+        "Arrays1": "Arrays1",
+        "Cstruct1": "Cstruct1",
+        "Cstruct_as_class": "Cstruct_as_class",
+        "Cstruct_as_subclass": "Cstruct_as_subclass",
+        "Cstruct_list": "Cstruct_list",
+        "Cstruct_numpy": "Cstruct_numpy",
+        "Cstruct_ptr": "Cstruct_ptr"
+    },
     "types": {
         "Arrays1": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",

--- a/regression/reference/struct-class-c/struct.json
+++ b/regression/reference/struct-class-c/struct.json
@@ -3236,6 +3236,15 @@
             "python": true
         }
     },
+    "symtab": {
+        "Arrays1": "Arrays1",
+        "Cstruct1": "Cstruct1",
+        "Cstruct_as_class": "Cstruct_as_class",
+        "Cstruct_as_subclass": "Cstruct_as_subclass",
+        "Cstruct_list": "Cstruct_list",
+        "Cstruct_numpy": "Cstruct_numpy",
+        "Cstruct_ptr": "Cstruct_ptr"
+    },
     "types": {
         "Arrays1": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",

--- a/regression/reference/struct-class-c/struct.json
+++ b/regression/reference/struct-class-c/struct.json
@@ -3237,13 +3237,20 @@
         }
     },
     "symtab": {
-        "Arrays1": "Arrays1",
-        "Cstruct1": "Cstruct1",
-        "Cstruct_as_class": "Cstruct_as_class",
-        "Cstruct_as_subclass": "Cstruct_as_subclass",
-        "Cstruct_list": "Cstruct_list",
-        "Cstruct_numpy": "Cstruct_numpy",
-        "Cstruct_ptr": "Cstruct_ptr"
+        "Arrays1": "struct-Arrays1",
+        "Cstruct1": "struct-Cstruct1",
+        "Cstruct_as_class": "struct-Cstruct_as_class",
+        "Cstruct_as_subclass": "struct-Cstruct_as_subclass",
+        "Cstruct_list": "struct-Cstruct_list",
+        "Cstruct_numpy": "struct-Cstruct_numpy",
+        "Cstruct_ptr": "struct-Cstruct_ptr",
+        "struct-Arrays1": "Arrays1",
+        "struct-Cstruct1": "Cstruct1",
+        "struct-Cstruct_as_class": "Cstruct_as_class",
+        "struct-Cstruct_as_subclass": "Cstruct_as_subclass",
+        "struct-Cstruct_list": "Cstruct_list",
+        "struct-Cstruct_numpy": "Cstruct_numpy",
+        "struct-Cstruct_ptr": "Cstruct_ptr"
     },
     "types": {
         "Arrays1": {

--- a/regression/reference/struct-class-cxx/struct.json
+++ b/regression/reference/struct-class-cxx/struct.json
@@ -3236,6 +3236,15 @@
             "python": true
         }
     },
+    "symtab": {
+        "Arrays1": "Arrays1",
+        "Cstruct1": "Cstruct1",
+        "Cstruct_as_class": "Cstruct_as_class",
+        "Cstruct_as_subclass": "Cstruct_as_subclass",
+        "Cstruct_list": "Cstruct_list",
+        "Cstruct_numpy": "Cstruct_numpy",
+        "Cstruct_ptr": "Cstruct_ptr"
+    },
     "types": {
         "Arrays1": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",

--- a/regression/reference/struct-class-cxx/struct.json
+++ b/regression/reference/struct-class-cxx/struct.json
@@ -3237,13 +3237,20 @@
         }
     },
     "symtab": {
-        "Arrays1": "Arrays1",
-        "Cstruct1": "Cstruct1",
-        "Cstruct_as_class": "Cstruct_as_class",
-        "Cstruct_as_subclass": "Cstruct_as_subclass",
-        "Cstruct_list": "Cstruct_list",
-        "Cstruct_numpy": "Cstruct_numpy",
-        "Cstruct_ptr": "Cstruct_ptr"
+        "Arrays1": "struct-Arrays1",
+        "Cstruct1": "struct-Cstruct1",
+        "Cstruct_as_class": "struct-Cstruct_as_class",
+        "Cstruct_as_subclass": "struct-Cstruct_as_subclass",
+        "Cstruct_list": "struct-Cstruct_list",
+        "Cstruct_numpy": "struct-Cstruct_numpy",
+        "Cstruct_ptr": "struct-Cstruct_ptr",
+        "struct-Arrays1": "Arrays1",
+        "struct-Cstruct1": "Cstruct1",
+        "struct-Cstruct_as_class": "Cstruct_as_class",
+        "struct-Cstruct_as_subclass": "Cstruct_as_subclass",
+        "struct-Cstruct_list": "Cstruct_list",
+        "struct-Cstruct_numpy": "Cstruct_numpy",
+        "struct-Cstruct_ptr": "Cstruct_ptr"
     },
     "types": {
         "Arrays1": {

--- a/regression/reference/struct-cxx/struct.json
+++ b/regression/reference/struct-cxx/struct.json
@@ -5912,13 +5912,20 @@
         }
     },
     "symtab": {
-        "Arrays1": "Arrays1",
-        "Cstruct1": "Cstruct1",
-        "Cstruct_as_class": "Cstruct_as_class",
-        "Cstruct_as_subclass": "Cstruct_as_subclass",
-        "Cstruct_list": "Cstruct_list",
-        "Cstruct_numpy": "Cstruct_numpy",
-        "Cstruct_ptr": "Cstruct_ptr"
+        "Arrays1": "struct-Arrays1",
+        "Cstruct1": "struct-Cstruct1",
+        "Cstruct_as_class": "struct-Cstruct_as_class",
+        "Cstruct_as_subclass": "struct-Cstruct_as_subclass",
+        "Cstruct_list": "struct-Cstruct_list",
+        "Cstruct_numpy": "struct-Cstruct_numpy",
+        "Cstruct_ptr": "struct-Cstruct_ptr",
+        "struct-Arrays1": "Arrays1",
+        "struct-Cstruct1": "Cstruct1",
+        "struct-Cstruct_as_class": "Cstruct_as_class",
+        "struct-Cstruct_as_subclass": "Cstruct_as_subclass",
+        "struct-Cstruct_list": "Cstruct_list",
+        "struct-Cstruct_numpy": "Cstruct_numpy",
+        "struct-Cstruct_ptr": "Cstruct_ptr"
     },
     "types": {
         "Arrays1": {

--- a/regression/reference/struct-cxx/struct.json
+++ b/regression/reference/struct-cxx/struct.json
@@ -5911,6 +5911,15 @@
             "fortran": true
         }
     },
+    "symtab": {
+        "Arrays1": "Arrays1",
+        "Cstruct1": "Cstruct1",
+        "Cstruct_as_class": "Cstruct_as_class",
+        "Cstruct_as_subclass": "Cstruct_as_subclass",
+        "Cstruct_list": "Cstruct_list",
+        "Cstruct_numpy": "Cstruct_numpy",
+        "Cstruct_ptr": "Cstruct_ptr"
+    },
     "types": {
         "Arrays1": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",

--- a/regression/reference/struct-list-cxx/struct.json
+++ b/regression/reference/struct-list-cxx/struct.json
@@ -2219,13 +2219,20 @@
         }
     },
     "symtab": {
-        "Arrays1": "Arrays1",
-        "Cstruct1": "Cstruct1",
-        "Cstruct_as_class": "Cstruct_as_class",
-        "Cstruct_as_subclass": "Cstruct_as_subclass",
-        "Cstruct_list": "Cstruct_list",
-        "Cstruct_numpy": "Cstruct_numpy",
-        "Cstruct_ptr": "Cstruct_ptr"
+        "Arrays1": "struct-Arrays1",
+        "Cstruct1": "struct-Cstruct1",
+        "Cstruct_as_class": "struct-Cstruct_as_class",
+        "Cstruct_as_subclass": "struct-Cstruct_as_subclass",
+        "Cstruct_list": "struct-Cstruct_list",
+        "Cstruct_numpy": "struct-Cstruct_numpy",
+        "Cstruct_ptr": "struct-Cstruct_ptr",
+        "struct-Arrays1": "Arrays1",
+        "struct-Cstruct1": "Cstruct1",
+        "struct-Cstruct_as_class": "Cstruct_as_class",
+        "struct-Cstruct_as_subclass": "Cstruct_as_subclass",
+        "struct-Cstruct_list": "Cstruct_list",
+        "struct-Cstruct_numpy": "Cstruct_numpy",
+        "struct-Cstruct_ptr": "Cstruct_ptr"
     },
     "types": {
         "Arrays1": {

--- a/regression/reference/struct-list-cxx/struct.json
+++ b/regression/reference/struct-list-cxx/struct.json
@@ -2218,6 +2218,15 @@
             "python": true
         }
     },
+    "symtab": {
+        "Arrays1": "Arrays1",
+        "Cstruct1": "Cstruct1",
+        "Cstruct_as_class": "Cstruct_as_class",
+        "Cstruct_as_subclass": "Cstruct_as_subclass",
+        "Cstruct_list": "Cstruct_list",
+        "Cstruct_numpy": "Cstruct_numpy",
+        "Cstruct_ptr": "Cstruct_ptr"
+    },
     "types": {
         "Arrays1": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",

--- a/regression/reference/struct-numpy-c/struct.json
+++ b/regression/reference/struct-numpy-c/struct.json
@@ -2210,13 +2210,20 @@
         }
     },
     "symtab": {
-        "Arrays1": "Arrays1",
-        "Cstruct1": "Cstruct1",
-        "Cstruct_as_class": "Cstruct_as_class",
-        "Cstruct_as_subclass": "Cstruct_as_subclass",
-        "Cstruct_list": "Cstruct_list",
-        "Cstruct_numpy": "Cstruct_numpy",
-        "Cstruct_ptr": "Cstruct_ptr"
+        "Arrays1": "struct-Arrays1",
+        "Cstruct1": "struct-Cstruct1",
+        "Cstruct_as_class": "struct-Cstruct_as_class",
+        "Cstruct_as_subclass": "struct-Cstruct_as_subclass",
+        "Cstruct_list": "struct-Cstruct_list",
+        "Cstruct_numpy": "struct-Cstruct_numpy",
+        "Cstruct_ptr": "struct-Cstruct_ptr",
+        "struct-Arrays1": "Arrays1",
+        "struct-Cstruct1": "Cstruct1",
+        "struct-Cstruct_as_class": "Cstruct_as_class",
+        "struct-Cstruct_as_subclass": "Cstruct_as_subclass",
+        "struct-Cstruct_list": "Cstruct_list",
+        "struct-Cstruct_numpy": "Cstruct_numpy",
+        "struct-Cstruct_ptr": "Cstruct_ptr"
     },
     "types": {
         "Arrays1": {

--- a/regression/reference/struct-numpy-c/struct.json
+++ b/regression/reference/struct-numpy-c/struct.json
@@ -2209,6 +2209,15 @@
             "python": true
         }
     },
+    "symtab": {
+        "Arrays1": "Arrays1",
+        "Cstruct1": "Cstruct1",
+        "Cstruct_as_class": "Cstruct_as_class",
+        "Cstruct_as_subclass": "Cstruct_as_subclass",
+        "Cstruct_list": "Cstruct_list",
+        "Cstruct_numpy": "Cstruct_numpy",
+        "Cstruct_ptr": "Cstruct_ptr"
+    },
     "types": {
         "Arrays1": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",

--- a/regression/reference/struct-numpy-cxx/struct.json
+++ b/regression/reference/struct-numpy-cxx/struct.json
@@ -2210,13 +2210,20 @@
         }
     },
     "symtab": {
-        "Arrays1": "Arrays1",
-        "Cstruct1": "Cstruct1",
-        "Cstruct_as_class": "Cstruct_as_class",
-        "Cstruct_as_subclass": "Cstruct_as_subclass",
-        "Cstruct_list": "Cstruct_list",
-        "Cstruct_numpy": "Cstruct_numpy",
-        "Cstruct_ptr": "Cstruct_ptr"
+        "Arrays1": "struct-Arrays1",
+        "Cstruct1": "struct-Cstruct1",
+        "Cstruct_as_class": "struct-Cstruct_as_class",
+        "Cstruct_as_subclass": "struct-Cstruct_as_subclass",
+        "Cstruct_list": "struct-Cstruct_list",
+        "Cstruct_numpy": "struct-Cstruct_numpy",
+        "Cstruct_ptr": "struct-Cstruct_ptr",
+        "struct-Arrays1": "Arrays1",
+        "struct-Cstruct1": "Cstruct1",
+        "struct-Cstruct_as_class": "Cstruct_as_class",
+        "struct-Cstruct_as_subclass": "Cstruct_as_subclass",
+        "struct-Cstruct_list": "Cstruct_list",
+        "struct-Cstruct_numpy": "Cstruct_numpy",
+        "struct-Cstruct_ptr": "Cstruct_ptr"
     },
     "types": {
         "Arrays1": {

--- a/regression/reference/struct-numpy-cxx/struct.json
+++ b/regression/reference/struct-numpy-cxx/struct.json
@@ -2209,6 +2209,15 @@
             "python": true
         }
     },
+    "symtab": {
+        "Arrays1": "Arrays1",
+        "Cstruct1": "Cstruct1",
+        "Cstruct_as_class": "Cstruct_as_class",
+        "Cstruct_as_subclass": "Cstruct_as_subclass",
+        "Cstruct_list": "Cstruct_list",
+        "Cstruct_numpy": "Cstruct_numpy",
+        "Cstruct_ptr": "Cstruct_ptr"
+    },
     "types": {
         "Arrays1": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",

--- a/regression/reference/struct-py-c/struct-py.json
+++ b/regression/reference/struct-py-c/struct-py.json
@@ -490,8 +490,10 @@
         }
     },
     "symtab": {
-        "Cstruct_as_class": "Cstruct_as_class",
-        "Cstruct_as_numpy": "Cstruct_as_numpy"
+        "Cstruct_as_class": "struct-Cstruct_as_class",
+        "Cstruct_as_numpy": "struct-Cstruct_as_numpy",
+        "struct-Cstruct_as_class": "Cstruct_as_class",
+        "struct-Cstruct_as_numpy": "Cstruct_as_numpy"
     },
     "types": {
         "Cstruct_as_class": {

--- a/regression/reference/struct-py-c/struct-py.json
+++ b/regression/reference/struct-py-c/struct-py.json
@@ -489,6 +489,10 @@
             "python": true
         }
     },
+    "symtab": {
+        "Cstruct_as_class": "Cstruct_as_class",
+        "Cstruct_as_numpy": "Cstruct_as_numpy"
+    },
     "types": {
         "Cstruct_as_class": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",

--- a/regression/reference/struct-py-cxx/struct-py.json
+++ b/regression/reference/struct-py-cxx/struct-py.json
@@ -490,8 +490,10 @@
         }
     },
     "symtab": {
-        "Cstruct_as_class": "Cstruct_as_class",
-        "Cstruct_as_numpy": "Cstruct_as_numpy"
+        "Cstruct_as_class": "struct-Cstruct_as_class",
+        "Cstruct_as_numpy": "struct-Cstruct_as_numpy",
+        "struct-Cstruct_as_class": "Cstruct_as_class",
+        "struct-Cstruct_as_numpy": "Cstruct_as_numpy"
     },
     "types": {
         "Cstruct_as_class": {

--- a/regression/reference/struct-py-cxx/struct-py.json
+++ b/regression/reference/struct-py-cxx/struct-py.json
@@ -489,6 +489,10 @@
             "python": true
         }
     },
+    "symtab": {
+        "Cstruct_as_class": "Cstruct_as_class",
+        "Cstruct_as_numpy": "Cstruct_as_numpy"
+    },
     "types": {
         "Cstruct_as_class": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",

--- a/regression/reference/structlist/structlist.json
+++ b/regression/reference/structlist/structlist.json
@@ -291,7 +291,8 @@
         }
     },
     "symtab": {
-        "Arrays1": "Arrays1"
+        "Arrays1": "struct-Arrays1",
+        "struct-Arrays1": "Arrays1"
     },
     "types": {
         "Arrays1": {

--- a/regression/reference/structlist/structlist.json
+++ b/regression/reference/structlist/structlist.json
@@ -290,6 +290,9 @@
             "python": true
         }
     },
+    "symtab": {
+        "Arrays1": "Arrays1"
+    },
     "types": {
         "Arrays1": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",

--- a/regression/reference/templates/templates.json
+++ b/regression/reference/templates/templates.json
@@ -4323,6 +4323,18 @@
             "python": true
         }
     },
+    "symtab": {
+        "Worker": "Worker",
+        "internal": {
+            "ImplWorker1": "internal::ImplWorker1",
+            "ImplWorker2": "internal::ImplWorker2"
+        },
+        "std": {
+            "vector": "std::vector"
+        },
+        "structAsClass": "structAsClass",
+        "user": "user"
+    },
     "types": {
         "Worker": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",

--- a/regression/reference/tutorial/tutorial.json
+++ b/regression/reference/tutorial/tutorial.json
@@ -60,7 +60,7 @@
                 "options": {
                     "bar": 4
                 },
-                "typemap_name": "enum-tutorial::Color",
+                "typemap_name": "tutorial::Color",
                 "wrap": {
                     "c": true,
                     "fortran": true,
@@ -5222,13 +5222,13 @@
                             "specifier": [
                                 "Color"
                             ],
-                            "typemap_name": "enum-tutorial::Color"
+                            "typemap_name": "tutorial::Color"
                         }
                     ],
                     "specifier": [
                         "Color"
                     ],
-                    "typemap_name": "enum-tutorial::Color"
+                    "typemap_name": "tutorial::Color"
                 },
                 "decl": "Color colorfunc(Color arg);",
                 "declgen": "Color colorfunc(Color arg +value)",
@@ -6127,7 +6127,7 @@
         }
     },
     "types": {
-        "enum-tutorial::Color": {
+        "tutorial::Color": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",
             "LUA_push": "lua_pushinteger({LUA_state_var}, {push_arg})",
             "LUA_type": "LUA_TNUMBER",

--- a/regression/reference/tutorial/tutorial.json
+++ b/regression/reference/tutorial/tutorial.json
@@ -6128,7 +6128,8 @@
     },
     "symtab": {
         "tutorial": {
-            "Color": "tutorial::Color"
+            "Color": "enum-Color",
+            "enum-Color": "tutorial::Color"
         }
     },
     "types": {

--- a/regression/reference/tutorial/tutorial.json
+++ b/regression/reference/tutorial/tutorial.json
@@ -6126,6 +6126,11 @@
             "python": true
         }
     },
+    "symtab": {
+        "tutorial": {
+            "Color": "tutorial::Color"
+        }
+    },
     "types": {
         "tutorial::Color": {
             "LUA_pop": "lua_tointeger({LUA_state_var}, {LUA_index})",

--- a/regression/reference/wrap/wrap.json
+++ b/regression/reference/wrap/wrap.json
@@ -90,6 +90,9 @@
             "fortran": true
         }
     },
+    "symtab": {
+        "Class1": "Class1"
+    },
     "types": {
         "Class1": {
             "LUA_pop": "\t({LUA_userdata_type} *)\t luaL_checkudata(\t{LUA_state_var}, 1, \"{LUA_metadata}\")",

--- a/shroud/declast.py
+++ b/shroud/declast.py
@@ -2131,6 +2131,8 @@ class TemplateParam(Node):
 class Typedef(Node):
     """
     Added to SymbolTable to record a typedef name.
+
+    Used with 'int', 'std::string', ...
     """
     def __init__(self, name, ntypemap):
         self.name = name
@@ -2372,12 +2374,15 @@ def symtab_to_dict(node):
     Used for debugging/testing.
     """
     d = dict(cls=node.__class__.__name__)
-    d["prefix"] = node.scope_prefix
-    if node.symbols:
-        symbols = {}
-        for k, v in node.symbols.items():
-            symbols[k] = symtab_to_dict(v)
-        d['symbols'] = symbols
+    if hasattr(node, "symbols"):
+        if node.symbols:
+            symbols = {}
+            for k, v in node.symbols.items():
+                symbols[k] = symtab_to_dict(v)
+            d['symbols'] = symbols
+    if hasattr(node, "typemap"):
+        # Global and Namespace do not have typemaps.
+        d["typemap"] = node.typemap.name
     return d
 
 def check_decl(decl, symtab, trace=False):

--- a/shroud/declast.py
+++ b/shroud/declast.py
@@ -2021,7 +2021,6 @@ class Enum(Node):
         if symtab.language == "cxx":
             symtab.add_child_to_current(self)
             symtab.register_typemap(type_name, ntypemap)
-        symtab.register_typemap(type_name, ntypemap)
         self.typemap = ntypemap
 
         symtab.push_scope(self)
@@ -2066,7 +2065,6 @@ class Struct(Node):
             if symtab.language == "cxx":
                 symtab.add_child_to_current(self)
                 symtab.register_typemap(type_name, ntypemap)
-            symtab.register_typemap("struct-" + type_name, ntypemap)
             self.newtypemap = ntypemap
             self.typemap = ntypemap
         symtab.push_scope(self)
@@ -2401,10 +2399,11 @@ def symtab_to_typemap(node):
     symbols = {}
     if hasattr(node, "symbols"):
         for k, v in node.symbols.items():
-            if k.startswith("enum-"):
-                pass
-            elif k.startswith("struct-"):
-                pass
+            # If a tag exists, just add name of tag.
+            if "enum-" + k in node.symbols:
+                symbols[k] = "enum-" + k
+            elif "struct-" + k in node.symbols:
+                symbols[k] = "struct-" + k
             else:
                 out = symtab_to_typemap(v)
                 if out is not None:

--- a/shroud/declast.py
+++ b/shroud/declast.py
@@ -2353,7 +2353,19 @@ class SymbolTable(object):
         self.add_typedef_by_name("string")
         self.add_typedef_by_name("vector")
         self.restore_depth(depth)
-        
+
+def symtab_to_dict(node):
+    """Return SymbolTable as a dictionary.
+    Used for debugging/testing.
+    """
+    d = dict(cls=node.__class__.__name__)
+    d["prefix"] = node.scope_prefix
+    if node.symbols:
+        symbols = {}
+        for k, v in node.symbols.items():
+            symbols[k] = symtab_to_dict(v)
+        d['symbols'] = symbols
+    return d
 
 def check_decl(decl, symtab, trace=False):
     """ parse expr as a declaration, return list/dict result.

--- a/shroud/main.py
+++ b/shroud/main.py
@@ -195,6 +195,9 @@ def dump_jsonfile(config, logdir, basename, newlibrary):
         user_types = typemap.return_shadow_types(typemaps)
         if user_types:
             out["types"] = todict.to_dict(user_types)
+        user_types = declast.symtab_to_typemap(newlibrary.symtab.scope_stack[0])
+        if user_types:
+            out["symtab"] = todict.to_dict(user_types)
         # Clean out this info since it's the same for all tests.
         # XXX - anytime a new fmt or option is added it changes all tests.
         del out['library']['zz_fmtdict']

--- a/shroud/todict.py
+++ b/shroud/todict.py
@@ -521,72 +521,7 @@ def to_dict(node, labelast=False):
     visitor = ToDict(labelast)
     return visitor.visit(node)
 
-
 ######################################################################
-
-blanks = "                                       "
-class PrintScope(visitor.Visitor):
-    """Print tree of symbol table AstNodes to verify the structure.
-
-    Node: children are the symbol table type nodes.
-    """
-    def __init__(self):
-        super(PrintScope, self).__init__()
-        self.nindent = 0
-
-    def get_indent(self):
-        return blanks[:self.nindent]
-    indent = property(get_indent)
-
-    def visit_list(self, node):
-        self.nindent += 2
-        for n in node:
-            self.visit(n)
-        self.nindent -= 2
-
-    def visit_CXXClass(self, node):
-        print("{}class {}".format(self.indent, node.scope_prefix))
-        self.visit(node.children)
-
-    def visit_Enum(self, node):
-        print("{}enum {}".format(self.indent, node.name))
-#        self.visit(node.children)
-
-    def visit_Global(self, node):
-        print("{}{}".format(self.indent, node.name))
-        self.visit(node.children)
-
-    def visit_Declaration(self, node):
-        print("{}{}".format(self.indent, str(node)))
-        
-    def visit_Namespace(self, node):
-        print("{}namespace {}".format(self.indent, node.name))
-        self.visit(node.children)
-
-    def visit_Struct(self, node):
-        print("{}struct {}".format(self.indent, node.scope_prefix))
-        self.visit(node.children)
-
-    def visit_Template(self, node):
-        print("{}template {}".format(self.indent, node.scope_prefix))
-        self.nindent += 2
-        self.visit(node.decl)
-        self.nindent -= 2
-
-    def visit_Typedef(self, node):
-        print("{}typedef {}".format(self.indent, node.name))
-#        print("{}typedef {}".format(self.indent, node.scope_prefix))
-
-def print_scope(node):
-    """Print nested scopes.
-    Useful for debugging.
-    """
-    visitor = PrintScope()
-    return visitor.visit(node)
-
-
-######################################################################
-
 
 class PrintNode(visitor.Visitor):
     """Unparse Nodes.

--- a/shroud/typemap.py
+++ b/shroud/typemap.py
@@ -1399,11 +1399,7 @@ def return_shadow_types(typemaps):  # typemaps -> dict
     for key, ntypemap in typemaps.items():
         if ntypemap.name == "--template-parameter--":
             continue
-        elif key.startswith("struct-"):
-            continue  # tag vs type name
         elif ntypemap.sgroup in ["shadow", "struct", "template", "enum"]:
-            dct[key] = ntypemap
-        elif key.startswith("enum-"):
             dct[key] = ntypemap
         elif hasattr(ntypemap, "is_enum"):
             dct[key] = ntypemap

--- a/shroud/typemap.py
+++ b/shroud/typemap.py
@@ -1405,4 +1405,6 @@ def return_shadow_types(typemaps):  # typemaps -> dict
             dct[key] = ntypemap
         elif key.startswith("enum-"):
             dct[key] = ntypemap
+        elif hasattr(ntypemap, "is_enum"):
+            dct[key] = ntypemap
     return dct

--- a/tests/check_decl.output
+++ b/tests/check_decl.output
@@ -25,7 +25,8 @@ stmts:
   - double
   typemap_name: double
 XXXX SymbolTable
-***global***
+cls: Global
+prefix: ''
 
 XXXXXXXXXXXXXXXXXXXX
 # variable pointer declarations
@@ -66,7 +67,8 @@ stmts:
   - int
   typemap_name: int
 XXXX SymbolTable
-***global***
+cls: Global
+prefix: ''
 
 XXXXXXXXXXXXXXXXXXXX
 # Class statement
@@ -85,8 +87,12 @@ stmts:
   - class Class1
   typemap_name: Class1
 XXXX SymbolTable
-***global***
-  class Class1::
+cls: Global
+prefix: ''
+symbols:
+  Class1:
+    cls: CXXClass
+    prefix: 'Class1::'
 
 XXXXXXXXXXXXXXXXXXXX
 # Structure for C++
@@ -160,8 +166,12 @@ stmts:
   - void
   typemap_name: void
 XXXX SymbolTable
-***global***
-  struct Point::
+cls: Global
+prefix: ''
+symbols:
+  Point:
+    cls: Struct
+    prefix: 'Point::'
 
 XXXXXXXXXXXXXXXXXXXX
 # Recursive structure
@@ -197,7 +207,8 @@ stmts:
   - struct list_s
   typemap_name: list_s
 XXXX SymbolTable
-***global***
+cls: Global
+prefix: ''
 
 XXXXXXXXXXXXXXXXXXXX
 # Recursive structure
@@ -256,8 +267,12 @@ stmts:
   - struct list_s
   typemap_name: list_s
 XXXX SymbolTable
-***global***
-  struct list_s::
+cls: Global
+prefix: ''
+symbols:
+  list_s:
+    cls: Struct
+    prefix: 'list_s::'
 
 XXXXXXXXXXXXXXXXXXXX
 # enumerations
@@ -289,7 +304,8 @@ stmts:
   - enum Color
   typemap_name: enum-Color
 XXXX SymbolTable
-***global***
+cls: Global
+prefix: ''
 
 XXXXXXXXXXXXXXXXXXXX
 # enumerations
@@ -362,8 +378,12 @@ stmts:
   - void
   typemap_name: void
 XXXX SymbolTable
-***global***
-  enum Color
+cls: Global
+prefix: ''
+symbols:
+  Color:
+    cls: Enum
+    prefix: 'Color::'
 
 XXXXXXXXXXXXXXXXXXXX
 # template
@@ -429,8 +449,12 @@ stmts:
     typemap_name: int
   typemap_name: user
 XXXX SymbolTable
-***global***
-  class user::
+cls: Global
+prefix: ''
+symbols:
+  user:
+    cls: CXXClass
+    prefix: 'user::'
 
 XXXXXXXXXXXXXXXXXXXX
 # nested namespace
@@ -466,9 +490,16 @@ stmts:
       - int
       typemap_name: int
 XXXX SymbolTable
-***global***
-  namespace ns1
-    namespace ns2
+cls: Global
+prefix: ''
+symbols:
+  ns1:
+    cls: Namespace
+    prefix: 'ns1::'
+    symbols:
+      ns2:
+        cls: Namespace
+        prefix: 'ns1::ns2::'
 
 XXXXXXXXXXXXXXXXXXXX
 # class in namespace
@@ -501,6 +532,13 @@ stmts:
     - class name
     typemap_name: ns::name
 XXXX SymbolTable
-***global***
-  namespace ns
-    class ns::name::
+cls: Global
+prefix: ''
+symbols:
+  ns:
+    cls: Namespace
+    prefix: 'ns::'
+    symbols:
+      name:
+        cls: CXXClass
+        prefix: 'ns::name::'

--- a/tests/check_decl.output
+++ b/tests/check_decl.output
@@ -1,8 +1,58 @@
 
 XXXXXXXXXXXXXXXXXXXX
-# variable declarations
+# create_std
 XXXX CODE
 
+XXXX PRINT_NODE
+
+XXXX AST
+stmts: []
+XXXX SymbolTable
+cls: Global
+symbols:
+  MPI_Comm:
+    cls: Typedef
+    typemap: MPI_Comm
+  int16_t:
+    cls: Typedef
+    typemap: int16_t
+  int32_t:
+    cls: Typedef
+    typemap: int32_t
+  int64_t:
+    cls: Typedef
+    typemap: int64_t
+  int8_t:
+    cls: Typedef
+    typemap: int8_t
+  size_t:
+    cls: Typedef
+    typemap: size_t
+  std:
+    cls: Namespace
+    symbols:
+      string:
+        cls: Typedef
+        typemap: std::string
+      vector:
+        cls: Typedef
+        typemap: std::vector
+  uint16_t:
+    cls: Typedef
+    typemap: uint16_t
+  uint32_t:
+    cls: Typedef
+    typemap: uint32_t
+  uint64_t:
+    cls: Typedef
+    typemap: uint64_t
+  uint8_t:
+    cls: Typedef
+    typemap: uint8_t
+
+XXXXXXXXXXXXXXXXXXXX
+# variable declarations
+XXXX CODE
 int i;
 const double d;
 XXXX PRINT_NODE
@@ -26,7 +76,6 @@ stmts:
   typemap_name: double
 XXXX SymbolTable
 cls: Global
-prefix: ''
 
 XXXXXXXXXXXXXXXXXXXX
 # variable pointer declarations
@@ -68,7 +117,6 @@ stmts:
   typemap_name: int
 XXXX SymbolTable
 cls: Global
-prefix: ''
 
 XXXXXXXXXXXXXXXXXXXX
 # Class statement
@@ -88,11 +136,10 @@ stmts:
   typemap_name: Class1
 XXXX SymbolTable
 cls: Global
-prefix: ''
 symbols:
   Class1:
     cls: CXXClass
-    prefix: 'Class1::'
+    typemap: Class1
 
 XXXXXXXXXXXXXXXXXXXX
 # Structure for C++
@@ -167,14 +214,13 @@ stmts:
   typemap_name: void
 XXXX SymbolTable
 cls: Global
-prefix: ''
 symbols:
   Point:
     cls: Struct
-    prefix: 'Point::'
+    typemap: Point
   struct-Point:
     cls: Struct
-    prefix: 'Point::'
+    typemap: Point
 
 XXXXXXXXXXXXXXXXXXXX
 # Recursive structure
@@ -219,11 +265,10 @@ stmts:
   typemap_name: list_s
 XXXX SymbolTable
 cls: Global
-prefix: ''
 symbols:
   struct-list_s:
     cls: Struct
-    prefix: 'list_s::'
+    typemap: list_s
 
 XXXXXXXXXXXXXXXXXXXX
 # Recursive structure
@@ -283,14 +328,13 @@ stmts:
   typemap_name: list_s
 XXXX SymbolTable
 cls: Global
-prefix: ''
 symbols:
   list_s:
     cls: Struct
-    prefix: 'list_s::'
+    typemap: list_s
   struct-list_s:
     cls: Struct
-    prefix: 'list_s::'
+    typemap: list_s
 
 XXXXXXXXXXXXXXXXXXXX
 # enumerations
@@ -323,11 +367,10 @@ stmts:
   typemap_name: enum-Color
 XXXX SymbolTable
 cls: Global
-prefix: ''
 symbols:
   enum-Color:
     cls: Enum
-    prefix: 'Color::'
+    typemap: enum-Color
 
 XXXXXXXXXXXXXXXXXXXX
 # enumerations
@@ -401,14 +444,13 @@ stmts:
   typemap_name: void
 XXXX SymbolTable
 cls: Global
-prefix: ''
 symbols:
   Color:
     cls: Enum
-    prefix: 'Color::'
+    typemap: enum-Color
   enum-Color:
     cls: Enum
-    prefix: 'Color::'
+    typemap: enum-Color
 
 XXXXXXXXXXXXXXXXXXXX
 # template
@@ -475,11 +517,10 @@ stmts:
   typemap_name: user
 XXXX SymbolTable
 cls: Global
-prefix: ''
 symbols:
   user:
     cls: CXXClass
-    prefix: 'user::'
+    typemap: user
 
 XXXXXXXXXXXXXXXXXXXX
 # nested namespace
@@ -516,15 +557,12 @@ stmts:
       typemap_name: int
 XXXX SymbolTable
 cls: Global
-prefix: ''
 symbols:
   ns1:
     cls: Namespace
-    prefix: 'ns1::'
     symbols:
       ns2:
         cls: Namespace
-        prefix: 'ns1::ns2::'
 
 XXXXXXXXXXXXXXXXXXXX
 # class in namespace
@@ -558,12 +596,10 @@ stmts:
     typemap_name: ns::name
 XXXX SymbolTable
 cls: Global
-prefix: ''
 symbols:
   ns:
     cls: Namespace
-    prefix: 'ns::'
     symbols:
       name:
         cls: CXXClass
-        prefix: 'ns::name::'
+        typemap: ns::name

--- a/tests/check_decl.output
+++ b/tests/check_decl.output
@@ -184,11 +184,13 @@ XXXX CODE
 struct list_s {
   struct list_s *next;
 };
+struct list_s var1;
 XXXX PRINT_NODE
 struct list_s{
 struct list_s * next;
 }
 ;
+struct list_s var1;
 
 XXXX AST
 stmts:
@@ -206,6 +208,12 @@ stmts:
       typemap_name: list_s
     name: list_s
     typemap_name: list_s
+  specifier:
+  - struct list_s
+  typemap_name: list_s
+- _ast: Declaration
+  declarator:
+    name: var1
   specifier:
   - struct list_s
   typemap_name: list_s

--- a/tests/check_decl.output
+++ b/tests/check_decl.output
@@ -172,6 +172,9 @@ symbols:
   Point:
     cls: Struct
     prefix: 'Point::'
+  struct-Point:
+    cls: Struct
+    prefix: 'Point::'
 
 XXXXXXXXXXXXXXXXXXXX
 # Recursive structure
@@ -209,6 +212,10 @@ stmts:
 XXXX SymbolTable
 cls: Global
 prefix: ''
+symbols:
+  struct-list_s:
+    cls: Struct
+    prefix: 'list_s::'
 
 XXXXXXXXXXXXXXXXXXXX
 # Recursive structure
@@ -273,6 +280,9 @@ symbols:
   list_s:
     cls: Struct
     prefix: 'list_s::'
+  struct-list_s:
+    cls: Struct
+    prefix: 'list_s::'
 
 XXXXXXXXXXXXXXXXXXXX
 # enumerations
@@ -306,6 +316,10 @@ stmts:
 XXXX SymbolTable
 cls: Global
 prefix: ''
+symbols:
+  enum-Color:
+    cls: Enum
+    prefix: 'Color::'
 
 XXXXXXXXXXXXXXXXXXXX
 # enumerations
@@ -382,6 +396,9 @@ cls: Global
 prefix: ''
 symbols:
   Color:
+    cls: Enum
+    prefix: 'Color::'
+  enum-Color:
     cls: Enum
     prefix: 'Color::'
 

--- a/tests/check_decl.output
+++ b/tests/check_decl.output
@@ -358,19 +358,19 @@ stmts:
     name: Color
   specifier:
   - enum Color
-  typemap_name: enum-Color
+  typemap_name: Color
 - _ast: Declaration
   declarator:
     name: global
   specifier:
   - enum Color
-  typemap_name: enum-Color
+  typemap_name: Color
 XXXX SymbolTable
 cls: Global
 symbols:
   enum-Color:
     cls: Enum
-    typemap: enum-Color
+    typemap: Color
 
 XXXXXXXXXXXXXXXXXXXX
 # enumerations
@@ -409,20 +409,20 @@ stmts:
     name: Color
   specifier:
   - enum Color
-  typemap_name: enum-Color
+  typemap_name: Color
 - _ast: Declaration
   declarator:
     name: global
   specifier:
   - enum Color
-  typemap_name: enum-Color
+  typemap_name: Color
 - _ast: Declaration
   declarator:
     name: flag
   init: RED
   specifier:
   - Color
-  typemap_name: enum-Color
+  typemap_name: Color
 - _ast: Declaration
   declarator:
     name: func1
@@ -432,13 +432,13 @@ stmts:
       name: arg1
     specifier:
     - enum Color
-    typemap_name: enum-Color
+    typemap_name: Color
   - _ast: Declaration
     declarator:
       name: arg2
     specifier:
     - Color
-    typemap_name: enum-Color
+    typemap_name: Color
   specifier:
   - void
   typemap_name: void
@@ -447,10 +447,10 @@ cls: Global
 symbols:
   Color:
     cls: Enum
-    typemap: enum-Color
+    typemap: Color
   enum-Color:
     cls: Enum
-    typemap: enum-Color
+    typemap: Color
 
 XXXXXXXXXXXXXXXXXXXX
 # template

--- a/tests/check_decl.py
+++ b/tests/check_decl.py
@@ -25,6 +25,8 @@ import pprint
 import sys
 
 lines = """
+# create_std
+--------------------
 # variable declarations
 int i;
 const double d;
@@ -130,8 +132,8 @@ template<typename T> struct structAsClass
 Xlines = """
 namespace ns {
 struct tag_s { int i; };
-struct tag_s var1;
-#typedef struct tag_s tagname;
+#struct tag_s var1;
+typedef struct tag_s tagname;
 #void caller(tagname *arg1);
 }
 --------------------
@@ -143,11 +145,14 @@ def test_block(comments, code, symtab):
     print("")
     print("XXXXXXXXXXXXXXXXXXXX")
     language = "cxx"
+    create_std = False
     for cmt in comments:
         if cmt.find("language=c++") != -1:
             language = "cxx"
         elif cmt.find("language=c") != -1:
             language = "c"
+        elif cmt.find("create_std") != -1:
+            create_std = True
         print(f"{cmt}")
     trace = True
     trace = False
@@ -155,6 +160,9 @@ def test_block(comments, code, symtab):
     print("XXXX CODE")
     print(decl)
     symtab = declast.SymbolTable(language=language)
+    if create_std:
+        symtab.create_std_names()
+        symtab.create_std_namespace()
     try:
         ast = declast.Parser(decl, symtab, trace).top_level()
         asdict = todict.to_dict(ast, labelast=True)

--- a/tests/check_decl.py
+++ b/tests/check_decl.py
@@ -162,7 +162,8 @@ def test_block(comments, code, symtab):
         yaml.safe_dump(asdict, sys.stdout)
 
         print("XXXX SymbolTable")
-        todict.print_scope(symtab.scope_stack[0])
+        symbols = declast.symtab_to_dict(symtab.scope_stack[0])
+        yaml.safe_dump(symbols, sys.stdout)
     except RuntimeError as err:
         print(err)
 

--- a/tests/check_decl.py
+++ b/tests/check_decl.py
@@ -48,6 +48,7 @@ void func1(struct Point arg1, Point arg2);
 struct list_s {
   struct list_s *next;
 };
+struct list_s var1;
 #  } listvar;
 --------------------
 # Recursive structure
@@ -127,8 +128,12 @@ template<typename T> struct structAsClass
 """
 
 Xlines = """
-# Class statement
-class Class1;
+namespace ns {
+struct tag_s { int i; };
+struct tag_s var1;
+#typedef struct tag_s tagname;
+#void caller(tagname *arg1);
+}
 --------------------
 """
 

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -82,7 +82,7 @@ class Namespace(unittest.TestCase):
         # test enum
         lib = ast.LibraryNode()
         enum1 = lib.add_enum("enum Enum1 {}")
-        self.assertEqual("enum-Enum1", enum1.typemap.name)
+        self.assertEqual("Enum1", enum1.typemap.name)
         self.assertEqual("Enum1::", enum1.scope)
         lib.symtab.pop_scope()
 
@@ -91,7 +91,7 @@ class Namespace(unittest.TestCase):
 
         ns = lib.add_namespace("namespace ns1")
         enum2 = ns.add_enum("enum Enum2 {}")
-        self.assertEqual("enum-ns1::Enum2", enum2.typemap.name)
+        self.assertEqual("ns1::Enum2", enum2.typemap.name)
         self.assertEqual("ns1::Enum2::", enum2.scope)
         lib.symtab.pop_scope()
 
@@ -112,7 +112,7 @@ class Namespace(unittest.TestCase):
         # Add enum to class
         class1 = ns.add_class("class Class1")
         enum3 = class1.add_enum("enum Enum3 {}")
-        self.assertEqual("enum-ns1::Class1::Enum3", enum3.typemap.name)
+        self.assertEqual("ns1::Class1::Enum3", enum3.typemap.name)
         self.assertEqual("ns1::Class1::Enum3::", enum3.scope)
         node = class1.qualified_lookup("Enum3")
         self.assertEqual(enum3.ast, node)

--- a/tests/test_declast.py
+++ b/tests/test_declast.py
@@ -1479,7 +1479,7 @@ class CheckEnum(unittest.TestCase):
                     ],
                 },
                 'specifier': ['enum Color'],
-                'typemap_name': 'enum-Color'
+                'typemap_name': 'Color'
             }
         )
 


### PR DESCRIPTION
* `struct` and `enum` are removed from the typemaps. They now are accessed from SymbolTable.
* Makes it possible to lookup tags via `unqualified_lookup`.
* Dump symtab into JSON file.
