### PR TITLE
Fix issues in util.un_camel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   This allows ``typedef struct tag name`` to be parsed properly.
 - Create type table earlier in parse. This allows recursive structs such as
   ``struct point { struct point *next; }`` to be parsed.
+- Fixed issues in converting function names from CamelCase
+  * Remove redundant underscore
+    ``Create_Cstruct_as_class`` was ``c_create__cstruct_as_class`` now ``c_create_cstruct_as_class``
+  * Add missing underscore
+    ``AFunction`` was ``afunction`` now ``a_function``.
 
 ### Changed
 - The *C_memory_dtor_function* is now written to the utility file,

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -591,6 +591,10 @@ F_capsule_data_type_template
 F_capsule_type_template
     ``{C_prefix}SHROUD_capsule``
 
+F_derived_name_template
+    Defaults to ``{underscore_name}``.
+    Other useful values are ``{lower_name}`` and ``{upper_name}``.
+    
 F_enum_member_template
     Name of enumeration member in Fortran wrapper.
     ``{F_name_scope}{enum_member_lower}``
@@ -1083,7 +1087,7 @@ flat_name
 
 C_enum_member
     C name for enum member.
-    Computed from *C_enum_member_template*.
+    Computed from option *C_enum_member_template*.
 
 C_value
     Evalued value of enumeration.
@@ -1101,7 +1105,7 @@ F_scope_name
 
 F_enum_member
     Fortran name for enum member.
-    Computed from *F_enum_member_template*.
+    Computed from option *F_enum_member_template*.
 
 F_value
     Evalued value of enumeration.
@@ -1119,9 +1123,8 @@ C_impl_file
     Defaulted from expansion of option *C_impl_filename_class_template*.
 
 F_derived_name
-   Name of Fortran derived type for this class.
-   Defaults to the value *cxx_class* (usually the C++ class name) converted
-   to lowercase.
+    Name of Fortran derived type for this class.
+    Computed from option *F_derived_name_template*.
 
 F_name_assign
     Name of method that controls assignment of shadow types.

--- a/regression/reference/arrayclass/arrayclass.json
+++ b/regression/reference/arrayclass/arrayclass.json
@@ -3533,7 +3533,10 @@
                     "cxx_type": "ArrayWrapper",
                     "f_capsule_data_type": "ARR_SHROUD_capsule_data",
                     "file_scope": "ArrayWrapper",
-                    "hnamefunc0": "capsule_data_helper"
+                    "hnamefunc0": "capsule_data_helper",
+                    "lower_name": "arraywrapper",
+                    "underscore_name": "array_wrapper",
+                    "upper_name": "ARRAYWRAPPER"
                 }
             }
         ],

--- a/regression/reference/classes/classes.json
+++ b/regression/reference/classes/classes.json
@@ -2558,7 +2558,10 @@
                     "cxx_type": "Class1",
                     "f_capsule_data_type": "CLA_SHROUD_capsule_data",
                     "file_scope": "Class1",
-                    "hnamefunc0": "capsule_data_helper"
+                    "hnamefunc0": "capsule_data_helper",
+                    "lower_name": "class1",
+                    "underscore_name": "class1",
+                    "upper_name": "CLASS1"
                 }
             },
             {
@@ -2817,7 +2820,10 @@
                     "cxx_type": "Class2",
                     "f_capsule_data_type": "CLA_SHROUD_capsule_data",
                     "file_scope": "Class2",
-                    "hnamefunc0": "capsule_data_helper"
+                    "hnamefunc0": "capsule_data_helper",
+                    "lower_name": "class2",
+                    "underscore_name": "class2",
+                    "upper_name": "CLASS2"
                 }
             },
             {
@@ -2983,7 +2989,10 @@
                     "cxx_type": "Singleton",
                     "f_capsule_data_type": "CLA_SHROUD_capsule_data",
                     "file_scope": "Singleton",
-                    "hnamefunc0": "capsule_data_helper"
+                    "hnamefunc0": "capsule_data_helper",
+                    "lower_name": "singleton",
+                    "underscore_name": "singleton",
+                    "upper_name": "SINGLETON"
                 }
             },
             {
@@ -3263,7 +3272,10 @@
                     "cxx_type": "Shape",
                     "f_capsule_data_type": "CLA_SHROUD_capsule_data",
                     "file_scope": "Shape",
-                    "hnamefunc0": "capsule_data_helper"
+                    "hnamefunc0": "capsule_data_helper",
+                    "lower_name": "shape",
+                    "underscore_name": "shape",
+                    "upper_name": "SHAPE"
                 }
             },
             {
@@ -3438,7 +3450,10 @@
                     "cxx_type": "Circle",
                     "f_capsule_data_type": "CLA_SHROUD_capsule_data",
                     "file_scope": "Circle",
-                    "hnamefunc0": "capsule_data_helper"
+                    "hnamefunc0": "capsule_data_helper",
+                    "lower_name": "circle",
+                    "underscore_name": "circle",
+                    "upper_name": "CIRCLE"
                 }
             },
             {
@@ -4341,7 +4356,10 @@
                     "cxx_type": "Data",
                     "f_capsule_data_type": "CLA_SHROUD_capsule_data",
                     "file_scope": "Data",
-                    "hnamefunc0": "capsule_data_helper"
+                    "hnamefunc0": "capsule_data_helper",
+                    "lower_name": "data",
+                    "underscore_name": "data",
+                    "upper_name": "DATA"
                 }
             }
         ],

--- a/regression/reference/clibrary/clibrary.json
+++ b/regression/reference/clibrary/clibrary.json
@@ -61,7 +61,10 @@
                     "class_scope": "array_info::",
                     "cxx_class": "array_info",
                     "cxx_type": "array_info",
-                    "file_scope": "array_info"
+                    "file_scope": "array_info",
+                    "lower_name": "array_info",
+                    "underscore_name": "array_info",
+                    "upper_name": "ARRAY_INFO"
                 }
             }
         ],

--- a/regression/reference/cxxlibrary/cxxlibrary.json
+++ b/regression/reference/cxxlibrary/cxxlibrary.json
@@ -235,7 +235,10 @@
                     "class_scope": "Cstruct1_cls::",
                     "cxx_class": "Cstruct1_cls",
                     "cxx_type": "Cstruct1_cls",
-                    "file_scope": "Cstruct1_cls"
+                    "file_scope": "Cstruct1_cls",
+                    "lower_name": "cstruct1_cls",
+                    "underscore_name": "cstruct1_cls",
+                    "upper_name": "CSTRUCT1_CLS"
                 }
             }
         ],
@@ -2141,7 +2144,10 @@
                             "class_scope": "Cstruct1::",
                             "cxx_class": "Cstruct1",
                             "cxx_type": "Cstruct1",
-                            "file_scope": "structns_Cstruct1"
+                            "file_scope": "structns_Cstruct1",
+                            "lower_name": "cstruct1",
+                            "underscore_name": "cstruct1",
+                            "upper_name": "CSTRUCT1"
                         }
                     }
                 ],

--- a/regression/reference/example/example.json
+++ b/regression/reference/example/example.json
@@ -1982,7 +1982,10 @@
                                     "cxx_type": "ExClass1",
                                     "f_capsule_data_type": "AA_SHROUD_capsule_data",
                                     "file_scope": "example_nested_ExClass1",
-                                    "hnamefunc0": "capsule_data_helper"
+                                    "hnamefunc0": "capsule_data_helper",
+                                    "lower_name": "exclass1",
+                                    "underscore_name": "ex_class1",
+                                    "upper_name": "EXCLASS1"
                                 }
                             },
                             {
@@ -2012,7 +2015,10 @@
                                             "class_scope": "ExClass2Nested::",
                                             "cxx_class": "ExClass2Nested",
                                             "cxx_type": "ExClass2Nested",
-                                            "file_scope": "example_nested_ExClass2_ExClass2Nested"
+                                            "file_scope": "example_nested_ExClass2_ExClass2Nested",
+                                            "lower_name": "exclass2nested",
+                                            "underscore_name": "ex_class2_nested",
+                                            "upper_name": "EXCLASS2NESTED"
                                         }
                                     }
                                 ],
@@ -6233,7 +6239,10 @@
                                     "cxx_type": "ExClass2",
                                     "f_capsule_data_type": "AA_SHROUD_capsule_data",
                                     "file_scope": "example_nested_ExClass2",
-                                    "hnamefunc0": "capsule_data_helper"
+                                    "hnamefunc0": "capsule_data_helper",
+                                    "lower_name": "exclass2",
+                                    "underscore_name": "ex_class2",
+                                    "upper_name": "EXCLASS2"
                                 }
                             }
                         ],

--- a/regression/reference/forward/forward.json
+++ b/regression/reference/forward/forward.json
@@ -52,7 +52,10 @@
                     "cxx_type": "Class3",
                     "f_capsule_data_type": "FOR_SHROUD_capsule_data",
                     "file_scope": "Class3",
-                    "hnamefunc0": "capsule_data_helper"
+                    "hnamefunc0": "capsule_data_helper",
+                    "lower_name": "class3",
+                    "underscore_name": "class3",
+                    "upper_name": "CLASS3"
                 }
             },
             {
@@ -589,7 +592,10 @@
                     "cxx_type": "Class2",
                     "f_capsule_data_type": "FOR_SHROUD_capsule_data",
                     "file_scope": "Class2",
-                    "hnamefunc0": "capsule_data_helper"
+                    "hnamefunc0": "capsule_data_helper",
+                    "lower_name": "class2",
+                    "underscore_name": "class2",
+                    "upper_name": "CLASS2"
                 }
             }
         ],

--- a/regression/reference/generic-cfi/generic.json
+++ b/regression/reference/generic-cfi/generic.json
@@ -36,7 +36,10 @@
                     "cxx_type": "StructAsClass",
                     "f_capsule_data_type": "GEN_SHROUD_capsule_data",
                     "file_scope": "StructAsClass",
-                    "hnamefunc0": "capsule_data_helper"
+                    "hnamefunc0": "capsule_data_helper",
+                    "lower_name": "structasclass",
+                    "underscore_name": "struct_as_class",
+                    "upper_name": "STRUCTASCLASS"
                 }
             }
         ],

--- a/regression/reference/generic/generic.json
+++ b/regression/reference/generic/generic.json
@@ -36,7 +36,10 @@
                     "cxx_type": "StructAsClass",
                     "f_capsule_data_type": "GEN_SHROUD_capsule_data",
                     "file_scope": "StructAsClass",
-                    "hnamefunc0": "capsule_data_helper"
+                    "hnamefunc0": "capsule_data_helper",
+                    "lower_name": "structasclass",
+                    "underscore_name": "struct_as_class",
+                    "upper_name": "STRUCTASCLASS"
                 }
             }
         ],

--- a/regression/reference/include/include.json
+++ b/regression/reference/include/include.json
@@ -242,7 +242,10 @@
                     "cxx_type": "Class2",
                     "f_capsule_data_type": "LIB_SHROUD_capsule_data",
                     "file_scope": "Class2",
-                    "hnamefunc0": "capsule_data_helper"
+                    "hnamefunc0": "capsule_data_helper",
+                    "lower_name": "class2",
+                    "underscore_name": "class2",
+                    "upper_name": "CLASS2"
                 }
             }
         ],
@@ -501,7 +504,10 @@
                             "cxx_type": "Class1",
                             "f_capsule_data_type": "LIB_SHROUD_capsule_data",
                             "file_scope": "three_Class1",
-                            "hnamefunc0": "capsule_data_helper"
+                            "hnamefunc0": "capsule_data_helper",
+                            "lower_name": "class1",
+                            "underscore_name": "class1",
+                            "upper_name": "CLASS1"
                         }
                     }
                 ],
@@ -611,7 +617,10 @@
                             "cxx_type": "class0",
                             "f_capsule_data_type": "LIB_SHROUD_capsule_data",
                             "file_scope": "outer1_class0",
-                            "hnamefunc0": "capsule_data_helper"
+                            "hnamefunc0": "capsule_data_helper",
+                            "lower_name": "class0",
+                            "underscore_name": "class0",
+                            "upper_name": "CLASS0"
                         }
                     }
                 ],
@@ -770,7 +779,10 @@
                             "cxx_type": "class0",
                             "f_capsule_data_type": "LIB_SHROUD_capsule_data",
                             "file_scope": "outer2_class0",
-                            "hnamefunc0": "capsule_data_helper"
+                            "hnamefunc0": "capsule_data_helper",
+                            "lower_name": "class0",
+                            "underscore_name": "class0",
+                            "upper_name": "CLASS0"
                         }
                     }
                 ],

--- a/regression/reference/names/names.json
+++ b/regression/reference/names/names.json
@@ -50,7 +50,10 @@
                     "cxx_type": "Names2",
                     "f_capsule_data_type": "TES_SHROUD_capsule_data",
                     "file_scope": "Names2",
-                    "hnamefunc0": "capsule_data_helper"
+                    "hnamefunc0": "capsule_data_helper",
+                    "lower_name": "names2",
+                    "underscore_name": "names2",
+                    "upper_name": "NAMES2"
                 }
             },
             {
@@ -130,7 +133,10 @@
                     "cxx_type": "twoTs<int, long>",
                     "f_capsule_data_type": "TES_SHROUD_capsule_data",
                     "file_scope": "twoTs_0",
-                    "hnamefunc0": "capsule_data_helper"
+                    "hnamefunc0": "capsule_data_helper",
+                    "lower_name": "twots",
+                    "underscore_name": "two_ts",
+                    "upper_name": "TWOTS"
                 }
             },
             {
@@ -211,7 +217,10 @@
                     "f_capsule_data_type": "TES_SHROUD_capsule_data",
                     "file_scope": "twoTs_instantiation4",
                     "hnamefunc0": "capsule_data_helper",
-                    "template_suffix": "_instantiation4"
+                    "lower_name": "twots",
+                    "template_suffix": "_instantiation4",
+                    "underscore_name": "two_ts",
+                    "upper_name": "TWOTS"
                 }
             },
             {
@@ -254,7 +263,10 @@
                     "cxx_type": "Cstruct_as_class",
                     "f_capsule_data_type": "TES_SHROUD_capsule_data",
                     "file_scope": "Cstruct_as_class",
-                    "hnamefunc0": "capsule_data_helper"
+                    "hnamefunc0": "capsule_data_helper",
+                    "lower_name": "cstruct_as_class",
+                    "underscore_name": "cstruct_as_class",
+                    "upper_name": "CSTRUCT_AS_CLASS"
                 }
             },
             {
@@ -299,7 +311,10 @@
                     "cxx_type": "Cstruct_as_subclass",
                     "f_capsule_data_type": "TES_SHROUD_capsule_data",
                     "file_scope": "Cstruct_as_subclass",
-                    "hnamefunc0": "capsule_data_helper"
+                    "hnamefunc0": "capsule_data_helper",
+                    "lower_name": "cstruct_as_subclass",
+                    "underscore_name": "cstruct_as_subclass",
+                    "upper_name": "CSTRUCT_AS_SUBCLASS"
                 }
             }
         ],
@@ -3359,7 +3374,10 @@
                             "cxx_type": "Names",
                             "f_capsule_data_type": "TES_SHROUD_capsule_data",
                             "file_scope": "ns0_Names",
-                            "hnamefunc0": "capsule_data_helper"
+                            "hnamefunc0": "capsule_data_helper",
+                            "lower_name": "names",
+                            "underscore_name": "names",
+                            "upper_name": "NAMES"
                         }
                     }
                 ],
@@ -3548,7 +3566,10 @@
                             "cxx_class": "ImplWorker1",
                             "cxx_type": "ImplWorker1",
                             "file_scope": "internal_ImplWorker1",
-                            "template_suffix": "_instantiation3"
+                            "lower_name": "implworker1",
+                            "template_suffix": "_instantiation3",
+                            "underscore_name": "impl_worker1",
+                            "upper_name": "IMPLWORKER1"
                         }
                     }
                 ],
@@ -3677,7 +3698,10 @@
                             "cxx_type": "vector<int>",
                             "f_capsule_data_type": "TES_SHROUD_capsule_data",
                             "file_scope": "std_vector_int",
-                            "hnamefunc0": "capsule_data_helper"
+                            "hnamefunc0": "capsule_data_helper",
+                            "lower_name": "vector",
+                            "underscore_name": "vector",
+                            "upper_name": "VECTOR"
                         }
                     },
                     {
@@ -3772,7 +3796,10 @@
                             "cxx_type": "vector<double>",
                             "f_capsule_data_type": "TES_SHROUD_capsule_data",
                             "file_scope": "std_vector_double",
-                            "hnamefunc0": "capsule_data_helper"
+                            "hnamefunc0": "capsule_data_helper",
+                            "lower_name": "vector",
+                            "underscore_name": "vector",
+                            "upper_name": "VECTOR"
                         }
                     },
                     {
@@ -3868,7 +3895,10 @@
                             "f_capsule_data_type": "TES_SHROUD_capsule_data",
                             "file_scope": "std_vector_instantiation5",
                             "hnamefunc0": "capsule_data_helper",
-                            "template_suffix": "_instantiation5"
+                            "lower_name": "vector",
+                            "template_suffix": "_instantiation5",
+                            "underscore_name": "vector",
+                            "upper_name": "VECTOR"
                         }
                     },
                     {
@@ -3963,7 +3993,10 @@
                             "cxx_type": "vector<internal::ImplWorker1>",
                             "f_capsule_data_type": "TES_SHROUD_capsule_data",
                             "file_scope": "std_vector_instantiation3",
-                            "hnamefunc0": "capsule_data_helper"
+                            "hnamefunc0": "capsule_data_helper",
+                            "lower_name": "vector",
+                            "underscore_name": "vector",
+                            "upper_name": "VECTOR"
                         }
                     }
                 ],
@@ -4076,7 +4109,10 @@
                             "cxx_type": "Class1",
                             "f_capsule_data_type": "TES_SHROUD_capsule_data",
                             "file_scope": "CAPI_Class1",
-                            "hnamefunc0": "capsule_data_helper"
+                            "hnamefunc0": "capsule_data_helper",
+                            "lower_name": "class1",
+                            "underscore_name": "class1",
+                            "upper_name": "CLASS1"
                         }
                     }
                 ],

--- a/regression/reference/names2/names2.json
+++ b/regression/reference/names2/names2.json
@@ -34,24 +34,24 @@
                     "fortran": true
                 },
                 "zz_fmtdict": {
-                    "C_name": "NAM_afunction",
+                    "C_name": "NAM_a_function",
                     "C_prototype": "void",
                     "C_return_type": "void",
                     "F_C_arguments": "",
-                    "F_C_call": "c_afunction",
-                    "F_C_name": "afunction",
+                    "F_C_call": "c_a_function",
+                    "F_C_name": "a_function",
                     "F_C_subprogram": "subroutine",
                     "F_arguments": "",
-                    "F_name_function": "afunction",
-                    "F_name_generic": "afunction",
-                    "F_name_impl": "afunction",
+                    "F_name_function": "a_function",
+                    "F_name_generic": "a_function",
+                    "F_name_impl": "a_function",
                     "F_subprogram": "subroutine",
                     "function_name": "AFunction",
                     "stmt0": "f_subroutine",
                     "stmt1": "f_subroutine",
                     "stmtc0": "c_subroutine",
                     "stmtc1": "c_subroutine",
-                    "underscore_name": "afunction"
+                    "underscore_name": "a_function"
                 }
             }
         ],

--- a/regression/reference/names2/wrapNames.cpp
+++ b/regression/reference/names2/wrapNames.cpp
@@ -22,11 +22,11 @@ extern "C" {
 // Function:  void AFunction
 // Attrs:     +intent(subroutine)
 // Exact:     c_subroutine
-void NAM_afunction(void)
+void NAM_a_function(void)
 {
-    // splicer begin function.afunction
+    // splicer begin function.a_function
     ignore1::ignore2::AFunction();
-    // splicer end function.afunction
+    // splicer end function.a_function
 }
 
 }  // extern "C"

--- a/regression/reference/names2/wrapNames.h
+++ b/regression/reference/names2/wrapNames.h
@@ -28,7 +28,7 @@ extern "C" {
 // splicer begin C_declarations
 // splicer end C_declarations
 
-void NAM_afunction(void);
+void NAM_a_function(void);
 
 #ifdef __cplusplus
 }

--- a/regression/reference/names2/wrapfnames.f
+++ b/regression/reference/names2/wrapfnames.f
@@ -27,10 +27,10 @@ module worker_names
         ! Attrs:     +intent(subroutine)
         ! Requested: c_subroutine_void_scalar
         ! Match:     c_subroutine
-        subroutine afunction() &
-                bind(C, name="NAM_afunction")
+        subroutine a_function() &
+                bind(C, name="NAM_a_function")
             implicit none
-        end subroutine afunction
+        end subroutine a_function
 
         ! splicer begin additional_interfaces
         ! splicer end additional_interfaces

--- a/regression/reference/namespace/namespace.json
+++ b/regression/reference/namespace/namespace.json
@@ -568,7 +568,10 @@
                             "class_scope": "Cstruct1::",
                             "cxx_class": "Cstruct1",
                             "cxx_type": "Cstruct1",
-                            "file_scope": "outer_Cstruct1"
+                            "file_scope": "outer_Cstruct1",
+                            "lower_name": "cstruct1",
+                            "underscore_name": "cstruct1",
+                            "upper_name": "CSTRUCT1"
                         }
                     }
                 ],
@@ -687,7 +690,10 @@
                             "cxx_type": "ClassWork",
                             "f_capsule_data_type": "NS_SHROUD_capsule_data",
                             "file_scope": "nswork_ClassWork",
-                            "hnamefunc0": "capsule_data_helper"
+                            "hnamefunc0": "capsule_data_helper",
+                            "lower_name": "classwork",
+                            "underscore_name": "class_work",
+                            "upper_name": "CLASSWORK"
                         }
                     }
                 ],

--- a/regression/reference/none/none.json
+++ b/regression/reference/none/none.json
@@ -45,6 +45,7 @@
             "F_create_bufferify_function": true,
             "F_create_generic": true,
             "F_default_args": "generic",
+            "F_derived_name_template": "{lower_name}",
             "F_enum_member_template": "{F_name_scope}{enum_member_lower}",
             "F_flatten_namespace": false,
             "F_force_wrapper": false,

--- a/regression/reference/ownership/ownership.json
+++ b/regression/reference/ownership/ownership.json
@@ -237,7 +237,10 @@
                     "cxx_type": "Class1",
                     "f_capsule_data_type": "OWN_SHROUD_capsule_data",
                     "file_scope": "Class1",
-                    "hnamefunc0": "capsule_data_helper"
+                    "hnamefunc0": "capsule_data_helper",
+                    "lower_name": "class1",
+                    "underscore_name": "class1",
+                    "upper_name": "CLASS1"
                 }
             }
         ],

--- a/regression/reference/preprocess/preprocess.json
+++ b/regression/reference/preprocess/preprocess.json
@@ -333,7 +333,10 @@
                     "cxx_type": "User1",
                     "f_capsule_data_type": "PRE_SHROUD_capsule_data",
                     "file_scope": "User1",
-                    "hnamefunc0": "capsule_data_helper"
+                    "hnamefunc0": "capsule_data_helper",
+                    "lower_name": "user1",
+                    "underscore_name": "user1",
+                    "upper_name": "USER1"
                 }
             },
             {
@@ -551,7 +554,10 @@
                     "cxx_type": "User2",
                     "f_capsule_data_type": "PRE_SHROUD_capsule_data",
                     "file_scope": "User2",
-                    "hnamefunc0": "capsule_data_helper"
+                    "hnamefunc0": "capsule_data_helper",
+                    "lower_name": "user2",
+                    "underscore_name": "user2",
+                    "upper_name": "USER2"
                 }
             }
         ],

--- a/regression/reference/scope/scope.json
+++ b/regression/reference/scope/scope.json
@@ -103,7 +103,10 @@
                     "class_scope": "DataPointer::",
                     "cxx_class": "DataPointer",
                     "cxx_type": "DataPointer",
-                    "file_scope": "ns3_DataPointer"
+                    "file_scope": "ns3_DataPointer",
+                    "lower_name": "datapointer",
+                    "underscore_name": "data_pointer",
+                    "upper_name": "DATAPOINTER"
                 }
             },
             {
@@ -195,7 +198,10 @@
                     "cxx_type": "Class1",
                     "f_capsule_data_type": "SCO_SHROUD_capsule_data",
                     "file_scope": "Class1",
-                    "hnamefunc0": "capsule_data_helper"
+                    "hnamefunc0": "capsule_data_helper",
+                    "lower_name": "class1",
+                    "underscore_name": "class1",
+                    "upper_name": "CLASS1"
                 }
             },
             {
@@ -287,7 +293,10 @@
                     "cxx_type": "Class2",
                     "f_capsule_data_type": "SCO_SHROUD_capsule_data",
                     "file_scope": "Class2",
-                    "hnamefunc0": "capsule_data_helper"
+                    "hnamefunc0": "capsule_data_helper",
+                    "lower_name": "class2",
+                    "underscore_name": "class2",
+                    "upper_name": "CLASS2"
                 }
             }
         ],
@@ -1015,7 +1024,10 @@
                             "class_scope": "DataPointer::",
                             "cxx_class": "DataPointer",
                             "cxx_type": "DataPointer",
-                            "file_scope": "ns1_DataPointer"
+                            "file_scope": "ns1_DataPointer",
+                            "lower_name": "datapointer",
+                            "underscore_name": "data_pointer",
+                            "upper_name": "DATAPOINTER"
                         }
                     }
                 ],
@@ -1632,7 +1644,10 @@
                             "class_scope": "DataPointer::",
                             "cxx_class": "DataPointer",
                             "cxx_type": "DataPointer",
-                            "file_scope": "ns2_DataPointer"
+                            "file_scope": "ns2_DataPointer",
+                            "lower_name": "datapointer",
+                            "underscore_name": "data_pointer",
+                            "upper_name": "DATAPOINTER"
                         }
                     }
                 ],

--- a/regression/reference/struct-c/struct.json
+++ b/regression/reference/struct-c/struct.json
@@ -92,7 +92,10 @@
                     "class_scope": "Cstruct1::",
                     "cxx_class": "Cstruct1",
                     "cxx_type": "Cstruct1",
-                    "file_scope": "Cstruct1"
+                    "file_scope": "Cstruct1",
+                    "lower_name": "cstruct1",
+                    "underscore_name": "cstruct1",
+                    "upper_name": "CSTRUCT1"
                 }
             },
             {
@@ -185,7 +188,10 @@
                     "class_scope": "Cstruct_ptr::",
                     "cxx_class": "Cstruct_ptr",
                     "cxx_type": "Cstruct_ptr",
-                    "file_scope": "Cstruct_ptr"
+                    "file_scope": "Cstruct_ptr",
+                    "lower_name": "cstruct_ptr",
+                    "underscore_name": "cstruct_ptr",
+                    "upper_name": "CSTRUCT_PTR"
                 }
             },
             {
@@ -381,7 +387,10 @@
                     "class_scope": "Cstruct_list::",
                     "cxx_class": "Cstruct_list",
                     "cxx_type": "Cstruct_list",
-                    "file_scope": "Cstruct_list"
+                    "file_scope": "Cstruct_list",
+                    "lower_name": "cstruct_list",
+                    "underscore_name": "cstruct_list",
+                    "upper_name": "CSTRUCT_LIST"
                 }
             },
             {
@@ -522,7 +531,10 @@
                     "class_scope": "Cstruct_numpy::",
                     "cxx_class": "Cstruct_numpy",
                     "cxx_type": "Cstruct_numpy",
-                    "file_scope": "Cstruct_numpy"
+                    "file_scope": "Cstruct_numpy",
+                    "lower_name": "cstruct_numpy",
+                    "underscore_name": "cstruct_numpy",
+                    "upper_name": "CSTRUCT_NUMPY"
                 }
             },
             {
@@ -616,7 +628,10 @@
                     "class_scope": "Arrays1::",
                     "cxx_class": "Arrays1",
                     "cxx_type": "Arrays1",
-                    "file_scope": "Arrays1"
+                    "file_scope": "Arrays1",
+                    "lower_name": "arrays1",
+                    "underscore_name": "arrays1",
+                    "upper_name": "ARRAYS1"
                 }
             },
             {
@@ -1116,7 +1131,10 @@
                     "cxx_type": "Cstruct_as_class",
                     "f_capsule_data_type": "STR_SHROUD_capsule_data",
                     "file_scope": "Cstruct_as_class",
-                    "hnamefunc0": "capsule_data_helper"
+                    "hnamefunc0": "capsule_data_helper",
+                    "lower_name": "cstruct_as_class",
+                    "underscore_name": "cstruct_as_class",
+                    "upper_name": "CSTRUCT_AS_CLASS"
                 }
             },
             {
@@ -1848,7 +1866,10 @@
                     "cxx_type": "Cstruct_as_subclass",
                     "f_capsule_data_type": "STR_SHROUD_capsule_data",
                     "file_scope": "Cstruct_as_subclass",
-                    "hnamefunc0": "capsule_data_helper"
+                    "hnamefunc0": "capsule_data_helper",
+                    "lower_name": "cstruct_as_subclass",
+                    "underscore_name": "cstruct_as_subclass",
+                    "upper_name": "CSTRUCT_AS_SUBCLASS"
                 }
             }
         ],
@@ -4106,25 +4127,25 @@
                     "fortran": true
                 },
                 "zz_fmtdict": {
-                    "C_name": "STR_create__cstruct_as_class",
+                    "C_name": "STR_create_cstruct_as_class",
                     "C_prototype": "STR_Cstruct_as_class * SHC_rv",
                     "C_return_type": "STR_Cstruct_as_class *",
                     "F_C_arguments": "SHT_rv",
-                    "F_C_call": "c_create__cstruct_as_class",
-                    "F_C_name": "c_create__cstruct_as_class",
+                    "F_C_call": "c_create_cstruct_as_class",
+                    "F_C_name": "c_create_cstruct_as_class",
                     "F_C_result_clause": "\fresult(SHT_prv)",
                     "F_C_subprogram": "function",
                     "F_arg_c_call": "SHT_rv%cxxmem",
                     "F_arguments": "",
-                    "F_name_function": "create__cstruct_as_class",
+                    "F_name_function": "create_cstruct_as_class",
                     "F_name_generic": "Cstruct_as_class",
-                    "F_name_impl": "create__cstruct_as_class",
+                    "F_name_impl": "create_cstruct_as_class",
                     "F_result": "SHT_prv",
                     "F_result_clause": "\fresult(SHT_rv)",
                     "F_subprogram": "function",
                     "cxx_rv_decl": "Cstruct_as_class * SHCXX_rv",
                     "function_name": "Create_Cstruct_as_class",
-                    "underscore_name": "create__cstruct_as_class"
+                    "underscore_name": "create_cstruct_as_class"
                 },
                 "zz_fmtresult": {
                     "fmtc": {
@@ -4293,25 +4314,25 @@
                 },
                 "zz_fmtdict": {
                     "C_call_list": "x,\t y",
-                    "C_name": "STR_create__cstruct_as_class_args",
+                    "C_name": "STR_create_cstruct_as_class_args",
                     "C_prototype": "int x,\t int y,\t STR_Cstruct_as_class * SHC_rv",
                     "C_return_type": "STR_Cstruct_as_class *",
                     "F_C_arguments": "x,\t y,\t SHT_rv",
-                    "F_C_call": "c_create__cstruct_as_class_args",
-                    "F_C_name": "c_create__cstruct_as_class_args",
+                    "F_C_call": "c_create_cstruct_as_class_args",
+                    "F_C_name": "c_create_cstruct_as_class_args",
                     "F_C_result_clause": "\fresult(SHT_prv)",
                     "F_C_subprogram": "function",
                     "F_arg_c_call": "x,\t y,\t SHT_rv%cxxmem",
                     "F_arguments": "x,\t y",
-                    "F_name_function": "create__cstruct_as_class_args",
+                    "F_name_function": "create_cstruct_as_class_args",
                     "F_name_generic": "Cstruct_as_class",
-                    "F_name_impl": "create__cstruct_as_class_args",
+                    "F_name_impl": "create_cstruct_as_class_args",
                     "F_result": "SHT_prv",
                     "F_result_clause": "\fresult(SHT_rv)",
                     "F_subprogram": "function",
                     "cxx_rv_decl": "Cstruct_as_class * SHCXX_rv",
                     "function_name": "Create_Cstruct_as_class_args",
-                    "underscore_name": "create__cstruct_as_class_args"
+                    "underscore_name": "create_cstruct_as_class_args"
                 },
                 "zz_fmtresult": {
                     "fmtc": {
@@ -4669,25 +4690,25 @@
                 },
                 "zz_fmtdict": {
                     "C_call_list": "x,\t y,\t z",
-                    "C_name": "STR_create__cstruct_as_subclass_args",
+                    "C_name": "STR_create_cstruct_as_subclass_args",
                     "C_prototype": "int x,\t int y,\t int z,\t STR_Cstruct_as_subclass * SHC_rv",
                     "C_return_type": "STR_Cstruct_as_subclass *",
                     "F_C_arguments": "x,\t y,\t z,\t SHT_rv",
-                    "F_C_call": "c_create__cstruct_as_subclass_args",
-                    "F_C_name": "c_create__cstruct_as_subclass_args",
+                    "F_C_call": "c_create_cstruct_as_subclass_args",
+                    "F_C_name": "c_create_cstruct_as_subclass_args",
                     "F_C_result_clause": "\fresult(SHT_prv)",
                     "F_C_subprogram": "function",
                     "F_arg_c_call": "x,\t y,\t z,\t SHT_rv%cxxmem",
                     "F_arguments": "x,\t y,\t z",
-                    "F_name_function": "create__cstruct_as_subclass_args",
+                    "F_name_function": "create_cstruct_as_subclass_args",
                     "F_name_generic": "Cstruct_as_subclass",
-                    "F_name_impl": "create__cstruct_as_subclass_args",
+                    "F_name_impl": "create_cstruct_as_subclass_args",
                     "F_result": "SHT_prv",
                     "F_result_clause": "\fresult(SHT_rv)",
                     "F_subprogram": "function",
                     "cxx_rv_decl": "Cstruct_as_subclass * SHCXX_rv",
                     "function_name": "Create_Cstruct_as_subclass_args",
-                    "underscore_name": "create__cstruct_as_subclass_args"
+                    "underscore_name": "create_cstruct_as_subclass_args"
                 },
                 "zz_fmtresult": {
                     "fmtc": {

--- a/regression/reference/struct-c/wrapfstruct.f
+++ b/regression/reference/struct-c/wrapfstruct.f
@@ -692,19 +692,19 @@ module struct_mod
     ! Function:  Cstruct_as_class * Create_Cstruct_as_class
     ! Attrs:     +api(capptr)+intent(function)
     ! Exact:     c_function_shadow_*_capptr
-    ! start c_create__cstruct_as_class
+    ! start c_create_cstruct_as_class
     interface
-        function c_create__cstruct_as_class(SHT_rv) &
+        function c_create_cstruct_as_class(SHT_rv) &
                 result(SHT_prv) &
-                bind(C, name="STR_create__cstruct_as_class")
+                bind(C, name="STR_create_cstruct_as_class")
             use iso_c_binding, only : C_PTR
             import :: STR_SHROUD_capsule_data
             implicit none
             type(STR_SHROUD_capsule_data), intent(OUT) :: SHT_rv
             type(C_PTR) :: SHT_prv
-        end function c_create__cstruct_as_class
+        end function c_create_cstruct_as_class
     end interface
-    ! end c_create__cstruct_as_class
+    ! end c_create_cstruct_as_class
 
     ! ----------------------------------------
     ! Function:  Cstruct_as_class * Create_Cstruct_as_class_args
@@ -721,9 +721,9 @@ module struct_mod
     ! Requested: c_in_native_scalar
     ! Match:     c_default
     interface
-        function c_create__cstruct_as_class_args(x, y, SHT_rv) &
+        function c_create_cstruct_as_class_args(x, y, SHT_rv) &
                 result(SHT_prv) &
-                bind(C, name="STR_create__cstruct_as_class_args")
+                bind(C, name="STR_create_cstruct_as_class_args")
             use iso_c_binding, only : C_INT, C_PTR
             import :: STR_SHROUD_capsule_data
             implicit none
@@ -731,7 +731,7 @@ module struct_mod
             integer(C_INT), value, intent(IN) :: y
             type(STR_SHROUD_capsule_data), intent(OUT) :: SHT_rv
             type(C_PTR) :: SHT_prv
-        end function c_create__cstruct_as_class_args
+        end function c_create_cstruct_as_class_args
     end interface
 
     ! ----------------------------------------
@@ -775,9 +775,9 @@ module struct_mod
     ! Requested: c_in_native_scalar
     ! Match:     c_default
     interface
-        function c_create__cstruct_as_subclass_args(x, y, z, SHT_rv) &
+        function c_create_cstruct_as_subclass_args(x, y, z, SHT_rv) &
                 result(SHT_prv) &
-                bind(C, name="STR_create__cstruct_as_subclass_args")
+                bind(C, name="STR_create_cstruct_as_subclass_args")
             use iso_c_binding, only : C_INT, C_PTR
             import :: STR_SHROUD_capsule_data
             implicit none
@@ -786,7 +786,7 @@ module struct_mod
             integer(C_INT), value, intent(IN) :: z
             type(STR_SHROUD_capsule_data), intent(OUT) :: SHT_rv
             type(C_PTR) :: SHT_prv
-        end function c_create__cstruct_as_subclass_args
+        end function c_create_cstruct_as_subclass_args
     end interface
 
     ! ----------------------------------------
@@ -933,13 +933,13 @@ module struct_mod
 
     ! start generic interface Cstruct_as_class
     interface Cstruct_as_class
-        module procedure create__cstruct_as_class
-        module procedure create__cstruct_as_class_args
+        module procedure create_cstruct_as_class
+        module procedure create_cstruct_as_class_args
     end interface Cstruct_as_class
     ! end generic interface Cstruct_as_class
 
     interface Cstruct_as_subclass
-        module procedure create__cstruct_as_subclass_args
+        module procedure create_cstruct_as_subclass_args
     end interface Cstruct_as_subclass
 
 contains
@@ -1333,17 +1333,17 @@ contains
     ! Exact:     f_function_shadow_*_capptr
     ! Attrs:     +api(capptr)+intent(function)
     ! Exact:     c_function_shadow_*_capptr
-    ! start create__cstruct_as_class
-    function create__cstruct_as_class() &
+    ! start create_cstruct_as_class
+    function create_cstruct_as_class() &
             result(SHT_rv)
         use iso_c_binding, only : C_PTR
         type(cstruct_as_class) :: SHT_rv
         type(C_PTR) :: SHT_prv
-        ! splicer begin function.create__cstruct_as_class
-        SHT_prv = c_create__cstruct_as_class(SHT_rv%cxxmem)
-        ! splicer end function.create__cstruct_as_class
-    end function create__cstruct_as_class
-    ! end create__cstruct_as_class
+        ! splicer begin function.create_cstruct_as_class
+        SHT_prv = c_create_cstruct_as_class(SHT_rv%cxxmem)
+        ! splicer end function.create_cstruct_as_class
+    end function create_cstruct_as_class
+    ! end create_cstruct_as_class
 
     ! ----------------------------------------
     ! Function:  Cstruct_as_class * Create_Cstruct_as_class_args
@@ -1367,17 +1367,17 @@ contains
     ! Attrs:     +intent(in)
     ! Requested: c_in_native_scalar
     ! Match:     c_default
-    function create__cstruct_as_class_args(x, y) &
+    function create_cstruct_as_class_args(x, y) &
             result(SHT_rv)
         use iso_c_binding, only : C_INT, C_PTR
         integer(C_INT), value, intent(IN) :: x
         integer(C_INT), value, intent(IN) :: y
         type(cstruct_as_class) :: SHT_rv
         type(C_PTR) :: SHT_prv
-        ! splicer begin function.create__cstruct_as_class_args
-        SHT_prv = c_create__cstruct_as_class_args(x, y, SHT_rv%cxxmem)
-        ! splicer end function.create__cstruct_as_class_args
-    end function create__cstruct_as_class_args
+        ! splicer begin function.create_cstruct_as_class_args
+        SHT_prv = c_create_cstruct_as_class_args(x, y, SHT_rv%cxxmem)
+        ! splicer end function.create_cstruct_as_class_args
+    end function create_cstruct_as_class_args
 
     ! ----------------------------------------
     ! Function:  int Cstruct_as_class_sum
@@ -1434,7 +1434,7 @@ contains
     ! Attrs:     +intent(in)
     ! Requested: c_in_native_scalar
     ! Match:     c_default
-    function create__cstruct_as_subclass_args(x, y, z) &
+    function create_cstruct_as_subclass_args(x, y, z) &
             result(SHT_rv)
         use iso_c_binding, only : C_INT, C_PTR
         integer(C_INT), value, intent(IN) :: x
@@ -1442,11 +1442,11 @@ contains
         integer(C_INT), value, intent(IN) :: z
         type(cstruct_as_subclass) :: SHT_rv
         type(C_PTR) :: SHT_prv
-        ! splicer begin function.create__cstruct_as_subclass_args
-        SHT_prv = c_create__cstruct_as_subclass_args(x, y, z, &
+        ! splicer begin function.create_cstruct_as_subclass_args
+        SHT_prv = c_create_cstruct_as_subclass_args(x, y, z, &
             SHT_rv%cxxmem)
-        ! splicer end function.create__cstruct_as_subclass_args
-    end function create__cstruct_as_subclass_args
+        ! splicer end function.create_cstruct_as_subclass_args
+    end function create_cstruct_as_subclass_args
 
     ! Generated by getter/setter - arg_to_buffer
     ! ----------------------------------------

--- a/regression/reference/struct-c/wrapstruct.c
+++ b/regression/reference/struct-c/wrapstruct.c
@@ -89,18 +89,18 @@ Cstruct1 * STR_return_struct_ptr2_bufferify(int i, double d,
 // Function:  Cstruct_as_class * Create_Cstruct_as_class
 // Attrs:     +api(capptr)+intent(function)
 // Exact:     c_function_shadow_*_capptr
-// start STR_create__cstruct_as_class
-STR_Cstruct_as_class * STR_create__cstruct_as_class(
+// start STR_create_cstruct_as_class
+STR_Cstruct_as_class * STR_create_cstruct_as_class(
     STR_Cstruct_as_class * SHC_rv)
 {
-    // splicer begin function.create__cstruct_as_class
+    // splicer begin function.create_cstruct_as_class
     Cstruct_as_class * SHCXX_rv = Create_Cstruct_as_class();
     SHC_rv->addr = SHCXX_rv;
     SHC_rv->idtor = 0;
     return SHC_rv;
-    // splicer end function.create__cstruct_as_class
+    // splicer end function.create_cstruct_as_class
 }
-// end STR_create__cstruct_as_class
+// end STR_create_cstruct_as_class
 
 // ----------------------------------------
 // Function:  Cstruct_as_class * Create_Cstruct_as_class_args
@@ -116,15 +116,15 @@ STR_Cstruct_as_class * STR_create__cstruct_as_class(
 // Attrs:     +intent(in)
 // Requested: c_in_native_scalar
 // Match:     c_default
-STR_Cstruct_as_class * STR_create__cstruct_as_class_args(int x, int y,
+STR_Cstruct_as_class * STR_create_cstruct_as_class_args(int x, int y,
     STR_Cstruct_as_class * SHC_rv)
 {
-    // splicer begin function.create__cstruct_as_class_args
+    // splicer begin function.create_cstruct_as_class_args
     Cstruct_as_class * SHCXX_rv = Create_Cstruct_as_class_args(x, y);
     SHC_rv->addr = SHCXX_rv;
     SHC_rv->idtor = 0;
     return SHC_rv;
-    // splicer end function.create__cstruct_as_class_args
+    // splicer end function.create_cstruct_as_class_args
 }
 
 // ----------------------------------------
@@ -165,16 +165,16 @@ int STR_cstruct_as_class_sum(STR_Cstruct_as_class * point)
 // Attrs:     +intent(in)
 // Requested: c_in_native_scalar
 // Match:     c_default
-STR_Cstruct_as_subclass * STR_create__cstruct_as_subclass_args(int x,
+STR_Cstruct_as_subclass * STR_create_cstruct_as_subclass_args(int x,
     int y, int z, STR_Cstruct_as_subclass * SHC_rv)
 {
-    // splicer begin function.create__cstruct_as_subclass_args
+    // splicer begin function.create_cstruct_as_subclass_args
     Cstruct_as_subclass * SHCXX_rv = Create_Cstruct_as_subclass_args(x,
         y, z);
     SHC_rv->addr = SHCXX_rv;
     SHC_rv->idtor = 0;
     return SHC_rv;
-    // splicer end function.create__cstruct_as_subclass_args
+    // splicer end function.create_cstruct_as_subclass_args
 }
 
 // ----------------------------------------

--- a/regression/reference/struct-c/wrapstruct.h
+++ b/regression/reference/struct-c/wrapstruct.h
@@ -29,15 +29,15 @@ int STR_pass_struct2_bufferify(const Cstruct1 * s1, char *outbuf,
 Cstruct1 * STR_return_struct_ptr2_bufferify(int i, double d,
     char *outbuf, int SHT_outbuf_len);
 
-STR_Cstruct_as_class * STR_create__cstruct_as_class(
+STR_Cstruct_as_class * STR_create_cstruct_as_class(
     STR_Cstruct_as_class * SHC_rv);
 
-STR_Cstruct_as_class * STR_create__cstruct_as_class_args(int x, int y,
+STR_Cstruct_as_class * STR_create_cstruct_as_class_args(int x, int y,
     STR_Cstruct_as_class * SHC_rv);
 
 int STR_cstruct_as_class_sum(STR_Cstruct_as_class * point);
 
-STR_Cstruct_as_subclass * STR_create__cstruct_as_subclass_args(int x,
+STR_Cstruct_as_subclass * STR_create_cstruct_as_subclass_args(int x,
     int y, int z, STR_Cstruct_as_subclass * SHC_rv);
 
 const double * STR_cstruct_ptr_get_const_dvalue_bufferify(

--- a/regression/reference/struct-class-c/struct.json
+++ b/regression/reference/struct-class-c/struct.json
@@ -240,7 +240,10 @@
                     "class_scope": "Cstruct1::",
                     "cxx_class": "Cstruct1",
                     "cxx_type": "Cstruct1",
-                    "file_scope": "Cstruct1"
+                    "file_scope": "Cstruct1",
+                    "lower_name": "cstruct1",
+                    "underscore_name": "cstruct1",
+                    "upper_name": "CSTRUCT1"
                 }
             },
             {
@@ -504,7 +507,10 @@
                     "class_scope": "Cstruct_ptr::",
                     "cxx_class": "Cstruct_ptr",
                     "cxx_type": "Cstruct_ptr",
-                    "file_scope": "Cstruct_ptr"
+                    "file_scope": "Cstruct_ptr",
+                    "lower_name": "cstruct_ptr",
+                    "underscore_name": "cstruct_ptr",
+                    "upper_name": "CSTRUCT_PTR"
                 }
             },
             {
@@ -1011,7 +1017,10 @@
                     "class_scope": "Cstruct_list::",
                     "cxx_class": "Cstruct_list",
                     "cxx_type": "Cstruct_list",
-                    "file_scope": "Cstruct_list"
+                    "file_scope": "Cstruct_list",
+                    "lower_name": "cstruct_list",
+                    "underscore_name": "cstruct_list",
+                    "upper_name": "CSTRUCT_LIST"
                 }
             },
             {
@@ -1386,7 +1395,10 @@
                     "class_scope": "Cstruct_numpy::",
                     "cxx_class": "Cstruct_numpy",
                     "cxx_type": "Cstruct_numpy",
-                    "file_scope": "Cstruct_numpy"
+                    "file_scope": "Cstruct_numpy",
+                    "lower_name": "cstruct_numpy",
+                    "underscore_name": "cstruct_numpy",
+                    "upper_name": "CSTRUCT_NUMPY"
                 }
             },
             {
@@ -1650,7 +1662,10 @@
                     "class_scope": "Arrays1::",
                     "cxx_class": "Arrays1",
                     "cxx_type": "Arrays1",
-                    "file_scope": "Arrays1"
+                    "file_scope": "Arrays1",
+                    "lower_name": "arrays1",
+                    "underscore_name": "arrays1",
+                    "upper_name": "ARRAYS1"
                 }
             },
             {
@@ -1728,7 +1743,10 @@
                     "class_scope": "Cstruct_as_class::",
                     "cxx_class": "Cstruct_as_class",
                     "cxx_type": "Cstruct_as_class",
-                    "file_scope": "Cstruct_as_class"
+                    "file_scope": "Cstruct_as_class",
+                    "lower_name": "cstruct_as_class",
+                    "underscore_name": "cstruct_as_class",
+                    "upper_name": "CSTRUCT_AS_CLASS"
                 }
             },
             {
@@ -1830,7 +1848,10 @@
                     "class_scope": "Cstruct_as_subclass::",
                     "cxx_class": "Cstruct_as_subclass",
                     "cxx_type": "Cstruct_as_subclass",
-                    "file_scope": "Cstruct_as_subclass"
+                    "file_scope": "Cstruct_as_subclass",
+                    "lower_name": "cstruct_as_subclass",
+                    "underscore_name": "cstruct_as_subclass",
+                    "upper_name": "CSTRUCT_AS_SUBCLASS"
                 }
             }
         ],
@@ -3031,7 +3052,7 @@
                 "wrap": {},
                 "zz_fmtdict": {
                     "function_name": "Create_Cstruct_as_class",
-                    "underscore_name": "create__cstruct_as_class"
+                    "underscore_name": "create_cstruct_as_class"
                 }
             },
             {
@@ -3095,7 +3116,7 @@
                 "wrap": {},
                 "zz_fmtdict": {
                     "function_name": "Create_Cstruct_as_class_args",
-                    "underscore_name": "create__cstruct_as_class_args"
+                    "underscore_name": "create_cstruct_as_class_args"
                 }
             },
             {
@@ -3227,7 +3248,7 @@
                 "wrap": {},
                 "zz_fmtdict": {
                     "function_name": "Create_Cstruct_as_subclass_args",
-                    "underscore_name": "create__cstruct_as_subclass_args"
+                    "underscore_name": "create_cstruct_as_subclass_args"
                 }
             }
         ],

--- a/regression/reference/struct-class-cxx/struct.json
+++ b/regression/reference/struct-class-cxx/struct.json
@@ -240,7 +240,10 @@
                     "class_scope": "Cstruct1::",
                     "cxx_class": "Cstruct1",
                     "cxx_type": "Cstruct1",
-                    "file_scope": "Cstruct1"
+                    "file_scope": "Cstruct1",
+                    "lower_name": "cstruct1",
+                    "underscore_name": "cstruct1",
+                    "upper_name": "CSTRUCT1"
                 }
             },
             {
@@ -504,7 +507,10 @@
                     "class_scope": "Cstruct_ptr::",
                     "cxx_class": "Cstruct_ptr",
                     "cxx_type": "Cstruct_ptr",
-                    "file_scope": "Cstruct_ptr"
+                    "file_scope": "Cstruct_ptr",
+                    "lower_name": "cstruct_ptr",
+                    "underscore_name": "cstruct_ptr",
+                    "upper_name": "CSTRUCT_PTR"
                 }
             },
             {
@@ -1011,7 +1017,10 @@
                     "class_scope": "Cstruct_list::",
                     "cxx_class": "Cstruct_list",
                     "cxx_type": "Cstruct_list",
-                    "file_scope": "Cstruct_list"
+                    "file_scope": "Cstruct_list",
+                    "lower_name": "cstruct_list",
+                    "underscore_name": "cstruct_list",
+                    "upper_name": "CSTRUCT_LIST"
                 }
             },
             {
@@ -1386,7 +1395,10 @@
                     "class_scope": "Cstruct_numpy::",
                     "cxx_class": "Cstruct_numpy",
                     "cxx_type": "Cstruct_numpy",
-                    "file_scope": "Cstruct_numpy"
+                    "file_scope": "Cstruct_numpy",
+                    "lower_name": "cstruct_numpy",
+                    "underscore_name": "cstruct_numpy",
+                    "upper_name": "CSTRUCT_NUMPY"
                 }
             },
             {
@@ -1650,7 +1662,10 @@
                     "class_scope": "Arrays1::",
                     "cxx_class": "Arrays1",
                     "cxx_type": "Arrays1",
-                    "file_scope": "Arrays1"
+                    "file_scope": "Arrays1",
+                    "lower_name": "arrays1",
+                    "underscore_name": "arrays1",
+                    "upper_name": "ARRAYS1"
                 }
             },
             {
@@ -1728,7 +1743,10 @@
                     "class_scope": "Cstruct_as_class::",
                     "cxx_class": "Cstruct_as_class",
                     "cxx_type": "Cstruct_as_class",
-                    "file_scope": "Cstruct_as_class"
+                    "file_scope": "Cstruct_as_class",
+                    "lower_name": "cstruct_as_class",
+                    "underscore_name": "cstruct_as_class",
+                    "upper_name": "CSTRUCT_AS_CLASS"
                 }
             },
             {
@@ -1830,7 +1848,10 @@
                     "class_scope": "Cstruct_as_subclass::",
                     "cxx_class": "Cstruct_as_subclass",
                     "cxx_type": "Cstruct_as_subclass",
-                    "file_scope": "Cstruct_as_subclass"
+                    "file_scope": "Cstruct_as_subclass",
+                    "lower_name": "cstruct_as_subclass",
+                    "underscore_name": "cstruct_as_subclass",
+                    "upper_name": "CSTRUCT_AS_SUBCLASS"
                 }
             }
         ],
@@ -3031,7 +3052,7 @@
                 "wrap": {},
                 "zz_fmtdict": {
                     "function_name": "Create_Cstruct_as_class",
-                    "underscore_name": "create__cstruct_as_class"
+                    "underscore_name": "create_cstruct_as_class"
                 }
             },
             {
@@ -3095,7 +3116,7 @@
                 "wrap": {},
                 "zz_fmtdict": {
                     "function_name": "Create_Cstruct_as_class_args",
-                    "underscore_name": "create__cstruct_as_class_args"
+                    "underscore_name": "create_cstruct_as_class_args"
                 }
             },
             {
@@ -3227,7 +3248,7 @@
                 "wrap": {},
                 "zz_fmtdict": {
                     "function_name": "Create_Cstruct_as_subclass_args",
-                    "underscore_name": "create__cstruct_as_subclass_args"
+                    "underscore_name": "create_cstruct_as_subclass_args"
                 }
             }
         ],

--- a/regression/reference/struct-cxx/struct.json
+++ b/regression/reference/struct-cxx/struct.json
@@ -92,7 +92,10 @@
                     "class_scope": "Cstruct1::",
                     "cxx_class": "Cstruct1",
                     "cxx_type": "Cstruct1",
-                    "file_scope": "Cstruct1"
+                    "file_scope": "Cstruct1",
+                    "lower_name": "cstruct1",
+                    "underscore_name": "cstruct1",
+                    "upper_name": "CSTRUCT1"
                 }
             },
             {
@@ -185,7 +188,10 @@
                     "class_scope": "Cstruct_ptr::",
                     "cxx_class": "Cstruct_ptr",
                     "cxx_type": "Cstruct_ptr",
-                    "file_scope": "Cstruct_ptr"
+                    "file_scope": "Cstruct_ptr",
+                    "lower_name": "cstruct_ptr",
+                    "underscore_name": "cstruct_ptr",
+                    "upper_name": "CSTRUCT_PTR"
                 }
             },
             {
@@ -381,7 +387,10 @@
                     "class_scope": "Cstruct_list::",
                     "cxx_class": "Cstruct_list",
                     "cxx_type": "Cstruct_list",
-                    "file_scope": "Cstruct_list"
+                    "file_scope": "Cstruct_list",
+                    "lower_name": "cstruct_list",
+                    "underscore_name": "cstruct_list",
+                    "upper_name": "CSTRUCT_LIST"
                 }
             },
             {
@@ -522,7 +531,10 @@
                     "class_scope": "Cstruct_numpy::",
                     "cxx_class": "Cstruct_numpy",
                     "cxx_type": "Cstruct_numpy",
-                    "file_scope": "Cstruct_numpy"
+                    "file_scope": "Cstruct_numpy",
+                    "lower_name": "cstruct_numpy",
+                    "underscore_name": "cstruct_numpy",
+                    "upper_name": "CSTRUCT_NUMPY"
                 }
             },
             {
@@ -616,7 +628,10 @@
                     "class_scope": "Arrays1::",
                     "cxx_class": "Arrays1",
                     "cxx_type": "Arrays1",
-                    "file_scope": "Arrays1"
+                    "file_scope": "Arrays1",
+                    "lower_name": "arrays1",
+                    "underscore_name": "arrays1",
+                    "upper_name": "ARRAYS1"
                 }
             },
             {
@@ -1116,7 +1131,10 @@
                     "cxx_type": "Cstruct_as_class",
                     "f_capsule_data_type": "STR_SHROUD_capsule_data",
                     "file_scope": "Cstruct_as_class",
-                    "hnamefunc0": "capsule_data_helper"
+                    "hnamefunc0": "capsule_data_helper",
+                    "lower_name": "cstruct_as_class",
+                    "underscore_name": "cstruct_as_class",
+                    "upper_name": "CSTRUCT_AS_CLASS"
                 }
             },
             {
@@ -1848,7 +1866,10 @@
                     "cxx_type": "Cstruct_as_subclass",
                     "f_capsule_data_type": "STR_SHROUD_capsule_data",
                     "file_scope": "Cstruct_as_subclass",
-                    "hnamefunc0": "capsule_data_helper"
+                    "hnamefunc0": "capsule_data_helper",
+                    "lower_name": "cstruct_as_subclass",
+                    "underscore_name": "cstruct_as_subclass",
+                    "upper_name": "CSTRUCT_AS_SUBCLASS"
                 }
             }
         ],
@@ -4106,25 +4127,25 @@
                     "fortran": true
                 },
                 "zz_fmtdict": {
-                    "C_name": "STR_create__cstruct_as_class",
+                    "C_name": "STR_create_cstruct_as_class",
                     "C_prototype": "STR_Cstruct_as_class * SHC_rv",
                     "C_return_type": "STR_Cstruct_as_class *",
                     "F_C_arguments": "SHT_rv",
-                    "F_C_call": "c_create__cstruct_as_class",
-                    "F_C_name": "c_create__cstruct_as_class",
+                    "F_C_call": "c_create_cstruct_as_class",
+                    "F_C_name": "c_create_cstruct_as_class",
                     "F_C_result_clause": "\fresult(SHT_prv)",
                     "F_C_subprogram": "function",
                     "F_arg_c_call": "SHT_rv%cxxmem",
                     "F_arguments": "",
-                    "F_name_function": "create__cstruct_as_class",
+                    "F_name_function": "create_cstruct_as_class",
                     "F_name_generic": "Cstruct_as_class",
-                    "F_name_impl": "create__cstruct_as_class",
+                    "F_name_impl": "create_cstruct_as_class",
                     "F_result": "SHT_prv",
                     "F_result_clause": "\fresult(SHT_rv)",
                     "F_subprogram": "function",
                     "cxx_rv_decl": "Cstruct_as_class * SHCXX_rv",
                     "function_name": "Create_Cstruct_as_class",
-                    "underscore_name": "create__cstruct_as_class"
+                    "underscore_name": "create_cstruct_as_class"
                 },
                 "zz_fmtresult": {
                     "fmtc": {
@@ -4293,25 +4314,25 @@
                 },
                 "zz_fmtdict": {
                     "C_call_list": "x,\t y",
-                    "C_name": "STR_create__cstruct_as_class_args",
+                    "C_name": "STR_create_cstruct_as_class_args",
                     "C_prototype": "int x,\t int y,\t STR_Cstruct_as_class * SHC_rv",
                     "C_return_type": "STR_Cstruct_as_class *",
                     "F_C_arguments": "x,\t y,\t SHT_rv",
-                    "F_C_call": "c_create__cstruct_as_class_args",
-                    "F_C_name": "c_create__cstruct_as_class_args",
+                    "F_C_call": "c_create_cstruct_as_class_args",
+                    "F_C_name": "c_create_cstruct_as_class_args",
                     "F_C_result_clause": "\fresult(SHT_prv)",
                     "F_C_subprogram": "function",
                     "F_arg_c_call": "x,\t y,\t SHT_rv%cxxmem",
                     "F_arguments": "x,\t y",
-                    "F_name_function": "create__cstruct_as_class_args",
+                    "F_name_function": "create_cstruct_as_class_args",
                     "F_name_generic": "Cstruct_as_class",
-                    "F_name_impl": "create__cstruct_as_class_args",
+                    "F_name_impl": "create_cstruct_as_class_args",
                     "F_result": "SHT_prv",
                     "F_result_clause": "\fresult(SHT_rv)",
                     "F_subprogram": "function",
                     "cxx_rv_decl": "Cstruct_as_class * SHCXX_rv",
                     "function_name": "Create_Cstruct_as_class_args",
-                    "underscore_name": "create__cstruct_as_class_args"
+                    "underscore_name": "create_cstruct_as_class_args"
                 },
                 "zz_fmtresult": {
                     "fmtc": {
@@ -4669,25 +4690,25 @@
                 },
                 "zz_fmtdict": {
                     "C_call_list": "x,\t y,\t z",
-                    "C_name": "STR_create__cstruct_as_subclass_args",
+                    "C_name": "STR_create_cstruct_as_subclass_args",
                     "C_prototype": "int x,\t int y,\t int z,\t STR_Cstruct_as_subclass * SHC_rv",
                     "C_return_type": "STR_Cstruct_as_subclass *",
                     "F_C_arguments": "x,\t y,\t z,\t SHT_rv",
-                    "F_C_call": "c_create__cstruct_as_subclass_args",
-                    "F_C_name": "c_create__cstruct_as_subclass_args",
+                    "F_C_call": "c_create_cstruct_as_subclass_args",
+                    "F_C_name": "c_create_cstruct_as_subclass_args",
                     "F_C_result_clause": "\fresult(SHT_prv)",
                     "F_C_subprogram": "function",
                     "F_arg_c_call": "x,\t y,\t z,\t SHT_rv%cxxmem",
                     "F_arguments": "x,\t y,\t z",
-                    "F_name_function": "create__cstruct_as_subclass_args",
+                    "F_name_function": "create_cstruct_as_subclass_args",
                     "F_name_generic": "Cstruct_as_subclass",
-                    "F_name_impl": "create__cstruct_as_subclass_args",
+                    "F_name_impl": "create_cstruct_as_subclass_args",
                     "F_result": "SHT_prv",
                     "F_result_clause": "\fresult(SHT_rv)",
                     "F_subprogram": "function",
                     "cxx_rv_decl": "Cstruct_as_subclass * SHCXX_rv",
                     "function_name": "Create_Cstruct_as_subclass_args",
-                    "underscore_name": "create__cstruct_as_subclass_args"
+                    "underscore_name": "create_cstruct_as_subclass_args"
                 },
                 "zz_fmtresult": {
                     "fmtc": {

--- a/regression/reference/struct-cxx/wrapfstruct.f
+++ b/regression/reference/struct-cxx/wrapfstruct.f
@@ -642,17 +642,17 @@ module struct_mod
         ! Function:  Cstruct_as_class * Create_Cstruct_as_class
         ! Attrs:     +api(capptr)+intent(function)
         ! Exact:     c_function_shadow_*_capptr
-        ! start c_create__cstruct_as_class
-        function c_create__cstruct_as_class(SHT_rv) &
+        ! start c_create_cstruct_as_class
+        function c_create_cstruct_as_class(SHT_rv) &
                 result(SHT_prv) &
-                bind(C, name="STR_create__cstruct_as_class")
+                bind(C, name="STR_create_cstruct_as_class")
             use iso_c_binding, only : C_PTR
             import :: STR_SHROUD_capsule_data
             implicit none
             type(STR_SHROUD_capsule_data), intent(OUT) :: SHT_rv
             type(C_PTR) :: SHT_prv
-        end function c_create__cstruct_as_class
-        ! end c_create__cstruct_as_class
+        end function c_create_cstruct_as_class
+        ! end c_create_cstruct_as_class
 
         ! ----------------------------------------
         ! Function:  Cstruct_as_class * Create_Cstruct_as_class_args
@@ -668,9 +668,9 @@ module struct_mod
         ! Attrs:     +intent(in)
         ! Requested: c_in_native_scalar
         ! Match:     c_default
-        function c_create__cstruct_as_class_args(x, y, SHT_rv) &
+        function c_create_cstruct_as_class_args(x, y, SHT_rv) &
                 result(SHT_prv) &
-                bind(C, name="STR_create__cstruct_as_class_args")
+                bind(C, name="STR_create_cstruct_as_class_args")
             use iso_c_binding, only : C_INT, C_PTR
             import :: STR_SHROUD_capsule_data
             implicit none
@@ -678,7 +678,7 @@ module struct_mod
             integer(C_INT), value, intent(IN) :: y
             type(STR_SHROUD_capsule_data), intent(OUT) :: SHT_rv
             type(C_PTR) :: SHT_prv
-        end function c_create__cstruct_as_class_args
+        end function c_create_cstruct_as_class_args
 
         ! ----------------------------------------
         ! Function:  int Cstruct_as_class_sum
@@ -718,9 +718,9 @@ module struct_mod
         ! Attrs:     +intent(in)
         ! Requested: c_in_native_scalar
         ! Match:     c_default
-        function c_create__cstruct_as_subclass_args(x, y, z, SHT_rv) &
+        function c_create_cstruct_as_subclass_args(x, y, z, SHT_rv) &
                 result(SHT_prv) &
-                bind(C, name="STR_create__cstruct_as_subclass_args")
+                bind(C, name="STR_create_cstruct_as_subclass_args")
             use iso_c_binding, only : C_INT, C_PTR
             import :: STR_SHROUD_capsule_data
             implicit none
@@ -729,7 +729,7 @@ module struct_mod
             integer(C_INT), value, intent(IN) :: z
             type(STR_SHROUD_capsule_data), intent(OUT) :: SHT_rv
             type(C_PTR) :: SHT_prv
-        end function c_create__cstruct_as_subclass_args
+        end function c_create_cstruct_as_subclass_args
 
         ! ----------------------------------------
         ! Function:  const double * Cstruct_ptr_get_const_dvalue
@@ -862,13 +862,13 @@ module struct_mod
 
     ! start generic interface Cstruct_as_class
     interface Cstruct_as_class
-        module procedure create__cstruct_as_class
-        module procedure create__cstruct_as_class_args
+        module procedure create_cstruct_as_class
+        module procedure create_cstruct_as_class_args
     end interface Cstruct_as_class
     ! end generic interface Cstruct_as_class
 
     interface Cstruct_as_subclass
-        module procedure create__cstruct_as_subclass_args
+        module procedure create_cstruct_as_subclass_args
     end interface Cstruct_as_subclass
 
 contains
@@ -1262,17 +1262,17 @@ contains
     ! Exact:     f_function_shadow_*_capptr
     ! Attrs:     +api(capptr)+intent(function)
     ! Exact:     c_function_shadow_*_capptr
-    ! start create__cstruct_as_class
-    function create__cstruct_as_class() &
+    ! start create_cstruct_as_class
+    function create_cstruct_as_class() &
             result(SHT_rv)
         use iso_c_binding, only : C_PTR
         type(cstruct_as_class) :: SHT_rv
         type(C_PTR) :: SHT_prv
-        ! splicer begin function.create__cstruct_as_class
-        SHT_prv = c_create__cstruct_as_class(SHT_rv%cxxmem)
-        ! splicer end function.create__cstruct_as_class
-    end function create__cstruct_as_class
-    ! end create__cstruct_as_class
+        ! splicer begin function.create_cstruct_as_class
+        SHT_prv = c_create_cstruct_as_class(SHT_rv%cxxmem)
+        ! splicer end function.create_cstruct_as_class
+    end function create_cstruct_as_class
+    ! end create_cstruct_as_class
 
     ! ----------------------------------------
     ! Function:  Cstruct_as_class * Create_Cstruct_as_class_args
@@ -1296,17 +1296,17 @@ contains
     ! Attrs:     +intent(in)
     ! Requested: c_in_native_scalar
     ! Match:     c_default
-    function create__cstruct_as_class_args(x, y) &
+    function create_cstruct_as_class_args(x, y) &
             result(SHT_rv)
         use iso_c_binding, only : C_INT, C_PTR
         integer(C_INT), value, intent(IN) :: x
         integer(C_INT), value, intent(IN) :: y
         type(cstruct_as_class) :: SHT_rv
         type(C_PTR) :: SHT_prv
-        ! splicer begin function.create__cstruct_as_class_args
-        SHT_prv = c_create__cstruct_as_class_args(x, y, SHT_rv%cxxmem)
-        ! splicer end function.create__cstruct_as_class_args
-    end function create__cstruct_as_class_args
+        ! splicer begin function.create_cstruct_as_class_args
+        SHT_prv = c_create_cstruct_as_class_args(x, y, SHT_rv%cxxmem)
+        ! splicer end function.create_cstruct_as_class_args
+    end function create_cstruct_as_class_args
 
     ! ----------------------------------------
     ! Function:  int Cstruct_as_class_sum
@@ -1363,7 +1363,7 @@ contains
     ! Attrs:     +intent(in)
     ! Requested: c_in_native_scalar
     ! Match:     c_default
-    function create__cstruct_as_subclass_args(x, y, z) &
+    function create_cstruct_as_subclass_args(x, y, z) &
             result(SHT_rv)
         use iso_c_binding, only : C_INT, C_PTR
         integer(C_INT), value, intent(IN) :: x
@@ -1371,11 +1371,11 @@ contains
         integer(C_INT), value, intent(IN) :: z
         type(cstruct_as_subclass) :: SHT_rv
         type(C_PTR) :: SHT_prv
-        ! splicer begin function.create__cstruct_as_subclass_args
-        SHT_prv = c_create__cstruct_as_subclass_args(x, y, z, &
+        ! splicer begin function.create_cstruct_as_subclass_args
+        SHT_prv = c_create_cstruct_as_subclass_args(x, y, z, &
             SHT_rv%cxxmem)
-        ! splicer end function.create__cstruct_as_subclass_args
-    end function create__cstruct_as_subclass_args
+        ! splicer end function.create_cstruct_as_subclass_args
+    end function create_cstruct_as_subclass_args
 
     ! Generated by getter/setter - arg_to_buffer
     ! ----------------------------------------

--- a/regression/reference/struct-cxx/wrapstruct.cpp
+++ b/regression/reference/struct-cxx/wrapstruct.cpp
@@ -389,18 +389,18 @@ STR_cstruct_list * STR_get_global_struct_list_bufferify(void)
 // Function:  Cstruct_as_class * Create_Cstruct_as_class
 // Attrs:     +api(capptr)+intent(function)
 // Exact:     c_function_shadow_*_capptr
-// start STR_create__cstruct_as_class
-STR_Cstruct_as_class * STR_create__cstruct_as_class(
+// start STR_create_cstruct_as_class
+STR_Cstruct_as_class * STR_create_cstruct_as_class(
     STR_Cstruct_as_class * SHC_rv)
 {
-    // splicer begin function.create__cstruct_as_class
+    // splicer begin function.create_cstruct_as_class
     Cstruct_as_class * SHCXX_rv = Create_Cstruct_as_class();
     SHC_rv->addr = SHCXX_rv;
     SHC_rv->idtor = 0;
     return SHC_rv;
-    // splicer end function.create__cstruct_as_class
+    // splicer end function.create_cstruct_as_class
 }
-// end STR_create__cstruct_as_class
+// end STR_create_cstruct_as_class
 
 // ----------------------------------------
 // Function:  Cstruct_as_class * Create_Cstruct_as_class_args
@@ -416,15 +416,15 @@ STR_Cstruct_as_class * STR_create__cstruct_as_class(
 // Attrs:     +intent(in)
 // Requested: c_in_native_scalar
 // Match:     c_default
-STR_Cstruct_as_class * STR_create__cstruct_as_class_args(int x, int y,
+STR_Cstruct_as_class * STR_create_cstruct_as_class_args(int x, int y,
     STR_Cstruct_as_class * SHC_rv)
 {
-    // splicer begin function.create__cstruct_as_class_args
+    // splicer begin function.create_cstruct_as_class_args
     Cstruct_as_class * SHCXX_rv = Create_Cstruct_as_class_args(x, y);
     SHC_rv->addr = SHCXX_rv;
     SHC_rv->idtor = 0;
     return SHC_rv;
-    // splicer end function.create__cstruct_as_class_args
+    // splicer end function.create_cstruct_as_class_args
 }
 
 // ----------------------------------------
@@ -465,16 +465,16 @@ int STR_cstruct_as_class_sum(STR_Cstruct_as_class * point)
 // Attrs:     +intent(in)
 // Requested: c_in_native_scalar
 // Match:     c_default
-STR_Cstruct_as_subclass * STR_create__cstruct_as_subclass_args(int x,
+STR_Cstruct_as_subclass * STR_create_cstruct_as_subclass_args(int x,
     int y, int z, STR_Cstruct_as_subclass * SHC_rv)
 {
-    // splicer begin function.create__cstruct_as_subclass_args
+    // splicer begin function.create_cstruct_as_subclass_args
     Cstruct_as_subclass * SHCXX_rv = Create_Cstruct_as_subclass_args(x,
         y, z);
     SHC_rv->addr = SHCXX_rv;
     SHC_rv->idtor = 0;
     return SHC_rv;
-    // splicer end function.create__cstruct_as_subclass_args
+    // splicer end function.create_cstruct_as_subclass_args
 }
 
 // ----------------------------------------

--- a/regression/reference/struct-cxx/wrapstruct.h
+++ b/regression/reference/struct-cxx/wrapstruct.h
@@ -96,15 +96,15 @@ STR_cstruct_list * STR_get_global_struct_list(void);
 
 STR_cstruct_list * STR_get_global_struct_list_bufferify(void);
 
-STR_Cstruct_as_class * STR_create__cstruct_as_class(
+STR_Cstruct_as_class * STR_create_cstruct_as_class(
     STR_Cstruct_as_class * SHC_rv);
 
-STR_Cstruct_as_class * STR_create__cstruct_as_class_args(int x, int y,
+STR_Cstruct_as_class * STR_create_cstruct_as_class_args(int x, int y,
     STR_Cstruct_as_class * SHC_rv);
 
 int STR_cstruct_as_class_sum(STR_Cstruct_as_class * point);
 
-STR_Cstruct_as_subclass * STR_create__cstruct_as_subclass_args(int x,
+STR_Cstruct_as_subclass * STR_create_cstruct_as_subclass_args(int x,
     int y, int z, STR_Cstruct_as_subclass * SHC_rv);
 
 const double * STR_cstruct_ptr_get_const_dvalue_bufferify(

--- a/regression/reference/struct-list-cxx/struct.json
+++ b/regression/reference/struct-list-cxx/struct.json
@@ -94,7 +94,10 @@
                     "class_scope": "Cstruct1::",
                     "cxx_class": "Cstruct1",
                     "cxx_type": "Cstruct1",
-                    "file_scope": "Cstruct1"
+                    "file_scope": "Cstruct1",
+                    "lower_name": "cstruct1",
+                    "underscore_name": "cstruct1",
+                    "upper_name": "CSTRUCT1"
                 }
             },
             {
@@ -189,7 +192,10 @@
                     "class_scope": "Cstruct_ptr::",
                     "cxx_class": "Cstruct_ptr",
                     "cxx_type": "Cstruct_ptr",
-                    "file_scope": "Cstruct_ptr"
+                    "file_scope": "Cstruct_ptr",
+                    "lower_name": "cstruct_ptr",
+                    "underscore_name": "cstruct_ptr",
+                    "upper_name": "CSTRUCT_PTR"
                 }
             },
             {
@@ -385,7 +391,10 @@
                     "class_scope": "Cstruct_list::",
                     "cxx_class": "Cstruct_list",
                     "cxx_type": "Cstruct_list",
-                    "file_scope": "Cstruct_list"
+                    "file_scope": "Cstruct_list",
+                    "lower_name": "cstruct_list",
+                    "underscore_name": "cstruct_list",
+                    "upper_name": "CSTRUCT_LIST"
                 }
             },
             {
@@ -527,7 +536,10 @@
                     "class_scope": "Cstruct_numpy::",
                     "cxx_class": "Cstruct_numpy",
                     "cxx_type": "Cstruct_numpy",
-                    "file_scope": "Cstruct_numpy"
+                    "file_scope": "Cstruct_numpy",
+                    "lower_name": "cstruct_numpy",
+                    "underscore_name": "cstruct_numpy",
+                    "upper_name": "CSTRUCT_NUMPY"
                 }
             },
             {
@@ -623,7 +635,10 @@
                     "class_scope": "Arrays1::",
                     "cxx_class": "Arrays1",
                     "cxx_type": "Arrays1",
-                    "file_scope": "Arrays1"
+                    "file_scope": "Arrays1",
+                    "lower_name": "arrays1",
+                    "underscore_name": "arrays1",
+                    "upper_name": "ARRAYS1"
                 }
             },
             {
@@ -701,7 +716,10 @@
                     "class_scope": "Cstruct_as_class::",
                     "cxx_class": "Cstruct_as_class",
                     "cxx_type": "Cstruct_as_class",
-                    "file_scope": "Cstruct_as_class"
+                    "file_scope": "Cstruct_as_class",
+                    "lower_name": "cstruct_as_class",
+                    "underscore_name": "cstruct_as_class",
+                    "upper_name": "CSTRUCT_AS_CLASS"
                 }
             },
             {
@@ -803,7 +821,10 @@
                     "class_scope": "Cstruct_as_subclass::",
                     "cxx_class": "Cstruct_as_subclass",
                     "cxx_type": "Cstruct_as_subclass",
-                    "file_scope": "Cstruct_as_subclass"
+                    "file_scope": "Cstruct_as_subclass",
+                    "lower_name": "cstruct_as_subclass",
+                    "underscore_name": "cstruct_as_subclass",
+                    "upper_name": "CSTRUCT_AS_SUBCLASS"
                 }
             }
         ],
@@ -2013,7 +2034,7 @@
                 "wrap": {},
                 "zz_fmtdict": {
                     "function_name": "Create_Cstruct_as_class",
-                    "underscore_name": "create__cstruct_as_class"
+                    "underscore_name": "create_cstruct_as_class"
                 }
             },
             {
@@ -2077,7 +2098,7 @@
                 "wrap": {},
                 "zz_fmtdict": {
                     "function_name": "Create_Cstruct_as_class_args",
-                    "underscore_name": "create__cstruct_as_class_args"
+                    "underscore_name": "create_cstruct_as_class_args"
                 }
             },
             {
@@ -2209,7 +2230,7 @@
                 "wrap": {},
                 "zz_fmtdict": {
                     "function_name": "Create_Cstruct_as_subclass_args",
-                    "underscore_name": "create__cstruct_as_subclass_args"
+                    "underscore_name": "create_cstruct_as_subclass_args"
                 }
             }
         ],

--- a/regression/reference/struct-numpy-c/struct.json
+++ b/regression/reference/struct-numpy-c/struct.json
@@ -94,7 +94,10 @@
                     "class_scope": "Cstruct1::",
                     "cxx_class": "Cstruct1",
                     "cxx_type": "Cstruct1",
-                    "file_scope": "Cstruct1"
+                    "file_scope": "Cstruct1",
+                    "lower_name": "cstruct1",
+                    "underscore_name": "cstruct1",
+                    "upper_name": "CSTRUCT1"
                 }
             },
             {
@@ -189,7 +192,10 @@
                     "class_scope": "Cstruct_ptr::",
                     "cxx_class": "Cstruct_ptr",
                     "cxx_type": "Cstruct_ptr",
-                    "file_scope": "Cstruct_ptr"
+                    "file_scope": "Cstruct_ptr",
+                    "lower_name": "cstruct_ptr",
+                    "underscore_name": "cstruct_ptr",
+                    "upper_name": "CSTRUCT_PTR"
                 }
             },
             {
@@ -385,7 +391,10 @@
                     "class_scope": "Cstruct_list::",
                     "cxx_class": "Cstruct_list",
                     "cxx_type": "Cstruct_list",
-                    "file_scope": "Cstruct_list"
+                    "file_scope": "Cstruct_list",
+                    "lower_name": "cstruct_list",
+                    "underscore_name": "cstruct_list",
+                    "upper_name": "CSTRUCT_LIST"
                 }
             },
             {
@@ -527,7 +536,10 @@
                     "class_scope": "Cstruct_numpy::",
                     "cxx_class": "Cstruct_numpy",
                     "cxx_type": "Cstruct_numpy",
-                    "file_scope": "Cstruct_numpy"
+                    "file_scope": "Cstruct_numpy",
+                    "lower_name": "cstruct_numpy",
+                    "underscore_name": "cstruct_numpy",
+                    "upper_name": "CSTRUCT_NUMPY"
                 }
             },
             {
@@ -623,7 +635,10 @@
                     "class_scope": "Arrays1::",
                     "cxx_class": "Arrays1",
                     "cxx_type": "Arrays1",
-                    "file_scope": "Arrays1"
+                    "file_scope": "Arrays1",
+                    "lower_name": "arrays1",
+                    "underscore_name": "arrays1",
+                    "upper_name": "ARRAYS1"
                 }
             },
             {
@@ -701,7 +716,10 @@
                     "class_scope": "Cstruct_as_class::",
                     "cxx_class": "Cstruct_as_class",
                     "cxx_type": "Cstruct_as_class",
-                    "file_scope": "Cstruct_as_class"
+                    "file_scope": "Cstruct_as_class",
+                    "lower_name": "cstruct_as_class",
+                    "underscore_name": "cstruct_as_class",
+                    "upper_name": "CSTRUCT_AS_CLASS"
                 }
             },
             {
@@ -803,7 +821,10 @@
                     "class_scope": "Cstruct_as_subclass::",
                     "cxx_class": "Cstruct_as_subclass",
                     "cxx_type": "Cstruct_as_subclass",
-                    "file_scope": "Cstruct_as_subclass"
+                    "file_scope": "Cstruct_as_subclass",
+                    "lower_name": "cstruct_as_subclass",
+                    "underscore_name": "cstruct_as_subclass",
+                    "upper_name": "CSTRUCT_AS_SUBCLASS"
                 }
             }
         ],
@@ -2004,7 +2025,7 @@
                 "wrap": {},
                 "zz_fmtdict": {
                     "function_name": "Create_Cstruct_as_class",
-                    "underscore_name": "create__cstruct_as_class"
+                    "underscore_name": "create_cstruct_as_class"
                 }
             },
             {
@@ -2068,7 +2089,7 @@
                 "wrap": {},
                 "zz_fmtdict": {
                     "function_name": "Create_Cstruct_as_class_args",
-                    "underscore_name": "create__cstruct_as_class_args"
+                    "underscore_name": "create_cstruct_as_class_args"
                 }
             },
             {
@@ -2200,7 +2221,7 @@
                 "wrap": {},
                 "zz_fmtdict": {
                     "function_name": "Create_Cstruct_as_subclass_args",
-                    "underscore_name": "create__cstruct_as_subclass_args"
+                    "underscore_name": "create_cstruct_as_subclass_args"
                 }
             }
         ],

--- a/regression/reference/struct-numpy-cxx/struct.json
+++ b/regression/reference/struct-numpy-cxx/struct.json
@@ -94,7 +94,10 @@
                     "class_scope": "Cstruct1::",
                     "cxx_class": "Cstruct1",
                     "cxx_type": "Cstruct1",
-                    "file_scope": "Cstruct1"
+                    "file_scope": "Cstruct1",
+                    "lower_name": "cstruct1",
+                    "underscore_name": "cstruct1",
+                    "upper_name": "CSTRUCT1"
                 }
             },
             {
@@ -189,7 +192,10 @@
                     "class_scope": "Cstruct_ptr::",
                     "cxx_class": "Cstruct_ptr",
                     "cxx_type": "Cstruct_ptr",
-                    "file_scope": "Cstruct_ptr"
+                    "file_scope": "Cstruct_ptr",
+                    "lower_name": "cstruct_ptr",
+                    "underscore_name": "cstruct_ptr",
+                    "upper_name": "CSTRUCT_PTR"
                 }
             },
             {
@@ -385,7 +391,10 @@
                     "class_scope": "Cstruct_list::",
                     "cxx_class": "Cstruct_list",
                     "cxx_type": "Cstruct_list",
-                    "file_scope": "Cstruct_list"
+                    "file_scope": "Cstruct_list",
+                    "lower_name": "cstruct_list",
+                    "underscore_name": "cstruct_list",
+                    "upper_name": "CSTRUCT_LIST"
                 }
             },
             {
@@ -527,7 +536,10 @@
                     "class_scope": "Cstruct_numpy::",
                     "cxx_class": "Cstruct_numpy",
                     "cxx_type": "Cstruct_numpy",
-                    "file_scope": "Cstruct_numpy"
+                    "file_scope": "Cstruct_numpy",
+                    "lower_name": "cstruct_numpy",
+                    "underscore_name": "cstruct_numpy",
+                    "upper_name": "CSTRUCT_NUMPY"
                 }
             },
             {
@@ -623,7 +635,10 @@
                     "class_scope": "Arrays1::",
                     "cxx_class": "Arrays1",
                     "cxx_type": "Arrays1",
-                    "file_scope": "Arrays1"
+                    "file_scope": "Arrays1",
+                    "lower_name": "arrays1",
+                    "underscore_name": "arrays1",
+                    "upper_name": "ARRAYS1"
                 }
             },
             {
@@ -701,7 +716,10 @@
                     "class_scope": "Cstruct_as_class::",
                     "cxx_class": "Cstruct_as_class",
                     "cxx_type": "Cstruct_as_class",
-                    "file_scope": "Cstruct_as_class"
+                    "file_scope": "Cstruct_as_class",
+                    "lower_name": "cstruct_as_class",
+                    "underscore_name": "cstruct_as_class",
+                    "upper_name": "CSTRUCT_AS_CLASS"
                 }
             },
             {
@@ -803,7 +821,10 @@
                     "class_scope": "Cstruct_as_subclass::",
                     "cxx_class": "Cstruct_as_subclass",
                     "cxx_type": "Cstruct_as_subclass",
-                    "file_scope": "Cstruct_as_subclass"
+                    "file_scope": "Cstruct_as_subclass",
+                    "lower_name": "cstruct_as_subclass",
+                    "underscore_name": "cstruct_as_subclass",
+                    "upper_name": "CSTRUCT_AS_SUBCLASS"
                 }
             }
         ],
@@ -2004,7 +2025,7 @@
                 "wrap": {},
                 "zz_fmtdict": {
                     "function_name": "Create_Cstruct_as_class",
-                    "underscore_name": "create__cstruct_as_class"
+                    "underscore_name": "create_cstruct_as_class"
                 }
             },
             {
@@ -2068,7 +2089,7 @@
                 "wrap": {},
                 "zz_fmtdict": {
                     "function_name": "Create_Cstruct_as_class_args",
-                    "underscore_name": "create__cstruct_as_class_args"
+                    "underscore_name": "create_cstruct_as_class_args"
                 }
             },
             {
@@ -2200,7 +2221,7 @@
                 "wrap": {},
                 "zz_fmtdict": {
                     "function_name": "Create_Cstruct_as_subclass_args",
-                    "underscore_name": "create__cstruct_as_subclass_args"
+                    "underscore_name": "create_cstruct_as_subclass_args"
                 }
             }
         ],

--- a/regression/reference/struct-py-c/struct-py.json
+++ b/regression/reference/struct-py-c/struct-py.json
@@ -235,7 +235,10 @@
                     "class_scope": "Cstruct_as_class::",
                     "cxx_class": "Cstruct_as_class",
                     "cxx_type": "Cstruct_as_class",
-                    "file_scope": "Cstruct_as_class"
+                    "file_scope": "Cstruct_as_class",
+                    "lower_name": "cstruct_as_class",
+                    "underscore_name": "cstruct_as_class",
+                    "upper_name": "CSTRUCT_AS_CLASS"
                 }
             },
             {
@@ -321,7 +324,10 @@
                     "class_scope": "Cstruct_as_numpy::",
                     "cxx_class": "Cstruct_as_numpy",
                     "cxx_type": "Cstruct_as_numpy",
-                    "file_scope": "Cstruct_as_numpy"
+                    "file_scope": "Cstruct_as_numpy",
+                    "lower_name": "cstruct_as_numpy",
+                    "underscore_name": "cstruct_as_numpy",
+                    "upper_name": "CSTRUCT_AS_NUMPY"
                 }
             }
         ],

--- a/regression/reference/struct-py-cxx/struct-py.json
+++ b/regression/reference/struct-py-cxx/struct-py.json
@@ -235,7 +235,10 @@
                     "class_scope": "Cstruct_as_class::",
                     "cxx_class": "Cstruct_as_class",
                     "cxx_type": "Cstruct_as_class",
-                    "file_scope": "Cstruct_as_class"
+                    "file_scope": "Cstruct_as_class",
+                    "lower_name": "cstruct_as_class",
+                    "underscore_name": "cstruct_as_class",
+                    "upper_name": "CSTRUCT_AS_CLASS"
                 }
             },
             {
@@ -321,7 +324,10 @@
                     "class_scope": "Cstruct_as_numpy::",
                     "cxx_class": "Cstruct_as_numpy",
                     "cxx_type": "Cstruct_as_numpy",
-                    "file_scope": "Cstruct_as_numpy"
+                    "file_scope": "Cstruct_as_numpy",
+                    "lower_name": "cstruct_as_numpy",
+                    "underscore_name": "cstruct_as_numpy",
+                    "upper_name": "CSTRUCT_AS_NUMPY"
                 }
             }
         ],

--- a/regression/reference/structlist/structlist.json
+++ b/regression/reference/structlist/structlist.json
@@ -267,7 +267,10 @@
                     "class_scope": "Arrays1::",
                     "cxx_class": "Arrays1",
                     "cxx_type": "Arrays1",
-                    "file_scope": "Arrays1"
+                    "file_scope": "Arrays1",
+                    "lower_name": "arrays1",
+                    "underscore_name": "arrays1",
+                    "upper_name": "ARRAYS1"
                 }
             }
         ],

--- a/regression/reference/templates/templates.json
+++ b/regression/reference/templates/templates.json
@@ -46,7 +46,10 @@
                     "cxx_type": "Worker",
                     "f_capsule_data_type": "TEM_SHROUD_capsule_data",
                     "file_scope": "Worker",
-                    "hnamefunc0": "capsule_data_helper"
+                    "hnamefunc0": "capsule_data_helper",
+                    "lower_name": "worker",
+                    "underscore_name": "worker",
+                    "upper_name": "WORKER"
                 }
             },
             {
@@ -397,7 +400,10 @@
                     "cxx_type": "user<int>",
                     "f_capsule_data_type": "TEM_SHROUD_capsule_data",
                     "file_scope": "user_int",
-                    "hnamefunc0": "capsule_data_helper"
+                    "hnamefunc0": "capsule_data_helper",
+                    "lower_name": "user",
+                    "underscore_name": "user",
+                    "upper_name": "USER"
                 }
             },
             {
@@ -985,7 +991,10 @@
                     "cxx_type": "structAsClass<int>",
                     "f_capsule_data_type": "TEM_SHROUD_capsule_data",
                     "file_scope": "structAsClass_int",
-                    "hnamefunc0": "capsule_data_helper"
+                    "hnamefunc0": "capsule_data_helper",
+                    "lower_name": "structasclass",
+                    "underscore_name": "struct_as_class",
+                    "upper_name": "STRUCTASCLASS"
                 }
             },
             {
@@ -1573,7 +1582,10 @@
                     "cxx_type": "structAsClass<double>",
                     "f_capsule_data_type": "TEM_SHROUD_capsule_data",
                     "file_scope": "structAsClass_double",
-                    "hnamefunc0": "capsule_data_helper"
+                    "hnamefunc0": "capsule_data_helper",
+                    "lower_name": "structasclass",
+                    "underscore_name": "struct_as_class",
+                    "upper_name": "STRUCTASCLASS"
                 }
             }
         ],
@@ -3397,7 +3409,10 @@
                             "f_capsule_data_type": "TEM_SHROUD_capsule_data",
                             "file_scope": "std_vector_int",
                             "fmtsample": "one",
-                            "hnamefunc0": "capsule_data_helper"
+                            "hnamefunc0": "capsule_data_helper",
+                            "lower_name": "vector",
+                            "underscore_name": "vector",
+                            "upper_name": "VECTOR"
                         }
                     },
                     {
@@ -4185,7 +4200,10 @@
                             "cxx_type": "vector<double>",
                             "f_capsule_data_type": "TEM_SHROUD_capsule_data",
                             "file_scope": "std_vector_double",
-                            "hnamefunc0": "capsule_data_helper"
+                            "hnamefunc0": "capsule_data_helper",
+                            "lower_name": "vector",
+                            "underscore_name": "vector",
+                            "upper_name": "VECTOR"
                         }
                     }
                 ],
@@ -4261,7 +4279,10 @@
                             "class_scope": "ImplWorker1::",
                             "cxx_class": "ImplWorker1",
                             "cxx_type": "ImplWorker1",
-                            "file_scope": "internal_ImplWorker1"
+                            "file_scope": "internal_ImplWorker1",
+                            "lower_name": "implworker1",
+                            "underscore_name": "impl_worker1",
+                            "upper_name": "IMPLWORKER1"
                         }
                     },
                     {
@@ -4299,7 +4320,10 @@
                             "class_scope": "ImplWorker2::",
                             "cxx_class": "ImplWorker2",
                             "cxx_type": "ImplWorker2",
-                            "file_scope": "internal_ImplWorker2"
+                            "file_scope": "internal_ImplWorker2",
+                            "lower_name": "implworker2",
+                            "underscore_name": "impl_worker2",
+                            "upper_name": "IMPLWORKER2"
                         }
                     }
                 ],

--- a/regression/reference/typedefs-c/typedefs.json
+++ b/regression/reference/typedefs-c/typedefs.json
@@ -92,7 +92,10 @@
                     "class_scope": "s_Struct1::",
                     "cxx_class": "s_Struct1",
                     "cxx_type": "s_Struct1",
-                    "file_scope": "s_Struct1"
+                    "file_scope": "s_Struct1",
+                    "lower_name": "s_struct1",
+                    "underscore_name": "s_struct1",
+                    "upper_name": "S_STRUCT1"
                 }
             }
         ],

--- a/regression/reference/typedefs-cxx/typedefs.json
+++ b/regression/reference/typedefs-cxx/typedefs.json
@@ -92,7 +92,10 @@
                     "class_scope": "s_Struct1::",
                     "cxx_class": "s_Struct1",
                     "cxx_type": "s_Struct1",
-                    "file_scope": "s_Struct1"
+                    "file_scope": "s_Struct1",
+                    "lower_name": "s_struct1",
+                    "underscore_name": "s_struct1",
+                    "upper_name": "S_STRUCT1"
                 }
             }
         ],

--- a/regression/reference/wrap/wrap.json
+++ b/regression/reference/wrap/wrap.json
@@ -70,7 +70,10 @@
                     "cxx_type": "Class1",
                     "f_capsule_data_type": "WRA_SHROUD_capsule_data",
                     "file_scope": "Class1",
-                    "hnamefunc0": "capsule_data_helper"
+                    "hnamefunc0": "capsule_data_helper",
+                    "lower_name": "class1",
+                    "underscore_name": "class1",
+                    "upper_name": "CLASS1"
                 }
             }
         ],

--- a/shroud/ast.py
+++ b/shroud/ast.py
@@ -1114,7 +1114,9 @@ class ClassNode(AstNode, NamespaceMixin):
         self.scope_file = self.parent.scope_file + [self.name]
 
         self.user_fmt = format
-        self.default_format(parent, format, kwargs)
+        self.deprecated_format(kwargs)
+        self.fmtdict = util.Scope(parent.fmtdict)
+        self.default_format()
 
         if self.parse_keyword == "struct":
             self.wrap_as = self.options.wrap_struct_as
@@ -1153,9 +1155,7 @@ class ClassNode(AstNode, NamespaceMixin):
 
     #####
 
-    def default_format(self, parent, format, kwargs):
-        """Set format dictionary."""
-
+    def deprecated_format(self, kwargs):
         for name in [
             "C_header_filename",
             "C_impl_filename",
@@ -1179,8 +1179,9 @@ class ClassNode(AstNode, NamespaceMixin):
                     )
                 )
 
-        self.fmtdict = util.Scope(
-            parent=parent.fmtdict,
+    def default_format(self):
+        """Set format dictionary."""
+        self.fmtdict.update(dict(
             cxx_type=self.name,
             cxx_class=self.name,
             class_scope=self.name + "::",
@@ -1189,11 +1190,10 @@ class ClassNode(AstNode, NamespaceMixin):
             F_name_scope=self.parent.fmtdict.F_name_scope + self.name.lower() + "_",
             F_derived_name=self.name.lower(),
             file_scope="_".join(self.scope_file[1:]),
-        )
+        ))
 
-        fmt_class = self.fmtdict
-        if format:
-            fmt_class.update(format, replace=True)
+        if self.user_fmt:
+            self.fmtdict.update(self.user_fmt, replace=True)
         self.expand_format_templates()
 
     def expand_format_templates(self):

--- a/shroud/ast.py
+++ b/shroud/ast.py
@@ -545,6 +545,7 @@ class LibraryNode(AstNode, NamespaceMixin):
             F_capsule_type_template="{C_prefix}SHROUD_capsule",
             F_abstract_interface_subprogram_template="{underscore_name}_{argname}",
             F_abstract_interface_argument_template="arg{index}",
+            F_derived_name_template="{lower_name}",
             F_typedef_name_template="{F_name_scope}{underscore_name}",
 
             LUA_module_name_template="{library_lower}",
@@ -1184,11 +1185,17 @@ class ClassNode(AstNode, NamespaceMixin):
         self.fmtdict.update(dict(
             cxx_type=self.name,
             cxx_class=self.name,
+
+            underscore_name = util.un_camel(self.name),
+            upper_name = self.name.upper(),
+            lower_name = self.name.lower(),
+
             class_scope=self.name + "::",
 #            namespace_scope=self.parent.fmtdict.namespace_scope + self.name + "::",
+
+            # The scope for things in the class.
             C_name_scope=self.parent.fmtdict.C_name_scope + self.apply_case_option(self.name) + "_",
             F_name_scope=self.parent.fmtdict.F_name_scope + self.name.lower() + "_",
-            F_derived_name=self.name.lower(),
             file_scope="_".join(self.scope_file[1:]),
         ))
 
@@ -1207,6 +1214,8 @@ class ClassNode(AstNode, NamespaceMixin):
         self.eval_template("C_header_filename", "_class")
         self.eval_template("C_impl_filename", "_class")
 
+        self.eval_template("F_derived_name")
+        
         # As PyArray_Descr
         if self.parse_keyword == "struct":
             self.eval_template("PY_struct_array_descr_create")

--- a/shroud/util.py
+++ b/shroud/util.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import
 
 import collections
 import os
+import re
 import string
 
 try:
@@ -69,32 +70,22 @@ def append_format_cmds(lstout, stmts, name, fmt):
     return True
 
 # http://stackoverflow.com/questions/1175208/elegant-python-function-to-convert-camelcase-to-camel-case
-def un_camel(text):
+def un_camel(name):
     """ Converts a CamelCase name into an under_score name.
 
         >>> un_camel('CamelCase')
         'camel_case'
         >>> un_camel('getHTTPResponseCode')
         'get_http_response_code'
+        >>> un_camel('TypeID')
+        'type_id'
+        >>> un_camel('AFunction')
+        'a_function
+        >>> un_camel("Create_Cstruct_as_class")
+        'create_cstruct_as_class'
     """
-    result = []
-    pos = 0
-    while pos < len(text):
-        if text[pos].isupper():
-            if (
-                pos - 1 > 0
-                and text[pos - 1].islower()
-                or pos - 1 > 0
-                and pos + 1 < len(text)
-                and text[pos + 1].islower()
-            ):
-                result.append("_%s" % text[pos].lower())
-            else:
-                result.append(text[pos].lower())
-        else:
-            result.append(text[pos])
-        pos += 1
-    return "".join(result)
+    name = re.sub('([^_])([A-Z][a-z]+)', r'\1_\2', name)
+    return re.sub('([a-z0-9])([A-Z])', r'\1_\2', name).lower()
 
 
 # http://stackoverflow.com/questions/3232943/update-value-of-a-nested-dictionary-of-varying-depth


### PR DESCRIPTION

Remove redundant underscore
```
     Create_Cstruct_as_class  (struct.yaml)
       c_create__cstruct_as_class
       c_create_cstruct_as_class
```
  
Add missing underscore
```
  AFunction   (names2.yaml)
    afunction
    a_function
```

Added option F_derived_name_template.
Used to compute ClassNode.fmtdict.F_derived_name.
Default is set to lower_case.
