### PR TITLE
Move some attributes from Declaration to Declarator

### DIFF
--- a/regression/reference/arrayclass/arrayclass.json
+++ b/regression/reference/arrayclass/arrayclass.json
@@ -17,6 +17,7 @@
                                 "_constructor": true,
                                 "_name": "ctor"
                             },
+                            "declarator": {},
                             "metaattrs": {
                                 "api": "capptr",
                                 "intent": "ctor"

--- a/regression/reference/arrayclass/arrayclass.json
+++ b/regression/reference/arrayclass/arrayclass.json
@@ -32,6 +32,7 @@
                         },
                         "decl": "ArrayWrapper()",
                         "declgen": "ArrayWrapper(void)",
+                        "name": "ctor",
                         "options": {
                             "F_create_generic": true
                         },
@@ -155,6 +156,7 @@
                         },
                         "decl": "void setSize(int size)",
                         "declgen": "void setSize(int size +value)",
+                        "name": "setSize",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -263,6 +265,7 @@
                         },
                         "decl": "int getSize() const",
                         "declgen": "int getSize(void) const",
+                        "name": "getSize",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -386,6 +389,7 @@
                         },
                         "decl": "void fillSize(int &size +intent(out))",
                         "declgen": "void fillSize(int & size +intent(out))",
+                        "name": "fillSize",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -494,6 +498,7 @@
                         },
                         "decl": "void allocate()",
                         "declgen": "void allocate(void)",
+                        "name": "allocate",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -565,6 +570,7 @@
                         },
                         "decl": "double* getArray() +dimension(getSize())",
                         "declgen": "double * getArray(void) +dimension(getSize())",
+                        "name": "getArray",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -695,6 +701,7 @@
                         },
                         "decl": "double* getArray() +dimension(getSize())",
                         "declgen": "double * getArray(void) +dimension(getSize())",
+                        "name": "getArray",
                         "options": {},
                         "splicer_group": "buf",
                         "wrap": {
@@ -791,6 +798,7 @@
                         },
                         "decl": "double* getArrayConst() const +dimension(getSize())",
                         "declgen": "double * getArrayConst(void) const +dimension(getSize())",
+                        "name": "getArrayConst",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -923,6 +931,7 @@
                         },
                         "decl": "double* getArrayConst() const +dimension(getSize())",
                         "declgen": "double * getArrayConst(void) const +dimension(getSize())",
+                        "name": "getArrayConst",
                         "options": {},
                         "splicer_group": "buf",
                         "wrap": {
@@ -1019,6 +1028,7 @@
                         },
                         "decl": "const double *getArrayC() +dimension(getSize())",
                         "declgen": "const double * getArrayC(void) +dimension(getSize())",
+                        "name": "getArrayC",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -1150,6 +1160,7 @@
                         },
                         "decl": "const double *getArrayC() +dimension(getSize())",
                         "declgen": "const double * getArrayC(void) +dimension(getSize())",
+                        "name": "getArrayC",
                         "options": {},
                         "splicer_group": "buf",
                         "wrap": {
@@ -1247,6 +1258,7 @@
                         },
                         "decl": "const double *getArrayConstC() const +dimension(getSize())",
                         "declgen": "const double * getArrayConstC(void) const +dimension(getSize())",
+                        "name": "getArrayConstC",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -1380,6 +1392,7 @@
                         },
                         "decl": "const double *getArrayConstC() const +dimension(getSize())",
                         "declgen": "const double * getArrayConstC(void) const +dimension(getSize())",
+                        "name": "getArrayConstC",
                         "options": {},
                         "splicer_group": "buf",
                         "wrap": {
@@ -1513,6 +1526,7 @@
                         },
                         "decl": "void fetchArrayPtr(double **array +intent(out)+dimension(isize), int *isize     +hidden)",
                         "declgen": "void fetchArrayPtr(double * * array +dimension(isize)+intent(out), int * isize +hidden)",
+                        "name": "fetchArrayPtr",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -1730,6 +1744,7 @@
                         },
                         "decl": "void fetchArrayPtr(double **array +intent(out)+dimension(isize), int *isize     +hidden)",
                         "declgen": "void fetchArrayPtr(double * * array +dimension(isize)+intent(out), int * isize +hidden)",
+                        "name": "fetchArrayPtr",
                         "options": {},
                         "splicer_group": "buf",
                         "wrap": {
@@ -1904,6 +1919,7 @@
                         },
                         "decl": "void fetchArrayRef(double *&array +intent(out)+dimension(isize), int &isize     +hidden)",
                         "declgen": "void fetchArrayRef(double * & array +dimension(isize)+intent(out), int & isize +hidden)",
+                        "name": "fetchArrayRef",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -2121,6 +2137,7 @@
                         },
                         "decl": "void fetchArrayRef(double *&array +intent(out)+dimension(isize), int &isize     +hidden)",
                         "declgen": "void fetchArrayRef(double * & array +dimension(isize)+intent(out), int & isize +hidden)",
+                        "name": "fetchArrayRef",
                         "options": {},
                         "splicer_group": "buf",
                         "wrap": {
@@ -2296,6 +2313,7 @@
                         },
                         "decl": "void fetchArrayPtrConst( const double **array +intent(out)+dimension(isize), int *isize     +hidden)",
                         "declgen": "void fetchArrayPtrConst(const double * * array +dimension(isize)+intent(out), int * isize +hidden)",
+                        "name": "fetchArrayPtrConst",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -2514,6 +2532,7 @@
                         },
                         "decl": "void fetchArrayPtrConst( const double **array +intent(out)+dimension(isize), int *isize     +hidden)",
                         "declgen": "void fetchArrayPtrConst(const double * * array +dimension(isize)+intent(out), int * isize +hidden)",
+                        "name": "fetchArrayPtrConst",
                         "options": {},
                         "splicer_group": "buf",
                         "wrap": {
@@ -2689,6 +2708,7 @@
                         },
                         "decl": "void fetchArrayRefConst( const double *&array +intent(out)+dimension(isize), int &isize     +hidden)",
                         "declgen": "void fetchArrayRefConst(const double * & array +dimension(isize)+intent(out), int & isize +hidden)",
+                        "name": "fetchArrayRefConst",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -2907,6 +2927,7 @@
                         },
                         "decl": "void fetchArrayRefConst( const double *&array +intent(out)+dimension(isize), int &isize     +hidden)",
                         "declgen": "void fetchArrayRefConst(const double * & array +dimension(isize)+intent(out), int & isize +hidden)",
+                        "name": "fetchArrayRefConst",
                         "options": {},
                         "splicer_group": "buf",
                         "wrap": {
@@ -3049,6 +3070,7 @@
                         },
                         "decl": "void fetchVoidPtr(void **array +intent(out))",
                         "declgen": "void fetchVoidPtr(void * * array +intent(out))",
+                        "name": "fetchVoidPtr",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -3181,6 +3203,7 @@
                         },
                         "decl": "void fetchVoidRef(void *&array +intent(out))",
                         "declgen": "void fetchVoidRef(void * & array +intent(out))",
+                        "name": "fetchVoidRef",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -3310,6 +3333,7 @@
                         },
                         "decl": "bool checkPtr(void *array)",
                         "declgen": "bool checkPtr(void * array +value)",
+                        "name": "checkPtr",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -3467,6 +3491,7 @@
                         },
                         "decl": "double sumArray()",
                         "declgen": "double sumArray(void)",
+                        "name": "sumArray",
                         "options": {},
                         "wrap": {
                             "c": true,

--- a/regression/reference/arrayclass/arrayclass.json
+++ b/regression/reference/arrayclass/arrayclass.json
@@ -25,6 +25,7 @@
                                 "params": [],
                                 "typemap_name": "ArrayWrapper"
                             },
+                            "is_ctor": true,
                             "specifier": [
                                 "ArrayWrapper"
                             ],

--- a/regression/reference/arrayclass/arrayclass.json
+++ b/regression/reference/arrayclass/arrayclass.json
@@ -13,16 +13,18 @@
                         "<FUNCTION>": "0 ****************************************",
                         "_overloaded": true,
                         "ast": {
-                            "attrs": {
-                                "_constructor": true,
-                                "_name": "ctor"
+                            "declarator": {
+                                "attrs": {
+                                    "_constructor": true,
+                                    "_name": "ctor"
+                                },
+                                "metaattrs": {
+                                    "api": "capptr",
+                                    "intent": "ctor"
+                                },
+                                "params": [],
+                                "typemap_name": "ArrayWrapper"
                             },
-                            "declarator": {},
-                            "metaattrs": {
-                                "api": "capptr",
-                                "intent": "ctor"
-                            },
-                            "params": [],
                             "specifier": [
                                 "ArrayWrapper"
                             ],
@@ -122,28 +124,30 @@
                         "<FUNCTION>": "1 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "setSize"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "setSize",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "in"
+                                            },
+                                            "name": "size",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "size"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],
@@ -244,13 +248,14 @@
                         "<FUNCTION>": "2 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "getSize"
+                                "func_const": true,
+                                "metaattrs": {
+                                    "intent": "function"
+                                },
+                                "name": "getSize",
+                                "params": [],
+                                "typemap_name": "int"
                             },
-                            "func_const": true,
-                            "metaattrs": {
-                                "intent": "function"
-                            },
-                            "params": [],
                             "specifier": [
                                 "int"
                             ],
@@ -345,33 +350,35 @@
                         "<FUNCTION>": "3 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "fillSize"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "fillSize",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "intent": "out"
+                                            },
+                                            "metaattrs": {
+                                                "intent": "out"
+                                            },
+                                            "name": "size",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "&"
+                                                }
+                                            ],
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "intent": "out"
-                                    },
-                                    "declarator": {
-                                        "name": "size",
-                                        "pointer": [
-                                            {
-                                                "ptr": "&"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "out"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],
@@ -473,12 +480,13 @@
                         "<FUNCTION>": "4 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "allocate"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "allocate",
+                                "params": [],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [],
                             "specifier": [
                                 "void"
                             ],
@@ -527,28 +535,29 @@
                         ],
                         "_PTR_F_C_index": "17",
                         "ast": {
-                            "attrs": {
-                                "dimension": "getSize()"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "getSize()"
+                                },
+                                "metaattrs": {
+                                    "deref": "pointer",
+                                    "dimension": [
+                                        {
+                                            "args": [],
+                                            "name": "getSize"
+                                        }
+                                    ],
+                                    "intent": "function"
+                                },
                                 "name": "getArray",
+                                "params": [],
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "args": [],
-                                        "name": "getSize"
-                                    }
                                 ],
-                                "intent": "function"
+                                "typemap_name": "double"
                             },
-                            "params": [],
                             "specifier": [
                                 "double"
                             ],
@@ -655,29 +664,30 @@
                         "_PTR_C_CXX_index": "5",
                         "_generated": "arg_to_buffer",
                         "ast": {
-                            "attrs": {
-                                "dimension": "getSize()"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "getSize()"
+                                },
+                                "metaattrs": {
+                                    "api": "cdesc",
+                                    "deref": "pointer",
+                                    "dimension": [
+                                        {
+                                            "args": [],
+                                            "name": "getSize"
+                                        }
+                                    ],
+                                    "intent": "function"
+                                },
                                 "name": "getArray",
+                                "params": [],
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "args": [],
-                                        "name": "getSize"
-                                    }
                                 ],
-                                "intent": "function"
+                                "typemap_name": "double"
                             },
-                            "params": [],
                             "specifier": [
                                 "double"
                             ],
@@ -750,29 +760,30 @@
                         ],
                         "_PTR_F_C_index": "18",
                         "ast": {
-                            "attrs": {
-                                "dimension": "getSize()"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "getSize()"
+                                },
+                                "func_const": true,
+                                "metaattrs": {
+                                    "deref": "pointer",
+                                    "dimension": [
+                                        {
+                                            "args": [],
+                                            "name": "getSize"
+                                        }
+                                    ],
+                                    "intent": "function"
+                                },
                                 "name": "getArrayConst",
+                                "params": [],
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "func_const": true,
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "args": [],
-                                        "name": "getSize"
-                                    }
                                 ],
-                                "intent": "function"
+                                "typemap_name": "double"
                             },
-                            "params": [],
                             "specifier": [
                                 "double"
                             ],
@@ -880,30 +891,31 @@
                         "_PTR_C_CXX_index": "6",
                         "_generated": "arg_to_buffer",
                         "ast": {
-                            "attrs": {
-                                "dimension": "getSize()"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "getSize()"
+                                },
+                                "func_const": true,
+                                "metaattrs": {
+                                    "api": "cdesc",
+                                    "deref": "pointer",
+                                    "dimension": [
+                                        {
+                                            "args": [],
+                                            "name": "getSize"
+                                        }
+                                    ],
+                                    "intent": "function"
+                                },
                                 "name": "getArrayConst",
+                                "params": [],
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "func_const": true,
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "args": [],
-                                        "name": "getSize"
-                                    }
                                 ],
-                                "intent": "function"
+                                "typemap_name": "double"
                             },
-                            "params": [],
                             "specifier": [
                                 "double"
                             ],
@@ -976,29 +988,30 @@
                         ],
                         "_PTR_F_C_index": "19",
                         "ast": {
-                            "attrs": {
-                                "dimension": "getSize()"
-                            },
                             "const": true,
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "getSize()"
+                                },
+                                "metaattrs": {
+                                    "deref": "pointer",
+                                    "dimension": [
+                                        {
+                                            "args": [],
+                                            "name": "getSize"
+                                        }
+                                    ],
+                                    "intent": "function"
+                                },
                                 "name": "getArrayC",
+                                "params": [],
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "args": [],
-                                        "name": "getSize"
-                                    }
                                 ],
-                                "intent": "function"
+                                "typemap_name": "double"
                             },
-                            "params": [],
                             "specifier": [
                                 "double"
                             ],
@@ -1105,30 +1118,31 @@
                         "_PTR_C_CXX_index": "7",
                         "_generated": "arg_to_buffer",
                         "ast": {
-                            "attrs": {
-                                "dimension": "getSize()"
-                            },
                             "const": true,
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "getSize()"
+                                },
+                                "metaattrs": {
+                                    "api": "cdesc",
+                                    "deref": "pointer",
+                                    "dimension": [
+                                        {
+                                            "args": [],
+                                            "name": "getSize"
+                                        }
+                                    ],
+                                    "intent": "function"
+                                },
                                 "name": "getArrayC",
+                                "params": [],
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "args": [],
-                                        "name": "getSize"
-                                    }
                                 ],
-                                "intent": "function"
+                                "typemap_name": "double"
                             },
-                            "params": [],
                             "specifier": [
                                 "double"
                             ],
@@ -1201,30 +1215,31 @@
                         ],
                         "_PTR_F_C_index": "20",
                         "ast": {
-                            "attrs": {
-                                "dimension": "getSize()"
-                            },
                             "const": true,
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "getSize()"
+                                },
+                                "func_const": true,
+                                "metaattrs": {
+                                    "deref": "pointer",
+                                    "dimension": [
+                                        {
+                                            "args": [],
+                                            "name": "getSize"
+                                        }
+                                    ],
+                                    "intent": "function"
+                                },
                                 "name": "getArrayConstC",
+                                "params": [],
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "func_const": true,
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "args": [],
-                                        "name": "getSize"
-                                    }
                                 ],
-                                "intent": "function"
+                                "typemap_name": "double"
                             },
-                            "params": [],
                             "specifier": [
                                 "double"
                             ],
@@ -1332,31 +1347,32 @@
                         "_PTR_C_CXX_index": "8",
                         "_generated": "arg_to_buffer",
                         "ast": {
-                            "attrs": {
-                                "dimension": "getSize()"
-                            },
                             "const": true,
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "getSize()"
+                                },
+                                "func_const": true,
+                                "metaattrs": {
+                                    "api": "cdesc",
+                                    "deref": "pointer",
+                                    "dimension": [
+                                        {
+                                            "args": [],
+                                            "name": "getSize"
+                                        }
+                                    ],
+                                    "intent": "function"
+                                },
                                 "name": "getArrayConstC",
+                                "params": [],
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "func_const": true,
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "args": [],
-                                        "name": "getSize"
-                                    }
                                 ],
-                                "intent": "function"
+                                "typemap_name": "double"
                             },
-                            "params": [],
                             "specifier": [
                                 "double"
                             ],
@@ -1430,63 +1446,66 @@
                         "_PTR_F_C_index": "21",
                         "ast": {
                             "declarator": {
-                                "name": "fetchArrayPtr"
-                            },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "dimension": "isize",
-                                        "intent": "out"
-                                    },
-                                    "declarator": {
-                                        "name": "array",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            },
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "deref": "pointer",
-                                        "dimension": [
-                                            {
-                                                "name": "isize"
-                                            }
-                                        ],
-                                        "intent": "out"
-                                    },
-                                    "specifier": [
-                                        "double"
-                                    ],
-                                    "typemap_name": "double"
+                                "metaattrs": {
+                                    "intent": "subroutine"
                                 },
-                                {
-                                    "attrs": {
-                                        "hidden": true
+                                "name": "fetchArrayPtr",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "dimension": "isize",
+                                                "intent": "out"
+                                            },
+                                            "metaattrs": {
+                                                "deref": "pointer",
+                                                "dimension": [
+                                                    {
+                                                        "name": "isize"
+                                                    }
+                                                ],
+                                                "intent": "out"
+                                            },
+                                            "name": "array",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                },
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "double"
+                                        },
+                                        "specifier": [
+                                            "double"
+                                        ],
+                                        "typemap_name": "double"
                                     },
-                                    "declarator": {
-                                        "name": "isize",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "inout"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "hidden": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "inout"
+                                            },
+                                            "name": "isize",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "void"
+                            },
                             "specifier": [
                                 "void"
                             ],
@@ -1643,64 +1662,67 @@
                         "_generated": "arg_to_buffer",
                         "ast": {
                             "declarator": {
-                                "name": "fetchArrayPtr"
-                            },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "dimension": "isize",
-                                        "intent": "out"
-                                    },
-                                    "declarator": {
-                                        "name": "array",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            },
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "api": "cdesc",
-                                        "deref": "pointer",
-                                        "dimension": [
-                                            {
-                                                "name": "isize"
-                                            }
-                                        ],
-                                        "intent": "out"
-                                    },
-                                    "specifier": [
-                                        "double"
-                                    ],
-                                    "typemap_name": "double"
+                                "metaattrs": {
+                                    "intent": "subroutine"
                                 },
-                                {
-                                    "attrs": {
-                                        "hidden": true
+                                "name": "fetchArrayPtr",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "dimension": "isize",
+                                                "intent": "out"
+                                            },
+                                            "metaattrs": {
+                                                "api": "cdesc",
+                                                "deref": "pointer",
+                                                "dimension": [
+                                                    {
+                                                        "name": "isize"
+                                                    }
+                                                ],
+                                                "intent": "out"
+                                            },
+                                            "name": "array",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                },
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "double"
+                                        },
+                                        "specifier": [
+                                            "double"
+                                        ],
+                                        "typemap_name": "double"
                                     },
-                                    "declarator": {
-                                        "name": "isize",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "inout"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "hidden": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "inout"
+                                            },
+                                            "name": "isize",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "void"
+                            },
                             "specifier": [
                                 "void"
                             ],
@@ -1815,63 +1837,66 @@
                         "_PTR_F_C_index": "22",
                         "ast": {
                             "declarator": {
-                                "name": "fetchArrayRef"
-                            },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "dimension": "isize",
-                                        "intent": "out"
-                                    },
-                                    "declarator": {
-                                        "name": "array",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            },
-                                            {
-                                                "ptr": "&"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "deref": "pointer",
-                                        "dimension": [
-                                            {
-                                                "name": "isize"
-                                            }
-                                        ],
-                                        "intent": "out"
-                                    },
-                                    "specifier": [
-                                        "double"
-                                    ],
-                                    "typemap_name": "double"
+                                "metaattrs": {
+                                    "intent": "subroutine"
                                 },
-                                {
-                                    "attrs": {
-                                        "hidden": true
+                                "name": "fetchArrayRef",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "dimension": "isize",
+                                                "intent": "out"
+                                            },
+                                            "metaattrs": {
+                                                "deref": "pointer",
+                                                "dimension": [
+                                                    {
+                                                        "name": "isize"
+                                                    }
+                                                ],
+                                                "intent": "out"
+                                            },
+                                            "name": "array",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                },
+                                                {
+                                                    "ptr": "&"
+                                                }
+                                            ],
+                                            "typemap_name": "double"
+                                        },
+                                        "specifier": [
+                                            "double"
+                                        ],
+                                        "typemap_name": "double"
                                     },
-                                    "declarator": {
-                                        "name": "isize",
-                                        "pointer": [
-                                            {
-                                                "ptr": "&"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "inout"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "hidden": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "inout"
+                                            },
+                                            "name": "isize",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "&"
+                                                }
+                                            ],
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "void"
+                            },
                             "specifier": [
                                 "void"
                             ],
@@ -2028,64 +2053,67 @@
                         "_generated": "arg_to_buffer",
                         "ast": {
                             "declarator": {
-                                "name": "fetchArrayRef"
-                            },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "dimension": "isize",
-                                        "intent": "out"
-                                    },
-                                    "declarator": {
-                                        "name": "array",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            },
-                                            {
-                                                "ptr": "&"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "api": "cdesc",
-                                        "deref": "pointer",
-                                        "dimension": [
-                                            {
-                                                "name": "isize"
-                                            }
-                                        ],
-                                        "intent": "out"
-                                    },
-                                    "specifier": [
-                                        "double"
-                                    ],
-                                    "typemap_name": "double"
+                                "metaattrs": {
+                                    "intent": "subroutine"
                                 },
-                                {
-                                    "attrs": {
-                                        "hidden": true
+                                "name": "fetchArrayRef",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "dimension": "isize",
+                                                "intent": "out"
+                                            },
+                                            "metaattrs": {
+                                                "api": "cdesc",
+                                                "deref": "pointer",
+                                                "dimension": [
+                                                    {
+                                                        "name": "isize"
+                                                    }
+                                                ],
+                                                "intent": "out"
+                                            },
+                                            "name": "array",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                },
+                                                {
+                                                    "ptr": "&"
+                                                }
+                                            ],
+                                            "typemap_name": "double"
+                                        },
+                                        "specifier": [
+                                            "double"
+                                        ],
+                                        "typemap_name": "double"
                                     },
-                                    "declarator": {
-                                        "name": "isize",
-                                        "pointer": [
-                                            {
-                                                "ptr": "&"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "inout"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "hidden": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "inout"
+                                            },
+                                            "name": "isize",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "&"
+                                                }
+                                            ],
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "void"
+                            },
                             "specifier": [
                                 "void"
                             ],
@@ -2200,64 +2228,67 @@
                         "_PTR_F_C_index": "23",
                         "ast": {
                             "declarator": {
-                                "name": "fetchArrayPtrConst"
-                            },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "dimension": "isize",
-                                        "intent": "out"
-                                    },
-                                    "const": true,
-                                    "declarator": {
-                                        "name": "array",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            },
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "deref": "pointer",
-                                        "dimension": [
-                                            {
-                                                "name": "isize"
-                                            }
-                                        ],
-                                        "intent": "out"
-                                    },
-                                    "specifier": [
-                                        "double"
-                                    ],
-                                    "typemap_name": "double"
+                                "metaattrs": {
+                                    "intent": "subroutine"
                                 },
-                                {
-                                    "attrs": {
-                                        "hidden": true
+                                "name": "fetchArrayPtrConst",
+                                "params": [
+                                    {
+                                        "const": true,
+                                        "declarator": {
+                                            "attrs": {
+                                                "dimension": "isize",
+                                                "intent": "out"
+                                            },
+                                            "metaattrs": {
+                                                "deref": "pointer",
+                                                "dimension": [
+                                                    {
+                                                        "name": "isize"
+                                                    }
+                                                ],
+                                                "intent": "out"
+                                            },
+                                            "name": "array",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                },
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "double"
+                                        },
+                                        "specifier": [
+                                            "double"
+                                        ],
+                                        "typemap_name": "double"
                                     },
-                                    "declarator": {
-                                        "name": "isize",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "inout"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "hidden": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "inout"
+                                            },
+                                            "name": "isize",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "void"
+                            },
                             "specifier": [
                                 "void"
                             ],
@@ -2414,65 +2445,68 @@
                         "_generated": "arg_to_buffer",
                         "ast": {
                             "declarator": {
-                                "name": "fetchArrayPtrConst"
-                            },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "dimension": "isize",
-                                        "intent": "out"
-                                    },
-                                    "const": true,
-                                    "declarator": {
-                                        "name": "array",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            },
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "api": "cdesc",
-                                        "deref": "pointer",
-                                        "dimension": [
-                                            {
-                                                "name": "isize"
-                                            }
-                                        ],
-                                        "intent": "out"
-                                    },
-                                    "specifier": [
-                                        "double"
-                                    ],
-                                    "typemap_name": "double"
+                                "metaattrs": {
+                                    "intent": "subroutine"
                                 },
-                                {
-                                    "attrs": {
-                                        "hidden": true
+                                "name": "fetchArrayPtrConst",
+                                "params": [
+                                    {
+                                        "const": true,
+                                        "declarator": {
+                                            "attrs": {
+                                                "dimension": "isize",
+                                                "intent": "out"
+                                            },
+                                            "metaattrs": {
+                                                "api": "cdesc",
+                                                "deref": "pointer",
+                                                "dimension": [
+                                                    {
+                                                        "name": "isize"
+                                                    }
+                                                ],
+                                                "intent": "out"
+                                            },
+                                            "name": "array",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                },
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "double"
+                                        },
+                                        "specifier": [
+                                            "double"
+                                        ],
+                                        "typemap_name": "double"
                                     },
-                                    "declarator": {
-                                        "name": "isize",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "inout"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "hidden": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "inout"
+                                            },
+                                            "name": "isize",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "void"
+                            },
                             "specifier": [
                                 "void"
                             ],
@@ -2587,64 +2621,67 @@
                         "_PTR_F_C_index": "24",
                         "ast": {
                             "declarator": {
-                                "name": "fetchArrayRefConst"
-                            },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "dimension": "isize",
-                                        "intent": "out"
-                                    },
-                                    "const": true,
-                                    "declarator": {
-                                        "name": "array",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            },
-                                            {
-                                                "ptr": "&"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "deref": "pointer",
-                                        "dimension": [
-                                            {
-                                                "name": "isize"
-                                            }
-                                        ],
-                                        "intent": "out"
-                                    },
-                                    "specifier": [
-                                        "double"
-                                    ],
-                                    "typemap_name": "double"
+                                "metaattrs": {
+                                    "intent": "subroutine"
                                 },
-                                {
-                                    "attrs": {
-                                        "hidden": true
+                                "name": "fetchArrayRefConst",
+                                "params": [
+                                    {
+                                        "const": true,
+                                        "declarator": {
+                                            "attrs": {
+                                                "dimension": "isize",
+                                                "intent": "out"
+                                            },
+                                            "metaattrs": {
+                                                "deref": "pointer",
+                                                "dimension": [
+                                                    {
+                                                        "name": "isize"
+                                                    }
+                                                ],
+                                                "intent": "out"
+                                            },
+                                            "name": "array",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                },
+                                                {
+                                                    "ptr": "&"
+                                                }
+                                            ],
+                                            "typemap_name": "double"
+                                        },
+                                        "specifier": [
+                                            "double"
+                                        ],
+                                        "typemap_name": "double"
                                     },
-                                    "declarator": {
-                                        "name": "isize",
-                                        "pointer": [
-                                            {
-                                                "ptr": "&"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "inout"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "hidden": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "inout"
+                                            },
+                                            "name": "isize",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "&"
+                                                }
+                                            ],
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "void"
+                            },
                             "specifier": [
                                 "void"
                             ],
@@ -2801,65 +2838,68 @@
                         "_generated": "arg_to_buffer",
                         "ast": {
                             "declarator": {
-                                "name": "fetchArrayRefConst"
-                            },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "dimension": "isize",
-                                        "intent": "out"
-                                    },
-                                    "const": true,
-                                    "declarator": {
-                                        "name": "array",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            },
-                                            {
-                                                "ptr": "&"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "api": "cdesc",
-                                        "deref": "pointer",
-                                        "dimension": [
-                                            {
-                                                "name": "isize"
-                                            }
-                                        ],
-                                        "intent": "out"
-                                    },
-                                    "specifier": [
-                                        "double"
-                                    ],
-                                    "typemap_name": "double"
+                                "metaattrs": {
+                                    "intent": "subroutine"
                                 },
-                                {
-                                    "attrs": {
-                                        "hidden": true
+                                "name": "fetchArrayRefConst",
+                                "params": [
+                                    {
+                                        "const": true,
+                                        "declarator": {
+                                            "attrs": {
+                                                "dimension": "isize",
+                                                "intent": "out"
+                                            },
+                                            "metaattrs": {
+                                                "api": "cdesc",
+                                                "deref": "pointer",
+                                                "dimension": [
+                                                    {
+                                                        "name": "isize"
+                                                    }
+                                                ],
+                                                "intent": "out"
+                                            },
+                                            "name": "array",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                },
+                                                {
+                                                    "ptr": "&"
+                                                }
+                                            ],
+                                            "typemap_name": "double"
+                                        },
+                                        "specifier": [
+                                            "double"
+                                        ],
+                                        "typemap_name": "double"
                                     },
-                                    "declarator": {
-                                        "name": "isize",
-                                        "pointer": [
-                                            {
-                                                "ptr": "&"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "inout"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "hidden": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "inout"
+                                            },
+                                            "name": "isize",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "&"
+                                                }
+                                            ],
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "void"
+                            },
                             "specifier": [
                                 "void"
                             ],
@@ -2970,36 +3010,38 @@
                         "<FUNCTION>": "13 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "fetchVoidPtr"
-                            },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "intent": "out"
-                                    },
-                                    "declarator": {
-                                        "name": "array",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "fetchVoidPtr",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "intent": "out"
                                             },
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "out"
-                                    },
-                                    "specifier": [
-                                        "void"
-                                    ],
-                                    "typemap_name": "void"
-                                }
-                            ],
+                                            "metaattrs": {
+                                                "intent": "out"
+                                            },
+                                            "name": "array",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                },
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "void"
+                                        },
+                                        "specifier": [
+                                            "void"
+                                        ],
+                                        "typemap_name": "void"
+                                    }
+                                ],
+                                "typemap_name": "void"
+                            },
                             "specifier": [
                                 "void"
                             ],
@@ -3100,36 +3142,38 @@
                         "<FUNCTION>": "14 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "fetchVoidRef"
-                            },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "intent": "out"
-                                    },
-                                    "declarator": {
-                                        "name": "array",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "fetchVoidRef",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "intent": "out"
                                             },
-                                            {
-                                                "ptr": "&"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "out"
-                                    },
-                                    "specifier": [
-                                        "void"
-                                    ],
-                                    "typemap_name": "void"
-                                }
-                            ],
+                                            "metaattrs": {
+                                                "intent": "out"
+                                            },
+                                            "name": "array",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                },
+                                                {
+                                                    "ptr": "&"
+                                                }
+                                            ],
+                                            "typemap_name": "void"
+                                        },
+                                        "specifier": [
+                                            "void"
+                                        ],
+                                        "typemap_name": "void"
+                                    }
+                                ],
+                                "typemap_name": "void"
+                            },
                             "specifier": [
                                 "void"
                             ],
@@ -3230,33 +3274,35 @@
                         "<FUNCTION>": "15 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "checkPtr"
+                                "metaattrs": {
+                                    "intent": "function"
+                                },
+                                "name": "checkPtr",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "in"
+                                            },
+                                            "name": "array",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "void"
+                                        },
+                                        "specifier": [
+                                            "void"
+                                        ],
+                                        "typemap_name": "void"
+                                    }
+                                ],
+                                "typemap_name": "bool"
                             },
-                            "metaattrs": {
-                                "intent": "function"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "array",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in"
-                                    },
-                                    "specifier": [
-                                        "void"
-                                    ],
-                                    "typemap_name": "void"
-                                }
-                            ],
                             "specifier": [
                                 "bool"
                             ],
@@ -3407,12 +3453,13 @@
                         "<FUNCTION>": "16 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "sumArray"
+                                "metaattrs": {
+                                    "intent": "function"
+                                },
+                                "name": "sumArray",
+                                "params": [],
+                                "typemap_name": "double"
                             },
-                            "metaattrs": {
-                                "intent": "function"
-                            },
-                            "params": [],
                             "specifier": [
                                 "double"
                             ],

--- a/regression/reference/ccomplex/ccomplex.json
+++ b/regression/reference/ccomplex/ccomplex.json
@@ -17,31 +17,33 @@
                 "<FUNCTION>": "0 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptFloatComplexInoutPtr"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptFloatComplexInoutPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "float_complex"
+                                },
+                                "specifier": [
+                                    "float",
+                                    "complex"
+                                ],
+                                "typemap_name": "float_complex"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "float",
-                                "complex"
-                            ],
-                            "typemap_name": "float_complex"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -119,31 +121,33 @@
                 "<FUNCTION>": "1 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptDoubleComplexInoutPtr"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptDoubleComplexInoutPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double_complex"
+                                },
+                                "specifier": [
+                                    "double",
+                                    "complex"
+                                ],
+                                "typemap_name": "double_complex"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "double",
-                                "complex"
-                            ],
-                            "typemap_name": "double_complex"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -244,34 +248,36 @@
                 "<FUNCTION>": "2 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptDoubleComplexOutPtr"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptDoubleComplexOutPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double_complex"
+                                },
+                                "specifier": [
+                                    "double",
+                                    "complex"
+                                ],
+                                "typemap_name": "double_complex"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "double",
-                                "complex"
-                            ],
-                            "typemap_name": "double_complex"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -371,51 +377,54 @@
                 "<FUNCTION>": "3 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptDoubleComplexInoutPtrFlag"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "double",
-                                "complex"
-                            ],
-                            "typemap_name": "double_complex"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                        "name": "acceptDoubleComplexInoutPtrFlag",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double_complex"
+                                },
+                                "specifier": [
+                                    "double",
+                                    "complex"
+                                ],
+                                "typemap_name": "double_complex"
                             },
-                            "declarator": {
-                                "name": "flag",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "flag",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -492,54 +501,57 @@
                 "<FUNCTION>": "4 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptDoubleComplexOutPtrFlag"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "double",
-                                "complex"
-                            ],
-                            "typemap_name": "double_complex"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                        "name": "acceptDoubleComplexOutPtrFlag",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double_complex"
+                                },
+                                "specifier": [
+                                    "double",
+                                    "complex"
+                                ],
+                                "typemap_name": "double_complex"
                             },
-                            "declarator": {
-                                "name": "flag",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "flag",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],

--- a/regression/reference/ccomplex/ccomplex.json
+++ b/regression/reference/ccomplex/ccomplex.json
@@ -51,6 +51,7 @@
                 },
                 "decl": "void acceptFloatComplexInoutPtr(float complex *arg1)",
                 "declgen": "void acceptFloatComplexInoutPtr(float complex * arg1)",
+                "name": "acceptFloatComplexInoutPtr",
                 "options": {
                     "wrap_python": false
                 },
@@ -155,6 +156,7 @@
                 },
                 "decl": "void acceptDoubleComplexInoutPtr(double complex *arg1)",
                 "declgen": "void acceptDoubleComplexInoutPtr(double complex * arg1)",
+                "name": "acceptDoubleComplexInoutPtr",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -285,6 +287,7 @@
                 },
                 "decl": "void acceptDoubleComplexOutPtr(double complex *arg1 +intent(out))",
                 "declgen": "void acceptDoubleComplexOutPtr(double complex * arg1 +intent(out))",
+                "name": "acceptDoubleComplexOutPtr",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -435,6 +438,7 @@
                 "doxygen": {
                     "description": "Return two values so Py_BuildValue is used.\n"
                 },
+                "name": "acceptDoubleComplexInoutPtrFlag",
                 "options": {
                     "wrap_c": false,
                     "wrap_fortran": false
@@ -562,6 +566,7 @@
                 "doxygen": {
                     "description": "Return two values so Py_BuildValue is used.\nCreates a Py_complex for intent(out)\n"
                 },
+                "name": "acceptDoubleComplexOutPtrFlag",
                 "options": {},
                 "wrap": {
                     "c": true,

--- a/regression/reference/cdesc/cdesc.json
+++ b/regression/reference/cdesc/cdesc.json
@@ -551,12 +551,11 @@
                                 "declarator": {
                                     "attrs": {
                                         "cdesc": true,
-                                        "intent": "in",
-                                        "rank": 0,
-                                        "value": true
+                                        "intent": "out",
+                                        "rank": 0
                                     },
                                     "metaattrs": {
-                                        "intent": "in"
+                                        "intent": "out"
                                     },
                                     "name": "value",
                                     "pointer": [
@@ -564,12 +563,12 @@
                                             "ptr": "*"
                                         }
                                     ],
-                                    "typemap_name": "void"
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
-                                    "void"
+                                    "int"
                                 ],
-                                "typemap_name": "void"
+                                "typemap_name": "int"
                             }
                         ],
                         "typemap_name": "void"
@@ -647,6 +646,7 @@
                                         "intent": "in"
                                     },
                                     "metaattrs": {
+                                        "api": "buf",
                                         "intent": "in"
                                     },
                                     "name": "name",
@@ -666,12 +666,12 @@
                                 "declarator": {
                                     "attrs": {
                                         "cdesc": true,
-                                        "intent": "in",
-                                        "rank": 0,
-                                        "value": true
+                                        "intent": "out",
+                                        "rank": 0
                                     },
                                     "metaattrs": {
-                                        "intent": "in"
+                                        "api": "cdesc",
+                                        "intent": "out"
                                     },
                                     "name": "value",
                                     "pointer": [
@@ -679,12 +679,12 @@
                                             "ptr": "*"
                                         }
                                     ],
-                                    "typemap_name": "void"
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
-                                    "void"
+                                    "int"
                                 ],
-                                "typemap_name": "void"
+                                "typemap_name": "int"
                             }
                         ],
                         "typemap_name": "void"
@@ -864,12 +864,11 @@
                                 "declarator": {
                                     "attrs": {
                                         "cdesc": true,
-                                        "intent": "in",
-                                        "rank": 0,
-                                        "value": true
+                                        "intent": "out",
+                                        "rank": 0
                                     },
                                     "metaattrs": {
-                                        "intent": "in"
+                                        "intent": "out"
                                     },
                                     "name": "value",
                                     "pointer": [
@@ -877,12 +876,12 @@
                                             "ptr": "*"
                                         }
                                     ],
-                                    "typemap_name": "void"
+                                    "typemap_name": "double"
                                 },
                                 "specifier": [
-                                    "void"
+                                    "double"
                                 ],
-                                "typemap_name": "void"
+                                "typemap_name": "double"
                             }
                         ],
                         "typemap_name": "void"
@@ -960,6 +959,7 @@
                                         "intent": "in"
                                     },
                                     "metaattrs": {
+                                        "api": "buf",
                                         "intent": "in"
                                     },
                                     "name": "name",
@@ -979,12 +979,12 @@
                                 "declarator": {
                                     "attrs": {
                                         "cdesc": true,
-                                        "intent": "in",
-                                        "rank": 0,
-                                        "value": true
+                                        "intent": "out",
+                                        "rank": 0
                                     },
                                     "metaattrs": {
-                                        "intent": "in"
+                                        "api": "cdesc",
+                                        "intent": "out"
                                     },
                                     "name": "value",
                                     "pointer": [
@@ -992,12 +992,12 @@
                                             "ptr": "*"
                                         }
                                     ],
-                                    "typemap_name": "void"
+                                    "typemap_name": "double"
                                 },
                                 "specifier": [
-                                    "void"
+                                    "double"
                                 ],
-                                "typemap_name": "void"
+                                "typemap_name": "double"
                             }
                         ],
                         "typemap_name": "void"
@@ -1665,8 +1665,7 @@
                             {
                                 "declarator": {
                                     "attrs": {
-                                        "intent": "out",
-                                        "value": true
+                                        "intent": "out"
                                     },
                                     "metaattrs": {
                                         "intent": "out"
@@ -1677,12 +1676,12 @@
                                             "ptr": "*"
                                         }
                                     ],
-                                    "typemap_name": "void"
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
-                                    "void"
+                                    "int"
                                 ],
-                                "typemap_name": "void"
+                                "typemap_name": "int"
                             }
                         ],
                         "typemap_name": "void"
@@ -1752,6 +1751,7 @@
                                         "intent": "in"
                                     },
                                     "metaattrs": {
+                                        "api": "buf",
                                         "intent": "in"
                                     },
                                     "name": "name",
@@ -1770,8 +1770,7 @@
                             {
                                 "declarator": {
                                     "attrs": {
-                                        "intent": "out",
-                                        "value": true
+                                        "intent": "out"
                                     },
                                     "metaattrs": {
                                         "intent": "out"
@@ -1782,12 +1781,12 @@
                                             "ptr": "*"
                                         }
                                     ],
-                                    "typemap_name": "void"
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
-                                    "void"
+                                    "int"
                                 ],
-                                "typemap_name": "void"
+                                "typemap_name": "int"
                             }
                         ],
                         "typemap_name": "void"
@@ -1901,8 +1900,7 @@
                             {
                                 "declarator": {
                                     "attrs": {
-                                        "intent": "out",
-                                        "value": true
+                                        "intent": "out"
                                     },
                                     "metaattrs": {
                                         "intent": "out"
@@ -1913,12 +1911,12 @@
                                             "ptr": "*"
                                         }
                                     ],
-                                    "typemap_name": "void"
+                                    "typemap_name": "double"
                                 },
                                 "specifier": [
-                                    "void"
+                                    "double"
                                 ],
-                                "typemap_name": "void"
+                                "typemap_name": "double"
                             }
                         ],
                         "typemap_name": "void"
@@ -1988,6 +1986,7 @@
                                         "intent": "in"
                                     },
                                     "metaattrs": {
+                                        "api": "buf",
                                         "intent": "in"
                                     },
                                     "name": "name",
@@ -2006,8 +2005,7 @@
                             {
                                 "declarator": {
                                     "attrs": {
-                                        "intent": "out",
-                                        "value": true
+                                        "intent": "out"
                                     },
                                     "metaattrs": {
                                         "intent": "out"
@@ -2018,12 +2016,12 @@
                                             "ptr": "*"
                                         }
                                     ],
-                                    "typemap_name": "void"
+                                    "typemap_name": "double"
                                 },
                                 "specifier": [
-                                    "void"
+                                    "double"
                                 ],
-                                "typemap_name": "void"
+                                "typemap_name": "double"
                             }
                         ],
                         "typemap_name": "void"

--- a/regression/reference/cdesc/cdesc.json
+++ b/regression/reference/cdesc/cdesc.json
@@ -59,6 +59,7 @@
                 },
                 "decl": "void Rank2In(int *arg +intent(in)+rank(2)+cdesc)",
                 "declgen": "void Rank2In(int * arg +cdesc+intent(in)+rank(2))",
+                "name": "Rank2In",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -168,6 +169,7 @@
                 },
                 "decl": "void Rank2In(int *arg +intent(in)+rank(2)+cdesc)",
                 "declgen": "void Rank2In(int * arg +cdesc+intent(in)+rank(2))",
+                "name": "Rank2In",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -404,6 +406,7 @@
                         "generic": "(double *value+intent(out)+rank(0)+cdesc)"
                     }
                 ],
+                "name": "GetScalar1",
                 "options": {},
                 "splicer": {
                     "c_buf": [
@@ -583,6 +586,7 @@
                 "doxygen": {
                     "description": "Create several Fortran generic functions which call a single\nC wrapper that checks the type of the Fortran argument\nand calls the correct templated function.\nAdding the string argument forces a bufferified function\nto be create.\nArgument value is intent(in). The pointer does not change, only\nthe pointee.\nXXX - The function is virtual in the sense that GetScalar1 should\nnot need to exist but there is no way, yet, to avoid wrapping the\nnon-bufferify function.\n"
                 },
+                "name": "GetScalar1",
                 "options": {},
                 "splicer": {
                     "c_buf": [
@@ -699,6 +703,7 @@
                 "doxygen": {
                     "description": "Create several Fortran generic functions which call a single\nC wrapper that checks the type of the Fortran argument\nand calls the correct templated function.\nAdding the string argument forces a bufferified function\nto be create.\nArgument value is intent(in). The pointer does not change, only\nthe pointee.\nXXX - The function is virtual in the sense that GetScalar1 should\nnot need to exist but there is no way, yet, to avoid wrapping the\nnon-bufferify function.\n"
                 },
+                "name": "GetScalar1",
                 "options": {},
                 "splicer": {
                     "c_buf": [
@@ -896,6 +901,7 @@
                 "doxygen": {
                     "description": "Create several Fortran generic functions which call a single\nC wrapper that checks the type of the Fortran argument\nand calls the correct templated function.\nAdding the string argument forces a bufferified function\nto be create.\nArgument value is intent(in). The pointer does not change, only\nthe pointee.\nXXX - The function is virtual in the sense that GetScalar1 should\nnot need to exist but there is no way, yet, to avoid wrapping the\nnon-bufferify function.\n"
                 },
+                "name": "GetScalar1",
                 "options": {},
                 "splicer": {
                     "c_buf": [
@@ -1012,6 +1018,7 @@
                 "doxygen": {
                     "description": "Create several Fortran generic functions which call a single\nC wrapper that checks the type of the Fortran argument\nand calls the correct templated function.\nAdding the string argument forces a bufferified function\nto be create.\nArgument value is intent(in). The pointer does not change, only\nthe pointee.\nXXX - The function is virtual in the sense that GetScalar1 should\nnot need to exist but there is no way, yet, to avoid wrapping the\nnon-bufferify function.\n"
                 },
+                "name": "GetScalar1",
                 "options": {},
                 "splicer": {
                     "c_buf": [
@@ -1162,6 +1169,7 @@
                     "description": "Wrapper for function which is templated on the return value.\n"
                 },
                 "have_template_args": true,
+                "name": "getData",
                 "options": {},
                 "template_arguments": [
                     {
@@ -1223,6 +1231,7 @@
                     "description": "Wrapper for function which is templated on the return value.\n"
                 },
                 "have_template_args": true,
+                "name": "getData",
                 "options": {
                     "F_create_generic": false
                 },
@@ -1343,6 +1352,7 @@
                     "double"
                 ],
                 "have_template_args": true,
+                "name": "getData",
                 "options": {
                     "F_create_generic": false
                 },
@@ -1609,6 +1619,7 @@
                         ]
                     }
                 },
+                "name": "GetScalar2",
                 "options": {
                     "wrap_c": false
                 },
@@ -1703,6 +1714,7 @@
                         ]
                     }
                 },
+                "name": "GetScalar2",
                 "options": {
                     "wrap_c": false
                 },
@@ -1808,6 +1820,7 @@
                         ]
                     }
                 },
+                "name": "GetScalar2",
                 "options": {
                     "wrap_c": false
                 },
@@ -1938,6 +1951,7 @@
                         ]
                     }
                 },
+                "name": "GetScalar2",
                 "options": {
                     "wrap_c": false
                 },
@@ -2043,6 +2057,7 @@
                         ]
                     }
                 },
+                "name": "GetScalar2",
                 "options": {
                     "wrap_c": false
                 },

--- a/regression/reference/cdesc/cdesc.json
+++ b/regression/reference/cdesc/cdesc.json
@@ -21,35 +21,37 @@
                 "_PTR_F_C_index": "10",
                 "ast": {
                     "declarator": {
-                        "name": "Rank2In"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "Rank2In",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "cdesc": true,
+                                        "intent": "in",
+                                        "rank": 2
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "cdesc": true,
-                                "intent": "in",
-                                "rank": 2
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -127,36 +129,38 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "Rank2In"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "Rank2In",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "cdesc": true,
+                                        "intent": "in",
+                                        "rank": 2
+                                    },
+                                    "metaattrs": {
+                                        "api": "cdesc",
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "cdesc": true,
-                                "intent": "in",
-                                "rank": 2
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -235,56 +239,59 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GetScalar1"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in"
-                            },
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "cdesc": true,
-                                "intent": "in",
-                                "rank": 0,
-                                "value": true
+                        "name": "GetScalar1",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "value",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "cdesc": true,
+                                        "intent": "in",
+                                        "rank": 0,
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "value",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -299,19 +306,20 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "intent": "in"
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
                                     "name": "name",
                                     "pointer": [
                                         {
                                             "ptr": "&"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    ],
+                                    "typemap_name": "std::string"
                                 },
                                 "specifier": [
                                     "std::string"
@@ -319,21 +327,22 @@
                                 "typemap_name": "std::string"
                             },
                             {
-                                "attrs": {
-                                    "cdesc": true,
-                                    "intent": "out",
-                                    "rank": 0
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "cdesc": true,
+                                        "intent": "out",
+                                        "rank": 0
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
                                     "name": "value",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "out"
+                                    ],
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -347,19 +356,20 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "intent": "in"
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
                                     "name": "name",
                                     "pointer": [
                                         {
                                             "ptr": "&"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    ],
+                                    "typemap_name": "std::string"
                                 },
                                 "specifier": [
                                     "std::string"
@@ -367,21 +377,22 @@
                                 "typemap_name": "std::string"
                             },
                             {
-                                "attrs": {
-                                    "cdesc": true,
-                                    "intent": "out",
-                                    "rank": 0
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "cdesc": true,
+                                        "intent": "out",
+                                        "rank": 0
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
                                     "name": "value",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "out"
+                                    ],
+                                    "typemap_name": "double"
                                 },
                                 "specifier": [
                                     "double"
@@ -510,55 +521,59 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GetScalar1"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in"
-                            },
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "cdesc": true,
-                                "intent": "out",
-                                "rank": 0
+                        "name": "GetScalar1",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "value",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "cdesc": true,
+                                        "intent": "in",
+                                        "rank": 0,
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "value",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -621,57 +636,59 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GetScalar1"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in"
-                            },
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "cdesc": true,
-                                "intent": "out",
-                                "rank": 0
+                        "name": "GetScalar1",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "value",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "cdesc": true,
+                                        "intent": "in",
+                                        "rank": 0,
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "value",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -817,55 +834,59 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GetScalar1"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in"
-                            },
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "cdesc": true,
-                                "intent": "out",
-                                "rank": 0
+                        "name": "GetScalar1",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "value",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "cdesc": true,
+                                        "intent": "in",
+                                        "rank": 0,
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "value",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -928,57 +949,59 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GetScalar1"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in"
-                            },
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "cdesc": true,
-                                "intent": "out",
-                                "rank": 0
+                        "name": "GetScalar1",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "value",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "cdesc": true,
+                                        "intent": "in",
+                                        "rank": 0,
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "value",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1116,12 +1139,12 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "getData"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "getData",
+                        "params": []
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "DataType"
                     ],
@@ -1182,12 +1205,12 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "getData"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "getData",
+                        "params": []
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -1298,12 +1321,12 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "getData"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "getData",
+                        "params": []
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "double"
                     ],
@@ -1414,54 +1437,57 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GetScalar2"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in"
-                            },
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out",
-                                "value": true
+                        "name": "GetScalar2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "value",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "value",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1476,19 +1502,20 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "intent": "in"
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
                                     "name": "name",
                                     "pointer": [
                                         {
                                             "ptr": "&"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    ],
+                                    "typemap_name": "std::string"
                                 },
                                 "specifier": [
                                     "std::string"
@@ -1496,19 +1523,20 @@
                                 "typemap_name": "std::string"
                             },
                             {
-                                "attrs": {
-                                    "intent": "out"
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
                                     "name": "value",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "out"
+                                    ],
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -1525,19 +1553,20 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "intent": "in"
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
                                     "name": "name",
                                     "pointer": [
                                         {
                                             "ptr": "&"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    ],
+                                    "typemap_name": "std::string"
                                 },
                                 "specifier": [
                                     "std::string"
@@ -1545,19 +1574,20 @@
                                 "typemap_name": "std::string"
                             },
                             {
-                                "attrs": {
-                                    "intent": "out"
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
                                     "name": "value",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "out"
+                                    ],
+                                    "typemap_name": "double"
                                 },
                                 "specifier": [
                                     "double"
@@ -1606,53 +1636,57 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GetScalar2"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in"
-                            },
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                        "name": "GetScalar2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "value",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "value",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1707,54 +1741,57 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GetScalar2"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in"
-                            },
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                        "name": "GetScalar2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "value",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "value",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1835,53 +1872,57 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GetScalar2"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in"
-                            },
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                        "name": "GetScalar2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "value",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "value",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1936,54 +1977,57 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GetScalar2"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in"
-                            },
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                        "name": "GetScalar2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "value",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "value",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],

--- a/regression/reference/classes/classes.json
+++ b/regression/reference/classes/classes.json
@@ -99,16 +99,18 @@
                         "<FUNCTION>": "0 ****************************************",
                         "_overloaded": true,
                         "ast": {
-                            "attrs": {
-                                "_constructor": true,
-                                "_name": "ctor"
+                            "declarator": {
+                                "attrs": {
+                                    "_constructor": true,
+                                    "_name": "ctor"
+                                },
+                                "metaattrs": {
+                                    "api": "capptr",
+                                    "intent": "ctor"
+                                },
+                                "params": [],
+                                "typemap_name": "classes::Class1"
                             },
-                            "declarator": {},
-                            "metaattrs": {
-                                "api": "capptr",
-                                "intent": "ctor"
-                            },
-                            "params": [],
                             "specifier": [
                                 "Class1"
                             ],
@@ -223,32 +225,35 @@
                         "<FUNCTION>": "1 ****************************************",
                         "_overloaded": true,
                         "ast": {
-                            "attrs": {
-                                "_constructor": true,
-                                "_name": "ctor"
+                            "declarator": {
+                                "attrs": {
+                                    "_constructor": true,
+                                    "_name": "ctor"
+                                },
+                                "metaattrs": {
+                                    "api": "capptr",
+                                    "intent": "ctor"
+                                },
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "in"
+                                            },
+                                            "name": "flag",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "classes::Class1"
                             },
-                            "declarator": {},
-                            "metaattrs": {
-                                "api": "capptr",
-                                "intent": "ctor"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "flag"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
                             "specifier": [
                                 "Class1"
                             ],
@@ -429,16 +434,18 @@
                     {
                         "<FUNCTION>": "2 ****************************************",
                         "ast": {
-                            "attrs": {
-                                "_destructor": "Class1",
-                                "_name": "dtor",
-                                "name": "delete"
+                            "declarator": {
+                                "attrs": {
+                                    "_destructor": "Class1",
+                                    "_name": "dtor",
+                                    "name": "delete"
+                                },
+                                "metaattrs": {
+                                    "intent": "dtor"
+                                },
+                                "params": [],
+                                "typemap_name": "void"
                             },
-                            "declarator": {},
-                            "metaattrs": {
-                                "intent": "dtor"
-                            },
-                            "params": [],
                             "specifier": [
                                 "void"
                             ],
@@ -493,12 +500,13 @@
                         "<FUNCTION>": "3 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "Method1"
+                                "metaattrs": {
+                                    "intent": "function"
+                                },
+                                "name": "Method1",
+                                "params": [],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "function"
-                            },
-                            "params": [],
                             "specifier": [
                                 "int"
                             ],
@@ -608,32 +616,34 @@
                         "<FUNCTION>": "4 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "equivalent"
+                                "func_const": true,
+                                "metaattrs": {
+                                    "intent": "function"
+                                },
+                                "name": "equivalent",
+                                "params": [
+                                    {
+                                        "const": true,
+                                        "declarator": {
+                                            "metaattrs": {
+                                                "intent": "in"
+                                            },
+                                            "name": "obj2",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "&"
+                                                }
+                                            ],
+                                            "typemap_name": "classes::Class1"
+                                        },
+                                        "specifier": [
+                                            "Class1"
+                                        ],
+                                        "typemap_name": "classes::Class1"
+                                    }
+                                ],
+                                "typemap_name": "bool"
                             },
-                            "func_const": true,
-                            "metaattrs": {
-                                "intent": "function"
-                            },
-                            "params": [
-                                {
-                                    "const": true,
-                                    "declarator": {
-                                        "name": "obj2",
-                                        "pointer": [
-                                            {
-                                                "ptr": "&"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in"
-                                    },
-                                    "specifier": [
-                                        "Class1"
-                                    ],
-                                    "typemap_name": "classes::Class1"
-                                }
-                            ],
                             "specifier": [
                                 "bool"
                             ],
@@ -795,18 +805,19 @@
                         "<FUNCTION>": "5 ****************************************",
                         "ast": {
                             "declarator": {
+                                "metaattrs": {
+                                    "api": "capptr",
+                                    "intent": "function"
+                                },
                                 "name": "returnThis",
+                                "params": [],
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
+                                ],
+                                "typemap_name": "classes::Class1"
                             },
-                            "metaattrs": {
-                                "api": "capptr",
-                                "intent": "function"
-                            },
-                            "params": [],
                             "specifier": [
                                 "Class1"
                             ],
@@ -836,13 +847,14 @@
                         "_generated": "return_this",
                         "ast": {
                             "declarator": {
-                                "name": "returnThis"
+                                "metaattrs": {
+                                    "api": "capptr",
+                                    "intent": "subroutine"
+                                },
+                                "name": "returnThis",
+                                "params": [],
+                                "typemap_name": "classes::Class1"
                             },
-                            "metaattrs": {
-                                "api": "capptr",
-                                "intent": "subroutine"
-                            },
-                            "params": [],
                             "specifier": [
                                 "void"
                             ],
@@ -897,54 +909,57 @@
                         "_PTR_F_C_index": "16",
                         "ast": {
                             "declarator": {
+                                "metaattrs": {
+                                    "api": "capptr",
+                                    "intent": "function"
+                                },
                                 "name": "returnThisBuffer",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "intent": "in"
+                                            },
+                                            "metaattrs": {
+                                                "intent": "in"
+                                            },
+                                            "name": "name",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "&"
+                                                }
+                                            ],
+                                            "typemap_name": "std::string"
+                                        },
+                                        "specifier": [
+                                            "std::string"
+                                        ],
+                                        "typemap_name": "std::string"
+                                    },
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "in"
+                                            },
+                                            "name": "flag",
+                                            "typemap_name": "bool"
+                                        },
+                                        "specifier": [
+                                            "bool"
+                                        ],
+                                        "typemap_name": "bool"
+                                    }
+                                ],
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
+                                ],
+                                "typemap_name": "classes::Class1"
                             },
-                            "metaattrs": {
-                                "api": "capptr",
-                                "intent": "function"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "intent": "in"
-                                    },
-                                    "declarator": {
-                                        "name": "name",
-                                        "pointer": [
-                                            {
-                                                "ptr": "&"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in"
-                                    },
-                                    "specifier": [
-                                        "std::string"
-                                    ],
-                                    "typemap_name": "std::string"
-                                },
-                                {
-                                    "attrs": {
-                                        "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "flag"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in"
-                                    },
-                                    "specifier": [
-                                        "bool"
-                                    ],
-                                    "typemap_name": "bool"
-                                }
-                            ],
                             "specifier": [
                                 "Class1"
                             ],
@@ -1089,55 +1104,58 @@
                         "_generated": "arg_to_buffer",
                         "ast": {
                             "declarator": {
+                                "metaattrs": {
+                                    "api": "capptr",
+                                    "intent": "function"
+                                },
                                 "name": "returnThisBuffer",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "intent": "in"
+                                            },
+                                            "metaattrs": {
+                                                "api": "buf",
+                                                "intent": "in"
+                                            },
+                                            "name": "name",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "&"
+                                                }
+                                            ],
+                                            "typemap_name": "std::string"
+                                        },
+                                        "specifier": [
+                                            "std::string"
+                                        ],
+                                        "typemap_name": "std::string"
+                                    },
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "in"
+                                            },
+                                            "name": "flag",
+                                            "typemap_name": "bool"
+                                        },
+                                        "specifier": [
+                                            "bool"
+                                        ],
+                                        "typemap_name": "bool"
+                                    }
+                                ],
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
+                                ],
+                                "typemap_name": "classes::Class1"
                             },
-                            "metaattrs": {
-                                "api": "capptr",
-                                "intent": "function"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "intent": "in"
-                                    },
-                                    "declarator": {
-                                        "name": "name",
-                                        "pointer": [
-                                            {
-                                                "ptr": "&"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "api": "buf",
-                                        "intent": "in"
-                                    },
-                                    "specifier": [
-                                        "std::string"
-                                    ],
-                                    "typemap_name": "std::string"
-                                },
-                                {
-                                    "attrs": {
-                                        "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "flag"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in"
-                                    },
-                                    "specifier": [
-                                        "bool"
-                                    ],
-                                    "typemap_name": "bool"
-                                }
-                            ],
                             "specifier": [
                                 "Class1"
                             ],
@@ -1278,19 +1296,20 @@
                         "<FUNCTION>": "7 ****************************************",
                         "ast": {
                             "declarator": {
+                                "func_const": true,
+                                "metaattrs": {
+                                    "api": "capptr",
+                                    "intent": "function"
+                                },
                                 "name": "getclass3",
+                                "params": [],
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
+                                ],
+                                "typemap_name": "classes::Class1"
                             },
-                            "func_const": true,
-                            "metaattrs": {
-                                "api": "capptr",
-                                "intent": "function"
-                            },
-                            "params": [],
                             "specifier": [
                                 "Class1"
                             ],
@@ -1400,18 +1419,19 @@
                         "ast": {
                             "const": true,
                             "declarator": {
+                                "metaattrs": {
+                                    "deref": "allocatable",
+                                    "intent": "function"
+                                },
                                 "name": "getName",
+                                "params": [],
                                 "pointer": [
                                     {
                                         "ptr": "&"
                                     }
-                                ]
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "metaattrs": {
-                                "deref": "allocatable",
-                                "intent": "function"
-                            },
-                            "params": [],
                             "specifier": [
                                 "std::string"
                             ],
@@ -1528,19 +1548,20 @@
                         "ast": {
                             "const": true,
                             "declarator": {
+                                "metaattrs": {
+                                    "api": "cdesc",
+                                    "deref": "allocatable",
+                                    "intent": "function"
+                                },
                                 "name": "getName",
+                                "params": [],
                                 "pointer": [
                                     {
                                         "ptr": "&"
                                     }
-                                ]
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "deref": "allocatable",
-                                "intent": "function"
-                            },
-                            "params": [],
                             "specifier": [
                                 "std::string"
                             ],
@@ -1607,28 +1628,30 @@
                         "<FUNCTION>": "9 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "directionFunc"
+                                "metaattrs": {
+                                    "intent": "function"
+                                },
+                                "name": "directionFunc",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "in"
+                                            },
+                                            "name": "arg",
+                                            "typemap_name": "classes::Class1::DIRECTION"
+                                        },
+                                        "specifier": [
+                                            "DIRECTION"
+                                        ],
+                                        "typemap_name": "classes::Class1::DIRECTION"
+                                    }
+                                ],
+                                "typemap_name": "classes::Class1::DIRECTION"
                             },
-                            "metaattrs": {
-                                "intent": "function"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "arg"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in"
-                                    },
-                                    "specifier": [
-                                        "DIRECTION"
-                                    ],
-                                    "typemap_name": "classes::Class1::DIRECTION"
-                                }
-                            ],
                             "specifier": [
                                 "DIRECTION"
                             ],
@@ -1814,12 +1837,13 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "get_m_flag"
+                                "metaattrs": {
+                                    "intent": "getter"
+                                },
+                                "name": "get_m_flag",
+                                "params": [],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "getter"
-                            },
-                            "params": [],
                             "specifier": [
                                 "int"
                             ],
@@ -1904,12 +1928,13 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "get_test"
+                                "metaattrs": {
+                                    "intent": "getter"
+                                },
+                                "name": "get_test",
+                                "params": [],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "getter"
-                            },
-                            "params": [],
                             "specifier": [
                                 "int"
                             ],
@@ -1994,29 +2019,31 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "set_test"
+                                "metaattrs": {
+                                    "intent": "setter"
+                                },
+                                "name": "set_test",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "intent": "in",
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "setter"
+                                            },
+                                            "name": "val",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "setter"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "intent": "in",
-                                        "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "val"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "setter"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],
@@ -2110,13 +2137,14 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "get_m_name"
+                                "metaattrs": {
+                                    "deref": "allocatable",
+                                    "intent": "getter"
+                                },
+                                "name": "get_m_name",
+                                "params": [],
+                                "typemap_name": "std::string"
                             },
-                            "metaattrs": {
-                                "deref": "allocatable",
-                                "intent": "getter"
-                            },
-                            "params": [],
                             "specifier": [
                                 "std::string"
                             ],
@@ -2173,14 +2201,15 @@
                         "_generated": "arg_to_buffer",
                         "ast": {
                             "declarator": {
-                                "name": "get_m_name"
+                                "metaattrs": {
+                                    "api": "cdesc",
+                                    "deref": "allocatable",
+                                    "intent": "getter"
+                                },
+                                "name": "get_m_name",
+                                "params": [],
+                                "typemap_name": "std::string"
                             },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "deref": "allocatable",
-                                "intent": "getter"
-                            },
-                            "params": [],
                             "specifier": [
                                 "std::string"
                             ],
@@ -2257,28 +2286,30 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "set_m_name"
+                                "metaattrs": {
+                                    "intent": "setter"
+                                },
+                                "name": "set_m_name",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "intent": "in"
+                                            },
+                                            "metaattrs": {
+                                                "intent": "setter"
+                                            },
+                                            "name": "val",
+                                            "typemap_name": "std::string"
+                                        },
+                                        "specifier": [
+                                            "std::string"
+                                        ],
+                                        "typemap_name": "std::string"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "setter"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "intent": "in"
-                                    },
-                                    "declarator": {
-                                        "name": "val"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "setter"
-                                    },
-                                    "specifier": [
-                                        "std::string"
-                                    ],
-                                    "typemap_name": "std::string"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],
@@ -2320,29 +2351,31 @@
                         "_generated": "arg_to_buffer",
                         "ast": {
                             "declarator": {
-                                "name": "set_m_name"
+                                "metaattrs": {
+                                    "intent": "setter"
+                                },
+                                "name": "set_m_name",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "intent": "in"
+                                            },
+                                            "metaattrs": {
+                                                "api": "buf",
+                                                "intent": "setter"
+                                            },
+                                            "name": "val",
+                                            "typemap_name": "std::string"
+                                        },
+                                        "specifier": [
+                                            "std::string"
+                                        ],
+                                        "typemap_name": "std::string"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "setter"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "intent": "in"
-                                    },
-                                    "declarator": {
-                                        "name": "val"
-                                    },
-                                    "metaattrs": {
-                                        "api": "buf",
-                                        "intent": "setter"
-                                    },
-                                    "specifier": [
-                                        "std::string"
-                                    ],
-                                    "typemap_name": "std::string"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],
@@ -2432,11 +2465,12 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "readonly": true
-                            },
                             "declarator": {
-                                "name": "m_flag"
+                                "attrs": {
+                                    "readonly": true
+                                },
+                                "name": "m_flag",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -2466,11 +2500,12 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "name": "test"
-                            },
                             "declarator": {
-                                "name": "m_test"
+                                "attrs": {
+                                    "name": "test"
+                                },
+                                "name": "m_test",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -2501,7 +2536,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "m_name"
+                                "name": "m_name",
+                                "typemap_name": "std::string"
                             },
                             "specifier": [
                                 "std::string"
@@ -2580,18 +2616,19 @@
                         "ast": {
                             "const": true,
                             "declarator": {
+                                "metaattrs": {
+                                    "deref": "allocatable",
+                                    "intent": "function"
+                                },
                                 "name": "getName",
+                                "params": [],
                                 "pointer": [
                                     {
                                         "ptr": "&"
                                     }
-                                ]
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "metaattrs": {
-                                "deref": "allocatable",
-                                "intent": "function"
-                            },
-                            "params": [],
                             "specifier": [
                                 "std::string"
                             ],
@@ -2708,19 +2745,20 @@
                         "ast": {
                             "const": true,
                             "declarator": {
+                                "metaattrs": {
+                                    "api": "cdesc",
+                                    "deref": "allocatable",
+                                    "intent": "function"
+                                },
                                 "name": "getName",
+                                "params": [],
                                 "pointer": [
                                     {
                                         "ptr": "&"
                                     }
-                                ]
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "deref": "allocatable",
-                                "intent": "function"
-                            },
-                            "params": [],
                             "specifier": [
                                 "std::string"
                             ],
@@ -2837,18 +2875,19 @@
                         "<FUNCTION>": "22 ****************************************",
                         "ast": {
                             "declarator": {
+                                "metaattrs": {
+                                    "api": "capptr",
+                                    "intent": "function"
+                                },
                                 "name": "getReference",
+                                "params": [],
                                 "pointer": [
                                     {
                                         "ptr": "&"
                                     }
-                                ]
+                                ],
+                                "typemap_name": "classes::Singleton"
                             },
-                            "metaattrs": {
-                                "api": "capptr",
-                                "intent": "function"
-                            },
-                            "params": [],
                             "specifier": [
                                 "Singleton"
                             ],
@@ -3006,16 +3045,18 @@
                         "<FUNCTION>": "23 ****************************************",
                         "_overloaded": true,
                         "ast": {
-                            "attrs": {
-                                "_constructor": true,
-                                "_name": "ctor"
+                            "declarator": {
+                                "attrs": {
+                                    "_constructor": true,
+                                    "_name": "ctor"
+                                },
+                                "metaattrs": {
+                                    "api": "capptr",
+                                    "intent": "ctor"
+                                },
+                                "params": [],
+                                "typemap_name": "classes::Shape"
                             },
-                            "declarator": {},
-                            "metaattrs": {
-                                "api": "capptr",
-                                "intent": "ctor"
-                            },
-                            "params": [],
                             "specifier": [
                                 "Shape"
                             ],
@@ -3126,13 +3167,14 @@
                         "<FUNCTION>": "24 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "get_ivar"
+                                "func_const": true,
+                                "metaattrs": {
+                                    "intent": "function"
+                                },
+                                "name": "get_ivar",
+                                "params": [],
+                                "typemap_name": "int"
                             },
-                            "func_const": true,
-                            "metaattrs": {
-                                "intent": "function"
-                            },
-                            "params": [],
                             "specifier": [
                                 "int"
                             ],
@@ -3297,16 +3339,18 @@
                         "<FUNCTION>": "25 ****************************************",
                         "_overloaded": true,
                         "ast": {
-                            "attrs": {
-                                "_constructor": true,
-                                "_name": "ctor"
+                            "declarator": {
+                                "attrs": {
+                                    "_constructor": true,
+                                    "_name": "ctor"
+                                },
+                                "metaattrs": {
+                                    "api": "capptr",
+                                    "intent": "ctor"
+                                },
+                                "params": [],
+                                "typemap_name": "classes::Circle"
                             },
-                            "declarator": {},
-                            "metaattrs": {
-                                "api": "capptr",
-                                "intent": "ctor"
-                            },
-                            "params": [],
                             "specifier": [
                                 "Circle"
                             ],
@@ -3469,28 +3513,30 @@
                         "<FUNCTION>": "26 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "allocate"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "allocate",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "in"
+                                            },
+                                            "name": "n",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "n"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],
@@ -3570,12 +3616,13 @@
                         "<FUNCTION>": "27 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "free"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "free",
+                                "params": [],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [],
                             "specifier": [
                                 "void"
                             ],
@@ -3619,16 +3666,18 @@
                         "<FUNCTION>": "28 ****************************************",
                         "_overloaded": true,
                         "ast": {
-                            "attrs": {
-                                "_constructor": true,
-                                "_name": "ctor"
+                            "declarator": {
+                                "attrs": {
+                                    "_constructor": true,
+                                    "_name": "ctor"
+                                },
+                                "metaattrs": {
+                                    "api": "capptr",
+                                    "intent": "ctor"
+                                },
+                                "params": [],
+                                "typemap_name": "classes::Data"
                             },
-                            "declarator": {},
-                            "metaattrs": {
-                                "api": "capptr",
-                                "intent": "ctor"
-                            },
-                            "params": [],
                             "specifier": [
                                 "Data"
                             ],
@@ -3701,15 +3750,17 @@
                     {
                         "<FUNCTION>": "29 ****************************************",
                         "ast": {
-                            "attrs": {
-                                "_destructor": "Data",
-                                "_name": "dtor"
+                            "declarator": {
+                                "attrs": {
+                                    "_destructor": "Data",
+                                    "_name": "dtor"
+                                },
+                                "metaattrs": {
+                                    "intent": "dtor"
+                                },
+                                "params": [],
+                                "typemap_name": "void"
                             },
-                            "declarator": {},
-                            "metaattrs": {
-                                "intent": "dtor"
-                            },
-                            "params": [],
                             "specifier": [
                                 "void"
                             ],
@@ -3758,12 +3809,13 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "get_nitems"
+                                "metaattrs": {
+                                    "intent": "getter"
+                                },
+                                "name": "get_nitems",
+                                "params": [],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "getter"
-                            },
-                            "params": [],
                             "specifier": [
                                 "int"
                             ],
@@ -3848,29 +3900,31 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "set_nitems"
+                                "metaattrs": {
+                                    "intent": "setter"
+                                },
+                                "name": "set_nitems",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "intent": "in",
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "setter"
+                                            },
+                                            "name": "val",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "setter"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "intent": "in",
-                                        "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "val"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "setter"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],
@@ -3964,23 +4018,24 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
+                                "metaattrs": {
+                                    "deref": "pointer",
+                                    "dimension": [
+                                        {
+                                            "name": "nitems"
+                                        }
+                                    ],
+                                    "intent": "getter"
+                                },
                                 "name": "get_items",
+                                "params": [],
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "name": "nitems"
-                                    }
                                 ],
-                                "intent": "getter"
+                                "typemap_name": "int"
                             },
-                            "params": [],
                             "specifier": [
                                 "int"
                             ],
@@ -4040,24 +4095,25 @@
                         "_generated": "arg_to_buffer",
                         "ast": {
                             "declarator": {
+                                "metaattrs": {
+                                    "api": "cdesc",
+                                    "deref": "pointer",
+                                    "dimension": [
+                                        {
+                                            "name": "nitems"
+                                        }
+                                    ],
+                                    "intent": "getter"
+                                },
                                 "name": "get_items",
+                                "params": [],
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "name": "nitems"
-                                    }
                                 ],
-                                "intent": "getter"
+                                "typemap_name": "int"
                             },
-                            "params": [],
                             "specifier": [
                                 "int"
                             ],
@@ -4138,39 +4194,41 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "set_items"
-                            },
-                            "metaattrs": {
-                                "intent": "setter"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "intent": "in",
-                                        "rank": 1
-                                    },
-                                    "declarator": {
-                                        "name": "val",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "dimension": [
-                                            {
-                                                "name": "nitems"
-                                            }
+                                "metaattrs": {
+                                    "intent": "setter"
+                                },
+                                "name": "set_items",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "intent": "in",
+                                                "rank": 1
+                                            },
+                                            "metaattrs": {
+                                                "dimension": [
+                                                    {
+                                                        "name": "nitems"
+                                                    }
+                                                ],
+                                                "intent": "setter"
+                                            },
+                                            "name": "val",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
                                         ],
-                                        "intent": "setter"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "void"
+                            },
                             "specifier": [
                                 "void"
                             ],
@@ -4279,7 +4337,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "nitems"
+                                "name": "nitems",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -4304,23 +4363,24 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "name": "nitems"
+                                        }
+                                    ]
+                                },
                                 "name": "items",
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nitems"
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -4386,28 +4446,30 @@
                 "<FUNCTION>": "35 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "directionFunc"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "directionFunc",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "classes::Class1::DIRECTION"
+                                },
+                                "specifier": [
+                                    "Class1::DIRECTION"
+                                ],
+                                "typemap_name": "classes::Class1::DIRECTION"
+                            }
+                        ],
+                        "typemap_name": "classes::Class1::DIRECTION"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Class1::DIRECTION"
-                            ],
-                            "typemap_name": "classes::Class1::DIRECTION"
-                        }
-                    ],
                     "specifier": [
                         "Class1::DIRECTION"
                     ],
@@ -4585,28 +4647,30 @@
                 "<FUNCTION>": "36 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passClassByValue"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "passClassByValue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "classes::Class1"
+                                },
+                                "specifier": [
+                                    "Class1"
+                                ],
+                                "typemap_name": "classes::Class1"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Class1"
-                            ],
-                            "typemap_name": "classes::Class1"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -4713,31 +4777,33 @@
                 "<FUNCTION>": "37 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "useclass"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "useclass",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "classes::Class1"
+                                },
+                                "specifier": [
+                                    "Class1"
+                                ],
+                                "typemap_name": "classes::Class1"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Class1"
-                            ],
-                            "typemap_name": "classes::Class1"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -4891,18 +4957,19 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
                         "name": "getclass2",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "classes::Class1"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "Class1"
                     ],
@@ -4981,18 +5048,19 @@
                 "<FUNCTION>": "39 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
                         "name": "getclass3",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "classes::Class1"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "Class1"
                     ],
@@ -5094,18 +5162,19 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "api": "capsule",
+                            "intent": "function"
+                        },
                         "name": "getclass2_void",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "classes::Class1"
                     },
-                    "metaattrs": {
-                        "api": "capsule",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "Class1"
                     ],
@@ -5183,18 +5252,19 @@
                 "<FUNCTION>": "41 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "capsule",
+                            "intent": "function"
+                        },
                         "name": "getclass3_void",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "classes::Class1"
                     },
-                    "metaattrs": {
-                        "api": "capsule",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "Class1"
                     ],
@@ -5273,18 +5343,19 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
                         "name": "getConstClassReference",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "classes::Class1"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "Class1"
                     ],
@@ -5360,18 +5431,19 @@
                 "<FUNCTION>": "43 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
                         "name": "getClassReference",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "classes::Class1"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "Class1"
                     ],
@@ -5469,29 +5541,31 @@
                 "<FUNCTION>": "44 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getClassCopy"
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
+                        "name": "getClassCopy",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "flag",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "classes::Class1"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "flag"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "Class1"
                     ],
@@ -5606,28 +5680,30 @@
                 "<FUNCTION>": "45 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "set_global_flag"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "set_global_flag",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -5747,12 +5823,13 @@
                 "<FUNCTION>": "46 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "get_global_flag"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "get_global_flag",
+                        "params": [],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -5857,23 +5934,24 @@
                 ],
                 "_PTR_F_C_index": "48",
                 "ast": {
-                    "attrs": {
-                        "len": "30"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "len": "30"
+                        },
+                        "metaattrs": {
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "LastFunctionCalled",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -5979,24 +6057,25 @@
                 "_PTR_C_CXX_index": "47",
                 "_generated": "arg_to_buffer",
                 "ast": {
-                    "attrs": {
-                        "len": "30"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "len": "30"
+                        },
+                        "metaattrs": {
+                            "api": "buf",
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "LastFunctionCalled",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "buf",
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],

--- a/regression/reference/classes/classes.json
+++ b/regression/reference/classes/classes.json
@@ -111,6 +111,7 @@
                                 "params": [],
                                 "typemap_name": "classes::Class1"
                             },
+                            "is_ctor": true,
                             "specifier": [
                                 "Class1"
                             ],
@@ -255,6 +256,7 @@
                                 ],
                                 "typemap_name": "classes::Class1"
                             },
+                            "is_ctor": true,
                             "specifier": [
                                 "Class1"
                             ],
@@ -448,6 +450,7 @@
                                 "params": [],
                                 "typemap_name": "void"
                             },
+                            "is_dtor": "Class1",
                             "specifier": [
                                 "void"
                             ],
@@ -3080,6 +3083,7 @@
                                 "params": [],
                                 "typemap_name": "classes::Shape"
                             },
+                            "is_ctor": true,
                             "specifier": [
                                 "Shape"
                             ],
@@ -3376,6 +3380,7 @@
                                 "params": [],
                                 "typemap_name": "classes::Circle"
                             },
+                            "is_ctor": true,
                             "specifier": [
                                 "Circle"
                             ],
@@ -3706,6 +3711,7 @@
                                 "params": [],
                                 "typemap_name": "classes::Data"
                             },
+                            "is_ctor": true,
                             "specifier": [
                                 "Data"
                             ],
@@ -3790,6 +3796,7 @@
                                 "params": [],
                                 "typemap_name": "void"
                             },
+                            "is_dtor": "Data",
                             "specifier": [
                                 "void"
                             ],

--- a/regression/reference/classes/classes.json
+++ b/regression/reference/classes/classes.json
@@ -853,7 +853,7 @@
                                 },
                                 "name": "returnThis",
                                 "params": [],
-                                "typemap_name": "classes::Class1"
+                                "typemap_name": "void"
                             },
                             "specifier": [
                                 "void"

--- a/regression/reference/classes/classes.json
+++ b/regression/reference/classes/classes.json
@@ -118,6 +118,7 @@
                         },
                         "decl": "Class1()",
                         "declgen": "Class1(void)",
+                        "name": "ctor",
                         "options": {
                             "F_create_generic": true
                         },
@@ -261,6 +262,7 @@
                         },
                         "decl": "Class1(int flag)",
                         "declgen": "Class1(int flag +value)",
+                        "name": "ctor",
                         "options": {
                             "F_create_generic": true
                         },
@@ -453,6 +455,7 @@
                         },
                         "decl": "~Class1()        +name(delete)",
                         "declgen": "~Class1(void) +name(delete)",
+                        "name": "delete",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -517,6 +520,7 @@
                         "doxygen": {
                             "brief": "returns the value of flag member"
                         },
+                        "name": "Method1",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -654,6 +658,7 @@
                         "doxygen": {
                             "brief": "Pass in reference to instance"
                         },
+                        "name": "equivalent",
                         "options": {
                             "wrap_lua": false
                         },
@@ -828,6 +833,7 @@
                         "doxygen": {
                             "brief": "Return pointer to 'this' to allow chaining calls"
                         },
+                        "name": "returnThis",
                         "options": {
                             "wrap_lua": false,
                             "wrap_python": false
@@ -865,6 +871,7 @@
                         "doxygen": {
                             "brief": "Return pointer to 'this' to allow chaining calls"
                         },
+                        "name": "returnThis",
                         "options": {
                             "wrap_lua": false,
                             "wrap_python": false
@@ -970,6 +977,7 @@
                         "doxygen": {
                             "brief": "Return pointer to 'this' to allow chaining calls"
                         },
+                        "name": "returnThisBuffer",
                         "options": {
                             "wrap_lua": false,
                             "wrap_python": false
@@ -1166,6 +1174,7 @@
                         "doxygen": {
                             "brief": "Return pointer to 'this' to allow chaining calls"
                         },
+                        "name": "returnThisBuffer",
                         "options": {
                             "wrap_lua": false,
                             "wrap_python": false
@@ -1320,6 +1329,7 @@
                         "doxygen": {
                             "brief": "Test const method"
                         },
+                        "name": "getclass3",
                         "options": {
                             "wrap_lua": false
                         },
@@ -1442,6 +1452,7 @@
                         "doxygen": {
                             "brief": "test helper"
                         },
+                        "name": "getName",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -1572,6 +1583,7 @@
                         "doxygen": {
                             "brief": "test helper"
                         },
+                        "name": "getName",
                         "options": {},
                         "splicer_group": "buf",
                         "wrap": {
@@ -1659,6 +1671,7 @@
                         },
                         "decl": "DIRECTION directionFunc(DIRECTION arg);",
                         "declgen": "DIRECTION directionFunc(DIRECTION arg +value)",
+                        "name": "directionFunc",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -1851,6 +1864,7 @@
                         },
                         "decl": "int get_m_flag()",
                         "declgen": "int get_m_flag(void)",
+                        "name": "get_m_flag",
                         "options": {},
                         "user_fmt": {
                             "field_name": "m_flag",
@@ -1942,6 +1956,7 @@
                         },
                         "decl": "int get_test()",
                         "declgen": "int get_test(void)",
+                        "name": "get_test",
                         "options": {},
                         "user_fmt": {
                             "field_name": "m_test",
@@ -2051,6 +2066,7 @@
                         },
                         "decl": "void set_test(int val)",
                         "declgen": "void set_test(int val +intent(in)+value)",
+                        "name": "set_test",
                         "options": {},
                         "user_fmt": {
                             "field_name": "m_test",
@@ -2152,6 +2168,7 @@
                         },
                         "decl": "std::string get_m_name()",
                         "declgen": "std::string get_m_name(void)",
+                        "name": "get_m_name",
                         "options": {},
                         "user_fmt": {
                             "field_name": "m_name",
@@ -2217,6 +2234,7 @@
                         },
                         "decl": "std::string get_m_name()",
                         "declgen": "std::string get_m_name(void)",
+                        "name": "get_m_name",
                         "options": {},
                         "splicer_group": "buf",
                         "user_fmt": {
@@ -2317,6 +2335,7 @@
                         },
                         "decl": "void set_m_name(std::string val)",
                         "declgen": "void set_m_name(std::string val +intent(in))",
+                        "name": "set_m_name",
                         "options": {},
                         "user_fmt": {
                             "field_name": "m_name",
@@ -2383,6 +2402,7 @@
                         },
                         "decl": "void set_m_name(std::string val)",
                         "declgen": "void set_m_name(std::string val +intent(in))",
+                        "name": "set_m_name",
                         "options": {},
                         "splicer_group": "buf",
                         "user_fmt": {
@@ -2639,6 +2659,7 @@
                         "doxygen": {
                             "brief": "test helper"
                         },
+                        "name": "getName",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -2769,6 +2790,7 @@
                         "doxygen": {
                             "brief": "test helper"
                         },
+                        "name": "getName",
                         "options": {},
                         "splicer_group": "buf",
                         "wrap": {
@@ -2898,6 +2920,7 @@
                         },
                         "decl": "static Singleton& getReference()",
                         "declgen": "static Singleton & getReference(void)",
+                        "name": "getReference",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -3064,6 +3087,7 @@
                         },
                         "decl": "Shape()",
                         "declgen": "Shape(void)",
+                        "name": "ctor",
                         "options": {
                             "F_create_generic": true
                         },
@@ -3182,6 +3206,7 @@
                         },
                         "decl": "int get_ivar() const",
                         "declgen": "int get_ivar(void) const",
+                        "name": "get_ivar",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -3358,6 +3383,7 @@
                         },
                         "decl": "Circle()",
                         "declgen": "Circle(void)",
+                        "name": "ctor",
                         "options": {
                             "F_create_generic": true
                         },
@@ -3544,6 +3570,7 @@
                         },
                         "decl": "void allocate(int n);",
                         "declgen": "void allocate(int n +value)",
+                        "name": "allocate",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -3630,6 +3657,7 @@
                         },
                         "decl": "void free();",
                         "declgen": "void free(void)",
+                        "name": "free",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -3685,6 +3713,7 @@
                         },
                         "decl": "Data()",
                         "declgen": "Data(void)",
+                        "name": "ctor",
                         "options": {
                             "F_create_generic": true
                         },
@@ -3768,6 +3797,7 @@
                         },
                         "decl": "~Data()",
                         "declgen": "~Data(void)",
+                        "name": "dtor",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -3823,6 +3853,7 @@
                         },
                         "decl": "int get_nitems()",
                         "declgen": "int get_nitems(void)",
+                        "name": "get_nitems",
                         "options": {},
                         "user_fmt": {
                             "field_name": "nitems",
@@ -3932,6 +3963,7 @@
                         },
                         "decl": "void set_nitems(int val)",
                         "declgen": "void set_nitems(int val +intent(in)+value)",
+                        "name": "set_nitems",
                         "options": {},
                         "user_fmt": {
                             "field_name": "nitems",
@@ -4043,6 +4075,7 @@
                         },
                         "decl": "int * get_items()",
                         "declgen": "int * get_items(void)",
+                        "name": "get_items",
                         "options": {},
                         "user_fmt": {
                             "field_name": "items",
@@ -4121,6 +4154,7 @@
                         },
                         "decl": "int * get_items()",
                         "declgen": "int * get_items(void)",
+                        "name": "get_items",
                         "options": {},
                         "splicer_group": "buf",
                         "user_fmt": {
@@ -4236,6 +4270,7 @@
                         },
                         "decl": "void set_items(int * val)",
                         "declgen": "void set_items(int * val +intent(in)+rank(1))",
+                        "name": "set_items",
                         "options": {},
                         "user_fmt": {
                             "field_name": "items",
@@ -4477,6 +4512,7 @@
                 },
                 "decl": "Class1::DIRECTION directionFunc(Class1::DIRECTION arg);",
                 "declgen": "Class1::DIRECTION directionFunc(Class1::DIRECTION arg +value)",
+                "name": "directionFunc",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -4681,6 +4717,7 @@
                 "doxygen": {
                     "brief": "Pass arguments to a function."
                 },
+                "name": "passClassByValue",
                 "options": {
                     "wrap_lua": false
                 },
@@ -4811,6 +4848,7 @@
                 },
                 "decl": "int useclass(const Class1 *arg)",
                 "declgen": "int useclass(const Class1 * arg)",
+                "name": "useclass",
                 "options": {
                     "wrap_lua": false
                 },
@@ -4980,6 +5018,7 @@
                 "doxygen": {
                     "brief": "Return const class pointer"
                 },
+                "name": "getclass2",
                 "options": {
                     "wrap_lua": false,
                     "wrap_python": false
@@ -5071,6 +5110,7 @@
                 "doxygen": {
                     "brief": "Return class pointer"
                 },
+                "name": "getclass3",
                 "options": {
                     "wrap_lua": false
                 },
@@ -5185,6 +5225,7 @@
                 "doxygen": {
                     "brief": "C wrapper will return void"
                 },
+                "name": "getclass2_void",
                 "options": {
                     "C_shadow_result": false,
                     "wrap_lua": false,
@@ -5275,6 +5316,7 @@
                 "doxygen": {
                     "brief": "C wrapper will return void"
                 },
+                "name": "getclass3_void",
                 "options": {
                     "C_shadow_result": false,
                     "wrap_lua": false,
@@ -5363,6 +5405,7 @@
                 },
                 "decl": "const Class1 &getConstClassReference()",
                 "declgen": "const Class1 & getConstClassReference(void)",
+                "name": "getConstClassReference",
                 "options": {
                     "wrap_lua": false,
                     "wrap_python": false
@@ -5451,6 +5494,7 @@
                 },
                 "decl": "Class1 &getClassReference()",
                 "declgen": "Class1 & getClassReference(void)",
+                "name": "getClassReference",
                 "options": {
                     "wrap_lua": false
                 },
@@ -5576,6 +5620,7 @@
                 "doxygen": {
                     "brief": "Return Class1 instance by value, uses copy constructor"
                 },
+                "name": "getClassCopy",
                 "options": {
                     "wrap_lua": false,
                     "wrap_python": false
@@ -5711,6 +5756,7 @@
                 },
                 "decl": "void set_global_flag(int arg)",
                 "declgen": "void set_global_flag(int arg +value)",
+                "name": "set_global_flag",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -5837,6 +5883,7 @@
                 },
                 "decl": "int get_global_flag()",
                 "declgen": "int get_global_flag(void)",
+                "name": "get_global_flag",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -5959,6 +6006,7 @@
                 },
                 "decl": "const std::string& LastFunctionCalled() +len(30)",
                 "declgen": "const std::string & LastFunctionCalled(void) +len(30)",
+                "name": "LastFunctionCalled",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -6083,6 +6131,7 @@
                 },
                 "decl": "const std::string& LastFunctionCalled() +len(30)",
                 "declgen": "const std::string & LastFunctionCalled(void) +len(30)",
+                "name": "LastFunctionCalled",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {

--- a/regression/reference/classes/classes.json
+++ b/regression/reference/classes/classes.json
@@ -103,6 +103,7 @@
                                 "_constructor": true,
                                 "_name": "ctor"
                             },
+                            "declarator": {},
                             "metaattrs": {
                                 "api": "capptr",
                                 "intent": "ctor"
@@ -226,6 +227,7 @@
                                 "_constructor": true,
                                 "_name": "ctor"
                             },
+                            "declarator": {},
                             "metaattrs": {
                                 "api": "capptr",
                                 "intent": "ctor"
@@ -432,6 +434,7 @@
                                 "_name": "dtor",
                                 "name": "delete"
                             },
+                            "declarator": {},
                             "metaattrs": {
                                 "intent": "dtor"
                             },
@@ -3007,6 +3010,7 @@
                                 "_constructor": true,
                                 "_name": "ctor"
                             },
+                            "declarator": {},
                             "metaattrs": {
                                 "api": "capptr",
                                 "intent": "ctor"
@@ -3297,6 +3301,7 @@
                                 "_constructor": true,
                                 "_name": "ctor"
                             },
+                            "declarator": {},
                             "metaattrs": {
                                 "api": "capptr",
                                 "intent": "ctor"
@@ -3618,6 +3623,7 @@
                                 "_constructor": true,
                                 "_name": "ctor"
                             },
+                            "declarator": {},
                             "metaattrs": {
                                 "api": "capptr",
                                 "intent": "ctor"
@@ -3699,6 +3705,7 @@
                                 "_destructor": "Data",
                                 "_name": "dtor"
                             },
+                            "declarator": {},
                             "metaattrs": {
                                 "intent": "dtor"
                             },

--- a/regression/reference/clibrary/clibrary.json
+++ b/regression/reference/clibrary/clibrary.json
@@ -4827,6 +4827,7 @@
                                     "metaattrs": {
                                         "intent": "in"
                                     },
+                                    "name": "incr",
                                     "params": [],
                                     "typemap_name": "void"
                                 },
@@ -4987,6 +4988,7 @@
                                     "metaattrs": {
                                         "intent": "in"
                                     },
+                                    "name": "incr",
                                     "params": [],
                                     "typemap_name": "void"
                                 },
@@ -5170,6 +5172,7 @@
                                     "metaattrs": {
                                         "intent": "in"
                                     },
+                                    "name": "incr",
                                     "params": [
                                         {
                                             "declarator": {
@@ -5401,6 +5404,7 @@
                                     "metaattrs": {
                                         "intent": "in"
                                     },
+                                    "name": "incr",
                                     "params": [
                                         {
                                             "declarator": {
@@ -5676,6 +5680,7 @@
                                     "metaattrs": {
                                         "intent": "in"
                                     },
+                                    "name": "incr",
                                     "params": [
                                         {
                                             "declarator": {
@@ -5944,6 +5949,7 @@
                                     "metaattrs": {
                                         "intent": "in"
                                     },
+                                    "name": "alloc",
                                     "params": [
                                         {
                                             "declarator": {

--- a/regression/reference/clibrary/clibrary.json
+++ b/regression/reference/clibrary/clibrary.json
@@ -21,7 +21,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "tc"
+                                "name": "tc",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -84,12 +85,13 @@
                 "<FUNCTION>": "0 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "NoReturnNoArguments"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "NoReturnNoArguments",
+                        "params": [],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [],
                     "specifier": [
                         "void"
                     ],
@@ -132,43 +134,46 @@
                 "<FUNCTION>": "1 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "PassByValue"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "PassByValue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "double"
+                    },
                     "specifier": [
                         "double"
                     ],
@@ -367,53 +372,56 @@
                 "<FUNCTION>": "2 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "PassByReference"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in"
-                            },
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                        "name": "PassByReference",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "arg2",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg2",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -566,28 +574,30 @@
                 "<FUNCTION>": "3 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "PassByValueMacro"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "PassByValueMacro",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "double"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "double"
                     ],
@@ -737,69 +747,73 @@
                 "<FUNCTION>": "4 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "checkBool"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "bool"
-                            ],
-                            "typemap_name": "bool"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                        "name": "checkBool",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "bool"
+                                },
+                                "specifier": [
+                                    "bool"
+                                ],
+                                "typemap_name": "bool"
                             },
-                            "declarator": {
-                                "name": "arg2",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg2",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "bool"
+                                },
+                                "specifier": [
+                                    "bool"
+                                ],
+                                "typemap_name": "bool"
                             },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "bool"
-                            ],
-                            "typemap_name": "bool"
-                        },
-                        {
-                            "attrs": {
-                                "intent": "inout"
-                            },
-                            "declarator": {
-                                "name": "arg3",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "bool"
-                            ],
-                            "typemap_name": "bool"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg3",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "bool"
+                                },
+                                "specifier": [
+                                    "bool"
+                                ],
+                                "typemap_name": "bool"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1015,61 +1029,64 @@
                 ],
                 "_PTR_F_C_index": "26",
                 "ast": {
-                    "attrs": {
-                        "len": "30"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "len": "30"
+                        },
+                        "metaattrs": {
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "Function4a",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "ftrim_char_in": true,
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            },
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "ftrim_char_in": true,
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "char"
                     },
-                    "metaattrs": {
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "ftrim_char_in": true,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        },
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg2",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "ftrim_char_in": true,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "char"
                     ],
@@ -1261,62 +1278,65 @@
                 "_PTR_C_CXX_index": "5",
                 "_generated": "arg_to_buffer",
                 "ast": {
-                    "attrs": {
-                        "len": "30"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "len": "30"
+                        },
+                        "metaattrs": {
+                            "api": "buf",
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "Function4a",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "ftrim_char_in": true,
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            },
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "ftrim_char_in": true,
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "char"
                     },
-                    "metaattrs": {
-                        "api": "buf",
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "ftrim_char_in": true,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        },
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg2",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "ftrim_char_in": true,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "char"
                     ],
@@ -1437,32 +1457,34 @@
                 "<FUNCTION>": "6 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptName"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptName",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "ftrim_char_in": true,
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "ftrim_char_in": true,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -1562,33 +1584,35 @@
                 "_PTR_F_C_index": "27",
                 "ast": {
                     "declarator": {
-                        "name": "passCharPtrInOut"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "passCharPtrInOut",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "s",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout"
-                            },
-                            "declarator": {
-                                "name": "s",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -1687,34 +1711,36 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "passCharPtrInOut"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "passCharPtrInOut",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout"
+                                    },
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "inout"
+                                    },
+                                    "name": "s",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout"
-                            },
-                            "declarator": {
-                                "name": "s",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -1792,34 +1818,36 @@
                 "_PTR_F_C_index": "28",
                 "ast": {
                     "declarator": {
-                        "name": "returnOneName"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "returnOneName",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "charlen": "MAXNAME",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "name1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "charlen": "MAXNAME",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "name1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -1921,35 +1949,37 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "returnOneName"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "returnOneName",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "charlen": "MAXNAME",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "out"
+                                    },
+                                    "name": "name1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "charlen": "MAXNAME",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "name1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -2029,55 +2059,58 @@
                 "_PTR_F_C_index": "29",
                 "ast": {
                     "declarator": {
-                        "name": "returnTwoNames"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "charlen": "MAXNAME",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "name1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "charlen": "MAXNAME",
-                                "intent": "out"
+                        "name": "returnTwoNames",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "charlen": "MAXNAME",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "name1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
                             },
-                            "declarator": {
-                                "name": "name2",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "charlen": "MAXNAME",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "name2",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2227,57 +2260,60 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "returnTwoNames"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "charlen": "MAXNAME",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "name1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "charlen": "MAXNAME",
-                                "intent": "out"
+                        "name": "returnTwoNames",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "charlen": "MAXNAME",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "out"
+                                    },
+                                    "name": "name1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
                             },
-                            "declarator": {
-                                "name": "name2",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "charlen": "MAXNAME",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "out"
+                                    },
+                                    "name": "name2",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2390,50 +2426,53 @@
                 "_PTR_F_C_index": "30",
                 "ast": {
                     "declarator": {
-                        "name": "ImpliedTextLen"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "charlen": "MAXNAME",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "text",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "len(text)",
-                                "value": true
+                        "name": "ImpliedTextLen",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "charlen": "MAXNAME",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "text",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
                             },
-                            "declarator": {
-                                "name": "ltext"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "len(text)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "ltext",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2581,51 +2620,54 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "ImpliedTextLen"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "charlen": "MAXNAME",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "text",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "len(text)",
-                                "value": true
+                        "name": "ImpliedTextLen",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "charlen": "MAXNAME",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "out"
+                                    },
+                                    "name": "text",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
                             },
-                            "declarator": {
-                                "name": "ltext"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "len(text)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "ltext",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2730,64 +2772,68 @@
                 "<FUNCTION>": "11 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "ImpliedLen"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "text",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "ftrim_char_in": true,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "implied": "len(text)",
-                                "value": true
+                        "name": "ImpliedLen",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "text",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "ftrim_char_in": true,
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
                             },
-                            "declarator": {
-                                "name": "ltext"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "len(text)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "ltext",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "false",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "flag"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "bool"
-                            ],
-                            "typemap_name": "bool"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "false",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "flag",
+                                    "typemap_name": "bool"
+                                },
+                                "specifier": [
+                                    "bool"
+                                ],
+                                "typemap_name": "bool"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -3032,64 +3078,68 @@
                 "<FUNCTION>": "12 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "ImpliedLenTrim"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "text",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "ftrim_char_in": true,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "implied": "len_trim(text)",
-                                "value": true
+                        "name": "ImpliedLenTrim",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "text",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "ftrim_char_in": true,
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
                             },
-                            "declarator": {
-                                "name": "ltext"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "len_trim(text)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "ltext",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "true",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "flag"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "bool"
-                            ],
-                            "typemap_name": "bool"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "true",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "flag",
+                                    "typemap_name": "bool"
+                                },
+                                "specifier": [
+                                    "bool"
+                                ],
+                                "typemap_name": "bool"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -3334,29 +3384,31 @@
                 "<FUNCTION>": "13 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "ImpliedBoolTrue"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "ImpliedBoolTrue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "true",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "flag",
+                                    "typemap_name": "bool"
+                                },
+                                "specifier": [
+                                    "bool"
+                                ],
+                                "typemap_name": "bool"
+                            }
+                        ],
+                        "typemap_name": "bool"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "implied": "true",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "flag"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "bool"
-                            ],
-                            "typemap_name": "bool"
-                        }
-                    ],
                     "specifier": [
                         "bool"
                     ],
@@ -3502,29 +3554,31 @@
                 "<FUNCTION>": "14 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "ImpliedBoolFalse"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "ImpliedBoolFalse",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "false",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "flag",
+                                    "typemap_name": "bool"
+                                },
+                                "specifier": [
+                                    "bool"
+                                ],
+                                "typemap_name": "bool"
+                            }
+                        ],
+                        "typemap_name": "bool"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "implied": "false",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "flag"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "bool"
-                            ],
-                            "typemap_name": "bool"
-                        }
-                    ],
                     "specifier": [
                         "bool"
                     ],
@@ -3670,12 +3724,13 @@
                 "<FUNCTION>": "15 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "bindC1"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "bindC1",
+                        "params": [],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [],
                     "specifier": [
                         "void"
                     ],
@@ -3728,33 +3783,35 @@
                 "_PTR_F_C_index": "31",
                 "ast": {
                     "declarator": {
-                        "name": "bindC2"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "bindC2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "outbuf",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "outbuf",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -3836,34 +3893,36 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "bindC2"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "bindC2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "out"
+                                    },
+                                    "name": "outbuf",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "outbuf",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -3943,57 +4002,60 @@
                 "<FUNCTION>": "17 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passVoidStarStar"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "in",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "out",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "name": "passVoidStarStar",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "value": true
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "in",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "out",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4107,33 +4169,35 @@
                 "<FUNCTION>": "18 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passAssumedType"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "passAssumedType",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "assumedtype": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "assumedtype": true
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -4242,34 +4306,36 @@
                 "<FUNCTION>": "19 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passAssumedTypeDim"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "passAssumedTypeDim",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "assumedtype": true,
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "assumedtype": true,
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -4354,53 +4420,56 @@
                 "_PTR_F_C_index": "32",
                 "ast": {
                     "declarator": {
-                        "name": "passAssumedTypeBuf"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "assumedtype": true
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                        "name": "passAssumedTypeBuf",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "assumedtype": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "declarator": {
-                                "name": "outbuf",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "outbuf",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -4538,54 +4607,57 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "passAssumedTypeBuf"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "assumedtype": true
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                        "name": "passAssumedTypeBuf",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "assumedtype": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "declarator": {
-                                "name": "outbuf",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "out"
+                                    },
+                                    "name": "outbuf",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -4716,52 +4788,56 @@
                 "<FUNCTION>": "21 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "callback1"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "type"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "external": true,
-                                "value": true
+                        "name": "callback1",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "func": {
-                                    "name": "incr",
-                                    "pointer": [
-                                        {
-                                            "ptr": "*"
-                                        }
-                                    ]
-                                }
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "params": [],
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "external": true,
+                                        "value": true
+                                    },
+                                    "func": {
+                                        "name": "incr",
+                                        "pointer": [
+                                            {
+                                                "ptr": "*"
+                                            }
+                                        ],
+                                        "typemap_name": "void"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "params": [],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4872,52 +4948,56 @@
                 "<FUNCTION>": "22 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "callback1a"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "type"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "external": true,
-                                "value": true
+                        "name": "callback1a",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "func": {
-                                    "name": "incr",
-                                    "pointer": [
-                                        {
-                                            "ptr": "*"
-                                        }
-                                    ]
-                                }
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "params": [],
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "external": true,
+                                        "value": true
+                                    },
+                                    "func": {
+                                        "name": "incr",
+                                        "pointer": [
+                                            {
+                                                "ptr": "*"
+                                            }
+                                        ],
+                                        "typemap_name": "void"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "params": [],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5030,86 +5110,92 @@
                 "<FUNCTION>": "23 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "callback2"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "type"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "assumedtype": true
+                        "name": "callback2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "in",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        },
-                        {
-                            "attrs": {
-                                "external": true,
-                                "value": true
-                            },
-                            "declarator": {
-                                "func": {
-                                    "name": "incr",
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "assumedtype": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "in",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "params": [
-                                {
-                                    "declarator": {
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "external": true,
+                                        "value": true
+                                    },
+                                    "func": {
+                                        "name": "incr",
                                         "pointer": [
                                             {
                                                 "ptr": "*"
                                             }
-                                        ]
+                                        ],
+                                        "typemap_name": "void"
                                     },
-                                    "specifier": [
-                                        "int"
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "params": [
+                                        {
+                                            "declarator": {
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            "specifier": [
+                                                "int"
+                                            ],
+                                            "typemap_name": "int"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5251,110 +5337,117 @@
                 "_PTR_F_C_index": "33",
                 "ast": {
                     "declarator": {
-                        "name": "callback3"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "type",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "ftrim_char_in": true,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "assumedtype": true
-                            },
-                            "declarator": {
-                                "name": "in",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        },
-                        {
-                            "attrs": {
-                                "external": true,
-                                "value": true
-                            },
-                            "declarator": {
-                                "func": {
-                                    "name": "incr",
+                        "name": "callback3",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "ftrim_char_in": true,
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
                             },
-                            "metaattrs": {
-                                "intent": "in"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "assumedtype": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "in",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "params": [
-                                {
-                                    "declarator": {
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "external": true,
+                                        "value": true
+                                    },
+                                    "func": {
+                                        "name": "incr",
                                         "pointer": [
                                             {
                                                 "ptr": "*"
                                             }
-                                        ]
+                                        ],
+                                        "typemap_name": "void"
                                     },
-                                    "specifier": [
-                                        "int"
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "params": [
+                                        {
+                                            "declarator": {
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            "specifier": [
+                                                "int"
+                                            ],
+                                            "typemap_name": "int"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "declarator": {
-                                "name": "outbuf",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "outbuf",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5519,111 +5612,118 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "callback3"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "type",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "ftrim_char_in": true,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "assumedtype": true
-                            },
-                            "declarator": {
-                                "name": "in",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        },
-                        {
-                            "attrs": {
-                                "external": true,
-                                "value": true
-                            },
-                            "declarator": {
-                                "func": {
-                                    "name": "incr",
+                        "name": "callback3",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "ftrim_char_in": true,
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
                             },
-                            "metaattrs": {
-                                "intent": "in"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "assumedtype": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "in",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "params": [
-                                {
-                                    "declarator": {
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "external": true,
+                                        "value": true
+                                    },
+                                    "func": {
+                                        "name": "incr",
                                         "pointer": [
                                             {
                                                 "ptr": "*"
                                             }
-                                        ]
+                                        ],
+                                        "typemap_name": "void"
                                     },
-                                    "specifier": [
-                                        "int"
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "params": [
+                                        {
+                                            "declarator": {
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            "specifier": [
+                                                "int"
+                                            ],
+                                            "typemap_name": "int"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "declarator": {
-                                "name": "outbuf",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "out"
+                                    },
+                                    "name": "outbuf",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5785,108 +5885,115 @@
                 "<FUNCTION>": "25 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "callback_set_alloc"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "tc"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "inout"
-                            },
-                            "declarator": {
-                                "name": "arr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "array_info"
-                            ],
-                            "typemap_name": "array_info"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "func": {
-                                    "name": "alloc",
-                                    "pointer": [
-                                        {
-                                            "ptr": "*"
-                                        }
-                                    ]
-                                }
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "params": [
-                                {
+                        "name": "callback_set_alloc",
+                        "params": [
+                            {
+                                "declarator": {
                                     "attrs": {
-                                        "intent": "in",
                                         "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "tc"
                                     },
                                     "metaattrs": {
                                         "intent": "in"
                                     },
-                                    "specifier": [
-                                        "int"
-                                    ],
+                                    "name": "tc",
                                     "typemap_name": "int"
                                 },
-                                {
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
                                     "attrs": {
                                         "intent": "inout"
-                                    },
-                                    "declarator": {
-                                        "name": "arr",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
                                     },
                                     "metaattrs": {
                                         "intent": "inout"
                                     },
-                                    "specifier": [
-                                        "array_info"
+                                    "name": "arr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
                                     ],
                                     "typemap_name": "array_info"
-                                }
-                            ],
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
+                                },
+                                "specifier": [
+                                    "array_info"
+                                ],
+                                "typemap_name": "array_info"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "func": {
+                                        "name": "alloc",
+                                        "pointer": [
+                                            {
+                                                "ptr": "*"
+                                            }
+                                        ],
+                                        "typemap_name": "void"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "params": [
+                                        {
+                                            "declarator": {
+                                                "attrs": {
+                                                    "intent": "in",
+                                                    "value": true
+                                                },
+                                                "metaattrs": {
+                                                    "intent": "in"
+                                                },
+                                                "name": "tc",
+                                                "typemap_name": "int"
+                                            },
+                                            "specifier": [
+                                                "int"
+                                            ],
+                                            "typemap_name": "int"
+                                        },
+                                        {
+                                            "declarator": {
+                                                "attrs": {
+                                                    "intent": "inout"
+                                                },
+                                                "metaattrs": {
+                                                    "intent": "inout"
+                                                },
+                                                "name": "arr",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "array_info"
+                                            },
+                                            "specifier": [
+                                                "array_info"
+                                            ],
+                                            "typemap_name": "array_info"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -6034,7 +6141,8 @@
                 "<TYPEDEF>": "****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "TypeID"
+                        "name": "TypeID",
+                        "typemap_name": "int"
                     },
                     "specifier": [
                         "int"
@@ -6069,7 +6177,8 @@
                 "<TYPEDEF>": "****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "EnumTypeID"
+                        "name": "EnumTypeID",
+                        "typemap_name": "int"
                     },
                     "specifier": [
                         "int"

--- a/regression/reference/clibrary/clibrary.json
+++ b/regression/reference/clibrary/clibrary.json
@@ -99,6 +99,7 @@
                 },
                 "decl": "void NoReturnNoArguments(void)",
                 "declgen": "void NoReturnNoArguments(void)",
+                "name": "NoReturnNoArguments",
                 "options": {
                     "literalinclude": true
                 },
@@ -181,6 +182,7 @@
                 },
                 "decl": "double PassByValue(double arg1, int arg2)",
                 "declgen": "double PassByValue(double arg1 +value, int arg2 +value)",
+                "name": "PassByValue",
                 "options": {
                     "literalinclude": true
                 },
@@ -429,6 +431,7 @@
                 },
                 "decl": "void PassByReference(double *arg1+intent(in), int *arg2+intent(out))",
                 "declgen": "void PassByReference(double * arg1 +intent(in), int * arg2 +intent(out))",
+                "name": "PassByReference",
                 "options": {
                     "literalinclude": true
                 },
@@ -608,6 +611,7 @@
                 "doxygen": {
                     "description": "PassByValueMacro is a #define macro. Force a C wrapper\nto allow Fortran to have an actual function to call.\n"
                 },
+                "name": "PassByValueMacro",
                 "options": {
                     "C_force_wrapper": true
                 },
@@ -824,6 +828,7 @@
                 "doxygen": {
                     "brief": "Check intent with bool"
                 },
+                "name": "checkBool",
                 "options": {
                     "literalinclude": true
                 },
@@ -1094,6 +1099,7 @@
                 },
                 "decl": "char *Function4a( const char *arg1, const char *arg2 ) +len(30)",
                 "declgen": "char * Function4a(const char * arg1, const char * arg2) +len(30)",
+                "name": "Function4a",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -1344,6 +1350,7 @@
                 },
                 "decl": "char *Function4a( const char *arg1, const char *arg2 ) +len(30)",
                 "declgen": "char * Function4a(const char * arg1, const char * arg2) +len(30)",
+                "name": "Function4a",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -1492,6 +1499,7 @@
                 },
                 "decl": "void acceptName(const char *name)",
                 "declgen": "void acceptName(const char * name)",
+                "name": "acceptName",
                 "options": {
                     "literalinclude": true
                 },
@@ -1624,6 +1632,7 @@
                     "brief": "toupper",
                     "description": "Change a string in-place.\nFor Python, return a new string since strings are immutable.\n"
                 },
+                "name": "passCharPtrInOut",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -1752,6 +1761,7 @@
                     "brief": "toupper",
                     "description": "Change a string in-place.\nFor Python, return a new string since strings are immutable.\n"
                 },
+                "name": "passCharPtrInOut",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -1859,6 +1869,7 @@
                     "brief": "Test charlen attribute",
                     "description": "Each argument is assumed to be at least MAXNAME long.\nThis define is provided by the user.\nThe function will copy into the user provided buffer.\n"
                 },
+                "name": "returnOneName",
                 "options": {
                     "literalinclude": true
                 },
@@ -1991,6 +2002,7 @@
                     "brief": "Test charlen attribute",
                     "description": "Each argument is assumed to be at least MAXNAME long.\nThis define is provided by the user.\nThe function will copy into the user provided buffer.\n"
                 },
+                "name": "returnOneName",
                 "options": {
                     "literalinclude": true
                 },
@@ -2122,6 +2134,7 @@
                     "brief": "Test charlen attribute",
                     "description": "Each argument is assumed to be at least MAXNAME long.\nThis define is provided by the user.\nThe function will copy into the user provided buffer.\n"
                 },
+                "name": "returnTwoNames",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2325,6 +2338,7 @@
                     "brief": "Test charlen attribute",
                     "description": "Each argument is assumed to be at least MAXNAME long.\nThis define is provided by the user.\nThe function will copy into the user provided buffer.\n"
                 },
+                "name": "returnTwoNames",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -2483,6 +2497,7 @@
                 "doxygen": {
                     "brief": "Fill text, at most ltext characters."
                 },
+                "name": "ImpliedTextLen",
                 "options": {
                     "literalinclude": true
                 },
@@ -2678,6 +2693,7 @@
                 "doxygen": {
                     "brief": "Fill text, at most ltext characters."
                 },
+                "name": "ImpliedTextLen",
                 "options": {
                     "literalinclude": true
                 },
@@ -2845,6 +2861,7 @@
                     "brief": "Return the implied argument - text length",
                     "description": "Pass the Fortran length of the char argument directy to the C function.\nNo need for the bufferify version which will needlessly copy the string.\n"
                 },
+                "name": "ImpliedLen",
                 "options": {
                     "F_create_bufferify_function": false
                 },
@@ -3151,6 +3168,7 @@
                     "brief": "Return the implied argument - text length",
                     "description": "Pass the Fortran length of the char argument directy to the C function.\nNo need for the bufferify version which will needlessly copy the string.\n"
                 },
+                "name": "ImpliedLenTrim",
                 "options": {
                     "F_create_bufferify_function": false
                 },
@@ -3419,6 +3437,7 @@
                 "doxygen": {
                     "brief": "Single, implied bool argument"
                 },
+                "name": "ImpliedBoolTrue",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3589,6 +3608,7 @@
                 "doxygen": {
                     "brief": "Single, implied bool argument"
                 },
+                "name": "ImpliedBoolFalse",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3742,6 +3762,7 @@
                     "brief": "Rename Fortran name for interface only function",
                     "description": "This creates only an interface.\n"
                 },
+                "name": "bindC1",
                 "options": {
                     "wrap_python": false
                 },
@@ -3823,6 +3844,7 @@
                     "brief": "Rename Fortran name for interface only function",
                     "description": "This creates a Fortran bufferify function and an interface.\n"
                 },
+                "name": "bindC2",
                 "options": {
                     "wrap_python": false
                 },
@@ -3934,6 +3956,7 @@
                     "brief": "Rename Fortran name for interface only function",
                     "description": "This creates a Fortran bufferify function and an interface.\n"
                 },
+                "name": "bindC2",
                 "options": {
                     "wrap_python": false
                 },
@@ -4067,6 +4090,7 @@
                     "brief": "Assign in to out.",
                     "description": "No bufferify function is created, only an interface.\n"
                 },
+                "name": "passVoidStarStar",
                 "options": {
                     "literalinclude": true,
                     "wrap_python": false
@@ -4209,6 +4233,7 @@
                     "brief": "Test assumed-type",
                     "description": "No bufferify function is created, only an interface.\nShould only be call with an C_INT argument, and will\nreturn the value passed in.\n"
                 },
+                "name": "passAssumedType",
                 "options": {
                     "literalinclude": true,
                     "wrap_python": false
@@ -4346,6 +4371,7 @@
                 "doxygen": {
                     "brief": "Test assumed-type with rank(1)"
                 },
+                "name": "passAssumedTypeDim",
                 "options": {
                     "literalinclude": true,
                     "wrap_python": false
@@ -4481,6 +4507,7 @@
                     "brief": "Test assumed-type",
                     "description": "A bufferify function is created.\nShould only be call with an C_INT argument, and will\nreturn the value passed in.\n"
                 },
+                "name": "passAssumedTypeBuf",
                 "options": {
                     "wrap_python": false
                 },
@@ -4669,6 +4696,7 @@
                     "brief": "Test assumed-type",
                     "description": "A bufferify function is created.\nShould only be call with an C_INT argument, and will\nreturn the value passed in.\n"
                 },
+                "name": "passAssumedTypeBuf",
                 "options": {
                     "wrap_python": false
                 },
@@ -4849,6 +4877,7 @@
                 "doxygen": {
                     "brief": "Test function pointer"
                 },
+                "name": "callback1",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false,
@@ -5011,6 +5040,7 @@
                     "brief": "Test function pointer",
                     "description": "Add C_force_wrapper to test generating function pointer prototype.\n"
                 },
+                "name": "callback1a",
                 "options": {
                     "C_force_wrapper": true,
                     "literalinclude": true,
@@ -5209,6 +5239,7 @@
                 "doxygen": {
                     "brief": "Test function pointer"
                 },
+                "name": "callback2",
                 "options": {
                     "wrap_lua": false,
                     "wrap_python": false
@@ -5463,6 +5494,7 @@
                     "brief": "Test function pointer",
                     "description": "A bufferify function will be created.\n"
                 },
+                "name": "callback3",
                 "options": {
                     "wrap_lua": false,
                     "wrap_python": false
@@ -5740,6 +5772,7 @@
                     "brief": "Test function pointer",
                     "description": "A bufferify function will be created.\n"
                 },
+                "name": "callback3",
                 "options": {
                     "wrap_lua": false,
                     "wrap_python": false
@@ -6010,6 +6043,7 @@
                 "doxygen": {
                     "description": "The function argument takes a struct argument\nwhich is defined in this library.\nUse IMPORT.\n"
                 },
+                "name": "callback_set_alloc",
                 "options": {
                     "wrap_lua": false,
                     "wrap_python": false

--- a/regression/reference/cxxlibrary/cxxlibrary.json
+++ b/regression/reference/cxxlibrary/cxxlibrary.json
@@ -61,6 +61,7 @@
                         },
                         "decl": "Cstruct1_cls_ctor",
                         "declgen": "Cstruct1_cls(int ifield, double dfield) +name(Cstruct1_cls_ctor)",
+                        "name": "Cstruct1_cls_ctor",
                         "options": {
                             "wrap_c": false,
                             "wrap_fortran": false,
@@ -298,6 +299,7 @@
                 },
                 "decl": "int passStructByReferenceCls(Cstruct1_cls &arg)",
                 "declgen": "int passStructByReferenceCls(Cstruct1_cls & arg)",
+                "name": "passStructByReferenceCls",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -397,6 +399,7 @@
                 "doxygen": {
                     "description": "const defaults to intent(in)\n"
                 },
+                "name": "passStructByReferenceInCls",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -495,6 +498,7 @@
                 },
                 "decl": "void passStructByReferenceInoutCls(Cstruct1_cls &arg +intent(inout))",
                 "declgen": "void passStructByReferenceInoutCls(Cstruct1_cls & arg +intent(inout))",
+                "name": "passStructByReferenceInoutCls",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -574,6 +578,7 @@
                 },
                 "decl": "void passStructByReferenceOutCls(Cstruct1_cls &arg +intent(out))",
                 "declgen": "void passStructByReferenceOutCls(Cstruct1_cls & arg +intent(out))",
+                "name": "passStructByReferenceOutCls",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -635,6 +640,7 @@
                 },
                 "decl": "bool defaultPtrIsNULL(double* data +intent(IN)+rank(1) = nullptr )",
                 "declgen": "bool defaultPtrIsNULL(void)",
+                "name": "defaultPtrIsNULL",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -745,6 +751,7 @@
                 },
                 "decl": "bool defaultPtrIsNULL(double* data +intent(IN)+rank(1) = nullptr )",
                 "declgen": "bool defaultPtrIsNULL(double * data=nullptr +intent(IN)+rank(1))",
+                "name": "defaultPtrIsNULL",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -969,6 +976,7 @@
                 },
                 "decl": "void defaultArgsInOut(int in1, int *out1+intent(out), int *out2+intent(out), bool flag = false)",
                 "declgen": "void defaultArgsInOut(int in1 +value, int * out1 +intent(out), int * out2 +intent(out))",
+                "name": "defaultArgsInOut",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -1203,6 +1211,7 @@
                 },
                 "decl": "void defaultArgsInOut(int in1, int *out1+intent(out), int *out2+intent(out), bool flag = false)",
                 "declgen": "void defaultArgsInOut(int in1 +value, int * out1 +intent(out), int * out2 +intent(out), bool flag=false +value)",
+                "name": "defaultArgsInOut",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -1545,6 +1554,7 @@
                         "generic": "(int64_t idx)"
                     }
                 ],
+                "name": "getGroupName",
                 "options": {
                     "wrap_python": false
                 },
@@ -1681,6 +1691,7 @@
                 "doxygen": {
                     "brief": "String reference function with scalar generic args"
                 },
+                "name": "getGroupName",
                 "options": {
                     "wrap_python": false
                 },
@@ -1770,6 +1781,7 @@
                 "doxygen": {
                     "brief": "String reference function with scalar generic args"
                 },
+                "name": "getGroupName",
                 "options": {
                     "wrap_python": false
                 },
@@ -1913,6 +1925,7 @@
                 "doxygen": {
                     "brief": "String reference function with scalar generic args"
                 },
+                "name": "getGroupName",
                 "options": {
                     "wrap_python": false
                 },
@@ -2002,6 +2015,7 @@
                 "doxygen": {
                     "brief": "String reference function with scalar generic args"
                 },
+                "name": "getGroupName",
                 "options": {
                     "wrap_python": false
                 },
@@ -2233,6 +2247,7 @@
                         "doxygen": {
                             "description": "Argument is modified by library, defaults to intent(inout).\n"
                         },
+                        "name": "passStructByReference",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -2412,6 +2427,7 @@
                         "doxygen": {
                             "description": "const defaults to intent(in)\n"
                         },
+                        "name": "passStructByReferenceIn",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -2590,6 +2606,7 @@
                         },
                         "decl": "void passStructByReferenceInout(Cstruct1 &arg +intent(inout))",
                         "declgen": "void passStructByReferenceInout(Cstruct1 & arg +intent(inout))",
+                        "name": "passStructByReferenceInout",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -2720,6 +2737,7 @@
                         },
                         "decl": "void passStructByReferenceOut(Cstruct1 &arg +intent(out))",
                         "declgen": "void passStructByReferenceOut(Cstruct1 & arg +intent(out))",
+                        "name": "passStructByReferenceOut",
                         "options": {},
                         "wrap": {
                             "c": true,

--- a/regression/reference/cxxlibrary/cxxlibrary.json
+++ b/regression/reference/cxxlibrary/cxxlibrary.json
@@ -18,6 +18,7 @@
                                 "_constructor": true,
                                 "name": "Cstruct1_cls_ctor"
                             },
+                            "declarator": {},
                             "metaattrs": {
                                 "intent": "ctor"
                             },

--- a/regression/reference/cxxlibrary/cxxlibrary.json
+++ b/regression/reference/cxxlibrary/cxxlibrary.json
@@ -15,6 +15,13 @@
                         "_generated": "struct_as_class_ctor",
                         "ast": {
                             "declarator": {
+                                "attrs": {
+                                    "_constructor": true,
+                                    "name": "Cstruct1_cls_ctor"
+                                },
+                                "metaattrs": {
+                                    "intent": "ctor"
+                                },
                                 "typemap_name": "Cstruct1_cls"
                             },
                             "specifier": [

--- a/regression/reference/cxxlibrary/cxxlibrary.json
+++ b/regression/reference/cxxlibrary/cxxlibrary.json
@@ -1656,12 +1656,12 @@
                                         "intent": "in"
                                     },
                                     "name": "idx",
-                                    "typemap_name": "long"
+                                    "typemap_name": "int32_t"
                                 },
                                 "specifier": [
-                                    "long"
+                                    "int32_t"
                                 ],
-                                "typemap_name": "long"
+                                "typemap_name": "int32_t"
                             }
                         ],
                         "pointer": [
@@ -1745,12 +1745,12 @@
                                         "intent": "in"
                                     },
                                     "name": "idx",
-                                    "typemap_name": "long"
+                                    "typemap_name": "int32_t"
                                 },
                                 "specifier": [
-                                    "long"
+                                    "int32_t"
                                 ],
-                                "typemap_name": "long"
+                                "typemap_name": "int32_t"
                             }
                         ],
                         "pointer": [
@@ -1888,12 +1888,12 @@
                                         "intent": "in"
                                     },
                                     "name": "idx",
-                                    "typemap_name": "long"
+                                    "typemap_name": "int64_t"
                                 },
                                 "specifier": [
-                                    "long"
+                                    "int64_t"
                                 ],
-                                "typemap_name": "long"
+                                "typemap_name": "int64_t"
                             }
                         ],
                         "pointer": [
@@ -1977,12 +1977,12 @@
                                         "intent": "in"
                                     },
                                     "name": "idx",
-                                    "typemap_name": "long"
+                                    "typemap_name": "int64_t"
                                 },
                                 "specifier": [
-                                    "long"
+                                    "int64_t"
                                 ],
-                                "typemap_name": "long"
+                                "typemap_name": "int64_t"
                             }
                         ],
                         "pointer": [

--- a/regression/reference/cxxlibrary/cxxlibrary.json
+++ b/regression/reference/cxxlibrary/cxxlibrary.json
@@ -22,6 +22,36 @@
                                 "metaattrs": {
                                     "intent": "ctor"
                                 },
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "metaattrs": {
+                                                "intent": "in",
+                                                "struct_member": "ifield"
+                                            },
+                                            "name": "ifield",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    },
+                                    {
+                                        "declarator": {
+                                            "metaattrs": {
+                                                "intent": "in",
+                                                "struct_member": "dfield"
+                                            },
+                                            "name": "dfield",
+                                            "typemap_name": "double"
+                                        },
+                                        "specifier": [
+                                            "double"
+                                        ],
+                                        "typemap_name": "double"
+                                    }
+                                ],
                                 "typemap_name": "Cstruct1_cls"
                             },
                             "specifier": [

--- a/regression/reference/cxxlibrary/cxxlibrary.json
+++ b/regression/reference/cxxlibrary/cxxlibrary.json
@@ -14,42 +14,9 @@
                         "<FUNCTION>": "0 ****************************************",
                         "_generated": "struct_as_class_ctor",
                         "ast": {
-                            "attrs": {
-                                "_constructor": true,
-                                "name": "Cstruct1_cls_ctor"
+                            "declarator": {
+                                "typemap_name": "Cstruct1_cls"
                             },
-                            "declarator": {},
-                            "metaattrs": {
-                                "intent": "ctor"
-                            },
-                            "params": [
-                                {
-                                    "declarator": {
-                                        "name": "ifield"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in",
-                                        "struct_member": "ifield"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                },
-                                {
-                                    "declarator": {
-                                        "name": "dfield"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in",
-                                        "struct_member": "dfield"
-                                    },
-                                    "specifier": [
-                                        "double"
-                                    ],
-                                    "typemap_name": "double"
-                                }
-                            ],
                             "specifier": [
                                 "Cstruct1_cls"
                             ],
@@ -159,7 +126,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "ifield"
+                                "name": "ifield",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -187,7 +155,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "dfield"
+                                "name": "dfield",
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -259,30 +228,32 @@
                 "<FUNCTION>": "1 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passStructByReferenceCls"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "passStructByReferenceCls",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1_cls"
+                                },
+                                "specifier": [
+                                    "Cstruct1_cls"
+                                ],
+                                "typemap_name": "Cstruct1_cls"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "Cstruct1_cls"
-                            ],
-                            "typemap_name": "Cstruct1_cls"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -352,31 +323,33 @@
                 "<FUNCTION>": "2 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passStructByReferenceInCls"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "passStructByReferenceInCls",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1_cls"
+                                },
+                                "specifier": [
+                                    "Cstruct1_cls"
+                                ],
+                                "typemap_name": "Cstruct1_cls"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1_cls"
-                            ],
-                            "typemap_name": "Cstruct1_cls"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -449,33 +422,35 @@
                 "<FUNCTION>": "3 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passStructByReferenceInoutCls"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "passStructByReferenceInoutCls",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1_cls"
+                                },
+                                "specifier": [
+                                    "Cstruct1_cls"
+                                ],
+                                "typemap_name": "Cstruct1_cls"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "Cstruct1_cls"
-                            ],
-                            "typemap_name": "Cstruct1_cls"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -526,33 +501,35 @@
                 "<FUNCTION>": "4 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passStructByReferenceOutCls"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "passStructByReferenceOutCls",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1_cls"
+                                },
+                                "specifier": [
+                                    "Cstruct1_cls"
+                                ],
+                                "typemap_name": "Cstruct1_cls"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "Cstruct1_cls"
-                            ],
-                            "typemap_name": "Cstruct1_cls"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -607,12 +584,13 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "defaultPtrIsNULL"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "defaultPtrIsNULL",
+                        "params": [],
+                        "typemap_name": "bool"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "bool"
                     ],
@@ -692,35 +670,37 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "defaultPtrIsNULL"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "defaultPtrIsNULL",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "IN",
+                                        "rank": 1
+                                    },
+                                    "init": "nullptr",
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "data",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "bool"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "IN",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "data",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "init": "nullptr",
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
                     "specifier": [
                         "bool"
                     ],
@@ -879,68 +859,72 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "defaultArgsInOut"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "in1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                        "name": "defaultArgsInOut",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "in1",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "out1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "out1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "out2",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "out2",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1092,84 +1076,89 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "defaultArgsInOut"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "defaultArgsInOut",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "in1",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "out1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "out2",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": "false",
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "flag",
+                                    "typemap_name": "bool"
+                                },
+                                "specifier": [
+                                    "bool"
+                                ],
+                                "typemap_name": "bool"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "in1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "out1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "out2",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "flag"
-                            },
-                            "init": "false",
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "bool"
-                            ],
-                            "typemap_name": "bool"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -1428,39 +1417,41 @@
                 "<FUNCTION>": "7 ****************************************",
                 "_overloaded": true,
                 "ast": {
-                    "attrs": {
-                        "len": "30"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "len": "30"
+                        },
+                        "metaattrs": {
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "getGroupName",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "idx",
+                                    "typemap_name": "long"
+                                },
+                                "specifier": [
+                                    "long"
+                                ],
+                                "typemap_name": "long"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "idx"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "long"
-                            ],
-                            "typemap_name": "long"
-                        }
-                    ],
                     "specifier": [
                         "std::string"
                     ],
@@ -1475,14 +1466,15 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "idx"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "idx",
+                                    "typemap_name": "int32_t"
                                 },
                                 "specifier": [
                                     "int32_t"
@@ -1496,14 +1488,15 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "idx"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "idx",
+                                    "typemap_name": "int64_t"
                                 },
                                 "specifier": [
                                     "int64_t"
@@ -1606,39 +1599,41 @@
                 "_generated": "fortran_generic",
                 "_overloaded": true,
                 "ast": {
-                    "attrs": {
-                        "len": "30"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "len": "30"
+                        },
+                        "metaattrs": {
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "getGroupName",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "idx",
+                                    "typemap_name": "long"
+                                },
+                                "specifier": [
+                                    "long"
+                                ],
+                                "typemap_name": "long"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "idx"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int32_t"
-                            ],
-                            "typemap_name": "int32_t"
-                        }
-                    ],
                     "specifier": [
                         "std::string"
                     ],
@@ -1692,40 +1687,42 @@
                 "_generated": "arg_to_buffer",
                 "_overloaded": true,
                 "ast": {
-                    "attrs": {
-                        "len": "30"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "len": "30"
+                        },
+                        "metaattrs": {
+                            "api": "buf",
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "getGroupName",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "idx",
+                                    "typemap_name": "long"
+                                },
+                                "specifier": [
+                                    "long"
+                                ],
+                                "typemap_name": "long"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "buf",
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "idx"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int32_t"
-                            ],
-                            "typemap_name": "int32_t"
-                        }
-                    ],
                     "specifier": [
                         "std::string"
                     ],
@@ -1834,39 +1831,41 @@
                 "_generated": "fortran_generic",
                 "_overloaded": true,
                 "ast": {
-                    "attrs": {
-                        "len": "30"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "len": "30"
+                        },
+                        "metaattrs": {
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "getGroupName",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "idx",
+                                    "typemap_name": "long"
+                                },
+                                "specifier": [
+                                    "long"
+                                ],
+                                "typemap_name": "long"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "idx"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int64_t"
-                            ],
-                            "typemap_name": "int64_t"
-                        }
-                    ],
                     "specifier": [
                         "std::string"
                     ],
@@ -1920,40 +1919,42 @@
                 "_generated": "arg_to_buffer",
                 "_overloaded": true,
                 "ast": {
-                    "attrs": {
-                        "len": "30"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "len": "30"
+                        },
+                        "metaattrs": {
+                            "api": "buf",
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "getGroupName",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "idx",
+                                    "typemap_name": "long"
+                                },
+                                "specifier": [
+                                    "long"
+                                ],
+                                "typemap_name": "long"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "buf",
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "idx"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int64_t"
-                            ],
-                            "typemap_name": "int64_t"
-                        }
-                    ],
                     "specifier": [
                         "std::string"
                     ],
@@ -2071,7 +2072,8 @@
                                 "<VARIABLE>": "****************************************",
                                 "ast": {
                                     "declarator": {
-                                        "name": "ifield"
+                                        "name": "ifield",
+                                        "typemap_name": "int"
                                     },
                                     "specifier": [
                                         "int"
@@ -2098,7 +2100,8 @@
                                 "<VARIABLE>": "****************************************",
                                 "ast": {
                                     "declarator": {
-                                        "name": "dfield"
+                                        "name": "dfield",
+                                        "typemap_name": "double"
                                     },
                                     "specifier": [
                                         "double"
@@ -2157,30 +2160,32 @@
                         "<FUNCTION>": "14 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "passStructByReference"
+                                "metaattrs": {
+                                    "intent": "function"
+                                },
+                                "name": "passStructByReference",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "metaattrs": {
+                                                "intent": "inout"
+                                            },
+                                            "name": "arg",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "&"
+                                                }
+                                            ],
+                                            "typemap_name": "structns::Cstruct1"
+                                        },
+                                        "specifier": [
+                                            "Cstruct1"
+                                        ],
+                                        "typemap_name": "structns::Cstruct1"
+                                    }
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "function"
-                            },
-                            "params": [
-                                {
-                                    "declarator": {
-                                        "name": "arg",
-                                        "pointer": [
-                                            {
-                                                "ptr": "&"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "inout"
-                                    },
-                                    "specifier": [
-                                        "Cstruct1"
-                                    ],
-                                    "typemap_name": "structns::Cstruct1"
-                                }
-                            ],
                             "specifier": [
                                 "int"
                             ],
@@ -2333,31 +2338,33 @@
                         "<FUNCTION>": "15 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "passStructByReferenceIn"
+                                "metaattrs": {
+                                    "intent": "function"
+                                },
+                                "name": "passStructByReferenceIn",
+                                "params": [
+                                    {
+                                        "const": true,
+                                        "declarator": {
+                                            "metaattrs": {
+                                                "intent": "in"
+                                            },
+                                            "name": "arg",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "&"
+                                                }
+                                            ],
+                                            "typemap_name": "structns::Cstruct1"
+                                        },
+                                        "specifier": [
+                                            "Cstruct1"
+                                        ],
+                                        "typemap_name": "structns::Cstruct1"
+                                    }
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "function"
-                            },
-                            "params": [
-                                {
-                                    "const": true,
-                                    "declarator": {
-                                        "name": "arg",
-                                        "pointer": [
-                                            {
-                                                "ptr": "&"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in"
-                                    },
-                                    "specifier": [
-                                        "Cstruct1"
-                                    ],
-                                    "typemap_name": "structns::Cstruct1"
-                                }
-                            ],
                             "specifier": [
                                 "int"
                             ],
@@ -2510,33 +2517,35 @@
                         "<FUNCTION>": "16 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "passStructByReferenceInout"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "passStructByReferenceInout",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "intent": "inout"
+                                            },
+                                            "metaattrs": {
+                                                "intent": "inout"
+                                            },
+                                            "name": "arg",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "&"
+                                                }
+                                            ],
+                                            "typemap_name": "structns::Cstruct1"
+                                        },
+                                        "specifier": [
+                                            "Cstruct1"
+                                        ],
+                                        "typemap_name": "structns::Cstruct1"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "intent": "inout"
-                                    },
-                                    "declarator": {
-                                        "name": "arg",
-                                        "pointer": [
-                                            {
-                                                "ptr": "&"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "inout"
-                                    },
-                                    "specifier": [
-                                        "Cstruct1"
-                                    ],
-                                    "typemap_name": "structns::Cstruct1"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],
@@ -2638,33 +2647,35 @@
                         "<FUNCTION>": "17 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "passStructByReferenceOut"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "passStructByReferenceOut",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "intent": "out"
+                                            },
+                                            "metaattrs": {
+                                                "intent": "out"
+                                            },
+                                            "name": "arg",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "&"
+                                                }
+                                            ],
+                                            "typemap_name": "structns::Cstruct1"
+                                        },
+                                        "specifier": [
+                                            "Cstruct1"
+                                        ],
+                                        "typemap_name": "structns::Cstruct1"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "intent": "out"
-                                    },
-                                    "declarator": {
-                                        "name": "arg",
-                                        "pointer": [
-                                            {
-                                                "ptr": "&"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "out"
-                                    },
-                                    "specifier": [
-                                        "Cstruct1"
-                                    ],
-                                    "typemap_name": "structns::Cstruct1"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],

--- a/regression/reference/cxxlibrary/cxxlibrary.json
+++ b/regression/reference/cxxlibrary/cxxlibrary.json
@@ -54,6 +54,7 @@
                                 ],
                                 "typemap_name": "Cstruct1_cls"
                             },
+                            "is_ctor": true,
                             "specifier": [
                                 "Cstruct1_cls"
                             ],

--- a/regression/reference/debugfalse/tutorial.json
+++ b/regression/reference/debugfalse/tutorial.json
@@ -83,12 +83,13 @@
                 "<FUNCTION>": "0 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "NoReturnNoArguments"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "NoReturnNoArguments",
+                        "params": [],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [],
                     "specifier": [
                         "void"
                     ],
@@ -140,43 +141,46 @@
                 "<FUNCTION>": "1 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "PassByValue"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "PassByValue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "double"
+                    },
                     "specifier": [
                         "double"
                     ],
@@ -419,50 +423,53 @@
                 "ast": {
                     "const": true,
                     "declarator": {
-                        "name": "ConcatenateStrings"
-                    },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "intent": "function"
                         },
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg2",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
+                        "name": "ConcatenateStrings",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "std::string"
+                    },
                     "specifier": [
                         "std::string"
                     ],
@@ -621,53 +628,56 @@
                 "ast": {
                     "const": true,
                     "declarator": {
-                        "name": "ConcatenateStrings"
-                    },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "deref": "allocatable",
+                            "intent": "function"
                         },
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg2",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
+                        "name": "ConcatenateStrings",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "std::string"
+                    },
                     "specifier": [
                         "std::string"
                     ],
@@ -808,12 +818,13 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UseDefaultArguments"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "UseDefaultArguments",
+                        "params": [],
+                        "typemap_name": "double"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "double"
                     ],
@@ -896,29 +907,31 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UseDefaultArguments"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "UseDefaultArguments",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 3.1415,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "double"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "init": 3.1415,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
                     "specifier": [
                         "double"
                     ],
@@ -1043,45 +1056,48 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UseDefaultArguments"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "init": 3.1415,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "UseDefaultArguments",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 3.1415,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "init": "true",
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "bool"
-                            ],
-                            "typemap_name": "bool"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": "true",
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "bool"
+                                },
+                                "specifier": [
+                                    "bool"
+                                ],
+                                "typemap_name": "bool"
+                            }
+                        ],
+                        "typemap_name": "double"
+                    },
                     "specifier": [
                         "double"
                     ],
@@ -1335,31 +1351,33 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "OverloadedFunction"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "OverloadedFunction",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -1482,32 +1500,34 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "OverloadedFunction"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "OverloadedFunction",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -1581,28 +1601,30 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "OverloadedFunction"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "OverloadedFunction",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "indx",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "indx"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -1725,28 +1747,29 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "TemplateArgument"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "TemplateArgument",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg"
+                                },
+                                "specifier": [
+                                    "ArgType"
+                                ],
+                                "template_argument": "ArgType"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "ArgType"
-                            ],
-                            "template_argument": "ArgType"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -1804,29 +1827,29 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "TemplateArgument"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "TemplateArgument",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg"
+                                },
+                                "specifier": [
+                                    "ArgType"
+                                ],
+                                "template_argument": "ArgType"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "template_argument": "ArgType",
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -1981,29 +2004,29 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "TemplateArgument"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "TemplateArgument",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg"
+                                },
+                                "specifier": [
+                                    "ArgType"
+                                ],
+                                "template_argument": "ArgType"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "template_argument": "ArgType",
-                            "typemap_name": "double"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -2156,12 +2179,12 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "TemplateReturn"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "TemplateReturn",
+                        "params": []
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "RetType"
                     ],
@@ -2222,12 +2245,12 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "TemplateReturn"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "TemplateReturn",
+                        "params": []
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -2337,12 +2360,12 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "TemplateReturn"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "TemplateReturn",
+                        "params": []
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "double"
                     ],
@@ -2452,12 +2475,13 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "FortranGenericOverloaded"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "FortranGenericOverloaded",
+                        "params": [],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [],
                     "specifier": [
                         "void"
                     ],
@@ -2509,46 +2533,49 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "FortranGenericOverloaded"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "FortranGenericOverloaded",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2562,15 +2589,16 @@
                             {
                                 "const": true,
                                 "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
                                     "name": "name",
                                     "pointer": [
                                         {
                                             "ptr": "&"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    ],
+                                    "typemap_name": "std::string"
                                 },
                                 "specifier": [
                                     "std::string"
@@ -2578,14 +2606,15 @@
                                 "typemap_name": "std::string"
                             },
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "arg2"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
                                     "float"
@@ -2601,15 +2630,16 @@
                             {
                                 "const": true,
                                 "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
                                     "name": "name",
                                     "pointer": [
                                         {
                                             "ptr": "&"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    ],
+                                    "typemap_name": "std::string"
                                 },
                                 "specifier": [
                                     "std::string"
@@ -2617,14 +2647,15 @@
                                 "typemap_name": "std::string"
                             },
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "arg2"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "double"
                                 },
                                 "specifier": [
                                     "double"
@@ -2806,46 +2837,49 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "FortranGenericOverloaded"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "FortranGenericOverloaded",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "float"
-                            ],
-                            "typemap_name": "float"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2884,47 +2918,49 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "FortranGenericOverloaded"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "FortranGenericOverloaded",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "float"
-                            ],
-                            "typemap_name": "float"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3038,46 +3074,49 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "FortranGenericOverloaded"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "FortranGenericOverloaded",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3116,47 +3155,49 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "FortranGenericOverloaded"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "FortranGenericOverloaded",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3266,28 +3307,30 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UseDefaultOverload"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "UseDefaultOverload",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "num",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "num"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -3405,44 +3448,47 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UseDefaultOverload"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "num"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "UseDefaultOverload",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "num",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "offset"
-                            },
-                            "init": 0,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 0,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "offset",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -3598,60 +3644,64 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UseDefaultOverload"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "num"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "UseDefaultOverload",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "num",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "offset"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 0,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "offset",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "init": 0,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "stride"
-                            },
-                            "init": 1,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 1,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "stride",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -3967,43 +4017,46 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UseDefaultOverload"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "type"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "UseDefaultOverload",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "num"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "num",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -4149,59 +4202,63 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UseDefaultOverload"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "type"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "UseDefaultOverload",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "num"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "num",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "offset"
-                            },
-                            "init": 0,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 0,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "offset",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -4385,75 +4442,80 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UseDefaultOverload"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "UseDefaultOverload",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "num",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 0,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "offset",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 1,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "stride",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "type"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "num"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "offset"
-                            },
-                            "init": 0,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "stride"
-                            },
-                            "init": 1,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -4823,28 +4885,30 @@
                 "<FUNCTION>": "12 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "typefunc"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "typefunc",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "tutorial::TypeID"
+                                },
+                                "specifier": [
+                                    "TypeID"
+                                ],
+                                "typemap_name": "tutorial::TypeID"
+                            }
+                        ],
+                        "typemap_name": "tutorial::TypeID"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "TypeID"
-                            ],
-                            "typemap_name": "tutorial::TypeID"
-                        }
-                    ],
                     "specifier": [
                         "TypeID"
                     ],
@@ -5018,28 +5082,30 @@
                 "<FUNCTION>": "13 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "enumfunc"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "enumfunc",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "tutorial::EnumTypeID"
+                                },
+                                "specifier": [
+                                    "EnumTypeID"
+                                ],
+                                "typemap_name": "tutorial::EnumTypeID"
+                            }
+                        ],
+                        "typemap_name": "tutorial::EnumTypeID"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "EnumTypeID"
-                            ],
-                            "typemap_name": "tutorial::EnumTypeID"
-                        }
-                    ],
                     "specifier": [
                         "EnumTypeID"
                     ],
@@ -5219,28 +5285,30 @@
                 "<FUNCTION>": "14 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "colorfunc"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "colorfunc",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "tutorial::Color"
+                                },
+                                "specifier": [
+                                    "Color"
+                                ],
+                                "typemap_name": "tutorial::Color"
+                            }
+                        ],
+                        "typemap_name": "tutorial::Color"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Color"
-                            ],
-                            "typemap_name": "tutorial::Color"
-                        }
-                    ],
                     "specifier": [
                         "Color"
                     ],
@@ -5418,53 +5486,56 @@
                 "<FUNCTION>": "15 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getMinMax"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "min",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                        "name": "getMinMax",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "min",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "max",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "max",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5621,62 +5692,68 @@
                 "<FUNCTION>": "16 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "callback1"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "in"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "func": {
-                                    "name": "incr",
-                                    "pointer": [
-                                        {
-                                            "ptr": "*"
-                                        }
-                                    ]
-                                }
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "params": [
-                                {
+                        "name": "callback1",
+                        "params": [
+                            {
+                                "declarator": {
                                     "attrs": {
                                         "value": true
                                     },
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "in",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "func": {
+                                        "name": "incr",
+                                        "pointer": [
+                                            {
+                                                "ptr": "*"
+                                            }
+                                        ],
+                                        "typemap_name": "int"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "params": [
+                                        {
+                                            "declarator": {
+                                                "attrs": {
+                                                    "value": true
+                                                },
+                                                "typemap_name": "int"
+                                            },
+                                            "specifier": [
+                                                "int"
+                                            ],
+                                            "typemap_name": "int"
+                                        }
                                     ],
                                     "typemap_name": "int"
-                                }
-                            ],
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -5822,23 +5899,24 @@
                 ],
                 "_PTR_F_C_index": "34",
                 "ast": {
-                    "attrs": {
-                        "len": "30"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "len": "30"
+                        },
+                        "metaattrs": {
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "LastFunctionCalled",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -5944,24 +6022,25 @@
                 "_PTR_C_CXX_index": "17",
                 "_generated": "arg_to_buffer",
                 "ast": {
-                    "attrs": {
-                        "len": "30"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "len": "30"
+                        },
+                        "metaattrs": {
+                            "api": "buf",
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "LastFunctionCalled",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "buf",
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -6027,7 +6106,8 @@
                 "<TYPEDEF>": "****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "TypeID"
+                        "name": "TypeID",
+                        "typemap_name": "int"
                     },
                     "specifier": [
                         "int"
@@ -6063,7 +6143,8 @@
                 "<TYPEDEF>": "****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "EnumTypeID"
+                        "name": "EnumTypeID",
+                        "typemap_name": "int"
                     },
                     "specifier": [
                         "int"
@@ -6105,7 +6186,8 @@
                 "<VARIABLE>": "****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "global_flag"
+                        "name": "global_flag",
+                        "typemap_name": "int"
                     },
                     "specifier": [
                         "int"
@@ -6136,7 +6218,8 @@
                 "<VARIABLE>": "****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "tutorial_flag"
+                        "name": "tutorial_flag",
+                        "typemap_name": "int"
                     },
                     "specifier": [
                         "int"

--- a/regression/reference/debugfalse/tutorial.json
+++ b/regression/reference/debugfalse/tutorial.json
@@ -1843,9 +1843,10 @@
                                     "name": "arg"
                                 },
                                 "specifier": [
-                                    "ArgType"
+                                    "int"
                                 ],
-                                "template_argument": "ArgType"
+                                "template_argument": "ArgType",
+                                "typemap_name": "int"
                             }
                         ],
                         "typemap_name": "void"
@@ -2020,9 +2021,10 @@
                                     "name": "arg"
                                 },
                                 "specifier": [
-                                    "ArgType"
+                                    "double"
                                 ],
-                                "template_argument": "ArgType"
+                                "template_argument": "ArgType",
+                                "typemap_name": "double"
                             }
                         ],
                         "typemap_name": "void"
@@ -2870,12 +2872,12 @@
                                         "intent": "in"
                                     },
                                     "name": "arg2",
-                                    "typemap_name": "double"
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
-                                    "double"
+                                    "float"
                                 ],
-                                "typemap_name": "double"
+                                "typemap_name": "float"
                             }
                         ],
                         "typemap_name": "void"
@@ -2927,6 +2929,7 @@
                                 "const": true,
                                 "declarator": {
                                     "metaattrs": {
+                                        "api": "buf",
                                         "intent": "in"
                                     },
                                     "name": "name",
@@ -2951,12 +2954,12 @@
                                         "intent": "in"
                                     },
                                     "name": "arg2",
-                                    "typemap_name": "double"
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
-                                    "double"
+                                    "float"
                                 ],
-                                "typemap_name": "double"
+                                "typemap_name": "float"
                             }
                         ],
                         "typemap_name": "void"
@@ -3164,6 +3167,7 @@
                                 "const": true,
                                 "declarator": {
                                     "metaattrs": {
+                                        "api": "buf",
                                         "intent": "in"
                                     },
                                     "name": "name",

--- a/regression/reference/debugfalse/tutorial.json
+++ b/regression/reference/debugfalse/tutorial.json
@@ -5664,6 +5664,7 @@
                                     "attrs": {
                                         "value": true
                                     },
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],

--- a/regression/reference/debugfalse/tutorial.json
+++ b/regression/reference/debugfalse/tutorial.json
@@ -97,6 +97,7 @@
                 },
                 "decl": "void NoReturnNoArguments()",
                 "declgen": "void NoReturnNoArguments(void)",
+                "name": "NoReturnNoArguments",
                 "options": {
                     "literalinclude": true
                 },
@@ -188,6 +189,7 @@
                 },
                 "decl": "double PassByValue(double arg1, int arg2)",
                 "declgen": "double PassByValue(double arg1 +value, int arg2 +value)",
+                "name": "PassByValue",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -480,6 +482,7 @@
                 "doxygen": {
                     "description": "Note that since a reference is returned, no intermediate string\nis allocated.  It is assumed +owner(library).\n"
                 },
+                "name": "ConcatenateStrings",
                 "options": {},
                 "wrap": {
                     "fortran": true,
@@ -688,6 +691,7 @@
                 "doxygen": {
                     "description": "Note that since a reference is returned, no intermediate string\nis allocated.  It is assumed +owner(library).\n"
                 },
+                "name": "ConcatenateStrings",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -837,6 +841,7 @@
                     "_arg1",
                     "_arg1_arg2"
                 ],
+                "name": "UseDefaultArguments",
                 "options": {
                     "literalinclude": true
                 },
@@ -944,6 +949,7 @@
                     "_arg1",
                     "_arg1_arg2"
                 ],
+                "name": "UseDefaultArguments",
                 "options": {
                     "literalinclude": true
                 },
@@ -1110,6 +1116,7 @@
                     "_arg1",
                     "_arg1_arg2"
                 ],
+                "name": "UseDefaultArguments",
                 "options": {
                     "literalinclude": true
                 },
@@ -1385,6 +1392,7 @@
                 },
                 "decl": "void OverloadedFunction(const std::string& name)",
                 "declgen": "void OverloadedFunction(const std::string & name)",
+                "name": "OverloadedFunction",
                 "options": {},
                 "user_fmt": {
                     "function_suffix": "_from_name"
@@ -1535,6 +1543,7 @@
                 },
                 "decl": "void OverloadedFunction(const std::string& name)",
                 "declgen": "void OverloadedFunction(const std::string & name)",
+                "name": "OverloadedFunction",
                 "options": {},
                 "splicer_group": "buf",
                 "user_fmt": {
@@ -1632,6 +1641,7 @@
                 },
                 "decl": "void OverloadedFunction(int indx)",
                 "declgen": "void OverloadedFunction(int indx +value)",
+                "name": "OverloadedFunction",
                 "options": {},
                 "user_fmt": {
                     "function_suffix": "_from_index"
@@ -1784,6 +1794,7 @@
                 "decl": "template<typename ArgType>\nvoid TemplateArgument(ArgType arg)\n",
                 "declgen": "void TemplateArgument(ArgType arg +value)",
                 "have_template_args": true,
+                "name": "TemplateArgument",
                 "options": {},
                 "template_arguments": [
                     {
@@ -1859,6 +1870,7 @@
                 "decl": "template<typename ArgType>\nvoid TemplateArgument(ArgType arg)\n",
                 "declgen": "void TemplateArgument(int arg +value)",
                 "have_template_args": true,
+                "name": "TemplateArgument",
                 "options": {},
                 "template_arguments": [
                     {
@@ -2041,6 +2053,7 @@
                     "double"
                 ],
                 "have_template_args": true,
+                "name": "TemplateArgument",
                 "options": {},
                 "template_arguments": [
                     {
@@ -2201,6 +2214,7 @@
                 "decl": "template<typename RetType> RetType TemplateReturn()",
                 "declgen": "RetType TemplateReturn(void)",
                 "have_template_args": true,
+                "name": "TemplateReturn",
                 "options": {
                     "wrap_lua": false,
                     "wrap_python": false
@@ -2262,6 +2276,7 @@
                 "decl": "template<typename RetType> RetType TemplateReturn()",
                 "declgen": "int TemplateReturn(void)",
                 "have_template_args": true,
+                "name": "TemplateReturn",
                 "options": {
                     "F_create_generic": false,
                     "wrap_lua": false,
@@ -2381,6 +2396,7 @@
                     "double"
                 ],
                 "have_template_args": true,
+                "name": "TemplateReturn",
                 "options": {
                     "F_create_generic": false,
                     "wrap_lua": false,
@@ -2491,6 +2507,7 @@
                 },
                 "decl": "void FortranGenericOverloaded()",
                 "declgen": "void FortranGenericOverloaded(void)",
+                "name": "FortranGenericOverloaded",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2669,6 +2686,7 @@
                         "generic": "(double arg2)"
                     }
                 ],
+                "name": "FortranGenericOverloaded",
                 "options": {
                     "F_string_len_trim": true
                 },
@@ -2889,6 +2907,7 @@
                 },
                 "decl": "void FortranGenericOverloaded(const std::string &name, double arg2)",
                 "declgen": "void FortranGenericOverloaded(const std::string & name, float arg2 +value)",
+                "name": "FortranGenericOverloaded",
                 "options": {
                     "F_string_len_trim": true
                 },
@@ -2971,6 +2990,7 @@
                 },
                 "decl": "void FortranGenericOverloaded(const std::string &name, double arg2)",
                 "declgen": "void FortranGenericOverloaded(const std::string & name, float arg2 +value)",
+                "name": "FortranGenericOverloaded",
                 "options": {
                     "F_string_len_trim": true
                 },
@@ -3127,6 +3147,7 @@
                 },
                 "decl": "void FortranGenericOverloaded(const std::string &name, double arg2)",
                 "declgen": "void FortranGenericOverloaded(const std::string & name, double arg2 +value)",
+                "name": "FortranGenericOverloaded",
                 "options": {
                     "F_string_len_trim": true
                 },
@@ -3209,6 +3230,7 @@
                 },
                 "decl": "void FortranGenericOverloaded(const std::string &name, double arg2)",
                 "declgen": "void FortranGenericOverloaded(const std::string & name, double arg2 +value)",
+                "name": "FortranGenericOverloaded",
                 "options": {
                     "F_string_len_trim": true
                 },
@@ -3347,6 +3369,7 @@
                     "_num_offset",
                     "_num_offset_stride"
                 ],
+                "name": "UseDefaultOverload",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3505,6 +3528,7 @@
                     "_num_offset",
                     "_num_offset_stride"
                 ],
+                "name": "UseDefaultOverload",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3718,6 +3742,7 @@
                     "_num_offset",
                     "_num_offset_stride"
                 ],
+                "name": "UseDefaultOverload",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -4068,6 +4093,7 @@
                 },
                 "decl": "int UseDefaultOverload(double type, int num, int offset = 0, int stride = 1)",
                 "declgen": "int UseDefaultOverload(double type +value, int num +value)",
+                "name": "UseDefaultOverload",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -4270,6 +4296,7 @@
                 },
                 "decl": "int UseDefaultOverload(double type, int num, int offset = 0, int stride = 1)",
                 "declgen": "int UseDefaultOverload(double type +value, int num +value, int offset=0 +value)",
+                "name": "UseDefaultOverload",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -4527,6 +4554,7 @@
                 },
                 "decl": "int UseDefaultOverload(double type, int num, int offset = 0, int stride = 1)",
                 "declgen": "int UseDefaultOverload(double type +value, int num +value, int offset=0 +value, int stride=1 +value)",
+                "name": "UseDefaultOverload",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -4920,6 +4948,7 @@
                 },
                 "decl": "TypeID typefunc(TypeID arg)",
                 "declgen": "TypeID typefunc(TypeID arg +value)",
+                "name": "typefunc",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -5117,6 +5146,7 @@
                 },
                 "decl": "EnumTypeID enumfunc(EnumTypeID arg)",
                 "declgen": "EnumTypeID enumfunc(EnumTypeID arg +value)",
+                "name": "enumfunc",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -5320,6 +5350,7 @@
                 },
                 "decl": "Color colorfunc(Color arg);",
                 "declgen": "Color colorfunc(Color arg +value)",
+                "name": "colorfunc",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -5550,6 +5581,7 @@
                 "doxygen": {
                     "brief": "Pass in reference to scalar"
                 },
+                "name": "getMinMax",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false
@@ -5769,6 +5801,7 @@
                 "doxygen": {
                     "brief": "Test function pointer"
                 },
+                "name": "callback1",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false,
@@ -5929,6 +5962,7 @@
                 },
                 "decl": "const std::string& LastFunctionCalled() +len(30)",
                 "declgen": "const std::string & LastFunctionCalled(void) +len(30)",
+                "name": "LastFunctionCalled",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -6053,6 +6087,7 @@
                 },
                 "decl": "const std::string& LastFunctionCalled() +len(30)",
                 "declgen": "const std::string & LastFunctionCalled(void) +len(30)",
+                "name": "LastFunctionCalled",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {

--- a/regression/reference/debugfalse/tutorial.json
+++ b/regression/reference/debugfalse/tutorial.json
@@ -5734,6 +5734,7 @@
                                     "metaattrs": {
                                         "intent": "in"
                                     },
+                                    "name": "incr",
                                     "params": [
                                         {
                                             "declarator": {

--- a/regression/reference/defaultarg/defaultarg.json
+++ b/regression/reference/defaultarg/defaultarg.json
@@ -58,6 +58,7 @@
                     "_nelems_offset",
                     "_nelems_offset_stride"
                 ],
+                "name": "apply_generic",
                 "options": {
                     "F_default_args": "generic"
                 },
@@ -188,6 +189,7 @@
                     "_nelems_offset",
                     "_nelems_offset_stride"
                 ],
+                "name": "apply_generic",
                 "options": {
                     "F_default_args": "generic"
                 },
@@ -374,6 +376,7 @@
                     "_nelems_offset",
                     "_nelems_offset_stride"
                 ],
+                "name": "apply_generic",
                 "options": {
                     "F_default_args": "generic"
                 },
@@ -571,6 +574,7 @@
                     "_type_nelems_offset",
                     "_type_nelems_offset_stride"
                 ],
+                "name": "apply_generic",
                 "options": {
                     "F_default_args": "generic"
                 },
@@ -753,6 +757,7 @@
                     "_type_nelems_offset",
                     "_type_nelems_offset_stride"
                 ],
+                "name": "apply_generic",
                 "options": {
                     "F_default_args": "generic"
                 },
@@ -991,6 +996,7 @@
                     "_type_nelems_offset",
                     "_type_nelems_offset_stride"
                 ],
+                "name": "apply_generic",
                 "options": {
                     "F_default_args": "generic"
                 },
@@ -1237,6 +1243,7 @@
                 "default_arg_suffix": [
                     "_nelems_offset_stride"
                 ],
+                "name": "apply_require",
                 "options": {
                     "F_default_args": "require"
                 },
@@ -1463,6 +1470,7 @@
                 "default_arg_suffix": [
                     "_type_nelems_offset_stride"
                 ],
+                "name": "apply_require",
                 "options": {
                     "F_default_args": "require"
                 },
@@ -1709,6 +1717,7 @@
                 "default_arg_suffix": [
                     "_nelems_offset_stride"
                 ],
+                "name": "apply_optional",
                 "options": {
                     "F_default_args": "optional"
                 },
@@ -1937,6 +1946,7 @@
                 "default_arg_suffix": [
                     "_type_nelems_offset_stride"
                 ],
+                "name": "apply_optional",
                 "options": {
                     "F_default_args": "optional"
                 },

--- a/regression/reference/defaultarg/defaultarg.json
+++ b/regression/reference/defaultarg/defaultarg.json
@@ -22,28 +22,30 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "apply_generic"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "apply_generic",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "num_elems",
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "num_elems"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "IndexType"
-                            ],
-                            "typemap_name": "IndexType"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -133,44 +135,47 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "apply_generic"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "num_elems"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "IndexType"
-                            ],
-                            "typemap_name": "IndexType"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "apply_generic",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "num_elems",
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
                             },
-                            "declarator": {
-                                "name": "offset"
-                            },
-                            "init": 0,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "IndexType"
-                            ],
-                            "typemap_name": "IndexType"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 0,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "offset",
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -299,60 +304,64 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "apply_generic"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "num_elems"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "IndexType"
-                            ],
-                            "typemap_name": "IndexType"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "apply_generic",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "num_elems",
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
                             },
-                            "declarator": {
-                                "name": "offset"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 0,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "offset",
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
                             },
-                            "init": 0,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "IndexType"
-                            ],
-                            "typemap_name": "IndexType"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "stride"
-                            },
-                            "init": 1,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "IndexType"
-                            ],
-                            "typemap_name": "IndexType"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 1,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "stride",
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -510,43 +519,46 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "apply_generic"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "type"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "TypeID"
-                            ],
-                            "typemap_name": "TypeID"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "apply_generic",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "TypeID"
+                                },
+                                "specifier": [
+                                    "TypeID"
+                                ],
+                                "typemap_name": "TypeID"
                             },
-                            "declarator": {
-                                "name": "num_elems"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "IndexType"
-                            ],
-                            "typemap_name": "IndexType"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "num_elems",
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -672,59 +684,63 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "apply_generic"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "type"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "TypeID"
-                            ],
-                            "typemap_name": "TypeID"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "apply_generic",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "TypeID"
+                                },
+                                "specifier": [
+                                    "TypeID"
+                                ],
+                                "typemap_name": "TypeID"
                             },
-                            "declarator": {
-                                "name": "num_elems"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "num_elems",
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "IndexType"
-                            ],
-                            "typemap_name": "IndexType"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "offset"
-                            },
-                            "init": 0,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "IndexType"
-                            ],
-                            "typemap_name": "IndexType"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 0,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "offset",
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -889,75 +905,80 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "apply_generic"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "apply_generic",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "TypeID"
+                                },
+                                "specifier": [
+                                    "TypeID"
+                                ],
+                                "typemap_name": "TypeID"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "num_elems",
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 0,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "offset",
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 1,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "stride",
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "type"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "TypeID"
-                            ],
-                            "typemap_name": "TypeID"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "num_elems"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "IndexType"
-                            ],
-                            "typemap_name": "IndexType"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "offset"
-                            },
-                            "init": 0,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "IndexType"
-                            ],
-                            "typemap_name": "IndexType"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "stride"
-                            },
-                            "init": 1,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "IndexType"
-                            ],
-                            "typemap_name": "IndexType"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -1148,60 +1169,64 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "apply_require"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "num_elems"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "IndexType"
-                            ],
-                            "typemap_name": "IndexType"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "apply_require",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "num_elems",
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
                             },
-                            "declarator": {
-                                "name": "offset"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 0,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "offset",
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
                             },
-                            "init": 0,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "IndexType"
-                            ],
-                            "typemap_name": "IndexType"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "stride"
-                            },
-                            "init": 1,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "IndexType"
-                            ],
-                            "typemap_name": "IndexType"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 1,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "stride",
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1354,75 +1379,80 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "apply_require"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "apply_require",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "TypeID"
+                                },
+                                "specifier": [
+                                    "TypeID"
+                                ],
+                                "typemap_name": "TypeID"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "num_elems",
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 0,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "offset",
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 1,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "stride",
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "type"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "TypeID"
-                            ],
-                            "typemap_name": "TypeID"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "num_elems"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "IndexType"
-                            ],
-                            "typemap_name": "IndexType"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "offset"
-                            },
-                            "init": 0,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "IndexType"
-                            ],
-                            "typemap_name": "IndexType"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "stride"
-                            },
-                            "init": 1,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "IndexType"
-                            ],
-                            "typemap_name": "IndexType"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -1611,60 +1641,64 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "apply_optional"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "num_elems"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "IndexType"
-                            ],
-                            "typemap_name": "IndexType"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "apply_optional",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "num_elems",
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
                             },
-                            "declarator": {
-                                "name": "offset"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 0,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "offset",
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
                             },
-                            "init": 0,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "IndexType"
-                            ],
-                            "typemap_name": "IndexType"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "stride"
-                            },
-                            "init": 1,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "IndexType"
-                            ],
-                            "typemap_name": "IndexType"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 1,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "stride",
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1819,75 +1853,80 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "apply_optional"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "apply_optional",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "TypeID"
+                                },
+                                "specifier": [
+                                    "TypeID"
+                                ],
+                                "typemap_name": "TypeID"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "num_elems",
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 0,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "offset",
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 1,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "stride",
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "type"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "TypeID"
-                            ],
-                            "typemap_name": "TypeID"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "num_elems"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "IndexType"
-                            ],
-                            "typemap_name": "IndexType"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "offset"
-                            },
-                            "init": 0,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "IndexType"
-                            ],
-                            "typemap_name": "IndexType"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "stride"
-                            },
-                            "init": 1,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "IndexType"
-                            ],
-                            "typemap_name": "IndexType"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -2082,7 +2121,8 @@
                 "<TYPEDEF>": "****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "TypeID"
+                        "name": "TypeID",
+                        "typemap_name": "int"
                     },
                     "specifier": [
                         "int"

--- a/regression/reference/enum-c/enum.json
+++ b/regression/reference/enum-c/enum.json
@@ -216,28 +216,30 @@
                 "<FUNCTION>": "0 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "convert_to_int"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "convert_to_int",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "in",
+                                    "typemap_name": "Color"
+                                },
+                                "specifier": [
+                                    "enum Color"
+                                ],
+                                "typemap_name": "Color"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "in"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "enum Color"
-                            ],
-                            "typemap_name": "Color"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],

--- a/regression/reference/enum-c/enum.json
+++ b/regression/reference/enum-c/enum.json
@@ -247,6 +247,7 @@
                 },
                 "decl": "int convert_to_int(enum Color in)",
                 "declgen": "int convert_to_int(enum Color in +value)",
+                "name": "convert_to_int",
                 "options": {},
                 "wrap": {
                     "c": true,

--- a/regression/reference/enum-cxx/enum.json
+++ b/regression/reference/enum-cxx/enum.json
@@ -216,28 +216,30 @@
                 "<FUNCTION>": "0 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "convert_to_int"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "convert_to_int",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "in",
+                                    "typemap_name": "Color"
+                                },
+                                "specifier": [
+                                    "enum Color"
+                                ],
+                                "typemap_name": "Color"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "in"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "enum Color"
-                            ],
-                            "typemap_name": "Color"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],

--- a/regression/reference/enum-cxx/enum.json
+++ b/regression/reference/enum-cxx/enum.json
@@ -247,6 +247,7 @@
                 },
                 "decl": "int convert_to_int(enum Color in)",
                 "declgen": "int convert_to_int(enum Color in +value)",
+                "name": "convert_to_int",
                 "options": {},
                 "wrap": {
                     "c": true,

--- a/regression/reference/example/example.json
+++ b/regression/reference/example/example.json
@@ -1115,9 +1115,10 @@
                                                         "declarator": {
                                                             "func_const": true,
                                                             "metaattrs": {
-                                                                "api": "cdesc",
-                                                                "deref": "allocatable",
-                                                                "intent": "function"
+                                                                "api": "buf",
+                                                                "deref": "result",
+                                                                "intent": "out",
+                                                                "is_result": true
                                                             },
                                                             "name": "name",
                                                             "params": [],
@@ -1134,7 +1135,7 @@
                                                         "typemap_name": "std::string"
                                                     }
                                                 ],
-                                                "typemap_name": "std::string"
+                                                "typemap_name": "void"
                                             },
                                             "specifier": [
                                                 "void"
@@ -1244,9 +1245,10 @@
                                                         "declarator": {
                                                             "func_const": true,
                                                             "metaattrs": {
-                                                                "api": "cdesc",
-                                                                "deref": "allocatable",
-                                                                "intent": "function"
+                                                                "api": "buf",
+                                                                "deref": "result",
+                                                                "intent": "out",
+                                                                "is_result": true
                                                             },
                                                             "name": "name",
                                                             "params": [],
@@ -1263,7 +1265,7 @@
                                                         "typemap_name": "std::string"
                                                     }
                                                 ],
-                                                "typemap_name": "std::string"
+                                                "typemap_name": "void"
                                             },
                                             "specifier": [
                                                 "void"

--- a/regression/reference/example/example.json
+++ b/regression/reference/example/example.json
@@ -33,16 +33,18 @@
                                         "<FUNCTION>": "0 ****************************************",
                                         "_overloaded": true,
                                         "ast": {
-                                            "attrs": {
-                                                "_constructor": true,
-                                                "_name": "ctor"
+                                            "declarator": {
+                                                "attrs": {
+                                                    "_constructor": true,
+                                                    "_name": "ctor"
+                                                },
+                                                "metaattrs": {
+                                                    "api": "capptr",
+                                                    "intent": "ctor"
+                                                },
+                                                "params": [],
+                                                "typemap_name": "example::nested::ExClass1"
                                             },
-                                            "declarator": {},
-                                            "metaattrs": {
-                                                "api": "capptr",
-                                                "intent": "ctor"
-                                            },
-                                            "params": [],
                                             "specifier": [
                                                 "ExClass1"
                                             ],
@@ -158,35 +160,38 @@
                                         "_PTR_F_C_index": "10",
                                         "_overloaded": true,
                                         "ast": {
-                                            "attrs": {
-                                                "_constructor": true,
-                                                "_name": "ctor"
+                                            "declarator": {
+                                                "attrs": {
+                                                    "_constructor": true,
+                                                    "_name": "ctor"
+                                                },
+                                                "metaattrs": {
+                                                    "api": "capptr",
+                                                    "intent": "ctor"
+                                                },
+                                                "params": [
+                                                    {
+                                                        "const": true,
+                                                        "declarator": {
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "name",
+                                                            "pointer": [
+                                                                {
+                                                                    "ptr": "*"
+                                                                }
+                                                            ],
+                                                            "typemap_name": "std::string"
+                                                        },
+                                                        "specifier": [
+                                                            "string"
+                                                        ],
+                                                        "typemap_name": "std::string"
+                                                    }
+                                                ],
+                                                "typemap_name": "example::nested::ExClass1"
                                             },
-                                            "declarator": {},
-                                            "metaattrs": {
-                                                "api": "capptr",
-                                                "intent": "ctor"
-                                            },
-                                            "params": [
-                                                {
-                                                    "const": true,
-                                                    "declarator": {
-                                                        "name": "name",
-                                                        "pointer": [
-                                                            {
-                                                                "ptr": "*"
-                                                            }
-                                                        ]
-                                                    },
-                                                    "metaattrs": {
-                                                        "intent": "in"
-                                                    },
-                                                    "specifier": [
-                                                        "string"
-                                                    ],
-                                                    "typemap_name": "std::string"
-                                                }
-                                            ],
                                             "specifier": [
                                                 "ExClass1"
                                             ],
@@ -368,36 +373,39 @@
                                         "_generated": "arg_to_buffer",
                                         "_overloaded": true,
                                         "ast": {
-                                            "attrs": {
-                                                "_constructor": true,
-                                                "_name": "ctor"
+                                            "declarator": {
+                                                "attrs": {
+                                                    "_constructor": true,
+                                                    "_name": "ctor"
+                                                },
+                                                "metaattrs": {
+                                                    "api": "capptr",
+                                                    "intent": "ctor"
+                                                },
+                                                "params": [
+                                                    {
+                                                        "const": true,
+                                                        "declarator": {
+                                                            "metaattrs": {
+                                                                "api": "buf",
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "name",
+                                                            "pointer": [
+                                                                {
+                                                                    "ptr": "*"
+                                                                }
+                                                            ],
+                                                            "typemap_name": "std::string"
+                                                        },
+                                                        "specifier": [
+                                                            "string"
+                                                        ],
+                                                        "typemap_name": "std::string"
+                                                    }
+                                                ],
+                                                "typemap_name": "example::nested::ExClass1"
                                             },
-                                            "declarator": {},
-                                            "metaattrs": {
-                                                "api": "capptr",
-                                                "intent": "ctor"
-                                            },
-                                            "params": [
-                                                {
-                                                    "const": true,
-                                                    "declarator": {
-                                                        "name": "name",
-                                                        "pointer": [
-                                                            {
-                                                                "ptr": "*"
-                                                            }
-                                                        ]
-                                                    },
-                                                    "metaattrs": {
-                                                        "api": "buf",
-                                                        "intent": "in"
-                                                    },
-                                                    "specifier": [
-                                                        "string"
-                                                    ],
-                                                    "typemap_name": "std::string"
-                                                }
-                                            ],
                                             "specifier": [
                                                 "ExClass1"
                                             ],
@@ -501,15 +509,17 @@
                                     {
                                         "<FUNCTION>": "2 ****************************************",
                                         "ast": {
-                                            "attrs": {
-                                                "_destructor": "ExClass1",
-                                                "_name": "dtor"
+                                            "declarator": {
+                                                "attrs": {
+                                                    "_destructor": "ExClass1",
+                                                    "_name": "dtor"
+                                                },
+                                                "metaattrs": {
+                                                    "intent": "dtor"
+                                                },
+                                                "params": [],
+                                                "typemap_name": "void"
                                             },
-                                            "declarator": {},
-                                            "metaattrs": {
-                                                "intent": "dtor"
-                                            },
-                                            "params": [],
                                             "specifier": [
                                                 "void"
                                             ],
@@ -571,28 +581,30 @@
                                         "<FUNCTION>": "3 ****************************************",
                                         "ast": {
                                             "declarator": {
-                                                "name": "incrementCount"
+                                                "metaattrs": {
+                                                    "intent": "function"
+                                                },
+                                                "name": "incrementCount",
+                                                "params": [
+                                                    {
+                                                        "declarator": {
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "incr",
+                                                            "typemap_name": "int"
+                                                        },
+                                                        "specifier": [
+                                                            "int"
+                                                        ],
+                                                        "typemap_name": "int"
+                                                    }
+                                                ],
+                                                "typemap_name": "int"
                                             },
-                                            "metaattrs": {
-                                                "intent": "function"
-                                            },
-                                            "params": [
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "incr"
-                                                    },
-                                                    "metaattrs": {
-                                                        "intent": "in"
-                                                    },
-                                                    "specifier": [
-                                                        "int"
-                                                    ],
-                                                    "typemap_name": "int"
-                                                }
-                                            ],
                                             "specifier": [
                                                 "int"
                                             ],
@@ -773,19 +785,20 @@
                                         "ast": {
                                             "const": true,
                                             "declarator": {
+                                                "func_const": true,
+                                                "metaattrs": {
+                                                    "deref": "allocatable",
+                                                    "intent": "function"
+                                                },
                                                 "name": "getNameErrorCheck",
+                                                "params": [],
                                                 "pointer": [
                                                     {
                                                         "ptr": "&"
                                                     }
-                                                ]
+                                                ],
+                                                "typemap_name": "std::string"
                                             },
-                                            "func_const": true,
-                                            "metaattrs": {
-                                                "deref": "allocatable",
-                                                "intent": "function"
-                                            },
-                                            "params": [],
                                             "specifier": [
                                                 "string"
                                             ],
@@ -900,20 +913,21 @@
                                         "ast": {
                                             "const": true,
                                             "declarator": {
+                                                "func_const": true,
+                                                "metaattrs": {
+                                                    "api": "cdesc",
+                                                    "deref": "allocatable",
+                                                    "intent": "function"
+                                                },
                                                 "name": "getNameErrorCheck",
+                                                "params": [],
                                                 "pointer": [
                                                     {
                                                         "ptr": "&"
                                                     }
-                                                ]
+                                                ],
+                                                "typemap_name": "std::string"
                                             },
-                                            "func_const": true,
-                                            "metaattrs": {
-                                                "api": "cdesc",
-                                                "deref": "allocatable",
-                                                "intent": "function"
-                                            },
-                                            "params": [],
                                             "specifier": [
                                                 "string"
                                             ],
@@ -978,18 +992,19 @@
                                         "ast": {
                                             "const": true,
                                             "declarator": {
+                                                "func_const": true,
+                                                "metaattrs": {
+                                                    "intent": "function"
+                                                },
                                                 "name": "getNameArg",
+                                                "params": [],
                                                 "pointer": [
                                                     {
                                                         "ptr": "&"
                                                     }
-                                                ]
+                                                ],
+                                                "typemap_name": "std::string"
                                             },
-                                            "func_const": true,
-                                            "metaattrs": {
-                                                "intent": "function"
-                                            },
-                                            "params": [],
                                             "specifier": [
                                                 "string"
                                             ],
@@ -1090,34 +1105,37 @@
                                         "_generated": "arg_to_buffer",
                                         "ast": {
                                             "declarator": {
-                                                "name": "getNameArg"
+                                                "func_const": true,
+                                                "metaattrs": {
+                                                    "intent": "subroutine"
+                                                },
+                                                "name": "getNameArg",
+                                                "params": [
+                                                    {
+                                                        "declarator": {
+                                                            "func_const": true,
+                                                            "metaattrs": {
+                                                                "api": "cdesc",
+                                                                "deref": "allocatable",
+                                                                "intent": "function"
+                                                            },
+                                                            "name": "name",
+                                                            "params": [],
+                                                            "pointer": [
+                                                                {
+                                                                    "ptr": "&"
+                                                                }
+                                                            ],
+                                                            "typemap_name": "std::string"
+                                                        },
+                                                        "specifier": [
+                                                            "string"
+                                                        ],
+                                                        "typemap_name": "std::string"
+                                                    }
+                                                ],
+                                                "typemap_name": "std::string"
                                             },
-                                            "func_const": true,
-                                            "metaattrs": {
-                                                "intent": "subroutine"
-                                            },
-                                            "params": [
-                                                {
-                                                    "declarator": {
-                                                        "name": "name",
-                                                        "pointer": [
-                                                            {
-                                                                "ptr": "&"
-                                                            }
-                                                        ]
-                                                    },
-                                                    "metaattrs": {
-                                                        "api": "buf",
-                                                        "deref": "result",
-                                                        "intent": "out",
-                                                        "is_result": true
-                                                    },
-                                                    "specifier": [
-                                                        "string"
-                                                    ],
-                                                    "typemap_name": "std::string"
-                                                }
-                                            ],
                                             "specifier": [
                                                 "void"
                                             ],
@@ -1216,34 +1234,37 @@
                                         "_generated": "arg_to_buffer",
                                         "ast": {
                                             "declarator": {
-                                                "name": "getNameArg"
+                                                "func_const": true,
+                                                "metaattrs": {
+                                                    "intent": "subroutine"
+                                                },
+                                                "name": "getNameArg",
+                                                "params": [
+                                                    {
+                                                        "declarator": {
+                                                            "func_const": true,
+                                                            "metaattrs": {
+                                                                "api": "cdesc",
+                                                                "deref": "allocatable",
+                                                                "intent": "function"
+                                                            },
+                                                            "name": "name",
+                                                            "params": [],
+                                                            "pointer": [
+                                                                {
+                                                                    "ptr": "&"
+                                                                }
+                                                            ],
+                                                            "typemap_name": "std::string"
+                                                        },
+                                                        "specifier": [
+                                                            "string"
+                                                        ],
+                                                        "typemap_name": "std::string"
+                                                    }
+                                                ],
+                                                "typemap_name": "std::string"
                                             },
-                                            "func_const": true,
-                                            "metaattrs": {
-                                                "intent": "subroutine"
-                                            },
-                                            "params": [
-                                                {
-                                                    "declarator": {
-                                                        "name": "name",
-                                                        "pointer": [
-                                                            {
-                                                                "ptr": "&"
-                                                            }
-                                                        ]
-                                                    },
-                                                    "metaattrs": {
-                                                        "api": "buf",
-                                                        "deref": "result",
-                                                        "intent": "out",
-                                                        "is_result": true
-                                                    },
-                                                    "specifier": [
-                                                        "string"
-                                                    ],
-                                                    "typemap_name": "std::string"
-                                                }
-                                            ],
                                             "specifier": [
                                                 "void"
                                             ],
@@ -1282,28 +1303,30 @@
                                         "_overloaded": true,
                                         "ast": {
                                             "declarator": {
-                                                "name": "getValue"
+                                                "metaattrs": {
+                                                    "intent": "function"
+                                                },
+                                                "name": "getValue",
+                                                "params": [
+                                                    {
+                                                        "declarator": {
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "value",
+                                                            "typemap_name": "int"
+                                                        },
+                                                        "specifier": [
+                                                            "int"
+                                                        ],
+                                                        "typemap_name": "int"
+                                                    }
+                                                ],
+                                                "typemap_name": "int"
                                             },
-                                            "metaattrs": {
-                                                "intent": "function"
-                                            },
-                                            "params": [
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "value"
-                                                    },
-                                                    "metaattrs": {
-                                                        "intent": "in"
-                                                    },
-                                                    "specifier": [
-                                                        "int"
-                                                    ],
-                                                    "typemap_name": "int"
-                                                }
-                                            ],
                                             "specifier": [
                                                 "int"
                                             ],
@@ -1484,28 +1507,30 @@
                                         "_overloaded": true,
                                         "ast": {
                                             "declarator": {
-                                                "name": "getValue"
+                                                "metaattrs": {
+                                                    "intent": "function"
+                                                },
+                                                "name": "getValue",
+                                                "params": [
+                                                    {
+                                                        "declarator": {
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "value",
+                                                            "typemap_name": "long"
+                                                        },
+                                                        "specifier": [
+                                                            "long"
+                                                        ],
+                                                        "typemap_name": "long"
+                                                    }
+                                                ],
+                                                "typemap_name": "long"
                                             },
-                                            "metaattrs": {
-                                                "intent": "function"
-                                            },
-                                            "params": [
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "value"
-                                                    },
-                                                    "metaattrs": {
-                                                        "intent": "in"
-                                                    },
-                                                    "specifier": [
-                                                        "long"
-                                                    ],
-                                                    "typemap_name": "long"
-                                                }
-                                            ],
                                             "specifier": [
                                                 "long"
                                             ],
@@ -1680,28 +1705,30 @@
                                         "<FUNCTION>": "8 ****************************************",
                                         "ast": {
                                             "declarator": {
-                                                "name": "hasAddr"
+                                                "metaattrs": {
+                                                    "intent": "function"
+                                                },
+                                                "name": "hasAddr",
+                                                "params": [
+                                                    {
+                                                        "declarator": {
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "in",
+                                                            "typemap_name": "bool"
+                                                        },
+                                                        "specifier": [
+                                                            "bool"
+                                                        ],
+                                                        "typemap_name": "bool"
+                                                    }
+                                                ],
+                                                "typemap_name": "bool"
                                             },
-                                            "metaattrs": {
-                                                "intent": "function"
-                                            },
-                                            "params": [
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "in"
-                                                    },
-                                                    "metaattrs": {
-                                                        "intent": "in"
-                                                    },
-                                                    "specifier": [
-                                                        "bool"
-                                                    ],
-                                                    "typemap_name": "bool"
-                                                }
-                                            ],
                                             "specifier": [
                                                 "bool"
                                             ],
@@ -1880,12 +1907,13 @@
                                         "<FUNCTION>": "9 ****************************************",
                                         "ast": {
                                             "declarator": {
-                                                "name": "SplicerSpecial"
+                                                "metaattrs": {
+                                                    "intent": "subroutine"
+                                                },
+                                                "name": "SplicerSpecial",
+                                                "params": [],
+                                                "typemap_name": "void"
                                             },
-                                            "metaattrs": {
-                                                "intent": "subroutine"
-                                            },
-                                            "params": [],
                                             "specifier": [
                                                 "void"
                                             ],
@@ -2038,38 +2066,41 @@
                                         "_PTR_F_C_index": "40",
                                         "_overloaded": true,
                                         "ast": {
-                                            "attrs": {
-                                                "_constructor": true,
-                                                "_name": "ctor"
+                                            "declarator": {
+                                                "attrs": {
+                                                    "_constructor": true,
+                                                    "_name": "ctor"
+                                                },
+                                                "metaattrs": {
+                                                    "api": "capptr",
+                                                    "intent": "ctor"
+                                                },
+                                                "params": [
+                                                    {
+                                                        "const": true,
+                                                        "declarator": {
+                                                            "attrs": {
+                                                                "len_trim": "trim_name"
+                                                            },
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "name",
+                                                            "pointer": [
+                                                                {
+                                                                    "ptr": "*"
+                                                                }
+                                                            ],
+                                                            "typemap_name": "std::string"
+                                                        },
+                                                        "specifier": [
+                                                            "string"
+                                                        ],
+                                                        "typemap_name": "std::string"
+                                                    }
+                                                ],
+                                                "typemap_name": "example::nested::ExClass2"
                                             },
-                                            "declarator": {},
-                                            "metaattrs": {
-                                                "api": "capptr",
-                                                "intent": "ctor"
-                                            },
-                                            "params": [
-                                                {
-                                                    "attrs": {
-                                                        "len_trim": "trim_name"
-                                                    },
-                                                    "const": true,
-                                                    "declarator": {
-                                                        "name": "name",
-                                                        "pointer": [
-                                                            {
-                                                                "ptr": "*"
-                                                            }
-                                                        ]
-                                                    },
-                                                    "metaattrs": {
-                                                        "intent": "in"
-                                                    },
-                                                    "specifier": [
-                                                        "string"
-                                                    ],
-                                                    "typemap_name": "std::string"
-                                                }
-                                            ],
                                             "specifier": [
                                                 "ExClass2"
                                             ],
@@ -2250,39 +2281,42 @@
                                         "_generated": "arg_to_buffer",
                                         "_overloaded": true,
                                         "ast": {
-                                            "attrs": {
-                                                "_constructor": true,
-                                                "_name": "ctor"
+                                            "declarator": {
+                                                "attrs": {
+                                                    "_constructor": true,
+                                                    "_name": "ctor"
+                                                },
+                                                "metaattrs": {
+                                                    "api": "capptr",
+                                                    "intent": "ctor"
+                                                },
+                                                "params": [
+                                                    {
+                                                        "const": true,
+                                                        "declarator": {
+                                                            "attrs": {
+                                                                "len_trim": "trim_name"
+                                                            },
+                                                            "metaattrs": {
+                                                                "api": "buf",
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "name",
+                                                            "pointer": [
+                                                                {
+                                                                    "ptr": "*"
+                                                                }
+                                                            ],
+                                                            "typemap_name": "std::string"
+                                                        },
+                                                        "specifier": [
+                                                            "string"
+                                                        ],
+                                                        "typemap_name": "std::string"
+                                                    }
+                                                ],
+                                                "typemap_name": "example::nested::ExClass2"
                                             },
-                                            "declarator": {},
-                                            "metaattrs": {
-                                                "api": "capptr",
-                                                "intent": "ctor"
-                                            },
-                                            "params": [
-                                                {
-                                                    "attrs": {
-                                                        "len_trim": "trim_name"
-                                                    },
-                                                    "const": true,
-                                                    "declarator": {
-                                                        "name": "name",
-                                                        "pointer": [
-                                                            {
-                                                                "ptr": "*"
-                                                            }
-                                                        ]
-                                                    },
-                                                    "metaattrs": {
-                                                        "api": "buf",
-                                                        "intent": "in"
-                                                    },
-                                                    "specifier": [
-                                                        "string"
-                                                    ],
-                                                    "typemap_name": "std::string"
-                                                }
-                                            ],
                                             "specifier": [
                                                 "ExClass2"
                                             ],
@@ -2384,15 +2418,17 @@
                                     {
                                         "<FUNCTION>": "15 ****************************************",
                                         "ast": {
-                                            "attrs": {
-                                                "_destructor": "ExClass2",
-                                                "_name": "dtor"
+                                            "declarator": {
+                                                "attrs": {
+                                                    "_destructor": "ExClass2",
+                                                    "_name": "dtor"
+                                                },
+                                                "metaattrs": {
+                                                    "intent": "dtor"
+                                                },
+                                                "params": [],
+                                                "typemap_name": "void"
                                             },
-                                            "declarator": {},
-                                            "metaattrs": {
-                                                "intent": "dtor"
-                                            },
-                                            "params": [],
                                             "specifier": [
                                                 "void"
                                             ],
@@ -2456,24 +2492,25 @@
                                         ],
                                         "_PTR_F_C_index": "41",
                                         "ast": {
-                                            "attrs": {
-                                                "len": "aa_exclass2_get_name_length({F_this}%{F_derived_member})"
-                                            },
                                             "const": true,
                                             "declarator": {
+                                                "attrs": {
+                                                    "len": "aa_exclass2_get_name_length({F_this}%{F_derived_member})"
+                                                },
+                                                "func_const": true,
+                                                "metaattrs": {
+                                                    "deref": "copy",
+                                                    "intent": "function"
+                                                },
                                                 "name": "getName",
+                                                "params": [],
                                                 "pointer": [
                                                     {
                                                         "ptr": "&"
                                                     }
-                                                ]
+                                                ],
+                                                "typemap_name": "std::string"
                                             },
-                                            "func_const": true,
-                                            "metaattrs": {
-                                                "deref": "copy",
-                                                "intent": "function"
-                                            },
-                                            "params": [],
                                             "specifier": [
                                                 "string"
                                             ],
@@ -2584,25 +2621,26 @@
                                         "_PTR_C_CXX_index": "16",
                                         "_generated": "arg_to_buffer",
                                         "ast": {
-                                            "attrs": {
-                                                "len": "aa_exclass2_get_name_length({F_this}%{F_derived_member})"
-                                            },
                                             "const": true,
                                             "declarator": {
+                                                "attrs": {
+                                                    "len": "aa_exclass2_get_name_length({F_this}%{F_derived_member})"
+                                                },
+                                                "func_const": true,
+                                                "metaattrs": {
+                                                    "api": "buf",
+                                                    "deref": "copy",
+                                                    "intent": "function"
+                                                },
                                                 "name": "getName",
+                                                "params": [],
                                                 "pointer": [
                                                     {
                                                         "ptr": "&"
                                                     }
-                                                ]
+                                                ],
+                                                "typemap_name": "std::string"
                                             },
-                                            "func_const": true,
-                                            "metaattrs": {
-                                                "api": "buf",
-                                                "deref": "copy",
-                                                "intent": "function"
-                                            },
-                                            "params": [],
                                             "specifier": [
                                                 "string"
                                             ],
@@ -2671,18 +2709,19 @@
                                         "ast": {
                                             "const": true,
                                             "declarator": {
+                                                "metaattrs": {
+                                                    "deref": "allocatable",
+                                                    "intent": "function"
+                                                },
                                                 "name": "getName2",
+                                                "params": [],
                                                 "pointer": [
                                                     {
                                                         "ptr": "&"
                                                     }
-                                                ]
+                                                ],
+                                                "typemap_name": "std::string"
                                             },
-                                            "metaattrs": {
-                                                "deref": "allocatable",
-                                                "intent": "function"
-                                            },
-                                            "params": [],
                                             "specifier": [
                                                 "string"
                                             ],
@@ -2796,19 +2835,20 @@
                                         "ast": {
                                             "const": true,
                                             "declarator": {
+                                                "metaattrs": {
+                                                    "api": "cdesc",
+                                                    "deref": "allocatable",
+                                                    "intent": "function"
+                                                },
                                                 "name": "getName2",
+                                                "params": [],
                                                 "pointer": [
                                                     {
                                                         "ptr": "&"
                                                     }
-                                                ]
+                                                ],
+                                                "typemap_name": "std::string"
                                             },
-                                            "metaattrs": {
-                                                "api": "cdesc",
-                                                "deref": "allocatable",
-                                                "intent": "function"
-                                            },
-                                            "params": [],
                                             "specifier": [
                                                 "string"
                                             ],
@@ -2876,19 +2916,20 @@
                                         "_PTR_F_C_index": "43",
                                         "ast": {
                                             "declarator": {
+                                                "func_const": true,
+                                                "metaattrs": {
+                                                    "deref": "allocatable",
+                                                    "intent": "function"
+                                                },
                                                 "name": "getName3",
+                                                "params": [],
                                                 "pointer": [
                                                     {
                                                         "ptr": "&"
                                                     }
-                                                ]
+                                                ],
+                                                "typemap_name": "std::string"
                                             },
-                                            "func_const": true,
-                                            "metaattrs": {
-                                                "deref": "allocatable",
-                                                "intent": "function"
-                                            },
-                                            "params": [],
                                             "specifier": [
                                                 "string"
                                             ],
@@ -3002,20 +3043,21 @@
                                         "_generated": "arg_to_buffer",
                                         "ast": {
                                             "declarator": {
+                                                "func_const": true,
+                                                "metaattrs": {
+                                                    "api": "cdesc",
+                                                    "deref": "allocatable",
+                                                    "intent": "function"
+                                                },
                                                 "name": "getName3",
+                                                "params": [],
                                                 "pointer": [
                                                     {
                                                         "ptr": "&"
                                                     }
-                                                ]
+                                                ],
+                                                "typemap_name": "std::string"
                                             },
-                                            "func_const": true,
-                                            "metaattrs": {
-                                                "api": "cdesc",
-                                                "deref": "allocatable",
-                                                "intent": "function"
-                                            },
-                                            "params": [],
                                             "specifier": [
                                                 "string"
                                             ],
@@ -3083,18 +3125,19 @@
                                         "_PTR_F_C_index": "44",
                                         "ast": {
                                             "declarator": {
+                                                "metaattrs": {
+                                                    "deref": "allocatable",
+                                                    "intent": "function"
+                                                },
                                                 "name": "getName4",
+                                                "params": [],
                                                 "pointer": [
                                                     {
                                                         "ptr": "&"
                                                     }
-                                                ]
+                                                ],
+                                                "typemap_name": "std::string"
                                             },
-                                            "metaattrs": {
-                                                "deref": "allocatable",
-                                                "intent": "function"
-                                            },
-                                            "params": [],
                                             "specifier": [
                                                 "string"
                                             ],
@@ -3207,19 +3250,20 @@
                                         "_generated": "arg_to_buffer",
                                         "ast": {
                                             "declarator": {
+                                                "metaattrs": {
+                                                    "api": "cdesc",
+                                                    "deref": "allocatable",
+                                                    "intent": "function"
+                                                },
                                                 "name": "getName4",
+                                                "params": [],
                                                 "pointer": [
                                                     {
                                                         "ptr": "&"
                                                     }
-                                                ]
+                                                ],
+                                                "typemap_name": "std::string"
                                             },
-                                            "metaattrs": {
-                                                "api": "cdesc",
-                                                "deref": "allocatable",
-                                                "intent": "function"
-                                            },
-                                            "params": [],
                                             "specifier": [
                                                 "string"
                                             ],
@@ -3283,13 +3327,14 @@
                                         "<FUNCTION>": "20 ****************************************",
                                         "ast": {
                                             "declarator": {
-                                                "name": "GetNameLength"
+                                                "func_const": true,
+                                                "metaattrs": {
+                                                    "intent": "function"
+                                                },
+                                                "name": "GetNameLength",
+                                                "params": [],
+                                                "typemap_name": "int"
                                             },
-                                            "func_const": true,
-                                            "metaattrs": {
-                                                "intent": "function"
-                                            },
-                                            "params": [],
                                             "specifier": [
                                                 "int"
                                             ],
@@ -3405,37 +3450,39 @@
                                         "<FUNCTION>": "21 ****************************************",
                                         "ast": {
                                             "declarator": {
+                                                "metaattrs": {
+                                                    "api": "capptr",
+                                                    "intent": "function"
+                                                },
                                                 "name": "get_class1",
+                                                "params": [
+                                                    {
+                                                        "const": true,
+                                                        "declarator": {
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "in",
+                                                            "pointer": [
+                                                                {
+                                                                    "ptr": "*"
+                                                                }
+                                                            ],
+                                                            "typemap_name": "example::nested::ExClass1"
+                                                        },
+                                                        "specifier": [
+                                                            "ExClass1"
+                                                        ],
+                                                        "typemap_name": "example::nested::ExClass1"
+                                                    }
+                                                ],
                                                 "pointer": [
                                                     {
                                                         "ptr": "*"
                                                     }
-                                                ]
+                                                ],
+                                                "typemap_name": "example::nested::ExClass1"
                                             },
-                                            "metaattrs": {
-                                                "api": "capptr",
-                                                "intent": "function"
-                                            },
-                                            "params": [
-                                                {
-                                                    "const": true,
-                                                    "declarator": {
-                                                        "name": "in",
-                                                        "pointer": [
-                                                            {
-                                                                "ptr": "*"
-                                                            }
-                                                        ]
-                                                    },
-                                                    "metaattrs": {
-                                                        "intent": "in"
-                                                    },
-                                                    "specifier": [
-                                                        "ExClass1"
-                                                    ],
-                                                    "typemap_name": "example::nested::ExClass1"
-                                                }
-                                            ],
                                             "specifier": [
                                                 "ExClass1"
                                             ],
@@ -3625,33 +3672,35 @@
                                         "_overloaded": true,
                                         "ast": {
                                             "declarator": {
+                                                "metaattrs": {
+                                                    "intent": "function"
+                                                },
                                                 "name": "declare",
+                                                "params": [
+                                                    {
+                                                        "declarator": {
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "type",
+                                                            "typemap_name": "TypeID"
+                                                        },
+                                                        "specifier": [
+                                                            "TypeID"
+                                                        ],
+                                                        "typemap_name": "TypeID"
+                                                    }
+                                                ],
                                                 "pointer": [
                                                     {
                                                         "ptr": "*"
                                                     }
-                                                ]
+                                                ],
+                                                "typemap_name": "void"
                                             },
-                                            "metaattrs": {
-                                                "intent": "function"
-                                            },
-                                            "params": [
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "type"
-                                                    },
-                                                    "metaattrs": {
-                                                        "intent": "in"
-                                                    },
-                                                    "specifier": [
-                                                        "TypeID"
-                                                    ],
-                                                    "typemap_name": "TypeID"
-                                                }
-                                            ],
                                             "specifier": [
                                                 "void"
                                             ],
@@ -3663,14 +3712,15 @@
                                             {
                                                 "decls": [
                                                     {
-                                                        "attrs": {
-                                                            "value": true
-                                                        },
                                                         "declarator": {
-                                                            "name": "type"
-                                                        },
-                                                        "metaattrs": {
-                                                            "intent": "in"
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "type",
+                                                            "typemap_name": "TypeID"
                                                         },
                                                         "specifier": [
                                                             "TypeID"
@@ -3678,15 +3728,16 @@
                                                         "typemap_name": "TypeID"
                                                     },
                                                     {
-                                                        "attrs": {
-                                                            "value": true
-                                                        },
                                                         "declarator": {
-                                                            "name": "len"
-                                                        },
-                                                        "init": 1,
-                                                        "metaattrs": {
-                                                            "intent": "in"
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "init": 1,
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "len",
+                                                            "typemap_name": "int"
                                                         },
                                                         "specifier": [
                                                             "int"
@@ -3700,14 +3751,15 @@
                                             {
                                                 "decls": [
                                                     {
-                                                        "attrs": {
-                                                            "value": true
-                                                        },
                                                         "declarator": {
-                                                            "name": "type"
-                                                        },
-                                                        "metaattrs": {
-                                                            "intent": "in"
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "type",
+                                                            "typemap_name": "TypeID"
                                                         },
                                                         "specifier": [
                                                             "TypeID"
@@ -3715,15 +3767,16 @@
                                                         "typemap_name": "TypeID"
                                                     },
                                                     {
-                                                        "attrs": {
-                                                            "value": true
-                                                        },
                                                         "declarator": {
-                                                            "name": "len"
-                                                        },
-                                                        "init": 1,
-                                                        "metaattrs": {
-                                                            "intent": "in"
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "init": 1,
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "len",
+                                                            "typemap_name": "long"
                                                         },
                                                         "specifier": [
                                                             "long"
@@ -3750,28 +3803,30 @@
                                         "_overloaded": true,
                                         "ast": {
                                             "declarator": {
-                                                "name": "declare"
+                                                "metaattrs": {
+                                                    "intent": "subroutine"
+                                                },
+                                                "name": "declare",
+                                                "params": [
+                                                    {
+                                                        "declarator": {
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "type",
+                                                            "typemap_name": "TypeID"
+                                                        },
+                                                        "specifier": [
+                                                            "TypeID"
+                                                        ],
+                                                        "typemap_name": "TypeID"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
                                             },
-                                            "metaattrs": {
-                                                "intent": "subroutine"
-                                            },
-                                            "params": [
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "type"
-                                                    },
-                                                    "metaattrs": {
-                                                        "intent": "in"
-                                                    },
-                                                    "specifier": [
-                                                        "TypeID"
-                                                    ],
-                                                    "typemap_name": "TypeID"
-                                                }
-                                            ],
                                             "specifier": [
                                                 "void"
                                             ],
@@ -3783,14 +3838,15 @@
                                             {
                                                 "decls": [
                                                     {
-                                                        "attrs": {
-                                                            "value": true
-                                                        },
                                                         "declarator": {
-                                                            "name": "type"
-                                                        },
-                                                        "metaattrs": {
-                                                            "intent": "in"
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "type",
+                                                            "typemap_name": "TypeID"
                                                         },
                                                         "specifier": [
                                                             "TypeID"
@@ -3798,15 +3854,16 @@
                                                         "typemap_name": "TypeID"
                                                     },
                                                     {
-                                                        "attrs": {
-                                                            "value": true
-                                                        },
                                                         "declarator": {
-                                                            "name": "len"
-                                                        },
-                                                        "init": 1,
-                                                        "metaattrs": {
-                                                            "intent": "in"
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "init": 1,
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "len",
+                                                            "typemap_name": "int"
                                                         },
                                                         "specifier": [
                                                             "int"
@@ -3820,14 +3877,15 @@
                                             {
                                                 "decls": [
                                                     {
-                                                        "attrs": {
-                                                            "value": true
-                                                        },
                                                         "declarator": {
-                                                            "name": "type"
-                                                        },
-                                                        "metaattrs": {
-                                                            "intent": "in"
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "type",
+                                                            "typemap_name": "TypeID"
                                                         },
                                                         "specifier": [
                                                             "TypeID"
@@ -3835,15 +3893,16 @@
                                                         "typemap_name": "TypeID"
                                                     },
                                                     {
-                                                        "attrs": {
-                                                            "value": true
-                                                        },
                                                         "declarator": {
-                                                            "name": "len"
-                                                        },
-                                                        "init": 1,
-                                                        "metaattrs": {
-                                                            "intent": "in"
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "init": 1,
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "len",
+                                                            "typemap_name": "long"
                                                         },
                                                         "specifier": [
                                                             "long"
@@ -3929,44 +3988,30 @@
                                         "_overloaded": true,
                                         "ast": {
                                             "declarator": {
-                                                "name": "declare"
-                                            },
-                                            "metaattrs": {
-                                                "intent": "subroutine"
-                                            },
-                                            "params": [
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "type"
-                                                    },
-                                                    "metaattrs": {
-                                                        "intent": "in"
-                                                    },
-                                                    "specifier": [
-                                                        "TypeID"
-                                                    ],
-                                                    "typemap_name": "TypeID"
+                                                "metaattrs": {
+                                                    "intent": "subroutine"
                                                 },
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "len"
-                                                    },
-                                                    "init": 1,
-                                                    "metaattrs": {
-                                                        "intent": "in"
-                                                    },
-                                                    "specifier": [
-                                                        "int"
-                                                    ],
-                                                    "typemap_name": "int"
-                                                }
-                                            ],
+                                                "name": "declare",
+                                                "params": [
+                                                    {
+                                                        "declarator": {
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "type",
+                                                            "typemap_name": "TypeID"
+                                                        },
+                                                        "specifier": [
+                                                            "TypeID"
+                                                        ],
+                                                        "typemap_name": "TypeID"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
+                                            },
                                             "specifier": [
                                                 "void"
                                             ],
@@ -4007,44 +4052,30 @@
                                         "_overloaded": true,
                                         "ast": {
                                             "declarator": {
-                                                "name": "declare"
-                                            },
-                                            "metaattrs": {
-                                                "intent": "subroutine"
-                                            },
-                                            "params": [
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "type"
-                                                    },
-                                                    "metaattrs": {
-                                                        "intent": "in"
-                                                    },
-                                                    "specifier": [
-                                                        "TypeID"
-                                                    ],
-                                                    "typemap_name": "TypeID"
+                                                "metaattrs": {
+                                                    "intent": "subroutine"
                                                 },
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "len"
-                                                    },
-                                                    "init": 1,
-                                                    "metaattrs": {
-                                                        "intent": "in"
-                                                    },
-                                                    "specifier": [
-                                                        "long"
-                                                    ],
-                                                    "typemap_name": "long"
-                                                }
-                                            ],
+                                                "name": "declare",
+                                                "params": [
+                                                    {
+                                                        "declarator": {
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "type",
+                                                            "typemap_name": "TypeID"
+                                                        },
+                                                        "specifier": [
+                                                            "TypeID"
+                                                        ],
+                                                        "typemap_name": "TypeID"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
+                                            },
                                             "specifier": [
                                                 "void"
                                             ],
@@ -4087,49 +4118,52 @@
                                         "_overloaded": true,
                                         "ast": {
                                             "declarator": {
+                                                "metaattrs": {
+                                                    "intent": "function"
+                                                },
                                                 "name": "declare",
+                                                "params": [
+                                                    {
+                                                        "declarator": {
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "type",
+                                                            "typemap_name": "TypeID"
+                                                        },
+                                                        "specifier": [
+                                                            "TypeID"
+                                                        ],
+                                                        "typemap_name": "TypeID"
+                                                    },
+                                                    {
+                                                        "declarator": {
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "init": 1,
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "len",
+                                                            "typemap_name": "SidreLength"
+                                                        },
+                                                        "specifier": [
+                                                            "SidreLength"
+                                                        ],
+                                                        "typemap_name": "SidreLength"
+                                                    }
+                                                ],
                                                 "pointer": [
                                                     {
                                                         "ptr": "*"
                                                     }
-                                                ]
+                                                ],
+                                                "typemap_name": "void"
                                             },
-                                            "metaattrs": {
-                                                "intent": "function"
-                                            },
-                                            "params": [
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "type"
-                                                    },
-                                                    "metaattrs": {
-                                                        "intent": "in"
-                                                    },
-                                                    "specifier": [
-                                                        "TypeID"
-                                                    ],
-                                                    "typemap_name": "TypeID"
-                                                },
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "len"
-                                                    },
-                                                    "init": 1,
-                                                    "metaattrs": {
-                                                        "intent": "in"
-                                                    },
-                                                    "specifier": [
-                                                        "SidreLength"
-                                                    ],
-                                                    "typemap_name": "SidreLength"
-                                                }
-                                            ],
                                             "specifier": [
                                                 "void"
                                             ],
@@ -4141,14 +4175,15 @@
                                             {
                                                 "decls": [
                                                     {
-                                                        "attrs": {
-                                                            "value": true
-                                                        },
                                                         "declarator": {
-                                                            "name": "type"
-                                                        },
-                                                        "metaattrs": {
-                                                            "intent": "in"
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "type",
+                                                            "typemap_name": "TypeID"
                                                         },
                                                         "specifier": [
                                                             "TypeID"
@@ -4156,15 +4191,16 @@
                                                         "typemap_name": "TypeID"
                                                     },
                                                     {
-                                                        "attrs": {
-                                                            "value": true
-                                                        },
                                                         "declarator": {
-                                                            "name": "len"
-                                                        },
-                                                        "init": 1,
-                                                        "metaattrs": {
-                                                            "intent": "in"
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "init": 1,
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "len",
+                                                            "typemap_name": "int"
                                                         },
                                                         "specifier": [
                                                             "int"
@@ -4178,14 +4214,15 @@
                                             {
                                                 "decls": [
                                                     {
-                                                        "attrs": {
-                                                            "value": true
-                                                        },
                                                         "declarator": {
-                                                            "name": "type"
-                                                        },
-                                                        "metaattrs": {
-                                                            "intent": "in"
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "type",
+                                                            "typemap_name": "TypeID"
                                                         },
                                                         "specifier": [
                                                             "TypeID"
@@ -4193,15 +4230,16 @@
                                                         "typemap_name": "TypeID"
                                                     },
                                                     {
-                                                        "attrs": {
-                                                            "value": true
-                                                        },
                                                         "declarator": {
-                                                            "name": "len"
-                                                        },
-                                                        "init": 1,
-                                                        "metaattrs": {
-                                                            "intent": "in"
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "init": 1,
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "len",
+                                                            "typemap_name": "long"
                                                         },
                                                         "specifier": [
                                                             "long"
@@ -4347,44 +4385,47 @@
                                         "_overloaded": true,
                                         "ast": {
                                             "declarator": {
-                                                "name": "declare"
-                                            },
-                                            "metaattrs": {
-                                                "intent": "subroutine"
-                                            },
-                                            "params": [
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "type"
-                                                    },
-                                                    "metaattrs": {
-                                                        "intent": "in"
-                                                    },
-                                                    "specifier": [
-                                                        "TypeID"
-                                                    ],
-                                                    "typemap_name": "TypeID"
+                                                "metaattrs": {
+                                                    "intent": "subroutine"
                                                 },
-                                                {
-                                                    "attrs": {
-                                                        "value": true
+                                                "name": "declare",
+                                                "params": [
+                                                    {
+                                                        "declarator": {
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "type",
+                                                            "typemap_name": "TypeID"
+                                                        },
+                                                        "specifier": [
+                                                            "TypeID"
+                                                        ],
+                                                        "typemap_name": "TypeID"
                                                     },
-                                                    "declarator": {
-                                                        "name": "len"
-                                                    },
-                                                    "init": 1,
-                                                    "metaattrs": {
-                                                        "intent": "in"
-                                                    },
-                                                    "specifier": [
-                                                        "SidreLength"
-                                                    ],
-                                                    "typemap_name": "SidreLength"
-                                                }
-                                            ],
+                                                    {
+                                                        "declarator": {
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "init": 1,
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "len",
+                                                            "typemap_name": "SidreLength"
+                                                        },
+                                                        "specifier": [
+                                                            "SidreLength"
+                                                        ],
+                                                        "typemap_name": "SidreLength"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
+                                            },
                                             "specifier": [
                                                 "void"
                                             ],
@@ -4396,14 +4437,15 @@
                                             {
                                                 "decls": [
                                                     {
-                                                        "attrs": {
-                                                            "value": true
-                                                        },
                                                         "declarator": {
-                                                            "name": "type"
-                                                        },
-                                                        "metaattrs": {
-                                                            "intent": "in"
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "type",
+                                                            "typemap_name": "TypeID"
                                                         },
                                                         "specifier": [
                                                             "TypeID"
@@ -4411,15 +4453,16 @@
                                                         "typemap_name": "TypeID"
                                                     },
                                                     {
-                                                        "attrs": {
-                                                            "value": true
-                                                        },
                                                         "declarator": {
-                                                            "name": "len"
-                                                        },
-                                                        "init": 1,
-                                                        "metaattrs": {
-                                                            "intent": "in"
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "init": 1,
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "len",
+                                                            "typemap_name": "int"
                                                         },
                                                         "specifier": [
                                                             "int"
@@ -4433,14 +4476,15 @@
                                             {
                                                 "decls": [
                                                     {
-                                                        "attrs": {
-                                                            "value": true
-                                                        },
                                                         "declarator": {
-                                                            "name": "type"
-                                                        },
-                                                        "metaattrs": {
-                                                            "intent": "in"
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "type",
+                                                            "typemap_name": "TypeID"
                                                         },
                                                         "specifier": [
                                                             "TypeID"
@@ -4448,15 +4492,16 @@
                                                         "typemap_name": "TypeID"
                                                     },
                                                     {
-                                                        "attrs": {
-                                                            "value": true
-                                                        },
                                                         "declarator": {
-                                                            "name": "len"
-                                                        },
-                                                        "init": 1,
-                                                        "metaattrs": {
-                                                            "intent": "in"
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "init": 1,
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "len",
+                                                            "typemap_name": "long"
                                                         },
                                                         "specifier": [
                                                             "long"
@@ -4584,44 +4629,47 @@
                                         "_overloaded": true,
                                         "ast": {
                                             "declarator": {
-                                                "name": "declare"
-                                            },
-                                            "metaattrs": {
-                                                "intent": "subroutine"
-                                            },
-                                            "params": [
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "type"
-                                                    },
-                                                    "metaattrs": {
-                                                        "intent": "in"
-                                                    },
-                                                    "specifier": [
-                                                        "TypeID"
-                                                    ],
-                                                    "typemap_name": "TypeID"
+                                                "metaattrs": {
+                                                    "intent": "subroutine"
                                                 },
-                                                {
-                                                    "attrs": {
-                                                        "value": true
+                                                "name": "declare",
+                                                "params": [
+                                                    {
+                                                        "declarator": {
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "type",
+                                                            "typemap_name": "TypeID"
+                                                        },
+                                                        "specifier": [
+                                                            "TypeID"
+                                                        ],
+                                                        "typemap_name": "TypeID"
                                                     },
-                                                    "declarator": {
-                                                        "name": "len"
-                                                    },
-                                                    "init": 1,
-                                                    "metaattrs": {
-                                                        "intent": "in"
-                                                    },
-                                                    "specifier": [
-                                                        "int"
-                                                    ],
-                                                    "typemap_name": "int"
-                                                }
-                                            ],
+                                                    {
+                                                        "declarator": {
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "init": 1,
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "len",
+                                                            "typemap_name": "SidreLength"
+                                                        },
+                                                        "specifier": [
+                                                            "SidreLength"
+                                                        ],
+                                                        "typemap_name": "SidreLength"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
+                                            },
                                             "specifier": [
                                                 "void"
                                             ],
@@ -4670,44 +4718,47 @@
                                         "_overloaded": true,
                                         "ast": {
                                             "declarator": {
-                                                "name": "declare"
-                                            },
-                                            "metaattrs": {
-                                                "intent": "subroutine"
-                                            },
-                                            "params": [
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "type"
-                                                    },
-                                                    "metaattrs": {
-                                                        "intent": "in"
-                                                    },
-                                                    "specifier": [
-                                                        "TypeID"
-                                                    ],
-                                                    "typemap_name": "TypeID"
+                                                "metaattrs": {
+                                                    "intent": "subroutine"
                                                 },
-                                                {
-                                                    "attrs": {
-                                                        "value": true
+                                                "name": "declare",
+                                                "params": [
+                                                    {
+                                                        "declarator": {
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "type",
+                                                            "typemap_name": "TypeID"
+                                                        },
+                                                        "specifier": [
+                                                            "TypeID"
+                                                        ],
+                                                        "typemap_name": "TypeID"
                                                     },
-                                                    "declarator": {
-                                                        "name": "len"
-                                                    },
-                                                    "init": 1,
-                                                    "metaattrs": {
-                                                        "intent": "in"
-                                                    },
-                                                    "specifier": [
-                                                        "long"
-                                                    ],
-                                                    "typemap_name": "long"
-                                                }
-                                            ],
+                                                    {
+                                                        "declarator": {
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "init": 1,
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "len",
+                                                            "typemap_name": "SidreLength"
+                                                        },
+                                                        "specifier": [
+                                                            "SidreLength"
+                                                        ],
+                                                        "typemap_name": "SidreLength"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
+                                            },
                                             "specifier": [
                                                 "void"
                                             ],
@@ -4741,12 +4792,13 @@
                                         "<FUNCTION>": "23 ****************************************",
                                         "ast": {
                                             "declarator": {
-                                                "name": "destroyall"
+                                                "metaattrs": {
+                                                    "intent": "subroutine"
+                                                },
+                                                "name": "destroyall",
+                                                "params": [],
+                                                "typemap_name": "void"
                                             },
-                                            "metaattrs": {
-                                                "intent": "subroutine"
-                                            },
-                                            "params": [],
                                             "specifier": [
                                                 "void"
                                             ],
@@ -4801,13 +4853,14 @@
                                         "<FUNCTION>": "24 ****************************************",
                                         "ast": {
                                             "declarator": {
-                                                "name": "getTypeID"
+                                                "func_const": true,
+                                                "metaattrs": {
+                                                    "intent": "function"
+                                                },
+                                                "name": "getTypeID",
+                                                "params": [],
+                                                "typemap_name": "TypeID"
                                             },
-                                            "func_const": true,
-                                            "metaattrs": {
-                                                "intent": "function"
-                                            },
-                                            "params": [],
                                             "specifier": [
                                                 "TypeID"
                                             ],
@@ -4919,28 +4972,29 @@
                                         "_overloaded": true,
                                         "ast": {
                                             "declarator": {
-                                                "name": "setValue"
+                                                "metaattrs": {
+                                                    "intent": "subroutine"
+                                                },
+                                                "name": "setValue",
+                                                "params": [
+                                                    {
+                                                        "declarator": {
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "value"
+                                                        },
+                                                        "specifier": [
+                                                            "ValueType"
+                                                        ],
+                                                        "template_argument": "ValueType"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
                                             },
-                                            "metaattrs": {
-                                                "intent": "subroutine"
-                                            },
-                                            "params": [
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "value"
-                                                    },
-                                                    "metaattrs": {
-                                                        "intent": "in"
-                                                    },
-                                                    "specifier": [
-                                                        "ValueType"
-                                                    ],
-                                                    "template_argument": "ValueType"
-                                                }
-                                            ],
                                             "specifier": [
                                                 "void"
                                             ],
@@ -5022,29 +5076,29 @@
                                         "_overloaded": true,
                                         "ast": {
                                             "declarator": {
-                                                "name": "setValue"
+                                                "metaattrs": {
+                                                    "intent": "subroutine"
+                                                },
+                                                "name": "setValue",
+                                                "params": [
+                                                    {
+                                                        "declarator": {
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "value"
+                                                        },
+                                                        "specifier": [
+                                                            "ValueType"
+                                                        ],
+                                                        "template_argument": "ValueType"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
                                             },
-                                            "metaattrs": {
-                                                "intent": "subroutine"
-                                            },
-                                            "params": [
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "value"
-                                                    },
-                                                    "metaattrs": {
-                                                        "intent": "in"
-                                                    },
-                                                    "specifier": [
-                                                        "int"
-                                                    ],
-                                                    "template_argument": "ValueType",
-                                                    "typemap_name": "int"
-                                                }
-                                            ],
                                             "specifier": [
                                                 "void"
                                             ],
@@ -5225,29 +5279,29 @@
                                         "_overloaded": true,
                                         "ast": {
                                             "declarator": {
-                                                "name": "setValue"
+                                                "metaattrs": {
+                                                    "intent": "subroutine"
+                                                },
+                                                "name": "setValue",
+                                                "params": [
+                                                    {
+                                                        "declarator": {
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "value"
+                                                        },
+                                                        "specifier": [
+                                                            "ValueType"
+                                                        ],
+                                                        "template_argument": "ValueType"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
                                             },
-                                            "metaattrs": {
-                                                "intent": "subroutine"
-                                            },
-                                            "params": [
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "value"
-                                                    },
-                                                    "metaattrs": {
-                                                        "intent": "in"
-                                                    },
-                                                    "specifier": [
-                                                        "long"
-                                                    ],
-                                                    "template_argument": "ValueType",
-                                                    "typemap_name": "long"
-                                                }
-                                            ],
                                             "specifier": [
                                                 "void"
                                             ],
@@ -5426,29 +5480,29 @@
                                         "_overloaded": true,
                                         "ast": {
                                             "declarator": {
-                                                "name": "setValue"
+                                                "metaattrs": {
+                                                    "intent": "subroutine"
+                                                },
+                                                "name": "setValue",
+                                                "params": [
+                                                    {
+                                                        "declarator": {
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "value"
+                                                        },
+                                                        "specifier": [
+                                                            "ValueType"
+                                                        ],
+                                                        "template_argument": "ValueType"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
                                             },
-                                            "metaattrs": {
-                                                "intent": "subroutine"
-                                            },
-                                            "params": [
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "value"
-                                                    },
-                                                    "metaattrs": {
-                                                        "intent": "in"
-                                                    },
-                                                    "specifier": [
-                                                        "float"
-                                                    ],
-                                                    "template_argument": "ValueType",
-                                                    "typemap_name": "float"
-                                                }
-                                            ],
                                             "specifier": [
                                                 "void"
                                             ],
@@ -5627,29 +5681,29 @@
                                         "_overloaded": true,
                                         "ast": {
                                             "declarator": {
-                                                "name": "setValue"
+                                                "metaattrs": {
+                                                    "intent": "subroutine"
+                                                },
+                                                "name": "setValue",
+                                                "params": [
+                                                    {
+                                                        "declarator": {
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "value"
+                                                        },
+                                                        "specifier": [
+                                                            "ValueType"
+                                                        ],
+                                                        "template_argument": "ValueType"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
                                             },
-                                            "metaattrs": {
-                                                "intent": "subroutine"
-                                            },
-                                            "params": [
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "value"
-                                                    },
-                                                    "metaattrs": {
-                                                        "intent": "in"
-                                                    },
-                                                    "specifier": [
-                                                        "double"
-                                                    ],
-                                                    "template_argument": "ValueType",
-                                                    "typemap_name": "double"
-                                                }
-                                            ],
                                             "specifier": [
                                                 "void"
                                             ],
@@ -5830,12 +5884,12 @@
                                         "_overloaded": true,
                                         "ast": {
                                             "declarator": {
-                                                "name": "getValue"
+                                                "metaattrs": {
+                                                    "intent": "function"
+                                                },
+                                                "name": "getValue",
+                                                "params": []
                                             },
-                                            "metaattrs": {
-                                                "intent": "function"
-                                            },
-                                            "params": [],
                                             "specifier": [
                                                 "ValueType"
                                             ],
@@ -5893,12 +5947,12 @@
                                         "_overloaded": true,
                                         "ast": {
                                             "declarator": {
-                                                "name": "getValue"
+                                                "metaattrs": {
+                                                    "intent": "function"
+                                                },
+                                                "name": "getValue",
+                                                "params": []
                                             },
-                                            "metaattrs": {
-                                                "intent": "function"
-                                            },
-                                            "params": [],
                                             "specifier": [
                                                 "int"
                                             ],
@@ -6043,12 +6097,12 @@
                                         "_overloaded": true,
                                         "ast": {
                                             "declarator": {
-                                                "name": "getValue"
+                                                "metaattrs": {
+                                                    "intent": "function"
+                                                },
+                                                "name": "getValue",
+                                                "params": []
                                             },
-                                            "metaattrs": {
-                                                "intent": "function"
-                                            },
-                                            "params": [],
                                             "specifier": [
                                                 "double"
                                             ],
@@ -6258,12 +6312,13 @@
                                 "<FUNCTION>": "45 ****************************************",
                                 "ast": {
                                     "declarator": {
-                                        "name": "local_function1"
+                                        "metaattrs": {
+                                            "intent": "subroutine"
+                                        },
+                                        "name": "local_function1",
+                                        "params": [],
+                                        "typemap_name": "void"
                                     },
-                                    "metaattrs": {
-                                        "intent": "subroutine"
-                                    },
-                                    "params": [],
                                     "specifier": [
                                         "void"
                                     ],
@@ -6317,31 +6372,33 @@
                                 "_PTR_F_C_index": "64",
                                 "ast": {
                                     "declarator": {
-                                        "name": "isNameValid"
+                                        "metaattrs": {
+                                            "intent": "function"
+                                        },
+                                        "name": "isNameValid",
+                                        "params": [
+                                            {
+                                                "const": true,
+                                                "declarator": {
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "name",
+                                                    "pointer": [
+                                                        {
+                                                            "ptr": "&"
+                                                        }
+                                                    ],
+                                                    "typemap_name": "std::string"
+                                                },
+                                                "specifier": [
+                                                    "std::string"
+                                                ],
+                                                "typemap_name": "std::string"
+                                            }
+                                        ],
+                                        "typemap_name": "bool"
                                     },
-                                    "metaattrs": {
-                                        "intent": "function"
-                                    },
-                                    "params": [
-                                        {
-                                            "const": true,
-                                            "declarator": {
-                                                "name": "name",
-                                                "pointer": [
-                                                    {
-                                                        "ptr": "&"
-                                                    }
-                                                ]
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "std::string"
-                                            ],
-                                            "typemap_name": "std::string"
-                                        }
-                                    ],
                                     "specifier": [
                                         "bool"
                                     ],
@@ -6523,32 +6580,34 @@
                                 "_generated": "arg_to_buffer",
                                 "ast": {
                                     "declarator": {
-                                        "name": "isNameValid"
+                                        "metaattrs": {
+                                            "intent": "function"
+                                        },
+                                        "name": "isNameValid",
+                                        "params": [
+                                            {
+                                                "const": true,
+                                                "declarator": {
+                                                    "metaattrs": {
+                                                        "api": "buf",
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "name",
+                                                    "pointer": [
+                                                        {
+                                                            "ptr": "&"
+                                                        }
+                                                    ],
+                                                    "typemap_name": "std::string"
+                                                },
+                                                "specifier": [
+                                                    "std::string"
+                                                ],
+                                                "typemap_name": "std::string"
+                                            }
+                                        ],
+                                        "typemap_name": "bool"
                                     },
-                                    "metaattrs": {
-                                        "intent": "function"
-                                    },
-                                    "params": [
-                                        {
-                                            "const": true,
-                                            "declarator": {
-                                                "name": "name",
-                                                "pointer": [
-                                                    {
-                                                        "ptr": "&"
-                                                    }
-                                                ]
-                                            },
-                                            "metaattrs": {
-                                                "api": "buf",
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "std::string"
-                                            ],
-                                            "typemap_name": "std::string"
-                                        }
-                                    ],
                                     "specifier": [
                                         "bool"
                                     ],
@@ -6656,12 +6715,13 @@
                                 "<FUNCTION>": "47 ****************************************",
                                 "ast": {
                                     "declarator": {
-                                        "name": "isInitialized"
+                                        "metaattrs": {
+                                            "intent": "function"
+                                        },
+                                        "name": "isInitialized",
+                                        "params": [],
+                                        "typemap_name": "bool"
                                     },
-                                    "metaattrs": {
-                                        "intent": "function"
-                                    },
-                                    "params": [],
                                     "specifier": [
                                         "bool"
                                     ],
@@ -6769,31 +6829,33 @@
                                 "_overloaded": true,
                                 "ast": {
                                     "declarator": {
-                                        "name": "test_names"
+                                        "metaattrs": {
+                                            "intent": "subroutine"
+                                        },
+                                        "name": "test_names",
+                                        "params": [
+                                            {
+                                                "const": true,
+                                                "declarator": {
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "name",
+                                                    "pointer": [
+                                                        {
+                                                            "ptr": "&"
+                                                        }
+                                                    ],
+                                                    "typemap_name": "std::string"
+                                                },
+                                                "specifier": [
+                                                    "std::string"
+                                                ],
+                                                "typemap_name": "std::string"
+                                            }
+                                        ],
+                                        "typemap_name": "void"
                                     },
-                                    "metaattrs": {
-                                        "intent": "subroutine"
-                                    },
-                                    "params": [
-                                        {
-                                            "const": true,
-                                            "declarator": {
-                                                "name": "name",
-                                                "pointer": [
-                                                    {
-                                                        "ptr": "&"
-                                                    }
-                                                ]
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "std::string"
-                                            ],
-                                            "typemap_name": "std::string"
-                                        }
-                                    ],
                                     "specifier": [
                                         "void"
                                     ],
@@ -6916,32 +6978,34 @@
                                 "_overloaded": true,
                                 "ast": {
                                     "declarator": {
-                                        "name": "test_names"
+                                        "metaattrs": {
+                                            "intent": "subroutine"
+                                        },
+                                        "name": "test_names",
+                                        "params": [
+                                            {
+                                                "const": true,
+                                                "declarator": {
+                                                    "metaattrs": {
+                                                        "api": "buf",
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "name",
+                                                    "pointer": [
+                                                        {
+                                                            "ptr": "&"
+                                                        }
+                                                    ],
+                                                    "typemap_name": "std::string"
+                                                },
+                                                "specifier": [
+                                                    "std::string"
+                                                ],
+                                                "typemap_name": "std::string"
+                                            }
+                                        ],
+                                        "typemap_name": "void"
                                     },
-                                    "metaattrs": {
-                                        "intent": "subroutine"
-                                    },
-                                    "params": [
-                                        {
-                                            "const": true,
-                                            "declarator": {
-                                                "name": "name",
-                                                "pointer": [
-                                                    {
-                                                        "ptr": "&"
-                                                    }
-                                                ]
-                                            },
-                                            "metaattrs": {
-                                                "api": "buf",
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "std::string"
-                                            ],
-                                            "typemap_name": "std::string"
-                                        }
-                                    ],
                                     "specifier": [
                                         "void"
                                     ],
@@ -7019,46 +7083,49 @@
                                 "_overloaded": true,
                                 "ast": {
                                     "declarator": {
-                                        "name": "test_names"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "subroutine"
-                                    },
-                                    "params": [
-                                        {
-                                            "const": true,
-                                            "declarator": {
-                                                "name": "name",
-                                                "pointer": [
-                                                    {
-                                                        "ptr": "&"
-                                                    }
-                                                ]
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "std::string"
-                                            ],
-                                            "typemap_name": "std::string"
+                                        "metaattrs": {
+                                            "intent": "subroutine"
                                         },
-                                        {
-                                            "attrs": {
-                                                "value": true
+                                        "name": "test_names",
+                                        "params": [
+                                            {
+                                                "const": true,
+                                                "declarator": {
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "name",
+                                                    "pointer": [
+                                                        {
+                                                            "ptr": "&"
+                                                        }
+                                                    ],
+                                                    "typemap_name": "std::string"
+                                                },
+                                                "specifier": [
+                                                    "std::string"
+                                                ],
+                                                "typemap_name": "std::string"
                                             },
-                                            "declarator": {
-                                                "name": "flag"
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "int"
-                                            ],
-                                            "typemap_name": "int"
-                                        }
-                                    ],
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "value": true
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "flag",
+                                                    "typemap_name": "int"
+                                                },
+                                                "specifier": [
+                                                    "int"
+                                                ],
+                                                "typemap_name": "int"
+                                            }
+                                        ],
+                                        "typemap_name": "void"
+                                    },
                                     "specifier": [
                                         "void"
                                     ],
@@ -7241,47 +7308,50 @@
                                 "_overloaded": true,
                                 "ast": {
                                     "declarator": {
-                                        "name": "test_names"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "subroutine"
-                                    },
-                                    "params": [
-                                        {
-                                            "const": true,
-                                            "declarator": {
-                                                "name": "name",
-                                                "pointer": [
-                                                    {
-                                                        "ptr": "&"
-                                                    }
-                                                ]
-                                            },
-                                            "metaattrs": {
-                                                "api": "buf",
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "std::string"
-                                            ],
-                                            "typemap_name": "std::string"
+                                        "metaattrs": {
+                                            "intent": "subroutine"
                                         },
-                                        {
-                                            "attrs": {
-                                                "value": true
+                                        "name": "test_names",
+                                        "params": [
+                                            {
+                                                "const": true,
+                                                "declarator": {
+                                                    "metaattrs": {
+                                                        "api": "buf",
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "name",
+                                                    "pointer": [
+                                                        {
+                                                            "ptr": "&"
+                                                        }
+                                                    ],
+                                                    "typemap_name": "std::string"
+                                                },
+                                                "specifier": [
+                                                    "std::string"
+                                                ],
+                                                "typemap_name": "std::string"
                                             },
-                                            "declarator": {
-                                                "name": "flag"
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "int"
-                                            ],
-                                            "typemap_name": "int"
-                                        }
-                                    ],
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "value": true
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "flag",
+                                                    "typemap_name": "int"
+                                                },
+                                                "specifier": [
+                                                    "int"
+                                                ],
+                                                "typemap_name": "int"
+                                            }
+                                        ],
+                                        "typemap_name": "void"
+                                    },
                                     "specifier": [
                                         "void"
                                     ],
@@ -7392,12 +7462,13 @@
                                 "_overloaded": true,
                                 "ast": {
                                     "declarator": {
-                                        "name": "testoptional"
+                                        "metaattrs": {
+                                            "intent": "subroutine"
+                                        },
+                                        "name": "testoptional",
+                                        "params": [],
+                                        "typemap_name": "void"
                                     },
-                                    "metaattrs": {
-                                        "intent": "subroutine"
-                                    },
-                                    "params": [],
                                     "specifier": [
                                         "void"
                                     ],
@@ -7442,29 +7513,31 @@
                                 "_overloaded": true,
                                 "ast": {
                                     "declarator": {
-                                        "name": "testoptional"
+                                        "metaattrs": {
+                                            "intent": "subroutine"
+                                        },
+                                        "name": "testoptional",
+                                        "params": [
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "value": true
+                                                    },
+                                                    "init": 1,
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "i",
+                                                    "typemap_name": "int"
+                                                },
+                                                "specifier": [
+                                                    "int"
+                                                ],
+                                                "typemap_name": "int"
+                                            }
+                                        ],
+                                        "typemap_name": "void"
                                     },
-                                    "metaattrs": {
-                                        "intent": "subroutine"
-                                    },
-                                    "params": [
-                                        {
-                                            "attrs": {
-                                                "value": true
-                                            },
-                                            "declarator": {
-                                                "name": "i"
-                                            },
-                                            "init": 1,
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "int"
-                                            ],
-                                            "typemap_name": "int"
-                                        }
-                                    ],
                                     "specifier": [
                                         "void"
                                     ],
@@ -7551,45 +7624,48 @@
                                 "_overloaded": true,
                                 "ast": {
                                     "declarator": {
-                                        "name": "testoptional"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "subroutine"
-                                    },
-                                    "params": [
-                                        {
-                                            "attrs": {
-                                                "value": true
-                                            },
-                                            "declarator": {
-                                                "name": "i"
-                                            },
-                                            "init": 1,
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "int"
-                                            ],
-                                            "typemap_name": "int"
+                                        "metaattrs": {
+                                            "intent": "subroutine"
                                         },
-                                        {
-                                            "attrs": {
-                                                "value": true
+                                        "name": "testoptional",
+                                        "params": [
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "value": true
+                                                    },
+                                                    "init": 1,
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "i",
+                                                    "typemap_name": "int"
+                                                },
+                                                "specifier": [
+                                                    "int"
+                                                ],
+                                                "typemap_name": "int"
                                             },
-                                            "declarator": {
-                                                "name": "j"
-                                            },
-                                            "init": 2,
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "long"
-                                            ],
-                                            "typemap_name": "long"
-                                        }
-                                    ],
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "value": true
+                                                    },
+                                                    "init": 2,
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "j",
+                                                    "typemap_name": "long"
+                                                },
+                                                "specifier": [
+                                                    "long"
+                                                ],
+                                                "typemap_name": "long"
+                                            }
+                                        ],
+                                        "typemap_name": "void"
+                                    },
                                     "specifier": [
                                         "void"
                                     ],
@@ -7777,12 +7853,13 @@
                                 "<FUNCTION>": "51 ****************************************",
                                 "ast": {
                                     "declarator": {
-                                        "name": "test_size_t"
+                                        "metaattrs": {
+                                            "intent": "function"
+                                        },
+                                        "name": "test_size_t",
+                                        "params": [],
+                                        "typemap_name": "size_t"
                                     },
-                                    "metaattrs": {
-                                        "intent": "function"
-                                    },
-                                    "params": [],
                                     "specifier": [
                                         "size_t"
                                     ],
@@ -7885,28 +7962,30 @@
                                 "_overloaded": true,
                                 "ast": {
                                     "declarator": {
-                                        "name": "testmpi"
+                                        "metaattrs": {
+                                            "intent": "subroutine"
+                                        },
+                                        "name": "testmpi",
+                                        "params": [
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "value": true
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "comm",
+                                                    "typemap_name": "MPI_Comm"
+                                                },
+                                                "specifier": [
+                                                    "MPI_Comm"
+                                                ],
+                                                "typemap_name": "MPI_Comm"
+                                            }
+                                        ],
+                                        "typemap_name": "void"
                                     },
-                                    "metaattrs": {
-                                        "intent": "subroutine"
-                                    },
-                                    "params": [
-                                        {
-                                            "attrs": {
-                                                "value": true
-                                            },
-                                            "declarator": {
-                                                "name": "comm"
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "MPI_Comm"
-                                            ],
-                                            "typemap_name": "MPI_Comm"
-                                        }
-                                    ],
                                     "specifier": [
                                         "void"
                                     ],
@@ -8035,12 +8114,13 @@
                                 "_overloaded": true,
                                 "ast": {
                                     "declarator": {
-                                        "name": "testmpi"
+                                        "metaattrs": {
+                                            "intent": "subroutine"
+                                        },
+                                        "name": "testmpi",
+                                        "params": [],
+                                        "typemap_name": "void"
                                     },
-                                    "metaattrs": {
-                                        "intent": "subroutine"
-                                    },
-                                    "params": [],
                                     "specifier": [
                                         "void"
                                     ],
@@ -8092,36 +8172,39 @@
                                 "<FUNCTION>": "54 ****************************************",
                                 "ast": {
                                     "declarator": {
-                                        "name": "FuncPtr1"
+                                        "metaattrs": {
+                                            "intent": "subroutine"
+                                        },
+                                        "name": "FuncPtr1",
+                                        "params": [
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "value": true
+                                                    },
+                                                    "func": {
+                                                        "name": "get",
+                                                        "pointer": [
+                                                            {
+                                                                "ptr": "*"
+                                                            }
+                                                        ],
+                                                        "typemap_name": "void"
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "params": [],
+                                                    "typemap_name": "void"
+                                                },
+                                                "specifier": [
+                                                    "void"
+                                                ],
+                                                "typemap_name": "void"
+                                            }
+                                        ],
+                                        "typemap_name": "void"
                                     },
-                                    "metaattrs": {
-                                        "intent": "subroutine"
-                                    },
-                                    "params": [
-                                        {
-                                            "attrs": {
-                                                "value": true
-                                            },
-                                            "declarator": {
-                                                "func": {
-                                                    "name": "get",
-                                                    "pointer": [
-                                                        {
-                                                            "ptr": "*"
-                                                        }
-                                                    ]
-                                                }
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "params": [],
-                                            "specifier": [
-                                                "void"
-                                            ],
-                                            "typemap_name": "void"
-                                        }
-                                    ],
                                     "specifier": [
                                         "void"
                                     ],
@@ -8237,38 +8320,41 @@
                                 "<FUNCTION>": "55 ****************************************",
                                 "ast": {
                                     "declarator": {
-                                        "name": "FuncPtr2"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "subroutine"
-                                    },
-                                    "params": [
-                                        {
-                                            "declarator": {
-                                                "func": {
-                                                    "name": "get",
+                                        "metaattrs": {
+                                            "intent": "subroutine"
+                                        },
+                                        "name": "FuncPtr2",
+                                        "params": [
+                                            {
+                                                "declarator": {
+                                                    "func": {
+                                                        "name": "get",
+                                                        "pointer": [
+                                                            {
+                                                                "ptr": "*"
+                                                            }
+                                                        ],
+                                                        "typemap_name": "double"
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "params": [],
                                                     "pointer": [
                                                         {
                                                             "ptr": "*"
                                                         }
-                                                    ]
+                                                    ],
+                                                    "typemap_name": "double"
                                                 },
-                                                "pointer": [
-                                                    {
-                                                        "ptr": "*"
-                                                    }
-                                                ]
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "params": [],
-                                            "specifier": [
-                                                "double"
-                                            ],
-                                            "typemap_name": "double"
-                                        }
-                                    ],
+                                                "specifier": [
+                                                    "double"
+                                                ],
+                                                "typemap_name": "double"
+                                            }
+                                        ],
+                                        "typemap_name": "void"
+                                    },
                                     "specifier": [
                                         "void"
                                     ],
@@ -8386,59 +8472,65 @@
                                 "<FUNCTION>": "56 ****************************************",
                                 "ast": {
                                     "declarator": {
-                                        "name": "FuncPtr3"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "subroutine"
-                                    },
-                                    "params": [
-                                        {
-                                            "attrs": {
-                                                "value": true
-                                            },
-                                            "declarator": {
-                                                "func": {
-                                                    "name": "get",
-                                                    "pointer": [
+                                        "metaattrs": {
+                                            "intent": "subroutine"
+                                        },
+                                        "name": "FuncPtr3",
+                                        "params": [
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "value": true
+                                                    },
+                                                    "func": {
+                                                        "name": "get",
+                                                        "pointer": [
+                                                            {
+                                                                "ptr": "*"
+                                                            }
+                                                        ],
+                                                        "typemap_name": "double"
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "params": [
                                                         {
-                                                            "ptr": "*"
+                                                            "declarator": {
+                                                                "attrs": {
+                                                                    "value": true
+                                                                },
+                                                                "name": "i",
+                                                                "typemap_name": "int"
+                                                            },
+                                                            "specifier": [
+                                                                "int"
+                                                            ],
+                                                            "typemap_name": "int"
+                                                        },
+                                                        {
+                                                            "declarator": {
+                                                                "attrs": {
+                                                                    "value": true
+                                                                },
+                                                                "typemap_name": "int"
+                                                            },
+                                                            "specifier": [
+                                                                "int"
+                                                            ],
+                                                            "typemap_name": "int"
                                                         }
-                                                    ]
-                                                }
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "params": [
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "i"
-                                                    },
-                                                    "specifier": [
-                                                        "int"
                                                     ],
-                                                    "typemap_name": "int"
+                                                    "typemap_name": "double"
                                                 },
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {},
-                                                    "specifier": [
-                                                        "int"
-                                                    ],
-                                                    "typemap_name": "int"
-                                                }
-                                            ],
-                                            "specifier": [
-                                                "double"
-                                            ],
-                                            "typemap_name": "double"
-                                        }
-                                    ],
+                                                "specifier": [
+                                                    "double"
+                                                ],
+                                                "typemap_name": "double"
+                                            }
+                                        ],
+                                        "typemap_name": "void"
+                                    },
                                     "specifier": [
                                         "void"
                                     ],
@@ -8557,57 +8649,64 @@
                                 "<FUNCTION>": "57 ****************************************",
                                 "ast": {
                                     "declarator": {
-                                        "name": "FuncPtr4"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "subroutine"
-                                    },
-                                    "params": [
-                                        {
-                                            "attrs": {
-                                                "value": true
-                                            },
-                                            "declarator": {
-                                                "func": {
-                                                    "name": "get",
-                                                    "pointer": [
-                                                        {
-                                                            "ptr": "*"
-                                                        }
-                                                    ]
-                                                }
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "params": [
-                                                {
+                                        "metaattrs": {
+                                            "intent": "subroutine"
+                                        },
+                                        "name": "FuncPtr4",
+                                        "params": [
+                                            {
+                                                "declarator": {
                                                     "attrs": {
                                                         "value": true
                                                     },
-                                                    "declarator": {},
-                                                    "specifier": [
-                                                        "double"
+                                                    "func": {
+                                                        "name": "get",
+                                                        "pointer": [
+                                                            {
+                                                                "ptr": "*"
+                                                            }
+                                                        ],
+                                                        "typemap_name": "double"
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "params": [
+                                                        {
+                                                            "declarator": {
+                                                                "attrs": {
+                                                                    "value": true
+                                                                },
+                                                                "typemap_name": "double"
+                                                            },
+                                                            "specifier": [
+                                                                "double"
+                                                            ],
+                                                            "typemap_name": "double"
+                                                        },
+                                                        {
+                                                            "declarator": {
+                                                                "attrs": {
+                                                                    "value": true
+                                                                },
+                                                                "typemap_name": "int"
+                                                            },
+                                                            "specifier": [
+                                                                "int"
+                                                            ],
+                                                            "typemap_name": "int"
+                                                        }
                                                     ],
                                                     "typemap_name": "double"
                                                 },
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {},
-                                                    "specifier": [
-                                                        "int"
-                                                    ],
-                                                    "typemap_name": "int"
-                                                }
-                                            ],
-                                            "specifier": [
-                                                "double"
-                                            ],
-                                            "typemap_name": "double"
-                                        }
-                                    ],
+                                                "specifier": [
+                                                    "double"
+                                                ],
+                                                "typemap_name": "double"
+                                            }
+                                        ],
+                                        "typemap_name": "void"
+                                    },
                                     "specifier": [
                                         "void"
                                     ],
@@ -8688,157 +8787,170 @@
                                 "<FUNCTION>": "58 ****************************************",
                                 "ast": {
                                     "declarator": {
-                                        "name": "FuncPtr5"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "subroutine"
-                                    },
-                                    "params": [
-                                        {
-                                            "attrs": {
-                                                "value": true
-                                            },
-                                            "declarator": {
-                                                "func": {
-                                                    "name": "get",
-                                                    "pointer": [
+                                        "metaattrs": {
+                                            "intent": "subroutine"
+                                        },
+                                        "name": "FuncPtr5",
+                                        "params": [
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "value": true
+                                                    },
+                                                    "func": {
+                                                        "name": "get",
+                                                        "pointer": [
+                                                            {
+                                                                "ptr": "*"
+                                                            }
+                                                        ],
+                                                        "typemap_name": "void"
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "params": [
                                                         {
-                                                            "ptr": "*"
+                                                            "declarator": {
+                                                                "attrs": {
+                                                                    "value": true
+                                                                },
+                                                                "name": "verylongname1",
+                                                                "typemap_name": "int"
+                                                            },
+                                                            "specifier": [
+                                                                "int"
+                                                            ],
+                                                            "typemap_name": "int"
+                                                        },
+                                                        {
+                                                            "declarator": {
+                                                                "attrs": {
+                                                                    "value": true
+                                                                },
+                                                                "name": "verylongname2",
+                                                                "typemap_name": "int"
+                                                            },
+                                                            "specifier": [
+                                                                "int"
+                                                            ],
+                                                            "typemap_name": "int"
+                                                        },
+                                                        {
+                                                            "declarator": {
+                                                                "attrs": {
+                                                                    "value": true
+                                                                },
+                                                                "name": "verylongname3",
+                                                                "typemap_name": "int"
+                                                            },
+                                                            "specifier": [
+                                                                "int"
+                                                            ],
+                                                            "typemap_name": "int"
+                                                        },
+                                                        {
+                                                            "declarator": {
+                                                                "attrs": {
+                                                                    "value": true
+                                                                },
+                                                                "name": "verylongname4",
+                                                                "typemap_name": "int"
+                                                            },
+                                                            "specifier": [
+                                                                "int"
+                                                            ],
+                                                            "typemap_name": "int"
+                                                        },
+                                                        {
+                                                            "declarator": {
+                                                                "attrs": {
+                                                                    "value": true
+                                                                },
+                                                                "name": "verylongname5",
+                                                                "typemap_name": "int"
+                                                            },
+                                                            "specifier": [
+                                                                "int"
+                                                            ],
+                                                            "typemap_name": "int"
+                                                        },
+                                                        {
+                                                            "declarator": {
+                                                                "attrs": {
+                                                                    "value": true
+                                                                },
+                                                                "name": "verylongname6",
+                                                                "typemap_name": "int"
+                                                            },
+                                                            "specifier": [
+                                                                "int"
+                                                            ],
+                                                            "typemap_name": "int"
+                                                        },
+                                                        {
+                                                            "declarator": {
+                                                                "attrs": {
+                                                                    "value": true
+                                                                },
+                                                                "name": "verylongname7",
+                                                                "typemap_name": "int"
+                                                            },
+                                                            "specifier": [
+                                                                "int"
+                                                            ],
+                                                            "typemap_name": "int"
+                                                        },
+                                                        {
+                                                            "declarator": {
+                                                                "attrs": {
+                                                                    "value": true
+                                                                },
+                                                                "name": "verylongname8",
+                                                                "typemap_name": "int"
+                                                            },
+                                                            "specifier": [
+                                                                "int"
+                                                            ],
+                                                            "typemap_name": "int"
+                                                        },
+                                                        {
+                                                            "declarator": {
+                                                                "attrs": {
+                                                                    "value": true
+                                                                },
+                                                                "name": "verylongname9",
+                                                                "typemap_name": "int"
+                                                            },
+                                                            "specifier": [
+                                                                "int"
+                                                            ],
+                                                            "typemap_name": "int"
+                                                        },
+                                                        {
+                                                            "declarator": {
+                                                                "attrs": {
+                                                                    "value": true
+                                                                },
+                                                                "name": "verylongname10",
+                                                                "typemap_name": "int"
+                                                            },
+                                                            "specifier": [
+                                                                "int"
+                                                            ],
+                                                            "typemap_name": "int"
                                                         }
-                                                    ]
-                                                }
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "params": [
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "verylongname1"
-                                                    },
-                                                    "specifier": [
-                                                        "int"
                                                     ],
-                                                    "typemap_name": "int"
+                                                    "typemap_name": "void"
                                                 },
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "verylongname2"
-                                                    },
-                                                    "specifier": [
-                                                        "int"
-                                                    ],
-                                                    "typemap_name": "int"
-                                                },
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "verylongname3"
-                                                    },
-                                                    "specifier": [
-                                                        "int"
-                                                    ],
-                                                    "typemap_name": "int"
-                                                },
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "verylongname4"
-                                                    },
-                                                    "specifier": [
-                                                        "int"
-                                                    ],
-                                                    "typemap_name": "int"
-                                                },
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "verylongname5"
-                                                    },
-                                                    "specifier": [
-                                                        "int"
-                                                    ],
-                                                    "typemap_name": "int"
-                                                },
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "verylongname6"
-                                                    },
-                                                    "specifier": [
-                                                        "int"
-                                                    ],
-                                                    "typemap_name": "int"
-                                                },
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "verylongname7"
-                                                    },
-                                                    "specifier": [
-                                                        "int"
-                                                    ],
-                                                    "typemap_name": "int"
-                                                },
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "verylongname8"
-                                                    },
-                                                    "specifier": [
-                                                        "int"
-                                                    ],
-                                                    "typemap_name": "int"
-                                                },
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "verylongname9"
-                                                    },
-                                                    "specifier": [
-                                                        "int"
-                                                    ],
-                                                    "typemap_name": "int"
-                                                },
-                                                {
-                                                    "attrs": {
-                                                        "value": true
-                                                    },
-                                                    "declarator": {
-                                                        "name": "verylongname10"
-                                                    },
-                                                    "specifier": [
-                                                        "int"
-                                                    ],
-                                                    "typemap_name": "int"
-                                                }
-                                            ],
-                                            "specifier": [
-                                                "void"
-                                            ],
-                                            "typemap_name": "void"
-                                        }
-                                    ],
+                                                "specifier": [
+                                                    "void"
+                                                ],
+                                                "typemap_name": "void"
+                                            }
+                                        ],
+                                        "typemap_name": "void"
+                                    },
                                     "specifier": [
                                         "void"
                                     ],
@@ -8951,213 +9063,224 @@
                                 "<FUNCTION>": "59 ****************************************",
                                 "ast": {
                                     "declarator": {
-                                        "name": "verylongfunctionname1"
+                                        "metaattrs": {
+                                            "intent": "subroutine"
+                                        },
+                                        "name": "verylongfunctionname1",
+                                        "params": [
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "intent": "inout"
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "inout"
+                                                    },
+                                                    "name": "verylongname1",
+                                                    "pointer": [
+                                                        {
+                                                            "ptr": "*"
+                                                        }
+                                                    ],
+                                                    "typemap_name": "int"
+                                                },
+                                                "specifier": [
+                                                    "int"
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "intent": "inout"
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "inout"
+                                                    },
+                                                    "name": "verylongname2",
+                                                    "pointer": [
+                                                        {
+                                                            "ptr": "*"
+                                                        }
+                                                    ],
+                                                    "typemap_name": "int"
+                                                },
+                                                "specifier": [
+                                                    "int"
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "intent": "inout"
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "inout"
+                                                    },
+                                                    "name": "verylongname3",
+                                                    "pointer": [
+                                                        {
+                                                            "ptr": "*"
+                                                        }
+                                                    ],
+                                                    "typemap_name": "int"
+                                                },
+                                                "specifier": [
+                                                    "int"
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "intent": "inout"
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "inout"
+                                                    },
+                                                    "name": "verylongname4",
+                                                    "pointer": [
+                                                        {
+                                                            "ptr": "*"
+                                                        }
+                                                    ],
+                                                    "typemap_name": "int"
+                                                },
+                                                "specifier": [
+                                                    "int"
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "intent": "inout"
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "inout"
+                                                    },
+                                                    "name": "verylongname5",
+                                                    "pointer": [
+                                                        {
+                                                            "ptr": "*"
+                                                        }
+                                                    ],
+                                                    "typemap_name": "int"
+                                                },
+                                                "specifier": [
+                                                    "int"
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "intent": "inout"
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "inout"
+                                                    },
+                                                    "name": "verylongname6",
+                                                    "pointer": [
+                                                        {
+                                                            "ptr": "*"
+                                                        }
+                                                    ],
+                                                    "typemap_name": "int"
+                                                },
+                                                "specifier": [
+                                                    "int"
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "intent": "inout"
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "inout"
+                                                    },
+                                                    "name": "verylongname7",
+                                                    "pointer": [
+                                                        {
+                                                            "ptr": "*"
+                                                        }
+                                                    ],
+                                                    "typemap_name": "int"
+                                                },
+                                                "specifier": [
+                                                    "int"
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "intent": "inout"
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "inout"
+                                                    },
+                                                    "name": "verylongname8",
+                                                    "pointer": [
+                                                        {
+                                                            "ptr": "*"
+                                                        }
+                                                    ],
+                                                    "typemap_name": "int"
+                                                },
+                                                "specifier": [
+                                                    "int"
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "intent": "inout"
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "inout"
+                                                    },
+                                                    "name": "verylongname9",
+                                                    "pointer": [
+                                                        {
+                                                            "ptr": "*"
+                                                        }
+                                                    ],
+                                                    "typemap_name": "int"
+                                                },
+                                                "specifier": [
+                                                    "int"
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "intent": "inout"
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "inout"
+                                                    },
+                                                    "name": "verylongname10",
+                                                    "pointer": [
+                                                        {
+                                                            "ptr": "*"
+                                                        }
+                                                    ],
+                                                    "typemap_name": "int"
+                                                },
+                                                "specifier": [
+                                                    "int"
+                                                ],
+                                                "typemap_name": "int"
+                                            }
+                                        ],
+                                        "typemap_name": "void"
                                     },
-                                    "metaattrs": {
-                                        "intent": "subroutine"
-                                    },
-                                    "params": [
-                                        {
-                                            "attrs": {
-                                                "intent": "inout"
-                                            },
-                                            "declarator": {
-                                                "name": "verylongname1",
-                                                "pointer": [
-                                                    {
-                                                        "ptr": "*"
-                                                    }
-                                                ]
-                                            },
-                                            "metaattrs": {
-                                                "intent": "inout"
-                                            },
-                                            "specifier": [
-                                                "int"
-                                            ],
-                                            "typemap_name": "int"
-                                        },
-                                        {
-                                            "attrs": {
-                                                "intent": "inout"
-                                            },
-                                            "declarator": {
-                                                "name": "verylongname2",
-                                                "pointer": [
-                                                    {
-                                                        "ptr": "*"
-                                                    }
-                                                ]
-                                            },
-                                            "metaattrs": {
-                                                "intent": "inout"
-                                            },
-                                            "specifier": [
-                                                "int"
-                                            ],
-                                            "typemap_name": "int"
-                                        },
-                                        {
-                                            "attrs": {
-                                                "intent": "inout"
-                                            },
-                                            "declarator": {
-                                                "name": "verylongname3",
-                                                "pointer": [
-                                                    {
-                                                        "ptr": "*"
-                                                    }
-                                                ]
-                                            },
-                                            "metaattrs": {
-                                                "intent": "inout"
-                                            },
-                                            "specifier": [
-                                                "int"
-                                            ],
-                                            "typemap_name": "int"
-                                        },
-                                        {
-                                            "attrs": {
-                                                "intent": "inout"
-                                            },
-                                            "declarator": {
-                                                "name": "verylongname4",
-                                                "pointer": [
-                                                    {
-                                                        "ptr": "*"
-                                                    }
-                                                ]
-                                            },
-                                            "metaattrs": {
-                                                "intent": "inout"
-                                            },
-                                            "specifier": [
-                                                "int"
-                                            ],
-                                            "typemap_name": "int"
-                                        },
-                                        {
-                                            "attrs": {
-                                                "intent": "inout"
-                                            },
-                                            "declarator": {
-                                                "name": "verylongname5",
-                                                "pointer": [
-                                                    {
-                                                        "ptr": "*"
-                                                    }
-                                                ]
-                                            },
-                                            "metaattrs": {
-                                                "intent": "inout"
-                                            },
-                                            "specifier": [
-                                                "int"
-                                            ],
-                                            "typemap_name": "int"
-                                        },
-                                        {
-                                            "attrs": {
-                                                "intent": "inout"
-                                            },
-                                            "declarator": {
-                                                "name": "verylongname6",
-                                                "pointer": [
-                                                    {
-                                                        "ptr": "*"
-                                                    }
-                                                ]
-                                            },
-                                            "metaattrs": {
-                                                "intent": "inout"
-                                            },
-                                            "specifier": [
-                                                "int"
-                                            ],
-                                            "typemap_name": "int"
-                                        },
-                                        {
-                                            "attrs": {
-                                                "intent": "inout"
-                                            },
-                                            "declarator": {
-                                                "name": "verylongname7",
-                                                "pointer": [
-                                                    {
-                                                        "ptr": "*"
-                                                    }
-                                                ]
-                                            },
-                                            "metaattrs": {
-                                                "intent": "inout"
-                                            },
-                                            "specifier": [
-                                                "int"
-                                            ],
-                                            "typemap_name": "int"
-                                        },
-                                        {
-                                            "attrs": {
-                                                "intent": "inout"
-                                            },
-                                            "declarator": {
-                                                "name": "verylongname8",
-                                                "pointer": [
-                                                    {
-                                                        "ptr": "*"
-                                                    }
-                                                ]
-                                            },
-                                            "metaattrs": {
-                                                "intent": "inout"
-                                            },
-                                            "specifier": [
-                                                "int"
-                                            ],
-                                            "typemap_name": "int"
-                                        },
-                                        {
-                                            "attrs": {
-                                                "intent": "inout"
-                                            },
-                                            "declarator": {
-                                                "name": "verylongname9",
-                                                "pointer": [
-                                                    {
-                                                        "ptr": "*"
-                                                    }
-                                                ]
-                                            },
-                                            "metaattrs": {
-                                                "intent": "inout"
-                                            },
-                                            "specifier": [
-                                                "int"
-                                            ],
-                                            "typemap_name": "int"
-                                        },
-                                        {
-                                            "attrs": {
-                                                "intent": "inout"
-                                            },
-                                            "declarator": {
-                                                "name": "verylongname10",
-                                                "pointer": [
-                                                    {
-                                                        "ptr": "*"
-                                                    }
-                                                ]
-                                            },
-                                            "metaattrs": {
-                                                "intent": "inout"
-                                            },
-                                            "specifier": [
-                                                "int"
-                                            ],
-                                            "typemap_name": "int"
-                                        }
-                                    ],
                                     "specifier": [
                                         "void"
                                     ],
@@ -9883,163 +10006,174 @@
                                 "<FUNCTION>": "60 ****************************************",
                                 "ast": {
                                     "declarator": {
-                                        "name": "verylongfunctionname2"
+                                        "metaattrs": {
+                                            "intent": "function"
+                                        },
+                                        "name": "verylongfunctionname2",
+                                        "params": [
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "value": true
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "verylongname1",
+                                                    "typemap_name": "int"
+                                                },
+                                                "specifier": [
+                                                    "int"
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "value": true
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "verylongname2",
+                                                    "typemap_name": "int"
+                                                },
+                                                "specifier": [
+                                                    "int"
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "value": true
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "verylongname3",
+                                                    "typemap_name": "int"
+                                                },
+                                                "specifier": [
+                                                    "int"
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "value": true
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "verylongname4",
+                                                    "typemap_name": "int"
+                                                },
+                                                "specifier": [
+                                                    "int"
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "value": true
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "verylongname5",
+                                                    "typemap_name": "int"
+                                                },
+                                                "specifier": [
+                                                    "int"
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "value": true
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "verylongname6",
+                                                    "typemap_name": "int"
+                                                },
+                                                "specifier": [
+                                                    "int"
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "value": true
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "verylongname7",
+                                                    "typemap_name": "int"
+                                                },
+                                                "specifier": [
+                                                    "int"
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "value": true
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "verylongname8",
+                                                    "typemap_name": "int"
+                                                },
+                                                "specifier": [
+                                                    "int"
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "value": true
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "verylongname9",
+                                                    "typemap_name": "int"
+                                                },
+                                                "specifier": [
+                                                    "int"
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "value": true
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "verylongname10",
+                                                    "typemap_name": "int"
+                                                },
+                                                "specifier": [
+                                                    "int"
+                                                ],
+                                                "typemap_name": "int"
+                                            }
+                                        ],
+                                        "typemap_name": "int"
                                     },
-                                    "metaattrs": {
-                                        "intent": "function"
-                                    },
-                                    "params": [
-                                        {
-                                            "attrs": {
-                                                "value": true
-                                            },
-                                            "declarator": {
-                                                "name": "verylongname1"
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "int"
-                                            ],
-                                            "typemap_name": "int"
-                                        },
-                                        {
-                                            "attrs": {
-                                                "value": true
-                                            },
-                                            "declarator": {
-                                                "name": "verylongname2"
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "int"
-                                            ],
-                                            "typemap_name": "int"
-                                        },
-                                        {
-                                            "attrs": {
-                                                "value": true
-                                            },
-                                            "declarator": {
-                                                "name": "verylongname3"
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "int"
-                                            ],
-                                            "typemap_name": "int"
-                                        },
-                                        {
-                                            "attrs": {
-                                                "value": true
-                                            },
-                                            "declarator": {
-                                                "name": "verylongname4"
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "int"
-                                            ],
-                                            "typemap_name": "int"
-                                        },
-                                        {
-                                            "attrs": {
-                                                "value": true
-                                            },
-                                            "declarator": {
-                                                "name": "verylongname5"
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "int"
-                                            ],
-                                            "typemap_name": "int"
-                                        },
-                                        {
-                                            "attrs": {
-                                                "value": true
-                                            },
-                                            "declarator": {
-                                                "name": "verylongname6"
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "int"
-                                            ],
-                                            "typemap_name": "int"
-                                        },
-                                        {
-                                            "attrs": {
-                                                "value": true
-                                            },
-                                            "declarator": {
-                                                "name": "verylongname7"
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "int"
-                                            ],
-                                            "typemap_name": "int"
-                                        },
-                                        {
-                                            "attrs": {
-                                                "value": true
-                                            },
-                                            "declarator": {
-                                                "name": "verylongname8"
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "int"
-                                            ],
-                                            "typemap_name": "int"
-                                        },
-                                        {
-                                            "attrs": {
-                                                "value": true
-                                            },
-                                            "declarator": {
-                                                "name": "verylongname9"
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "int"
-                                            ],
-                                            "typemap_name": "int"
-                                        },
-                                        {
-                                            "attrs": {
-                                                "value": true
-                                            },
-                                            "declarator": {
-                                                "name": "verylongname10"
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "int"
-                                            ],
-                                            "typemap_name": "int"
-                                        }
-                                    ],
                                     "specifier": [
                                         "int"
                                     ],
@@ -10809,81 +10943,85 @@
                                 "<FUNCTION>": "61 ****************************************",
                                 "ast": {
                                     "declarator": {
-                                        "name": "cos_doubles"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "subroutine"
-                                    },
-                                    "params": [
-                                        {
-                                            "attrs": {
-                                                "intent": "in",
-                                                "rank": 2
-                                            },
-                                            "declarator": {
-                                                "name": "in",
-                                                "pointer": [
-                                                    {
-                                                        "ptr": "*"
-                                                    }
-                                                ]
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "double"
-                                            ],
-                                            "typemap_name": "double"
+                                        "metaattrs": {
+                                            "intent": "subroutine"
                                         },
-                                        {
-                                            "attrs": {
-                                                "dimension": "shape(in)",
-                                                "intent": "out"
+                                        "name": "cos_doubles",
+                                        "params": [
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "intent": "in",
+                                                        "rank": 2
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "in",
+                                                    "pointer": [
+                                                        {
+                                                            "ptr": "*"
+                                                        }
+                                                    ],
+                                                    "typemap_name": "double"
+                                                },
+                                                "specifier": [
+                                                    "double"
+                                                ],
+                                                "typemap_name": "double"
                                             },
-                                            "declarator": {
-                                                "name": "out",
-                                                "pointer": [
-                                                    {
-                                                        "ptr": "*"
-                                                    }
-                                                ]
-                                            },
-                                            "metaattrs": {
-                                                "dimension": [
-                                                    {
-                                                        "args": [
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "dimension": "shape(in)",
+                                                        "intent": "out"
+                                                    },
+                                                    "metaattrs": {
+                                                        "dimension": [
                                                             {
-                                                                "name": "in"
+                                                                "args": [
+                                                                    {
+                                                                        "name": "in"
+                                                                    }
+                                                                ],
+                                                                "name": "shape"
                                                             }
                                                         ],
-                                                        "name": "shape"
-                                                    }
+                                                        "intent": "out"
+                                                    },
+                                                    "name": "out",
+                                                    "pointer": [
+                                                        {
+                                                            "ptr": "*"
+                                                        }
+                                                    ],
+                                                    "typemap_name": "double"
+                                                },
+                                                "specifier": [
+                                                    "double"
                                                 ],
-                                                "intent": "out"
+                                                "typemap_name": "double"
                                             },
-                                            "specifier": [
-                                                "double"
-                                            ],
-                                            "typemap_name": "double"
-                                        },
-                                        {
-                                            "attrs": {
-                                                "implied": "size(in)",
-                                                "value": true
-                                            },
-                                            "declarator": {
-                                                "name": "sizein"
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "int"
-                                            ],
-                                            "typemap_name": "int"
-                                        }
-                                    ],
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "implied": "size(in)",
+                                                        "value": true
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "sizein",
+                                                    "typemap_name": "int"
+                                                },
+                                                "specifier": [
+                                                    "int"
+                                                ],
+                                                "typemap_name": "int"
+                                            }
+                                        ],
+                                        "typemap_name": "void"
+                                    },
                                     "specifier": [
                                         "void"
                                     ],
@@ -11220,7 +11358,8 @@
                 "<TYPEDEF>": "****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "SidreLength"
+                        "name": "SidreLength",
+                        "typemap_name": "long"
                     },
                     "specifier": [
                         "long"
@@ -11260,7 +11399,8 @@
                 "<TYPEDEF>": "****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "TypeID"
+                        "name": "TypeID",
+                        "typemap_name": "int"
                     },
                     "specifier": [
                         "int"

--- a/regression/reference/example/example.json
+++ b/regression/reference/example/example.json
@@ -1121,7 +1121,6 @@
                                                                 "is_result": true
                                                             },
                                                             "name": "name",
-                                                            "params": [],
                                                             "pointer": [
                                                                 {
                                                                     "ptr": "&"
@@ -1251,7 +1250,6 @@
                                                                 "is_result": true
                                                             },
                                                             "name": "name",
-                                                            "params": [],
                                                             "pointer": [
                                                                 {
                                                                     "ptr": "&"
@@ -4010,6 +4008,23 @@
                                                             "TypeID"
                                                         ],
                                                         "typemap_name": "TypeID"
+                                                    },
+                                                    {
+                                                        "declarator": {
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "init": 1,
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "len",
+                                                            "typemap_name": "int"
+                                                        },
+                                                        "specifier": [
+                                                            "int"
+                                                        ],
+                                                        "typemap_name": "int"
                                                     }
                                                 ],
                                                 "typemap_name": "void"
@@ -4074,6 +4089,23 @@
                                                             "TypeID"
                                                         ],
                                                         "typemap_name": "TypeID"
+                                                    },
+                                                    {
+                                                        "declarator": {
+                                                            "attrs": {
+                                                                "value": true
+                                                            },
+                                                            "init": 1,
+                                                            "metaattrs": {
+                                                                "intent": "in"
+                                                            },
+                                                            "name": "len",
+                                                            "typemap_name": "long"
+                                                        },
+                                                        "specifier": [
+                                                            "long"
+                                                        ],
+                                                        "typemap_name": "long"
                                                     }
                                                 ],
                                                 "typemap_name": "void"
@@ -4662,12 +4694,12 @@
                                                                 "intent": "in"
                                                             },
                                                             "name": "len",
-                                                            "typemap_name": "SidreLength"
+                                                            "typemap_name": "int"
                                                         },
                                                         "specifier": [
-                                                            "SidreLength"
+                                                            "int"
                                                         ],
-                                                        "typemap_name": "SidreLength"
+                                                        "typemap_name": "int"
                                                     }
                                                 ],
                                                 "typemap_name": "void"
@@ -4751,12 +4783,12 @@
                                                                 "intent": "in"
                                                             },
                                                             "name": "len",
-                                                            "typemap_name": "SidreLength"
+                                                            "typemap_name": "long"
                                                         },
                                                         "specifier": [
-                                                            "SidreLength"
+                                                            "long"
                                                         ],
-                                                        "typemap_name": "SidreLength"
+                                                        "typemap_name": "long"
                                                     }
                                                 ],
                                                 "typemap_name": "void"
@@ -5094,9 +5126,10 @@
                                                             "name": "value"
                                                         },
                                                         "specifier": [
-                                                            "ValueType"
+                                                            "int"
                                                         ],
-                                                        "template_argument": "ValueType"
+                                                        "template_argument": "ValueType",
+                                                        "typemap_name": "int"
                                                     }
                                                 ],
                                                 "typemap_name": "void"
@@ -5297,9 +5330,10 @@
                                                             "name": "value"
                                                         },
                                                         "specifier": [
-                                                            "ValueType"
+                                                            "long"
                                                         ],
-                                                        "template_argument": "ValueType"
+                                                        "template_argument": "ValueType",
+                                                        "typemap_name": "long"
                                                     }
                                                 ],
                                                 "typemap_name": "void"
@@ -5498,9 +5532,10 @@
                                                             "name": "value"
                                                         },
                                                         "specifier": [
-                                                            "ValueType"
+                                                            "float"
                                                         ],
-                                                        "template_argument": "ValueType"
+                                                        "template_argument": "ValueType",
+                                                        "typemap_name": "float"
                                                     }
                                                 ],
                                                 "typemap_name": "void"
@@ -5699,9 +5734,10 @@
                                                             "name": "value"
                                                         },
                                                         "specifier": [
-                                                            "ValueType"
+                                                            "double"
                                                         ],
-                                                        "template_argument": "ValueType"
+                                                        "template_argument": "ValueType",
+                                                        "typemap_name": "double"
                                                     }
                                                 ],
                                                 "typemap_name": "void"

--- a/regression/reference/example/example.json
+++ b/regression/reference/example/example.json
@@ -8426,6 +8426,7 @@
                                                     "attrs": {
                                                         "value": true
                                                     },
+                                                    "declarator": {},
                                                     "specifier": [
                                                         "int"
                                                     ],
@@ -8584,6 +8585,7 @@
                                                     "attrs": {
                                                         "value": true
                                                     },
+                                                    "declarator": {},
                                                     "specifier": [
                                                         "double"
                                                     ],
@@ -8593,6 +8595,7 @@
                                                     "attrs": {
                                                         "value": true
                                                     },
+                                                    "declarator": {},
                                                     "specifier": [
                                                         "int"
                                                     ],

--- a/regression/reference/example/example.json
+++ b/regression/reference/example/example.json
@@ -37,6 +37,7 @@
                                                 "_constructor": true,
                                                 "_name": "ctor"
                                             },
+                                            "declarator": {},
                                             "metaattrs": {
                                                 "api": "capptr",
                                                 "intent": "ctor"
@@ -161,6 +162,7 @@
                                                 "_constructor": true,
                                                 "_name": "ctor"
                                             },
+                                            "declarator": {},
                                             "metaattrs": {
                                                 "api": "capptr",
                                                 "intent": "ctor"
@@ -370,6 +372,7 @@
                                                 "_constructor": true,
                                                 "_name": "ctor"
                                             },
+                                            "declarator": {},
                                             "metaattrs": {
                                                 "api": "capptr",
                                                 "intent": "ctor"
@@ -502,6 +505,7 @@
                                                 "_destructor": "ExClass1",
                                                 "_name": "dtor"
                                             },
+                                            "declarator": {},
                                             "metaattrs": {
                                                 "intent": "dtor"
                                             },
@@ -2038,6 +2042,7 @@
                                                 "_constructor": true,
                                                 "_name": "ctor"
                                             },
+                                            "declarator": {},
                                             "metaattrs": {
                                                 "api": "capptr",
                                                 "intent": "ctor"
@@ -2249,6 +2254,7 @@
                                                 "_constructor": true,
                                                 "_name": "ctor"
                                             },
+                                            "declarator": {},
                                             "metaattrs": {
                                                 "api": "capptr",
                                                 "intent": "ctor"
@@ -2382,6 +2388,7 @@
                                                 "_destructor": "ExClass2",
                                                 "_name": "dtor"
                                             },
+                                            "declarator": {},
                                             "metaattrs": {
                                                 "intent": "dtor"
                                             },

--- a/regression/reference/example/example.json
+++ b/regression/reference/example/example.json
@@ -45,6 +45,7 @@
                                                 "params": [],
                                                 "typemap_name": "example::nested::ExClass1"
                                             },
+                                            "is_ctor": true,
                                             "specifier": [
                                                 "ExClass1"
                                             ],
@@ -193,6 +194,7 @@
                                                 ],
                                                 "typemap_name": "example::nested::ExClass1"
                                             },
+                                            "is_ctor": true,
                                             "specifier": [
                                                 "ExClass1"
                                             ],
@@ -408,6 +410,7 @@
                                                 ],
                                                 "typemap_name": "example::nested::ExClass1"
                                             },
+                                            "is_ctor": true,
                                             "specifier": [
                                                 "ExClass1"
                                             ],
@@ -523,6 +526,7 @@
                                                 "params": [],
                                                 "typemap_name": "void"
                                             },
+                                            "is_dtor": "ExClass1",
                                             "specifier": [
                                                 "void"
                                             ],
@@ -2115,6 +2119,7 @@
                                                 ],
                                                 "typemap_name": "example::nested::ExClass2"
                                             },
+                                            "is_ctor": true,
                                             "specifier": [
                                                 "ExClass2"
                                             ],
@@ -2332,6 +2337,7 @@
                                                 ],
                                                 "typemap_name": "example::nested::ExClass2"
                                             },
+                                            "is_ctor": true,
                                             "specifier": [
                                                 "ExClass2"
                                             ],
@@ -2445,6 +2451,7 @@
                                                 "params": [],
                                                 "typemap_name": "void"
                                             },
+                                            "is_dtor": "ExClass2",
                                             "specifier": [
                                                 "void"
                                             ],

--- a/regression/reference/example/example.json
+++ b/regression/reference/example/example.json
@@ -8232,6 +8232,7 @@
                                                     "metaattrs": {
                                                         "intent": "in"
                                                     },
+                                                    "name": "get",
                                                     "params": [],
                                                     "typemap_name": "void"
                                                 },
@@ -8377,6 +8378,7 @@
                                                     "metaattrs": {
                                                         "intent": "in"
                                                     },
+                                                    "name": "get",
                                                     "params": [],
                                                     "pointer": [
                                                         {
@@ -8532,6 +8534,7 @@
                                                     "metaattrs": {
                                                         "intent": "in"
                                                     },
+                                                    "name": "get",
                                                     "params": [
                                                         {
                                                             "declarator": {
@@ -8709,6 +8712,7 @@
                                                     "metaattrs": {
                                                         "intent": "in"
                                                     },
+                                                    "name": "get",
                                                     "params": [
                                                         {
                                                             "declarator": {
@@ -8847,6 +8851,7 @@
                                                     "metaattrs": {
                                                         "intent": "in"
                                                     },
+                                                    "name": "get",
                                                     "params": [
                                                         {
                                                             "declarator": {

--- a/regression/reference/example/example.json
+++ b/regression/reference/example/example.json
@@ -52,6 +52,7 @@
                                         },
                                         "decl": "ExClass1()",
                                         "declgen": "ExClass1(void)",
+                                        "name": "ctor",
                                         "options": {
                                             "F_create_generic": true
                                         },
@@ -204,6 +205,7 @@
                                             "description": "longer description\nusually multiple lines\n",
                                             "return": "return new instance"
                                         },
+                                        "name": "ctor",
                                         "options": {
                                             "F_create_generic": true
                                         },
@@ -418,6 +420,7 @@
                                             "description": "longer description\nusually multiple lines\n",
                                             "return": "return new instance"
                                         },
+                                        "name": "ctor",
                                         "options": {
                                             "F_create_generic": true
                                         },
@@ -531,6 +534,7 @@
                                             "brief": "destructor",
                                             "description": "longer description joined with previous line"
                                         },
+                                        "name": "dtor",
                                         "options": {},
                                         "user_fmt": {
                                             "F_name_function": "delete"
@@ -612,6 +616,7 @@
                                         },
                                         "decl": "int incrementCount(int incr)",
                                         "declgen": "int incrementCount(int incr +value)",
+                                        "name": "incrementCount",
                                         "options": {},
                                         "wrap": {
                                             "c": true,
@@ -806,6 +811,7 @@
                                         },
                                         "decl": "const string& getNameErrorCheck() const",
                                         "declgen": "const string & getNameErrorCheck(void) const",
+                                        "name": "getNameErrorCheck",
                                         "options": {},
                                         "wrap": {
                                             "c": true,
@@ -935,6 +941,7 @@
                                         },
                                         "decl": "const string& getNameErrorCheck() const",
                                         "declgen": "const string & getNameErrorCheck(void) const",
+                                        "name": "getNameErrorCheck",
                                         "options": {},
                                         "splicer_group": "buf",
                                         "wrap": {
@@ -1012,6 +1019,7 @@
                                         },
                                         "decl": "const string& getNameArg() const",
                                         "declgen": "const string & getNameArg(void) const",
+                                        "name": "getNameArg",
                                         "options": {},
                                         "user_fmt": {
                                             "F_string_result_as_arg": "name"
@@ -1143,6 +1151,7 @@
                                         },
                                         "decl": "const string& getNameArg() const",
                                         "declgen": "void getNameArg(string & name) const",
+                                        "name": "getNameArg",
                                         "options": {},
                                         "splicer_group": "buf",
                                         "user_fmt": {
@@ -1272,6 +1281,7 @@
                                         },
                                         "decl": "const string& getNameArg() const",
                                         "declgen": "void getNameArg(string & name) const",
+                                        "name": "getNameArg",
                                         "options": {},
                                         "splicer_group": "buf",
                                         "user_fmt": {
@@ -1334,6 +1344,7 @@
                                         },
                                         "decl": "int  getValue(int value)",
                                         "declgen": "int getValue(int value +value)",
+                                        "name": "getValue",
                                         "options": {},
                                         "user_fmt": {
                                             "function_suffix": "_from_int"
@@ -1538,6 +1549,7 @@
                                         },
                                         "decl": "long getValue(long value)",
                                         "declgen": "long getValue(long value +value)",
+                                        "name": "getValue",
                                         "options": {},
                                         "wrap": {
                                             "c": true,
@@ -1736,6 +1748,7 @@
                                         },
                                         "decl": "bool hasAddr(bool in)",
                                         "declgen": "bool hasAddr(bool in +value)",
+                                        "name": "hasAddr",
                                         "options": {},
                                         "wrap": {
                                             "c": true,
@@ -1921,6 +1934,7 @@
                                         },
                                         "decl": "void SplicerSpecial()",
                                         "declgen": "void SplicerSpecial(void)",
+                                        "name": "SplicerSpecial",
                                         "options": {},
                                         "wrap": {
                                             "c": true,
@@ -2111,6 +2125,7 @@
                                         "doxygen": {
                                             "brief": "constructor"
                                         },
+                                        "name": "ctor",
                                         "options": {
                                             "F_create_generic": true
                                         },
@@ -2327,6 +2342,7 @@
                                         "doxygen": {
                                             "brief": "constructor"
                                         },
+                                        "name": "ctor",
                                         "options": {
                                             "F_create_generic": true
                                         },
@@ -2439,6 +2455,7 @@
                                         "doxygen": {
                                             "brief": "destructor"
                                         },
+                                        "name": "dtor",
                                         "options": {},
                                         "user_fmt": {
                                             "F_name_function": "delete"
@@ -2518,6 +2535,7 @@
                                         },
                                         "decl": "const string& getName() const",
                                         "declgen": "const string & getName(void) const +len(aa_exclass2_get_name_length({F_this}%{F_derived_member}))",
+                                        "name": "getName",
                                         "options": {},
                                         "wrap": {
                                             "c": true,
@@ -2648,6 +2666,7 @@
                                         },
                                         "decl": "const string& getName() const",
                                         "declgen": "const string & getName(void) const +len(aa_exclass2_get_name_length({F_this}%{F_derived_member}))",
+                                        "name": "getName",
                                         "options": {},
                                         "splicer_group": "buf",
                                         "wrap": {
@@ -2729,6 +2748,7 @@
                                         },
                                         "decl": "const string& getName2()",
                                         "declgen": "const string & getName2(void)",
+                                        "name": "getName2",
                                         "options": {},
                                         "wrap": {
                                             "c": true,
@@ -2856,6 +2876,7 @@
                                         },
                                         "decl": "const string& getName2()",
                                         "declgen": "const string & getName2(void)",
+                                        "name": "getName2",
                                         "options": {},
                                         "splicer_group": "buf",
                                         "wrap": {
@@ -2937,6 +2958,7 @@
                                         },
                                         "decl": "string& getName3() const",
                                         "declgen": "string & getName3(void) const",
+                                        "name": "getName3",
                                         "options": {},
                                         "wrap": {
                                             "c": true,
@@ -3065,6 +3087,7 @@
                                         },
                                         "decl": "string& getName3() const",
                                         "declgen": "string & getName3(void) const",
+                                        "name": "getName3",
                                         "options": {},
                                         "splicer_group": "buf",
                                         "wrap": {
@@ -3145,6 +3168,7 @@
                                         },
                                         "decl": "string& getName4()",
                                         "declgen": "string & getName4(void)",
+                                        "name": "getName4",
                                         "options": {},
                                         "wrap": {
                                             "c": true,
@@ -3271,6 +3295,7 @@
                                         },
                                         "decl": "string& getName4()",
                                         "declgen": "string & getName4(void)",
+                                        "name": "getName4",
                                         "options": {},
                                         "splicer_group": "buf",
                                         "wrap": {
@@ -3345,6 +3370,7 @@
                                         "doxygen": {
                                             "brief": "helper function for Fortran"
                                         },
+                                        "name": "GetNameLength",
                                         "options": {},
                                         "splicer": {
                                             "c": [
@@ -3490,6 +3516,7 @@
                                         },
                                         "decl": "ExClass1 *get_class1(const ExClass1 *in)",
                                         "declgen": "ExClass1 * get_class1(const ExClass1 * in)",
+                                        "name": "get_class1",
                                         "options": {},
                                         "wrap": {
                                             "c": true,
@@ -3788,6 +3815,7 @@
                                                 "generic": "(long len=1)"
                                             }
                                         ],
+                                        "name": "declare",
                                         "options": {},
                                         "return_this": true,
                                         "wrap": {},
@@ -3914,6 +3942,7 @@
                                                 "generic": "(long len=1)"
                                             }
                                         ],
+                                        "name": "declare",
                                         "options": {},
                                         "return_this": true,
                                         "wrap": {
@@ -4036,6 +4065,7 @@
                                         },
                                         "decl": "void* declare(TypeID type, SidreLength len = 1)",
                                         "declgen": "void declare(TypeID type +value, int len=1 +value)",
+                                        "name": "declare",
                                         "options": {},
                                         "return_this": true,
                                         "wrap": {
@@ -4117,6 +4147,7 @@
                                         },
                                         "decl": "void* declare(TypeID type, SidreLength len = 1)",
                                         "declgen": "void declare(TypeID type +value, long len=1 +value)",
+                                        "name": "declare",
                                         "options": {},
                                         "return_this": true,
                                         "wrap": {
@@ -4285,6 +4316,7 @@
                                                 "generic": "(long len=1)"
                                             }
                                         ],
+                                        "name": "declare",
                                         "options": {},
                                         "return_this": true,
                                         "wrap": {
@@ -4547,6 +4579,7 @@
                                                 "generic": "(long len=1)"
                                             }
                                         ],
+                                        "name": "declare",
                                         "options": {},
                                         "return_this": true,
                                         "wrap": {
@@ -4711,6 +4744,7 @@
                                         },
                                         "decl": "void* declare(TypeID type, SidreLength len = 1)",
                                         "declgen": "void declare(TypeID type +value, int len=1 +value)",
+                                        "name": "declare",
                                         "options": {},
                                         "return_this": true,
                                         "wrap": {
@@ -4800,6 +4834,7 @@
                                         },
                                         "decl": "void* declare(TypeID type, SidreLength len = 1)",
                                         "declgen": "void declare(TypeID type +value, long len=1 +value)",
+                                        "name": "declare",
                                         "options": {},
                                         "return_this": true,
                                         "wrap": {
@@ -4840,6 +4875,7 @@
                                         },
                                         "decl": "void destroyall()",
                                         "declgen": "void destroyall(void)",
+                                        "name": "destroyall",
                                         "options": {},
                                         "wrap": {
                                             "c": true,
@@ -4902,6 +4938,7 @@
                                         },
                                         "decl": "TypeID getTypeID() const",
                                         "declgen": "TypeID getTypeID(void) const",
+                                        "name": "getTypeID",
                                         "options": {},
                                         "wrap": {
                                             "c": true,
@@ -5045,6 +5082,7 @@
                                         "decl": "template<typename ValueType> void setValue(ValueType value)",
                                         "declgen": "void setValue(ValueType value +value)",
                                         "have_template_args": true,
+                                        "name": "setValue",
                                         "options": {},
                                         "template_arguments": [
                                             {
@@ -5142,6 +5180,7 @@
                                         "decl": "template<typename ValueType> void setValue(ValueType value)",
                                         "declgen": "void setValue(int value +value)",
                                         "have_template_args": true,
+                                        "name": "setValue",
                                         "options": {},
                                         "template_arguments": [
                                             {
@@ -5346,6 +5385,7 @@
                                         "decl": "template<typename ValueType> void setValue(ValueType value)",
                                         "declgen": "void setValue(long value +value)",
                                         "have_template_args": true,
+                                        "name": "setValue",
                                         "options": {},
                                         "template_arguments": [
                                             {
@@ -5548,6 +5588,7 @@
                                         "decl": "template<typename ValueType> void setValue(ValueType value)",
                                         "declgen": "void setValue(float value +value)",
                                         "have_template_args": true,
+                                        "name": "setValue",
                                         "options": {},
                                         "template_arguments": [
                                             {
@@ -5756,6 +5797,7 @@
                                             "double"
                                         ],
                                         "have_template_args": true,
+                                        "name": "setValue",
                                         "options": {},
                                         "template_arguments": [
                                             {
@@ -5942,6 +5984,7 @@
                                         "decl": "template<typename ValueType> ValueType getValue()",
                                         "declgen": "ValueType getValue(void)",
                                         "have_template_args": true,
+                                        "name": "getValue",
                                         "options": {},
                                         "template_arguments": [
                                             {
@@ -6000,6 +6043,7 @@
                                         "decl": "template<typename ValueType> ValueType getValue()",
                                         "declgen": "int getValue(void)",
                                         "have_template_args": true,
+                                        "name": "getValue",
                                         "options": {
                                             "F_create_generic": false
                                         },
@@ -6154,6 +6198,7 @@
                                             "double"
                                         ],
                                         "have_template_args": true,
+                                        "name": "getValue",
                                         "options": {
                                             "F_create_generic": false
                                         },
@@ -6364,6 +6409,7 @@
                                 },
                                 "decl": "void local_function1()",
                                 "declgen": "void local_function1(void)",
+                                "name": "local_function1",
                                 "options": {},
                                 "wrap": {
                                     "c": true,
@@ -6444,6 +6490,7 @@
                                 },
                                 "decl": "bool isNameValid(const std::string& name)",
                                 "declgen": "bool isNameValid(const std::string & name)",
+                                "name": "isNameValid",
                                 "options": {},
                                 "splicer": {
                                     "c": [
@@ -6653,6 +6700,7 @@
                                 },
                                 "decl": "bool isNameValid(const std::string& name)",
                                 "declgen": "bool isNameValid(const std::string & name)",
+                                "name": "isNameValid",
                                 "options": {},
                                 "splicer": {
                                     "c": [
@@ -6767,6 +6815,7 @@
                                 },
                                 "decl": "bool isInitialized()",
                                 "declgen": "bool isInitialized(void)",
+                                "name": "isInitialized",
                                 "options": {},
                                 "wrap": {
                                     "c": true,
@@ -6901,6 +6950,7 @@
                                 },
                                 "decl": "void test_names(const std::string &name)",
                                 "declgen": "void test_names(const std::string & name)",
+                                "name": "test_names",
                                 "options": {},
                                 "user_fmt": {
                                     "function_suffix": ""
@@ -7051,6 +7101,7 @@
                                 },
                                 "decl": "void test_names(const std::string &name)",
                                 "declgen": "void test_names(const std::string & name)",
+                                "name": "test_names",
                                 "options": {},
                                 "splicer_group": "buf",
                                 "user_fmt": {
@@ -7171,6 +7222,7 @@
                                 },
                                 "decl": "void test_names(const std::string &name, int flag)",
                                 "declgen": "void test_names(const std::string & name, int flag +value)",
+                                "name": "test_names",
                                 "options": {},
                                 "user_fmt": {
                                     "function_suffix": "_flag"
@@ -7397,6 +7449,7 @@
                                 },
                                 "decl": "void test_names(const std::string &name, int flag)",
                                 "declgen": "void test_names(const std::string & name, int flag +value)",
+                                "name": "test_names",
                                 "options": {},
                                 "splicer_group": "buf",
                                 "user_fmt": {
@@ -7514,6 +7567,7 @@
                                 },
                                 "decl": "void testoptional(int i = 1, long j=2)",
                                 "declgen": "void testoptional(void)",
+                                "name": "testoptional",
                                 "options": {},
                                 "wrap": {
                                     "c": true,
@@ -7583,6 +7637,7 @@
                                 },
                                 "decl": "void testoptional(int i = 1, long j=2)",
                                 "declgen": "void testoptional(int i=1 +value)",
+                                "name": "testoptional",
                                 "options": {},
                                 "wrap": {
                                     "c": true,
@@ -7711,6 +7766,7 @@
                                 },
                                 "decl": "void testoptional(int i = 1, long j=2)",
                                 "declgen": "void testoptional(int i=1 +value, long j=2 +value)",
+                                "name": "testoptional",
                                 "options": {},
                                 "wrap": {
                                     "c": true,
@@ -7905,6 +7961,7 @@
                                 },
                                 "decl": "size_t test_size_t()",
                                 "declgen": "size_t test_size_t(void)",
+                                "name": "test_size_t",
                                 "options": {},
                                 "wrap": {
                                     "c": true,
@@ -8031,6 +8088,7 @@
                                 },
                                 "decl": "void testmpi(MPI_Comm comm)",
                                 "declgen": "void testmpi(MPI_Comm comm +value)",
+                                "name": "testmpi",
                                 "options": {},
                                 "user_fmt": {
                                     "function_suffix": "_mpi"
@@ -8166,6 +8224,7 @@
                                 },
                                 "decl": "void testmpi()",
                                 "declgen": "void testmpi(void)",
+                                "name": "testmpi",
                                 "options": {},
                                 "user_fmt": {
                                     "function_suffix": "_serial"
@@ -8254,6 +8313,7 @@
                                 "doxygen": {
                                     "brief": "subroutine"
                                 },
+                                "name": "FuncPtr1",
                                 "options": {},
                                 "wrap": {
                                     "c": true,
@@ -8405,6 +8465,7 @@
                                 "doxygen": {
                                     "brief": "return a pointer"
                                 },
+                                "name": "FuncPtr2",
                                 "options": {},
                                 "wrap": {
                                     "c": true,
@@ -8582,6 +8643,7 @@
                                 "doxygen": {
                                     "brief": "abstract argument"
                                 },
+                                "name": "FuncPtr3",
                                 "options": {
                                     "F_force_wrapper": true
                                 },
@@ -8759,6 +8821,7 @@
                                 "doxygen": {
                                     "brief": "abstract argument"
                                 },
+                                "name": "FuncPtr4",
                                 "options": {
                                     "F_abstract_interface_argument_template": "XX{index}arg",
                                     "F_abstract_interface_subprogram_template": "custom_funptr",
@@ -9001,6 +9064,7 @@
                                 },
                                 "decl": "void FuncPtr5(void (*get)(int verylongname1, int verylongname2, int verylongname3, int verylongname4, int verylongname5, int verylongname6, int verylongname7, int verylongname8, int verylongname9, int verylongname10))",
                                 "declgen": "void FuncPtr5(void ( * get)(int verylongname1 +value, int verylongname2 +value, int verylongname3 +value, int verylongname4 +value, int verylongname5 +value, int verylongname6 +value, int verylongname7 +value, int verylongname8 +value, int verylongname9 +value, int verylongname10 +value) +value)",
+                                "name": "FuncPtr5",
                                 "options": {},
                                 "wrap": {
                                     "c": true,
@@ -9331,6 +9395,7 @@
                                 },
                                 "decl": "void verylongfunctionname1(int *verylongname1 +intent(inout), int *verylongname2 +intent(inout), int *verylongname3 +intent(inout), int *verylongname4 +intent(inout), int *verylongname5 +intent(inout), int *verylongname6 +intent(inout), int *verylongname7 +intent(inout), int *verylongname8 +intent(inout), int *verylongname9 +intent(inout), int *verylongname10 +intent(inout))",
                                 "declgen": "void verylongfunctionname1(int * verylongname1 +intent(inout), int * verylongname2 +intent(inout), int * verylongname3 +intent(inout), int * verylongname4 +intent(inout), int * verylongname5 +intent(inout), int * verylongname6 +intent(inout), int * verylongname7 +intent(inout), int * verylongname8 +intent(inout), int * verylongname9 +intent(inout), int * verylongname10 +intent(inout))",
+                                "name": "verylongfunctionname1",
                                 "options": {
                                     "F_force_wrapper": true
                                 },
@@ -10224,6 +10289,7 @@
                                 },
                                 "decl": "int verylongfunctionname2(int verylongname1, int verylongname2, int verylongname3, int verylongname4, int verylongname5, int verylongname6, int verylongname7, int verylongname8, int verylongname9, int verylongname10)",
                                 "declgen": "int verylongfunctionname2(int verylongname1 +value, int verylongname2 +value, int verylongname3 +value, int verylongname4 +value, int verylongname5 +value, int verylongname6 +value, int verylongname7 +value, int verylongname8 +value, int verylongname9 +value, int verylongname10 +value)",
+                                "name": "verylongfunctionname2",
                                 "options": {
                                     "C_line_length": 0,
                                     "F_force_wrapper": true,
@@ -11075,6 +11141,7 @@
                                 "doxygen": {
                                     "brief": "Test multidimensional arrays with allocatable"
                                 },
+                                "name": "cos_doubles",
                                 "options": {
                                     "F_standard": 2008
                                 },

--- a/regression/reference/forward/forward.json
+++ b/regression/reference/forward/forward.json
@@ -85,6 +85,7 @@
                         },
                         "decl": "Class2()",
                         "declgen": "Class2(void)",
+                        "name": "ctor",
                         "options": {
                             "F_create_generic": true
                         },
@@ -205,6 +206,7 @@
                         },
                         "decl": "~Class2()",
                         "declgen": "~Class2(void)",
+                        "name": "dtor",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -288,6 +290,7 @@
                         },
                         "decl": "void func1(tutorial::Class1 *arg +intent(in))",
                         "declgen": "void func1(tutorial::Class1 * arg +intent(in))",
+                        "name": "func1",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -444,6 +447,7 @@
                         },
                         "decl": "void acceptClass3(Class3 *arg +intent(in))",
                         "declgen": "void acceptClass3(Class3 * arg +intent(in))",
+                        "name": "acceptClass3",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -659,6 +663,7 @@
                 },
                 "decl": "int passStruct1(const Cstruct1 *arg)",
                 "declgen": "int passStruct1(const Cstruct1 * arg)",
+                "name": "passStruct1",
                 "options": {
                     "wrap_lua": false,
                     "wrap_python": false

--- a/regression/reference/forward/forward.json
+++ b/regression/reference/forward/forward.json
@@ -66,16 +66,18 @@
                         "<FUNCTION>": "0 ****************************************",
                         "_overloaded": true,
                         "ast": {
-                            "attrs": {
-                                "_constructor": true,
-                                "_name": "ctor"
+                            "declarator": {
+                                "attrs": {
+                                    "_constructor": true,
+                                    "_name": "ctor"
+                                },
+                                "metaattrs": {
+                                    "api": "capptr",
+                                    "intent": "ctor"
+                                },
+                                "params": [],
+                                "typemap_name": "forward::Class2"
                             },
-                            "declarator": {},
-                            "metaattrs": {
-                                "api": "capptr",
-                                "intent": "ctor"
-                            },
-                            "params": [],
                             "specifier": [
                                 "Class2"
                             ],
@@ -185,15 +187,17 @@
                     {
                         "<FUNCTION>": "1 ****************************************",
                         "ast": {
-                            "attrs": {
-                                "_destructor": "Class2",
-                                "_name": "dtor"
+                            "declarator": {
+                                "attrs": {
+                                    "_destructor": "Class2",
+                                    "_name": "dtor"
+                                },
+                                "metaattrs": {
+                                    "intent": "dtor"
+                                },
+                                "params": [],
+                                "typemap_name": "void"
                             },
-                            "declarator": {},
-                            "metaattrs": {
-                                "intent": "dtor"
-                            },
-                            "params": [],
                             "specifier": [
                                 "void"
                             ],
@@ -248,33 +252,35 @@
                         "<FUNCTION>": "2 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "func1"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "func1",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "intent": "in"
+                                            },
+                                            "metaattrs": {
+                                                "intent": "in"
+                                            },
+                                            "name": "arg",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "tutorial::Class1"
+                                        },
+                                        "specifier": [
+                                            "tutorial::Class1"
+                                        ],
+                                        "typemap_name": "tutorial::Class1"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "intent": "in"
-                                    },
-                                    "declarator": {
-                                        "name": "arg",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in"
-                                    },
-                                    "specifier": [
-                                        "tutorial::Class1"
-                                    ],
-                                    "typemap_name": "tutorial::Class1"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],
@@ -402,33 +408,35 @@
                         "<FUNCTION>": "3 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "acceptClass3"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "acceptClass3",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "intent": "in"
+                                            },
+                                            "metaattrs": {
+                                                "intent": "in"
+                                            },
+                                            "name": "arg",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "forward::Class3"
+                                        },
+                                        "specifier": [
+                                            "Class3"
+                                        ],
+                                        "typemap_name": "forward::Class3"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "intent": "in"
-                                    },
-                                    "declarator": {
-                                        "name": "arg",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in"
-                                    },
-                                    "specifier": [
-                                        "Class3"
-                                    ],
-                                    "typemap_name": "forward::Class3"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],
@@ -617,31 +625,33 @@
                 "<FUNCTION>": "4 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passStruct1"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "passStruct1",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],

--- a/regression/reference/forward/forward.json
+++ b/regression/reference/forward/forward.json
@@ -70,6 +70,7 @@
                                 "_constructor": true,
                                 "_name": "ctor"
                             },
+                            "declarator": {},
                             "metaattrs": {
                                 "api": "capptr",
                                 "intent": "ctor"
@@ -188,6 +189,7 @@
                                 "_destructor": "Class2",
                                 "_name": "dtor"
                             },
+                            "declarator": {},
                             "metaattrs": {
                                 "intent": "dtor"
                             },

--- a/regression/reference/forward/forward.json
+++ b/regression/reference/forward/forward.json
@@ -78,6 +78,7 @@
                                 "params": [],
                                 "typemap_name": "forward::Class2"
                             },
+                            "is_ctor": true,
                             "specifier": [
                                 "Class2"
                             ],
@@ -199,6 +200,7 @@
                                 "params": [],
                                 "typemap_name": "void"
                             },
+                            "is_dtor": "Class2",
                             "specifier": [
                                 "void"
                             ],

--- a/regression/reference/generic-cfi/generic.json
+++ b/regression/reference/generic-cfi/generic.json
@@ -60,28 +60,30 @@
                 "<FUNCTION>": "0 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "UpdateAsFloat"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "UpdateAsFloat",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "float"
+                                },
+                                "specifier": [
+                                    "float"
+                                ],
+                                "typemap_name": "float"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "float"
-                            ],
-                            "typemap_name": "float"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -162,28 +164,30 @@
                 "<FUNCTION>": "1 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "UpdateAsDouble"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "UpdateAsDouble",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -264,12 +268,13 @@
                 "<FUNCTION>": "2 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "GetGlobalDouble"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "GetGlobalDouble",
+                        "params": [],
+                        "typemap_name": "double"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "double"
                     ],
@@ -340,28 +345,30 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GenericReal"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "GenericReal",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -376,14 +383,15 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "arg"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
                                     "float"
@@ -397,14 +405,15 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "arg"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "double"
                                 },
                                 "specifier": [
                                     "double"
@@ -482,28 +491,30 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GenericReal"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "GenericReal",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "float"
-                            ],
-                            "typemap_name": "float"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -547,28 +558,30 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GenericReal"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "GenericReal",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -607,43 +620,46 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GenericReal2"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "long"
-                            ],
-                            "typemap_name": "long"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "GenericReal2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "long"
+                                },
+                                "specifier": [
+                                    "long"
+                                ],
+                                "typemap_name": "long"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "long"
-                            ],
-                            "typemap_name": "long"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "long"
+                                },
+                                "specifier": [
+                                    "long"
+                                ],
+                                "typemap_name": "long"
+                            }
+                        ],
+                        "typemap_name": "long"
+                    },
                     "specifier": [
                         "long"
                     ],
@@ -659,14 +675,15 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "arg1"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -674,14 +691,15 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "arg2"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -695,14 +713,15 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "arg1"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "long"
                                 },
                                 "specifier": [
                                     "long"
@@ -710,14 +729,15 @@
                                 "typemap_name": "long"
                             },
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "arg2"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "long"
                                 },
                                 "specifier": [
                                     "long"
@@ -853,43 +873,46 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GenericReal2"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "GenericReal2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "long"
+                                },
+                                "specifier": [
+                                    "long"
+                                ],
+                                "typemap_name": "long"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "long"
+                                },
+                                "specifier": [
+                                    "long"
+                                ],
+                                "typemap_name": "long"
+                            }
+                        ],
+                        "typemap_name": "long"
+                    },
                     "specifier": [
                         "long"
                     ],
@@ -944,43 +967,46 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GenericReal2"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "long"
-                            ],
-                            "typemap_name": "long"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "GenericReal2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "long"
+                                },
+                                "specifier": [
+                                    "long"
+                                ],
+                                "typemap_name": "long"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "long"
-                            ],
-                            "typemap_name": "long"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "long"
+                                },
+                                "specifier": [
+                                    "long"
+                                ],
+                                "typemap_name": "long"
+                            }
+                        ],
+                        "typemap_name": "long"
+                    },
                     "specifier": [
                         "long"
                     ],
@@ -1034,53 +1060,56 @@
                 "_gen_fortran_generic": true,
                 "ast": {
                     "declarator": {
-                        "name": "SumValues"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": ".."
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "values",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "assumed-rank": true,
-                                "dimension": {
-                                    "assumedrank": true
-                                },
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "SumValues",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": ".."
+                                    },
+                                    "metaattrs": {
+                                        "assumed-rank": true,
+                                        "dimension": {
+                                            "assumedrank": true
+                                        },
+                                        "intent": "in"
+                                    },
+                                    "name": "values",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "nvalues"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nvalues",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -1223,54 +1252,57 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "SumValues"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": ".."
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "values",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "assumed-rank": true,
-                                "dimension": {
-                                    "assumedrank": true
-                                },
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "SumValues",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": ".."
+                                    },
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "assumed-rank": true,
+                                        "dimension": {
+                                            "assumedrank": true
+                                        },
+                                        "intent": "in"
+                                    },
+                                    "name": "values",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "nvalues"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nvalues",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -1414,78 +1446,83 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "AssignValues"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "AssignValues",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "from",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nfrom",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "to",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nto",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "from",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "nfrom"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "declarator": {
-                                "name": "to",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "nto"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -1502,30 +1539,16 @@
                             {
                                 "const": true,
                                 "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
                                     "name": "from",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
-                                },
-                                "specifier": [
-                                    "int"
-                                ],
-                                "typemap_name": "int"
-                            },
-                            {
-                                "attrs": {
-                                    "value": true
-                                },
-                                "declarator": {
-                                    "name": "nfrom"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    ],
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -1534,15 +1557,32 @@
                             },
                             {
                                 "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nfrom",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
                                     "name": "to",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "inout"
+                                    ],
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -1550,14 +1590,15 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "nto"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nto",
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -1573,15 +1614,16 @@
                             {
                                 "const": true,
                                 "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
                                     "name": "from",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    ],
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -1589,14 +1631,15 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "nfrom"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nfrom",
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -1604,19 +1647,20 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "rank": 1
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
                                     "name": "to",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "inout"
+                                    ],
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -1624,14 +1668,15 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "nto"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nto",
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -1645,20 +1690,21 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "rank": 1
-                                },
                                 "const": true,
                                 "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
                                     "name": "from",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    ],
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -1666,14 +1712,15 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "nfrom"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nfrom",
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -1681,19 +1728,20 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "rank": 1
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
                                     "name": "to",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "inout"
+                                    ],
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -1701,14 +1749,15 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "nto"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nto",
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -1867,78 +1916,83 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "AssignValues"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "AssignValues",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "from",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nfrom",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "to",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nto",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "from",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "nfrom"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "declarator": {
-                                "name": "to",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "nto"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -2126,81 +2180,83 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "AssignValues"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "AssignValues",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "from",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nfrom",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "to",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nto",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "from",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "nfrom"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "to",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "nto"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -2242,82 +2298,83 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "AssignValues"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "AssignValues",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "from",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nfrom",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "to",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nto",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "from",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "nfrom"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "to",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "nto"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -2508,84 +2565,83 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "AssignValues"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "AssignValues",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "from",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nfrom",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "to",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nto",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "from",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "nfrom"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "to",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "nto"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -2627,86 +2683,83 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "AssignValues"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "AssignValues",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "from",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nfrom",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "to",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nto",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "from",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "nfrom"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "to",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "nto"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -2899,64 +2952,68 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "SavePointer"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "SavePointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "declarator": {
-                                "name": "type"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(addr)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "size"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "size",
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2968,20 +3025,21 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "intent": "in",
-                                    "rank": 1
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
                                     "name": "addr",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    ],
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
                                     "float"
@@ -2989,15 +3047,16 @@
                                 "typemap_name": "float"
                             },
                             {
-                                "attrs": {
-                                    "implied": "T_FLOAT",
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "type"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "implied": "T_FLOAT",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -3005,15 +3064,16 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "implied": "size(addr)",
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "size"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "implied": "size(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "size",
+                                    "typemap_name": "size_t"
                                 },
                                 "specifier": [
                                     "size_t"
@@ -3027,20 +3087,21 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "intent": "in",
-                                    "rank": 2
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 2
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
                                     "name": "addr",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    ],
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
                                     "float"
@@ -3048,15 +3109,16 @@
                                 "typemap_name": "float"
                             },
                             {
-                                "attrs": {
-                                    "implied": "T_FLOAT",
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "type"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "implied": "T_FLOAT",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -3064,15 +3126,16 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "implied": "size(addr)",
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "size"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "implied": "size(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "size",
+                                    "typemap_name": "size_t"
                                 },
                                 "specifier": [
                                     "size_t"
@@ -3203,66 +3266,68 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "SavePointer"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "float"
-                            ],
-                            "typemap_name": "float"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "T_FLOAT",
-                                "value": true
+                        "name": "SavePointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "declarator": {
-                                "name": "type"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(addr)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "size"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "size",
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3301,67 +3366,68 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "SavePointer"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "float"
-                            ],
-                            "typemap_name": "float"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "T_FLOAT",
-                                "value": true
+                        "name": "SavePointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "declarator": {
-                                "name": "type"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(addr)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "size"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "size",
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3510,66 +3576,68 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "SavePointer"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 2
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "float"
-                            ],
-                            "typemap_name": "float"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "T_FLOAT",
-                                "value": true
+                        "name": "SavePointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "declarator": {
-                                "name": "type"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(addr)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "size"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "size",
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3608,67 +3676,68 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "SavePointer"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 2
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "float"
-                            ],
-                            "typemap_name": "float"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "T_FLOAT",
-                                "value": true
+                        "name": "SavePointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "declarator": {
-                                "name": "type"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(addr)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "size"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "size",
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3809,65 +3878,69 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "SavePointer2"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "type(addr)",
-                                "value": true
+                        "name": "SavePointer2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "declarator": {
-                                "name": "type"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "type(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(addr)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "size"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "size",
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3879,20 +3952,21 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "intent": "in",
-                                    "rank": 1
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
                                     "name": "addr",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    ],
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
                                     "float"
@@ -3900,15 +3974,16 @@
                                 "typemap_name": "float"
                             },
                             {
-                                "attrs": {
-                                    "implied": "type(addr)",
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "type"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "implied": "type(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -3916,15 +3991,16 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "implied": "size(addr)",
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "size"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "implied": "size(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "size",
+                                    "typemap_name": "size_t"
                                 },
                                 "specifier": [
                                     "size_t"
@@ -3938,20 +4014,21 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "intent": "in",
-                                    "rank": 2
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 2
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
                                     "name": "addr",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    ],
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
                                     "float"
@@ -3959,15 +4036,16 @@
                                 "typemap_name": "float"
                             },
                             {
-                                "attrs": {
-                                    "implied": "type(addr)",
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "type"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "implied": "type(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -3975,15 +4053,16 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "implied": "size(addr)",
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "size"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "implied": "size(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "size",
+                                    "typemap_name": "size_t"
                                 },
                                 "specifier": [
                                     "size_t"
@@ -4124,66 +4203,69 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "SavePointer2"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "float"
-                            ],
-                            "typemap_name": "float"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "type(addr)",
-                                "value": true
+                        "name": "SavePointer2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "declarator": {
-                                "name": "type"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "type(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(addr)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "size"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "size",
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4232,67 +4314,69 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "SavePointer2"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "float"
-                            ],
-                            "typemap_name": "float"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "type(addr)",
-                                "value": true
+                        "name": "SavePointer2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "declarator": {
-                                "name": "type"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "type(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(addr)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "size"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "size",
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4451,66 +4535,69 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "SavePointer2"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 2
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "float"
-                            ],
-                            "typemap_name": "float"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "type(addr)",
-                                "value": true
+                        "name": "SavePointer2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "declarator": {
-                                "name": "type"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "type(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(addr)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "size"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "size",
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4559,67 +4646,69 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "SavePointer2"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 2
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "float"
-                            ],
-                            "typemap_name": "float"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "type(addr)",
-                                "value": true
+                        "name": "SavePointer2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "declarator": {
-                                "name": "type"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "type(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(addr)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "size"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "size",
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4769,76 +4858,80 @@
                 "<FUNCTION>": "9 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "GetPointer"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "GetPointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "out"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "type",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        },
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "type",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "size",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "size",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4980,78 +5073,82 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GetPointerAsPointer"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "GetPointerAsPointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "out"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "type",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "type",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "size",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "size",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5063,12 +5160,16 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "deref": "pointer",
-                                    "intent": "out",
-                                    "rank": 1
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "deref": "pointer",
+                                        "intent": "out",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "intent": "out"
+                                    },
                                     "name": "addr",
                                     "pointer": [
                                         {
@@ -5077,11 +5178,8 @@
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "deref": "pointer",
-                                    "intent": "out"
+                                    ],
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
                                     "float"
@@ -5089,20 +5187,21 @@
                                 "typemap_name": "float"
                             },
                             {
-                                "attrs": {
-                                    "hidden": true,
-                                    "intent": "out"
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
                                     "name": "type",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "out"
+                                    ],
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -5110,20 +5209,21 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "hidden": true,
-                                    "intent": "out"
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
                                     "name": "size",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "out"
+                                    ],
+                                    "typemap_name": "size_t"
                                 },
                                 "specifier": [
                                     "size_t"
@@ -5137,12 +5237,16 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "deref": "pointer",
-                                    "intent": "out",
-                                    "rank": 2
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "deref": "pointer",
+                                        "intent": "out",
+                                        "rank": 2
+                                    },
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "intent": "out"
+                                    },
                                     "name": "addr",
                                     "pointer": [
                                         {
@@ -5151,11 +5255,8 @@
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "deref": "pointer",
-                                    "intent": "out"
+                                    ],
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
                                     "float"
@@ -5163,20 +5264,21 @@
                                 "typemap_name": "float"
                             },
                             {
-                                "attrs": {
-                                    "hidden": true,
-                                    "intent": "out"
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
                                     "name": "type",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "out"
+                                    ],
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -5184,20 +5286,21 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "hidden": true,
-                                    "intent": "out"
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
                                     "name": "size",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "out"
+                                    ],
+                                    "typemap_name": "size_t"
                                 },
                                 "specifier": [
                                     "size_t"
@@ -5328,81 +5431,82 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GetPointerAsPointer"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "pointer",
-                                "intent": "out",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "GetPointerAsPointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "intent": "out"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "type",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "float"
-                            ],
-                            "typemap_name": "float"
-                        },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "type",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "size",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "size",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5441,82 +5545,82 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GetPointerAsPointer"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "pointer",
-                                "intent": "out",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "GetPointerAsPointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "deref": "pointer",
-                                "intent": "out"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "type",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "float"
-                            ],
-                            "typemap_name": "float"
-                        },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "type",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "size",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "size",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5671,81 +5775,82 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GetPointerAsPointer"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "pointer",
-                                "intent": "out",
-                                "rank": 2
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "GetPointerAsPointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "intent": "out"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "type",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "float"
-                            ],
-                            "typemap_name": "float"
-                        },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "type",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "size",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "size",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5784,82 +5889,82 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GetPointerAsPointer"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "pointer",
-                                "intent": "out",
-                                "rank": 2
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "GetPointerAsPointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "deref": "pointer",
-                                "intent": "out"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "type",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "float"
-                            ],
-                            "typemap_name": "float"
-                        },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "type",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "size",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "size",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -6005,18 +6110,19 @@
                 "<FUNCTION>": "11 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
                         "name": "CreateStructAsClass",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "StructAsClass"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "StructAsClass"
                     ],
@@ -6092,45 +6198,48 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UpdateStructAsClass"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "StructAsClass"
-                            ],
-                            "typemap_name": "StructAsClass"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "UpdateStructAsClass",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "StructAsClass"
+                                },
+                                "specifier": [
+                                    "StructAsClass"
+                                ],
+                                "typemap_name": "StructAsClass"
                             },
-                            "declarator": {
-                                "name": "inew"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "long"
-                            ],
-                            "typemap_name": "long"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "inew",
+                                    "typemap_name": "long"
+                                },
+                                "specifier": [
+                                    "long"
+                                ],
+                                "typemap_name": "long"
+                            }
+                        ],
+                        "typemap_name": "long"
+                    },
                     "specifier": [
                         "long"
                     ],
@@ -6143,15 +6252,16 @@
                         "decls": [
                             {
                                 "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
                                     "name": "arg",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "inout"
+                                    ],
+                                    "typemap_name": "StructAsClass"
                                 },
                                 "specifier": [
                                     "StructAsClass"
@@ -6159,14 +6269,15 @@
                                 "typemap_name": "StructAsClass"
                             },
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "inew"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "inew",
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -6181,15 +6292,16 @@
                         "decls": [
                             {
                                 "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
                                     "name": "arg",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "inout"
+                                    ],
+                                    "typemap_name": "StructAsClass"
                                 },
                                 "specifier": [
                                     "StructAsClass"
@@ -6197,14 +6309,15 @@
                                 "typemap_name": "StructAsClass"
                             },
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "inew"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "inew",
+                                    "typemap_name": "long"
                                 },
                                 "specifier": [
                                     "long"
@@ -6333,45 +6446,48 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UpdateStructAsClass"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "StructAsClass"
-                            ],
-                            "typemap_name": "StructAsClass"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "UpdateStructAsClass",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "StructAsClass"
+                                },
+                                "specifier": [
+                                    "StructAsClass"
+                                ],
+                                "typemap_name": "StructAsClass"
                             },
-                            "declarator": {
-                                "name": "inew"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "inew",
+                                    "typemap_name": "long"
+                                },
+                                "specifier": [
+                                    "long"
+                                ],
+                                "typemap_name": "long"
+                            }
+                        ],
+                        "typemap_name": "long"
+                    },
                     "specifier": [
                         "long"
                     ],
@@ -6520,45 +6636,48 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UpdateStructAsClass"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "StructAsClass"
-                            ],
-                            "typemap_name": "StructAsClass"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "UpdateStructAsClass",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "StructAsClass"
+                                },
+                                "specifier": [
+                                    "StructAsClass"
+                                ],
+                                "typemap_name": "StructAsClass"
                             },
-                            "declarator": {
-                                "name": "inew"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "long"
-                            ],
-                            "typemap_name": "long"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "inew",
+                                    "typemap_name": "long"
+                                },
+                                "specifier": [
+                                    "long"
+                                ],
+                                "typemap_name": "long"
+                            }
+                        ],
+                        "typemap_name": "long"
+                    },
                     "specifier": [
                         "long"
                     ],

--- a/regression/reference/generic-cfi/generic.json
+++ b/regression/reference/generic-cfi/generic.json
@@ -505,12 +505,12 @@
                                         "intent": "in"
                                     },
                                     "name": "arg",
-                                    "typemap_name": "double"
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
-                                    "double"
+                                    "float"
                                 ],
-                                "typemap_name": "double"
+                                "typemap_name": "float"
                             }
                         ],
                         "typemap_name": "void"
@@ -887,12 +887,12 @@
                                         "intent": "in"
                                     },
                                     "name": "arg1",
-                                    "typemap_name": "long"
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
-                                    "long"
+                                    "int"
                                 ],
-                                "typemap_name": "long"
+                                "typemap_name": "int"
                             },
                             {
                                 "declarator": {
@@ -903,12 +903,12 @@
                                         "intent": "in"
                                     },
                                     "name": "arg2",
-                                    "typemap_name": "long"
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
-                                    "long"
+                                    "int"
                                 ],
-                                "typemap_name": "long"
+                                "typemap_name": "int"
                             }
                         ],
                         "typemap_name": "long"
@@ -2222,6 +2222,9 @@
                             },
                             {
                                 "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
                                     "metaattrs": {
                                         "intent": "inout"
                                     },
@@ -2340,7 +2343,11 @@
                             },
                             {
                                 "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
                                     "metaattrs": {
+                                        "api": "cfi",
                                         "intent": "inout"
                                     },
                                     "name": "to",
@@ -2573,6 +2580,9 @@
                             {
                                 "const": true,
                                 "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
                                     "metaattrs": {
                                         "intent": "in"
                                     },
@@ -2607,6 +2617,9 @@
                             },
                             {
                                 "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
                                     "metaattrs": {
                                         "intent": "inout"
                                     },
@@ -2691,7 +2704,11 @@
                             {
                                 "const": true,
                                 "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
                                     "metaattrs": {
+                                        "api": "cfi",
                                         "intent": "in"
                                     },
                                     "name": "from",
@@ -2725,7 +2742,11 @@
                             },
                             {
                                 "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
                                     "metaattrs": {
+                                        "api": "cfi",
                                         "intent": "inout"
                                     },
                                     "name": "to",
@@ -3274,7 +3295,8 @@
                             {
                                 "declarator": {
                                     "attrs": {
-                                        "value": true
+                                        "intent": "in",
+                                        "rank": 1
                                     },
                                     "metaattrs": {
                                         "intent": "in"
@@ -3285,16 +3307,17 @@
                                             "ptr": "*"
                                         }
                                     ],
-                                    "typemap_name": "void"
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
-                                    "void"
+                                    "float"
                                 ],
-                                "typemap_name": "void"
+                                "typemap_name": "float"
                             },
                             {
                                 "declarator": {
                                     "attrs": {
+                                        "implied": "T_FLOAT",
                                         "value": true
                                     },
                                     "metaattrs": {
@@ -3374,9 +3397,11 @@
                             {
                                 "declarator": {
                                     "attrs": {
-                                        "value": true
+                                        "intent": "in",
+                                        "rank": 1
                                     },
                                     "metaattrs": {
+                                        "api": "cfi",
                                         "intent": "in"
                                     },
                                     "name": "addr",
@@ -3385,16 +3410,17 @@
                                             "ptr": "*"
                                         }
                                     ],
-                                    "typemap_name": "void"
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
-                                    "void"
+                                    "float"
                                 ],
-                                "typemap_name": "void"
+                                "typemap_name": "float"
                             },
                             {
                                 "declarator": {
                                     "attrs": {
+                                        "implied": "T_FLOAT",
                                         "value": true
                                     },
                                     "metaattrs": {
@@ -3584,7 +3610,8 @@
                             {
                                 "declarator": {
                                     "attrs": {
-                                        "value": true
+                                        "intent": "in",
+                                        "rank": 2
                                     },
                                     "metaattrs": {
                                         "intent": "in"
@@ -3595,16 +3622,17 @@
                                             "ptr": "*"
                                         }
                                     ],
-                                    "typemap_name": "void"
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
-                                    "void"
+                                    "float"
                                 ],
-                                "typemap_name": "void"
+                                "typemap_name": "float"
                             },
                             {
                                 "declarator": {
                                     "attrs": {
+                                        "implied": "T_FLOAT",
                                         "value": true
                                     },
                                     "metaattrs": {
@@ -3684,9 +3712,11 @@
                             {
                                 "declarator": {
                                     "attrs": {
-                                        "value": true
+                                        "intent": "in",
+                                        "rank": 2
                                     },
                                     "metaattrs": {
+                                        "api": "cfi",
                                         "intent": "in"
                                     },
                                     "name": "addr",
@@ -3695,16 +3725,17 @@
                                             "ptr": "*"
                                         }
                                     ],
-                                    "typemap_name": "void"
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
-                                    "void"
+                                    "float"
                                 ],
-                                "typemap_name": "void"
+                                "typemap_name": "float"
                             },
                             {
                                 "declarator": {
                                     "attrs": {
+                                        "implied": "T_FLOAT",
                                         "value": true
                                     },
                                     "metaattrs": {
@@ -4211,7 +4242,8 @@
                             {
                                 "declarator": {
                                     "attrs": {
-                                        "value": true
+                                        "intent": "in",
+                                        "rank": 1
                                     },
                                     "metaattrs": {
                                         "intent": "in"
@@ -4222,12 +4254,12 @@
                                             "ptr": "*"
                                         }
                                     ],
-                                    "typemap_name": "void"
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
-                                    "void"
+                                    "float"
                                 ],
-                                "typemap_name": "void"
+                                "typemap_name": "float"
                             },
                             {
                                 "declarator": {
@@ -4322,9 +4354,11 @@
                             {
                                 "declarator": {
                                     "attrs": {
-                                        "value": true
+                                        "intent": "in",
+                                        "rank": 1
                                     },
                                     "metaattrs": {
+                                        "api": "cfi",
                                         "intent": "in"
                                     },
                                     "name": "addr",
@@ -4333,12 +4367,12 @@
                                             "ptr": "*"
                                         }
                                     ],
-                                    "typemap_name": "void"
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
-                                    "void"
+                                    "float"
                                 ],
-                                "typemap_name": "void"
+                                "typemap_name": "float"
                             },
                             {
                                 "declarator": {
@@ -4543,7 +4577,8 @@
                             {
                                 "declarator": {
                                     "attrs": {
-                                        "value": true
+                                        "intent": "in",
+                                        "rank": 2
                                     },
                                     "metaattrs": {
                                         "intent": "in"
@@ -4554,12 +4589,12 @@
                                             "ptr": "*"
                                         }
                                     ],
-                                    "typemap_name": "void"
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
-                                    "void"
+                                    "float"
                                 ],
-                                "typemap_name": "void"
+                                "typemap_name": "float"
                             },
                             {
                                 "declarator": {
@@ -4654,9 +4689,11 @@
                             {
                                 "declarator": {
                                     "attrs": {
-                                        "value": true
+                                        "intent": "in",
+                                        "rank": 2
                                     },
                                     "metaattrs": {
+                                        "api": "cfi",
                                         "intent": "in"
                                     },
                                     "name": "addr",
@@ -4665,12 +4702,12 @@
                                             "ptr": "*"
                                         }
                                     ],
-                                    "typemap_name": "void"
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
-                                    "void"
+                                    "float"
                                 ],
-                                "typemap_name": "void"
+                                "typemap_name": "float"
                             },
                             {
                                 "declarator": {
@@ -5439,9 +5476,12 @@
                             {
                                 "declarator": {
                                     "attrs": {
-                                        "intent": "out"
+                                        "deref": "pointer",
+                                        "intent": "out",
+                                        "rank": 1
                                     },
                                     "metaattrs": {
+                                        "deref": "pointer",
                                         "intent": "out"
                                     },
                                     "name": "addr",
@@ -5453,12 +5493,12 @@
                                             "ptr": "*"
                                         }
                                     ],
-                                    "typemap_name": "void"
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
-                                    "void"
+                                    "float"
                                 ],
-                                "typemap_name": "void"
+                                "typemap_name": "float"
                             },
                             {
                                 "declarator": {
@@ -5553,9 +5593,13 @@
                             {
                                 "declarator": {
                                     "attrs": {
-                                        "intent": "out"
+                                        "deref": "pointer",
+                                        "intent": "out",
+                                        "rank": 1
                                     },
                                     "metaattrs": {
+                                        "api": "cfi",
+                                        "deref": "pointer",
                                         "intent": "out"
                                     },
                                     "name": "addr",
@@ -5567,12 +5611,12 @@
                                             "ptr": "*"
                                         }
                                     ],
-                                    "typemap_name": "void"
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
-                                    "void"
+                                    "float"
                                 ],
-                                "typemap_name": "void"
+                                "typemap_name": "float"
                             },
                             {
                                 "declarator": {
@@ -5783,9 +5827,12 @@
                             {
                                 "declarator": {
                                     "attrs": {
-                                        "intent": "out"
+                                        "deref": "pointer",
+                                        "intent": "out",
+                                        "rank": 2
                                     },
                                     "metaattrs": {
+                                        "deref": "pointer",
                                         "intent": "out"
                                     },
                                     "name": "addr",
@@ -5797,12 +5844,12 @@
                                             "ptr": "*"
                                         }
                                     ],
-                                    "typemap_name": "void"
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
-                                    "void"
+                                    "float"
                                 ],
-                                "typemap_name": "void"
+                                "typemap_name": "float"
                             },
                             {
                                 "declarator": {
@@ -5897,9 +5944,13 @@
                             {
                                 "declarator": {
                                     "attrs": {
-                                        "intent": "out"
+                                        "deref": "pointer",
+                                        "intent": "out",
+                                        "rank": 2
                                     },
                                     "metaattrs": {
+                                        "api": "cfi",
+                                        "deref": "pointer",
                                         "intent": "out"
                                     },
                                     "name": "addr",
@@ -5911,12 +5962,12 @@
                                             "ptr": "*"
                                         }
                                     ],
-                                    "typemap_name": "void"
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
-                                    "void"
+                                    "float"
                                 ],
-                                "typemap_name": "void"
+                                "typemap_name": "float"
                             },
                             {
                                 "declarator": {
@@ -6478,12 +6529,12 @@
                                         "intent": "in"
                                     },
                                     "name": "inew",
-                                    "typemap_name": "long"
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
-                                    "long"
+                                    "int"
                                 ],
-                                "typemap_name": "long"
+                                "typemap_name": "int"
                             }
                         ],
                         "typemap_name": "long"

--- a/regression/reference/generic-cfi/generic.json
+++ b/regression/reference/generic-cfi/generic.json
@@ -91,6 +91,7 @@
                 },
                 "decl": "void UpdateAsFloat(float arg)",
                 "declgen": "void UpdateAsFloat(float arg +value)",
+                "name": "UpdateAsFloat",
                 "options": {
                     "F_force_wrapper": true
                 },
@@ -195,6 +196,7 @@
                 },
                 "decl": "void UpdateAsDouble(double arg)",
                 "declgen": "void UpdateAsDouble(double arg +value)",
+                "name": "UpdateAsDouble",
                 "options": {
                     "F_force_wrapper": true
                 },
@@ -282,6 +284,7 @@
                 },
                 "decl": "double GetGlobalDouble(void)",
                 "declgen": "double GetGlobalDouble(void)",
+                "name": "GetGlobalDouble",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -425,6 +428,7 @@
                         "generic": "(double arg)"
                     }
                 ],
+                "name": "GenericReal",
                 "options": {
                     "literalinclude": true
                 },
@@ -525,6 +529,7 @@
                 "doxygen": {
                     "brief": "Single argument generic"
                 },
+                "name": "GenericReal",
                 "options": {
                     "literalinclude": true
                 },
@@ -592,6 +597,7 @@
                 "doxygen": {
                     "brief": "Single argument generic"
                 },
+                "name": "GenericReal",
                 "options": {
                     "literalinclude": true
                 },
@@ -749,6 +755,7 @@
                         "generic": "(long arg1, long arg2)"
                     }
                 ],
+                "name": "GenericReal2",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -924,6 +931,7 @@
                     "brief": "Two argument generic",
                     "description": "It is not possible to call the function with (int, long)\nor (long, int)\n"
                 },
+                "name": "GenericReal2",
                 "options": {},
                 "wrap": {
                     "fortran": true
@@ -1018,6 +1026,7 @@
                     "brief": "Two argument generic",
                     "description": "It is not possible to call the function with (int, long)\nor (long, int)\n"
                 },
+                "name": "GenericReal2",
                 "options": {},
                 "wrap": {
                     "fortran": true
@@ -1120,6 +1129,7 @@
                 "doxygen": {
                     "brief": "scalar or array argument using assumed rank"
                 },
+                "name": "SumValues",
                 "options": {
                     "F_assumed_rank_max": 2,
                     "wrap_fortran": false
@@ -1313,6 +1323,7 @@
                 "doxygen": {
                     "brief": "scalar or array argument using assumed rank"
                 },
+                "name": "SumValues",
                 "options": {
                     "F_assumed_rank_max": 2,
                     "wrap_fortran": false
@@ -1769,6 +1780,7 @@
                         "generic": "(const int *from+rank(1), int *to+rank(1))"
                     }
                 ],
+                "name": "AssignValues",
                 "options": {},
                 "wrap": {
                     "c": true
@@ -2003,6 +2015,7 @@
                 "doxygen": {
                     "description": "Broadcast if nfrom == 1\nCopy if nfrom == nto\n"
                 },
+                "name": "AssignValues",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2270,6 +2283,7 @@
                 "doxygen": {
                     "description": "Broadcast if nfrom == 1\nCopy if nfrom == nto\n"
                 },
+                "name": "AssignValues",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -2392,6 +2406,7 @@
                 "doxygen": {
                     "description": "Broadcast if nfrom == 1\nCopy if nfrom == nto\n"
                 },
+                "name": "AssignValues",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -2665,6 +2680,7 @@
                 "doxygen": {
                     "description": "Broadcast if nfrom == 1\nCopy if nfrom == nto\n"
                 },
+                "name": "AssignValues",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -2791,6 +2807,7 @@
                 "doxygen": {
                     "description": "Broadcast if nfrom == 1\nCopy if nfrom == nto\n"
                 },
+                "name": "AssignValues",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -3168,6 +3185,7 @@
                         "generic": "(float *addr+rank(2)+intent(in),  int type+implied(T_FLOAT))"
                     }
                 ],
+                "name": "SavePointer",
                 "options": {},
                 "wrap": {
                     "c": true
@@ -3358,6 +3376,7 @@
                 },
                 "decl": "void SavePointer(void *addr, int type, size_t size+implied(size(addr)))",
                 "declgen": "void SavePointer(float * addr +intent(in)+rank(1), int type +implied(T_FLOAT)+value, size_t size +implied(size(addr))+value)",
+                "name": "SavePointer",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -3461,6 +3480,7 @@
                 },
                 "decl": "void SavePointer(void *addr, int type, size_t size+implied(size(addr)))",
                 "declgen": "void SavePointer(float * addr +intent(in)+rank(1), int type +implied(T_FLOAT)+value, size_t size +implied(size(addr))+value)",
+                "name": "SavePointer",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -3673,6 +3693,7 @@
                 },
                 "decl": "void SavePointer(void *addr, int type, size_t size+implied(size(addr)))",
                 "declgen": "void SavePointer(float * addr +intent(in)+rank(2), int type +implied(T_FLOAT)+value, size_t size +implied(size(addr))+value)",
+                "name": "SavePointer",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -3776,6 +3797,7 @@
                 },
                 "decl": "void SavePointer(void *addr, int type, size_t size+implied(size(addr)))",
                 "declgen": "void SavePointer(float * addr +intent(in)+rank(2), int type +implied(T_FLOAT)+value, size_t size +implied(size(addr))+value)",
+                "name": "SavePointer",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -4115,6 +4137,7 @@
                         ]
                     }
                 },
+                "name": "SavePointer2",
                 "options": {},
                 "wrap": {
                     "c": true
@@ -4315,6 +4338,7 @@
                         ]
                     }
                 },
+                "name": "SavePointer2",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -4428,6 +4452,7 @@
                         ]
                     }
                 },
+                "name": "SavePointer2",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -4650,6 +4675,7 @@
                         ]
                     }
                 },
+                "name": "SavePointer2",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -4763,6 +4789,7 @@
                         ]
                     }
                 },
+                "name": "SavePointer2",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -4976,6 +5003,7 @@
                 },
                 "decl": "void GetPointer(void **addr+intent(out), int *type+intent(out), size_t *size+intent(out))",
                 "declgen": "void GetPointer(void * * addr +intent(out), int * type +intent(out), size_t * size +intent(out))",
+                "name": "GetPointer",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -5349,6 +5377,7 @@
                         "generic": "(float **addr+intent(out)+rank(2)+deref(pointer))"
                     }
                 ],
+                "name": "GetPointerAsPointer",
                 "options": {},
                 "wrap": {
                     "c": true
@@ -5554,6 +5583,7 @@
                 },
                 "decl": "void GetPointerAsPointer( void **addr+intent(out), int *type+intent(out)+hidden, size_t *size+intent(out)+hidden)",
                 "declgen": "void GetPointerAsPointer(float * * addr +deref(pointer)+intent(out)+rank(1), int * type +hidden+intent(out), size_t * size +hidden+intent(out))",
+                "name": "GetPointerAsPointer",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -5672,6 +5702,7 @@
                 },
                 "decl": "void GetPointerAsPointer( void **addr+intent(out), int *type+intent(out)+hidden, size_t *size+intent(out)+hidden)",
                 "declgen": "void GetPointerAsPointer(float * * addr +deref(pointer)+intent(out)+rank(1), int * type +hidden+intent(out), size_t * size +hidden+intent(out))",
+                "name": "GetPointerAsPointer",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -5905,6 +5936,7 @@
                 },
                 "decl": "void GetPointerAsPointer( void **addr+intent(out), int *type+intent(out)+hidden, size_t *size+intent(out)+hidden)",
                 "declgen": "void GetPointerAsPointer(float * * addr +deref(pointer)+intent(out)+rank(2), int * type +hidden+intent(out), size_t * size +hidden+intent(out))",
+                "name": "GetPointerAsPointer",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -6023,6 +6055,7 @@
                 },
                 "decl": "void GetPointerAsPointer( void **addr+intent(out), int *type+intent(out)+hidden, size_t *size+intent(out)+hidden)",
                 "declgen": "void GetPointerAsPointer(float * * addr +deref(pointer)+intent(out)+rank(2), int * type +hidden+intent(out), size_t * size +hidden+intent(out))",
+                "name": "GetPointerAsPointer",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -6181,6 +6214,7 @@
                 },
                 "decl": "StructAsClass *CreateStructAsClass(void)",
                 "declgen": "StructAsClass * CreateStructAsClass(void)",
+                "name": "CreateStructAsClass",
                 "options": {
                     "class_ctor": "StructAsClass"
                 },
@@ -6380,6 +6414,7 @@
                         "generic": "(long inew)"
                     }
                 ],
+                "name": "UpdateStructAsClass",
                 "options": {},
                 "wrap": {
                     "c": true
@@ -6546,6 +6581,7 @@
                 },
                 "decl": "long UpdateStructAsClass(StructAsClass *arg, long inew)",
                 "declgen": "long UpdateStructAsClass(StructAsClass * arg, int inew +value)",
+                "name": "UpdateStructAsClass",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -6736,6 +6772,7 @@
                 },
                 "decl": "long UpdateStructAsClass(StructAsClass *arg, long inew)",
                 "declgen": "long UpdateStructAsClass(StructAsClass * arg, long inew +value)",
+                "name": "UpdateStructAsClass",
                 "options": {},
                 "wrap": {
                     "c": true,

--- a/regression/reference/generic/generic.json
+++ b/regression/reference/generic/generic.json
@@ -505,12 +505,12 @@
                                         "intent": "in"
                                     },
                                     "name": "arg",
-                                    "typemap_name": "double"
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
-                                    "double"
+                                    "float"
                                 ],
-                                "typemap_name": "double"
+                                "typemap_name": "float"
                             }
                         ],
                         "typemap_name": "void"
@@ -887,12 +887,12 @@
                                         "intent": "in"
                                     },
                                     "name": "arg1",
-                                    "typemap_name": "long"
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
-                                    "long"
+                                    "int"
                                 ],
-                                "typemap_name": "long"
+                                "typemap_name": "int"
                             },
                             {
                                 "declarator": {
@@ -903,12 +903,12 @@
                                         "intent": "in"
                                     },
                                     "name": "arg2",
-                                    "typemap_name": "long"
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
-                                    "long"
+                                    "int"
                                 ],
-                                "typemap_name": "long"
+                                "typemap_name": "int"
                             }
                         ],
                         "typemap_name": "long"
@@ -1385,6 +1385,9 @@
                             {
                                 "const": true,
                                 "declarator": {
+                                    "attrs": {
+                                        "rank": 0
+                                    },
                                     "metaattrs": {
                                         "dimension": {
                                             "assumedrank": true
@@ -1587,6 +1590,9 @@
                             {
                                 "const": true,
                                 "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
                                     "metaattrs": {
                                         "dimension": {
                                             "assumedrank": true
@@ -1791,6 +1797,9 @@
                             {
                                 "const": true,
                                 "declarator": {
+                                    "attrs": {
+                                        "rank": 2
+                                    },
                                     "metaattrs": {
                                         "dimension": {
                                             "assumedrank": true
@@ -2754,6 +2763,9 @@
                             },
                             {
                                 "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
                                     "metaattrs": {
                                         "intent": "inout"
                                     },
@@ -2986,6 +2998,9 @@
                             {
                                 "const": true,
                                 "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
                                     "metaattrs": {
                                         "intent": "in"
                                     },
@@ -3020,6 +3035,9 @@
                             },
                             {
                                 "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
                                     "metaattrs": {
                                         "intent": "inout"
                                     },
@@ -3562,7 +3580,8 @@
                             {
                                 "declarator": {
                                     "attrs": {
-                                        "value": true
+                                        "intent": "in",
+                                        "rank": 1
                                     },
                                     "metaattrs": {
                                         "intent": "in"
@@ -3573,16 +3592,17 @@
                                             "ptr": "*"
                                         }
                                     ],
-                                    "typemap_name": "void"
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
-                                    "void"
+                                    "float"
                                 ],
-                                "typemap_name": "void"
+                                "typemap_name": "float"
                             },
                             {
                                 "declarator": {
                                     "attrs": {
+                                        "implied": "T_FLOAT",
                                         "value": true
                                     },
                                     "metaattrs": {
@@ -3771,7 +3791,8 @@
                             {
                                 "declarator": {
                                     "attrs": {
-                                        "value": true
+                                        "intent": "in",
+                                        "rank": 2
                                     },
                                     "metaattrs": {
                                         "intent": "in"
@@ -3782,16 +3803,17 @@
                                             "ptr": "*"
                                         }
                                     ],
-                                    "typemap_name": "void"
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
-                                    "void"
+                                    "float"
                                 ],
-                                "typemap_name": "void"
+                                "typemap_name": "float"
                             },
                             {
                                 "declarator": {
                                     "attrs": {
+                                        "implied": "T_FLOAT",
                                         "value": true
                                     },
                                     "metaattrs": {
@@ -4297,7 +4319,8 @@
                             {
                                 "declarator": {
                                     "attrs": {
-                                        "value": true
+                                        "intent": "in",
+                                        "rank": 1
                                     },
                                     "metaattrs": {
                                         "intent": "in"
@@ -4308,12 +4331,12 @@
                                             "ptr": "*"
                                         }
                                     ],
-                                    "typemap_name": "void"
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
-                                    "void"
+                                    "float"
                                 ],
-                                "typemap_name": "void"
+                                "typemap_name": "float"
                             },
                             {
                                 "declarator": {
@@ -4517,7 +4540,8 @@
                             {
                                 "declarator": {
                                     "attrs": {
-                                        "value": true
+                                        "intent": "in",
+                                        "rank": 2
                                     },
                                     "metaattrs": {
                                         "intent": "in"
@@ -4528,12 +4552,12 @@
                                             "ptr": "*"
                                         }
                                     ],
-                                    "typemap_name": "void"
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
-                                    "void"
+                                    "float"
                                 ],
-                                "typemap_name": "void"
+                                "typemap_name": "float"
                             },
                             {
                                 "declarator": {
@@ -5303,9 +5327,12 @@
                             {
                                 "declarator": {
                                     "attrs": {
-                                        "intent": "out"
+                                        "deref": "pointer",
+                                        "intent": "out",
+                                        "rank": 1
                                     },
                                     "metaattrs": {
+                                        "deref": "pointer",
                                         "intent": "out"
                                     },
                                     "name": "addr",
@@ -5317,12 +5344,12 @@
                                             "ptr": "*"
                                         }
                                     ],
-                                    "typemap_name": "void"
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
-                                    "void"
+                                    "float"
                                 ],
-                                "typemap_name": "void"
+                                "typemap_name": "float"
                             },
                             {
                                 "declarator": {
@@ -5415,9 +5442,13 @@
                             {
                                 "declarator": {
                                     "attrs": {
-                                        "intent": "out"
+                                        "deref": "pointer",
+                                        "intent": "out",
+                                        "rank": 1
                                     },
                                     "metaattrs": {
+                                        "api": "cdesc",
+                                        "deref": "pointer",
                                         "intent": "out"
                                     },
                                     "name": "addr",
@@ -5429,12 +5460,12 @@
                                             "ptr": "*"
                                         }
                                     ],
-                                    "typemap_name": "void"
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
-                                    "void"
+                                    "float"
                                 ],
-                                "typemap_name": "void"
+                                "typemap_name": "float"
                             },
                             {
                                 "declarator": {
@@ -5632,9 +5663,12 @@
                             {
                                 "declarator": {
                                     "attrs": {
-                                        "intent": "out"
+                                        "deref": "pointer",
+                                        "intent": "out",
+                                        "rank": 2
                                     },
                                     "metaattrs": {
+                                        "deref": "pointer",
                                         "intent": "out"
                                     },
                                     "name": "addr",
@@ -5646,12 +5680,12 @@
                                             "ptr": "*"
                                         }
                                     ],
-                                    "typemap_name": "void"
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
-                                    "void"
+                                    "float"
                                 ],
-                                "typemap_name": "void"
+                                "typemap_name": "float"
                             },
                             {
                                 "declarator": {
@@ -5744,9 +5778,13 @@
                             {
                                 "declarator": {
                                     "attrs": {
-                                        "intent": "out"
+                                        "deref": "pointer",
+                                        "intent": "out",
+                                        "rank": 2
                                     },
                                     "metaattrs": {
+                                        "api": "cdesc",
+                                        "deref": "pointer",
                                         "intent": "out"
                                     },
                                     "name": "addr",
@@ -5758,12 +5796,12 @@
                                             "ptr": "*"
                                         }
                                     ],
-                                    "typemap_name": "void"
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
-                                    "void"
+                                    "float"
                                 ],
-                                "typemap_name": "void"
+                                "typemap_name": "float"
                             },
                             {
                                 "declarator": {
@@ -6312,12 +6350,12 @@
                                         "intent": "in"
                                     },
                                     "name": "inew",
-                                    "typemap_name": "long"
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
-                                    "long"
+                                    "int"
                                 ],
-                                "typemap_name": "long"
+                                "typemap_name": "int"
                             }
                         ],
                         "typemap_name": "long"

--- a/regression/reference/generic/generic.json
+++ b/regression/reference/generic/generic.json
@@ -60,28 +60,30 @@
                 "<FUNCTION>": "0 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "UpdateAsFloat"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "UpdateAsFloat",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "float"
+                                },
+                                "specifier": [
+                                    "float"
+                                ],
+                                "typemap_name": "float"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "float"
-                            ],
-                            "typemap_name": "float"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -162,28 +164,30 @@
                 "<FUNCTION>": "1 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "UpdateAsDouble"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "UpdateAsDouble",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -264,12 +268,13 @@
                 "<FUNCTION>": "2 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "GetGlobalDouble"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "GetGlobalDouble",
+                        "params": [],
+                        "typemap_name": "double"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "double"
                     ],
@@ -340,28 +345,30 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GenericReal"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "GenericReal",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -376,14 +383,15 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "arg"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
                                     "float"
@@ -397,14 +405,15 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "arg"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "double"
                                 },
                                 "specifier": [
                                     "double"
@@ -482,28 +491,30 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GenericReal"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "GenericReal",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "float"
-                            ],
-                            "typemap_name": "float"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -547,28 +558,30 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GenericReal"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "GenericReal",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -607,43 +620,46 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GenericReal2"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "long"
-                            ],
-                            "typemap_name": "long"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "GenericReal2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "long"
+                                },
+                                "specifier": [
+                                    "long"
+                                ],
+                                "typemap_name": "long"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "long"
-                            ],
-                            "typemap_name": "long"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "long"
+                                },
+                                "specifier": [
+                                    "long"
+                                ],
+                                "typemap_name": "long"
+                            }
+                        ],
+                        "typemap_name": "long"
+                    },
                     "specifier": [
                         "long"
                     ],
@@ -659,14 +675,15 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "arg1"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -674,14 +691,15 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "arg2"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -695,14 +713,15 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "arg1"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "long"
                                 },
                                 "specifier": [
                                     "long"
@@ -710,14 +729,15 @@
                                 "typemap_name": "long"
                             },
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "arg2"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "long"
                                 },
                                 "specifier": [
                                     "long"
@@ -853,43 +873,46 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GenericReal2"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "GenericReal2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "long"
+                                },
+                                "specifier": [
+                                    "long"
+                                ],
+                                "typemap_name": "long"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "long"
+                                },
+                                "specifier": [
+                                    "long"
+                                ],
+                                "typemap_name": "long"
+                            }
+                        ],
+                        "typemap_name": "long"
+                    },
                     "specifier": [
                         "long"
                     ],
@@ -944,43 +967,46 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GenericReal2"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "long"
-                            ],
-                            "typemap_name": "long"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "GenericReal2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "long"
+                                },
+                                "specifier": [
+                                    "long"
+                                ],
+                                "typemap_name": "long"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "long"
-                            ],
-                            "typemap_name": "long"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "long"
+                                },
+                                "specifier": [
+                                    "long"
+                                ],
+                                "typemap_name": "long"
+                            }
+                        ],
+                        "typemap_name": "long"
+                    },
                     "specifier": [
                         "long"
                     ],
@@ -1031,49 +1057,52 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "SumValues"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "values",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": {
-                                    "assumedrank": true
-                                },
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "SumValues",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "dimension": {
+                                            "assumedrank": true
+                                        },
+                                        "intent": "in"
+                                    },
+                                    "name": "values",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "nvalues"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nvalues",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -1088,23 +1117,24 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "rank": 0
-                                },
                                 "const": true,
                                 "declarator": {
+                                    "attrs": {
+                                        "rank": 0
+                                    },
+                                    "metaattrs": {
+                                        "dimension": {
+                                            "assumedrank": true
+                                        },
+                                        "intent": "in"
+                                    },
                                     "name": "values",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "dimension": {
-                                        "assumedrank": true
-                                    },
-                                    "intent": "in"
+                                    ],
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -1112,14 +1142,15 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "nvalues"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nvalues",
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -1133,23 +1164,24 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "rank": 1
-                                },
                                 "const": true,
                                 "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "dimension": {
+                                            "assumedrank": true
+                                        },
+                                        "intent": "in"
+                                    },
                                     "name": "values",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "dimension": {
-                                        "assumedrank": true
-                                    },
-                                    "intent": "in"
+                                    ],
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -1157,14 +1189,15 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "nvalues"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nvalues",
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -1178,23 +1211,24 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "rank": 2
-                                },
                                 "const": true,
                                 "declarator": {
+                                    "attrs": {
+                                        "rank": 2
+                                    },
+                                    "metaattrs": {
+                                        "dimension": {
+                                            "assumedrank": true
+                                        },
+                                        "intent": "in"
+                                    },
                                     "name": "values",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "dimension": {
-                                        "assumedrank": true
-                                    },
-                                    "intent": "in"
+                                    ],
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -1202,14 +1236,15 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "nvalues"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nvalues",
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -1342,52 +1377,52 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "SumValues"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 0
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "values",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": {
-                                    "assumedrank": true
-                                },
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "SumValues",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "dimension": {
+                                            "assumedrank": true
+                                        },
+                                        "intent": "in"
+                                    },
+                                    "name": "values",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "nvalues"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nvalues",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -1544,52 +1579,52 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "SumValues"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "values",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": {
-                                    "assumedrank": true
-                                },
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "SumValues",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "dimension": {
+                                            "assumedrank": true
+                                        },
+                                        "intent": "in"
+                                    },
+                                    "name": "values",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "nvalues"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nvalues",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -1748,52 +1783,52 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "SumValues"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 2
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "values",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": {
-                                    "assumedrank": true
-                                },
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "SumValues",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "dimension": {
+                                            "assumedrank": true
+                                        },
+                                        "intent": "in"
+                                    },
+                                    "name": "values",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "nvalues"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nvalues",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -1945,78 +1980,83 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "AssignValues"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "AssignValues",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "from",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nfrom",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "to",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nto",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "from",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "nfrom"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "declarator": {
-                                "name": "to",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "nto"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -2033,30 +2073,16 @@
                             {
                                 "const": true,
                                 "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
                                     "name": "from",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
-                                },
-                                "specifier": [
-                                    "int"
-                                ],
-                                "typemap_name": "int"
-                            },
-                            {
-                                "attrs": {
-                                    "value": true
-                                },
-                                "declarator": {
-                                    "name": "nfrom"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    ],
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -2065,15 +2091,32 @@
                             },
                             {
                                 "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nfrom",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
                                     "name": "to",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "inout"
+                                    ],
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -2081,14 +2124,15 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "nto"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nto",
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -2104,15 +2148,16 @@
                             {
                                 "const": true,
                                 "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
                                     "name": "from",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    ],
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -2120,14 +2165,15 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "nfrom"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nfrom",
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -2135,19 +2181,20 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "rank": 1
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
                                     "name": "to",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "inout"
+                                    ],
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -2155,14 +2202,15 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "nto"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nto",
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -2176,20 +2224,21 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "rank": 1
-                                },
                                 "const": true,
                                 "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
                                     "name": "from",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    ],
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -2197,14 +2246,15 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "nfrom"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nfrom",
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -2212,19 +2262,20 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "rank": 1
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
                                     "name": "to",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "inout"
+                                    ],
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -2232,14 +2283,15 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "nto"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nto",
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -2398,78 +2450,83 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "AssignValues"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "AssignValues",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "from",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nfrom",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "to",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nto",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "from",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "nfrom"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "declarator": {
-                                "name": "to",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "nto"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -2655,81 +2712,83 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "AssignValues"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "AssignValues",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "from",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nfrom",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "to",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nto",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "from",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "nfrom"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "to",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "nto"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -2919,84 +2978,83 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "AssignValues"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "AssignValues",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "from",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nfrom",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "to",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nto",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "from",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "nfrom"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "to",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "nto"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -3184,64 +3242,68 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "SavePointer"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "SavePointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "declarator": {
-                                "name": "type"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(addr)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "size"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "size",
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3253,20 +3315,21 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "intent": "in",
-                                    "rank": 1
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
                                     "name": "addr",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    ],
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
                                     "float"
@@ -3274,15 +3337,16 @@
                                 "typemap_name": "float"
                             },
                             {
-                                "attrs": {
-                                    "implied": "T_FLOAT",
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "type"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "implied": "T_FLOAT",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -3290,15 +3354,16 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "implied": "size(addr)",
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "size"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "implied": "size(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "size",
+                                    "typemap_name": "size_t"
                                 },
                                 "specifier": [
                                     "size_t"
@@ -3312,20 +3377,21 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "intent": "in",
-                                    "rank": 2
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 2
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
                                     "name": "addr",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    ],
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
                                     "float"
@@ -3333,15 +3399,16 @@
                                 "typemap_name": "float"
                             },
                             {
-                                "attrs": {
-                                    "implied": "T_FLOAT",
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "type"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "implied": "T_FLOAT",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -3349,15 +3416,16 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "implied": "size(addr)",
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "size"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "implied": "size(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "size",
+                                    "typemap_name": "size_t"
                                 },
                                 "specifier": [
                                     "size_t"
@@ -3486,66 +3554,68 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "SavePointer"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "float"
-                            ],
-                            "typemap_name": "float"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "T_FLOAT",
-                                "value": true
+                        "name": "SavePointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "declarator": {
-                                "name": "type"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(addr)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "size"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "size",
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3693,66 +3763,68 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "SavePointer"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 2
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "float"
-                            ],
-                            "typemap_name": "float"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "T_FLOAT",
-                                "value": true
+                        "name": "SavePointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "declarator": {
-                                "name": "type"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(addr)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "size"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "size",
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3894,65 +3966,69 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "SavePointer2"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "type(addr)",
-                                "value": true
+                        "name": "SavePointer2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "declarator": {
-                                "name": "type"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "type(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(addr)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "size"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "size",
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3964,20 +4040,21 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "intent": "in",
-                                    "rank": 1
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
                                     "name": "addr",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    ],
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
                                     "float"
@@ -3985,15 +4062,16 @@
                                 "typemap_name": "float"
                             },
                             {
-                                "attrs": {
-                                    "implied": "type(addr)",
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "type"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "implied": "type(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -4001,15 +4079,16 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "implied": "size(addr)",
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "size"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "implied": "size(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "size",
+                                    "typemap_name": "size_t"
                                 },
                                 "specifier": [
                                     "size_t"
@@ -4023,20 +4102,21 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "intent": "in",
-                                    "rank": 2
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 2
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
                                     "name": "addr",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    ],
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
                                     "float"
@@ -4044,15 +4124,16 @@
                                 "typemap_name": "float"
                             },
                             {
-                                "attrs": {
-                                    "implied": "type(addr)",
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "type"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "implied": "type(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -4060,15 +4141,16 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "implied": "size(addr)",
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "size"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "implied": "size(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "size",
+                                    "typemap_name": "size_t"
                                 },
                                 "specifier": [
                                     "size_t"
@@ -4207,66 +4289,69 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "SavePointer2"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "float"
-                            ],
-                            "typemap_name": "float"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "type(addr)",
-                                "value": true
+                        "name": "SavePointer2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "declarator": {
-                                "name": "type"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "type(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(addr)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "size"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "size",
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4424,66 +4509,69 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "SavePointer2"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 2
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "float"
-                            ],
-                            "typemap_name": "float"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "type(addr)",
-                                "value": true
+                        "name": "SavePointer2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "declarator": {
-                                "name": "type"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "type(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(addr)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "size"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(addr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "size",
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4634,76 +4722,80 @@
                 "<FUNCTION>": "9 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "GetPointer"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "GetPointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "out"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "type",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        },
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "type",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "size",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "size",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4845,78 +4937,82 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GetPointerAsPointer"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "GetPointerAsPointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "out"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "type",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "type",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "size",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "size",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4928,12 +5024,16 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "deref": "pointer",
-                                    "intent": "out",
-                                    "rank": 1
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "deref": "pointer",
+                                        "intent": "out",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "intent": "out"
+                                    },
                                     "name": "addr",
                                     "pointer": [
                                         {
@@ -4942,11 +5042,8 @@
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "deref": "pointer",
-                                    "intent": "out"
+                                    ],
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
                                     "float"
@@ -4954,20 +5051,21 @@
                                 "typemap_name": "float"
                             },
                             {
-                                "attrs": {
-                                    "hidden": true,
-                                    "intent": "out"
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
                                     "name": "type",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "out"
+                                    ],
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -4975,20 +5073,21 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "hidden": true,
-                                    "intent": "out"
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
                                     "name": "size",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "out"
+                                    ],
+                                    "typemap_name": "size_t"
                                 },
                                 "specifier": [
                                     "size_t"
@@ -5002,12 +5101,16 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "deref": "pointer",
-                                    "intent": "out",
-                                    "rank": 2
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "deref": "pointer",
+                                        "intent": "out",
+                                        "rank": 2
+                                    },
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "intent": "out"
+                                    },
                                     "name": "addr",
                                     "pointer": [
                                         {
@@ -5016,11 +5119,8 @@
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "deref": "pointer",
-                                    "intent": "out"
+                                    ],
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
                                     "float"
@@ -5028,20 +5128,21 @@
                                 "typemap_name": "float"
                             },
                             {
-                                "attrs": {
-                                    "hidden": true,
-                                    "intent": "out"
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
                                     "name": "type",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "out"
+                                    ],
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -5049,20 +5150,21 @@
                                 "typemap_name": "int"
                             },
                             {
-                                "attrs": {
-                                    "hidden": true,
-                                    "intent": "out"
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
                                     "name": "size",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "out"
+                                    ],
+                                    "typemap_name": "size_t"
                                 },
                                 "specifier": [
                                     "size_t"
@@ -5193,81 +5295,82 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GetPointerAsPointer"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "pointer",
-                                "intent": "out",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "GetPointerAsPointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "intent": "out"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "type",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "float"
-                            ],
-                            "typemap_name": "float"
-                        },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "type",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "size",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "size",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5304,82 +5407,82 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GetPointerAsPointer"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "pointer",
-                                "intent": "out",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "GetPointerAsPointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "deref": "pointer",
-                                "intent": "out"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "type",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "float"
-                            ],
-                            "typemap_name": "float"
-                        },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "type",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "size",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "size",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5521,81 +5624,82 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GetPointerAsPointer"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "pointer",
-                                "intent": "out",
-                                "rank": 2
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "GetPointerAsPointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "intent": "out"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "type",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "float"
-                            ],
-                            "typemap_name": "float"
-                        },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "type",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "size",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "size",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5632,82 +5736,82 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "GetPointerAsPointer"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "pointer",
-                                "intent": "out",
-                                "rank": 2
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "GetPointerAsPointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "deref": "pointer",
-                                "intent": "out"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "type",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "float"
-                            ],
-                            "typemap_name": "float"
-                        },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "type",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "size",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "size",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5840,18 +5944,19 @@
                 "<FUNCTION>": "11 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
                         "name": "CreateStructAsClass",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "StructAsClass"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "StructAsClass"
                     ],
@@ -5927,45 +6032,48 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UpdateStructAsClass"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "StructAsClass"
-                            ],
-                            "typemap_name": "StructAsClass"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "UpdateStructAsClass",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "StructAsClass"
+                                },
+                                "specifier": [
+                                    "StructAsClass"
+                                ],
+                                "typemap_name": "StructAsClass"
                             },
-                            "declarator": {
-                                "name": "inew"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "long"
-                            ],
-                            "typemap_name": "long"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "inew",
+                                    "typemap_name": "long"
+                                },
+                                "specifier": [
+                                    "long"
+                                ],
+                                "typemap_name": "long"
+                            }
+                        ],
+                        "typemap_name": "long"
+                    },
                     "specifier": [
                         "long"
                     ],
@@ -5978,15 +6086,16 @@
                         "decls": [
                             {
                                 "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
                                     "name": "arg",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "inout"
+                                    ],
+                                    "typemap_name": "StructAsClass"
                                 },
                                 "specifier": [
                                     "StructAsClass"
@@ -5994,14 +6103,15 @@
                                 "typemap_name": "StructAsClass"
                             },
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "inew"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "inew",
+                                    "typemap_name": "int"
                                 },
                                 "specifier": [
                                     "int"
@@ -6016,15 +6126,16 @@
                         "decls": [
                             {
                                 "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
                                     "name": "arg",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "inout"
+                                    ],
+                                    "typemap_name": "StructAsClass"
                                 },
                                 "specifier": [
                                     "StructAsClass"
@@ -6032,14 +6143,15 @@
                                 "typemap_name": "StructAsClass"
                             },
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "inew"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "inew",
+                                    "typemap_name": "long"
                                 },
                                 "specifier": [
                                     "long"
@@ -6168,45 +6280,48 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UpdateStructAsClass"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "StructAsClass"
-                            ],
-                            "typemap_name": "StructAsClass"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "UpdateStructAsClass",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "StructAsClass"
+                                },
+                                "specifier": [
+                                    "StructAsClass"
+                                ],
+                                "typemap_name": "StructAsClass"
                             },
-                            "declarator": {
-                                "name": "inew"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "inew",
+                                    "typemap_name": "long"
+                                },
+                                "specifier": [
+                                    "long"
+                                ],
+                                "typemap_name": "long"
+                            }
+                        ],
+                        "typemap_name": "long"
+                    },
                     "specifier": [
                         "long"
                     ],
@@ -6355,45 +6470,48 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UpdateStructAsClass"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "StructAsClass"
-                            ],
-                            "typemap_name": "StructAsClass"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "UpdateStructAsClass",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "StructAsClass"
+                                },
+                                "specifier": [
+                                    "StructAsClass"
+                                ],
+                                "typemap_name": "StructAsClass"
                             },
-                            "declarator": {
-                                "name": "inew"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "long"
-                            ],
-                            "typemap_name": "long"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "inew",
+                                    "typemap_name": "long"
+                                },
+                                "specifier": [
+                                    "long"
+                                ],
+                                "typemap_name": "long"
+                            }
+                        ],
+                        "typemap_name": "long"
+                    },
                     "specifier": [
                         "long"
                     ],

--- a/regression/reference/generic/generic.json
+++ b/regression/reference/generic/generic.json
@@ -91,6 +91,7 @@
                 },
                 "decl": "void UpdateAsFloat(float arg)",
                 "declgen": "void UpdateAsFloat(float arg +value)",
+                "name": "UpdateAsFloat",
                 "options": {
                     "F_force_wrapper": true
                 },
@@ -195,6 +196,7 @@
                 },
                 "decl": "void UpdateAsDouble(double arg)",
                 "declgen": "void UpdateAsDouble(double arg +value)",
+                "name": "UpdateAsDouble",
                 "options": {
                     "F_force_wrapper": true
                 },
@@ -282,6 +284,7 @@
                 },
                 "decl": "double GetGlobalDouble(void)",
                 "declgen": "double GetGlobalDouble(void)",
+                "name": "GetGlobalDouble",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -425,6 +428,7 @@
                         "generic": "(double arg)"
                     }
                 ],
+                "name": "GenericReal",
                 "options": {
                     "literalinclude": true
                 },
@@ -525,6 +529,7 @@
                 "doxygen": {
                     "brief": "Single argument generic"
                 },
+                "name": "GenericReal",
                 "options": {
                     "literalinclude": true
                 },
@@ -592,6 +597,7 @@
                 "doxygen": {
                     "brief": "Single argument generic"
                 },
+                "name": "GenericReal",
                 "options": {
                     "literalinclude": true
                 },
@@ -749,6 +755,7 @@
                         "generic": "(long arg1, long arg2)"
                     }
                 ],
+                "name": "GenericReal2",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -924,6 +931,7 @@
                     "brief": "Two argument generic",
                     "description": "It is not possible to call the function with (int, long)\nor (long, int)\n"
                 },
+                "name": "GenericReal2",
                 "options": {},
                 "wrap": {
                     "fortran": true
@@ -1018,6 +1026,7 @@
                     "brief": "Two argument generic",
                     "description": "It is not possible to call the function with (int, long)\nor (long, int)\n"
                 },
+                "name": "GenericReal2",
                 "options": {},
                 "wrap": {
                     "fortran": true
@@ -1256,6 +1265,7 @@
                         "generic": ""
                     }
                 ],
+                "name": "SumValues",
                 "options": {
                     "F_assumed_rank_max": 2
                 },
@@ -1436,6 +1446,7 @@
                 "doxygen": {
                     "brief": "scalar or array argument using assumed rank"
                 },
+                "name": "SumValues",
                 "options": {
                     "F_assumed_rank_max": 2
                 },
@@ -1641,6 +1652,7 @@
                 "doxygen": {
                     "brief": "scalar or array argument using assumed rank"
                 },
+                "name": "SumValues",
                 "options": {
                     "F_assumed_rank_max": 2
                 },
@@ -1848,6 +1860,7 @@
                 "doxygen": {
                     "brief": "scalar or array argument using assumed rank"
                 },
+                "name": "SumValues",
                 "options": {
                     "F_assumed_rank_max": 2
                 },
@@ -2312,6 +2325,7 @@
                         "generic": "(const int *from+rank(1), int *to+rank(1))"
                     }
                 ],
+                "name": "AssignValues",
                 "options": {},
                 "wrap": {
                     "c": true
@@ -2546,6 +2560,7 @@
                 "doxygen": {
                     "description": "Broadcast if nfrom == 1\nCopy if nfrom == nto\n"
                 },
+                "name": "AssignValues",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2811,6 +2826,7 @@
                 "doxygen": {
                     "description": "Broadcast if nfrom == 1\nCopy if nfrom == nto\n"
                 },
+                "name": "AssignValues",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3083,6 +3099,7 @@
                 "doxygen": {
                     "description": "Broadcast if nfrom == 1\nCopy if nfrom == nto\n"
                 },
+                "name": "AssignValues",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3455,6 +3472,7 @@
                         "generic": "(float *addr+rank(2)+intent(in),  int type+implied(T_FLOAT))"
                     }
                 ],
+                "name": "SavePointer",
                 "options": {},
                 "wrap": {
                     "c": true
@@ -3643,6 +3661,7 @@
                 },
                 "decl": "void SavePointer(void *addr, int type, size_t size+implied(size(addr)))",
                 "declgen": "void SavePointer(float * addr +intent(in)+rank(1), int type +implied(T_FLOAT)+value, size_t size +implied(size(addr))+value)",
+                "name": "SavePointer",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3854,6 +3873,7 @@
                 },
                 "decl": "void SavePointer(void *addr, int type, size_t size+implied(size(addr)))",
                 "declgen": "void SavePointer(float * addr +intent(in)+rank(2), int type +implied(T_FLOAT)+value, size_t size +implied(size(addr))+value)",
+                "name": "SavePointer",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -4194,6 +4214,7 @@
                         ]
                     }
                 },
+                "name": "SavePointer2",
                 "options": {},
                 "wrap": {
                     "c": true
@@ -4392,6 +4413,7 @@
                         ]
                     }
                 },
+                "name": "SavePointer2",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -4613,6 +4635,7 @@
                         ]
                     }
                 },
+                "name": "SavePointer2",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -4827,6 +4850,7 @@
                 },
                 "decl": "void GetPointer(void **addr+intent(out), int *type+intent(out), size_t *size+intent(out))",
                 "declgen": "void GetPointer(void * * addr +intent(out), int * type +intent(out), size_t * size +intent(out))",
+                "name": "GetPointer",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -5200,6 +5224,7 @@
                         "generic": "(float **addr+intent(out)+rank(2)+deref(pointer))"
                     }
                 ],
+                "name": "GetPointerAsPointer",
                 "options": {},
                 "wrap": {
                     "c": true
@@ -5405,6 +5430,7 @@
                 },
                 "decl": "void GetPointerAsPointer( void **addr+intent(out), int *type+intent(out)+hidden, size_t *size+intent(out)+hidden)",
                 "declgen": "void GetPointerAsPointer(float * * addr +deref(pointer)+intent(out)+rank(1), int * type +hidden+intent(out), size_t * size +hidden+intent(out))",
+                "name": "GetPointerAsPointer",
                 "options": {},
                 "wrap": {
                     "fortran": true
@@ -5521,6 +5547,7 @@
                 },
                 "decl": "void GetPointerAsPointer( void **addr+intent(out), int *type+intent(out)+hidden, size_t *size+intent(out)+hidden)",
                 "declgen": "void GetPointerAsPointer(float * * addr +deref(pointer)+intent(out)+rank(1), int * type +hidden+intent(out), size_t * size +hidden+intent(out))",
+                "name": "GetPointerAsPointer",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -5741,6 +5768,7 @@
                 },
                 "decl": "void GetPointerAsPointer( void **addr+intent(out), int *type+intent(out)+hidden, size_t *size+intent(out)+hidden)",
                 "declgen": "void GetPointerAsPointer(float * * addr +deref(pointer)+intent(out)+rank(2), int * type +hidden+intent(out), size_t * size +hidden+intent(out))",
+                "name": "GetPointerAsPointer",
                 "options": {},
                 "wrap": {
                     "fortran": true
@@ -5857,6 +5885,7 @@
                 },
                 "decl": "void GetPointerAsPointer( void **addr+intent(out), int *type+intent(out)+hidden, size_t *size+intent(out)+hidden)",
                 "declgen": "void GetPointerAsPointer(float * * addr +deref(pointer)+intent(out)+rank(2), int * type +hidden+intent(out), size_t * size +hidden+intent(out))",
+                "name": "GetPointerAsPointer",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -6002,6 +6031,7 @@
                 },
                 "decl": "StructAsClass *CreateStructAsClass(void)",
                 "declgen": "StructAsClass * CreateStructAsClass(void)",
+                "name": "CreateStructAsClass",
                 "options": {
                     "class_ctor": "StructAsClass"
                 },
@@ -6201,6 +6231,7 @@
                         "generic": "(long inew)"
                     }
                 ],
+                "name": "UpdateStructAsClass",
                 "options": {},
                 "wrap": {
                     "c": true
@@ -6367,6 +6398,7 @@
                 },
                 "decl": "long UpdateStructAsClass(StructAsClass *arg, long inew)",
                 "declgen": "long UpdateStructAsClass(StructAsClass * arg, int inew +value)",
+                "name": "UpdateStructAsClass",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -6557,6 +6589,7 @@
                 },
                 "decl": "long UpdateStructAsClass(StructAsClass *arg, long inew)",
                 "declgen": "long UpdateStructAsClass(StructAsClass * arg, long inew +value)",
+                "name": "UpdateStructAsClass",
                 "options": {},
                 "wrap": {
                     "c": true,

--- a/regression/reference/include/include.json
+++ b/regression/reference/include/include.json
@@ -47,6 +47,7 @@
                         },
                         "decl": "void method1(MPI_Comm comm)",
                         "declgen": "void method1(MPI_Comm comm +value)",
+                        "name": "method1",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -154,6 +155,7 @@
                         },
                         "decl": "void method2(three::Class1 * c2)",
                         "declgen": "void method2(three::Class1 * c2)",
+                        "name": "method2",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -292,6 +294,7 @@
                                 },
                                 "decl": "void function1()",
                                 "declgen": "void function1(void)",
+                                "name": "function1",
                                 "options": {},
                                 "wrap": {
                                     "c": true,
@@ -419,6 +422,7 @@
                                 },
                                 "decl": "void method1(CustomType arg1)",
                                 "declgen": "void method1(CustomType arg1 +value)",
+                                "name": "method1",
                                 "options": {},
                                 "wrap": {
                                     "c": true,
@@ -570,6 +574,7 @@
                                 },
                                 "decl": "void method()",
                                 "declgen": "void method(void)",
+                                "name": "method",
                                 "options": {},
                                 "wrap": {
                                     "c": true,
@@ -651,6 +656,7 @@
                         },
                         "decl": "void outer_func()",
                         "declgen": "void outer_func(void)",
+                        "name": "outer_func",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -734,6 +740,7 @@
                                 },
                                 "decl": "void method()",
                                 "declgen": "void method(void)",
+                                "name": "method",
                                 "options": {},
                                 "wrap": {
                                     "c": true,
@@ -815,6 +822,7 @@
                         },
                         "decl": "void outer_func()",
                         "declgen": "void outer_func(void)",
+                        "name": "outer_func",
                         "options": {},
                         "wrap": {
                             "c": true,

--- a/regression/reference/include/include.json
+++ b/regression/reference/include/include.json
@@ -16,28 +16,30 @@
                         "<FUNCTION>": "0 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "method1"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "method1",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "in"
+                                            },
+                                            "name": "comm",
+                                            "typemap_name": "MPI_Comm"
+                                        },
+                                        "specifier": [
+                                            "MPI_Comm"
+                                        ],
+                                        "typemap_name": "MPI_Comm"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "comm"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in"
-                                    },
-                                    "specifier": [
-                                        "MPI_Comm"
-                                    ],
-                                    "typemap_name": "MPI_Comm"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],
@@ -119,30 +121,32 @@
                         "<FUNCTION>": "1 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "method2"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "method2",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "metaattrs": {
+                                                "intent": "inout"
+                                            },
+                                            "name": "c2",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "three::Class1"
+                                        },
+                                        "specifier": [
+                                            "three::Class1"
+                                        ],
+                                        "typemap_name": "three::Class1"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [
-                                {
-                                    "declarator": {
-                                        "name": "c2",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "inout"
-                                    },
-                                    "specifier": [
-                                        "three::Class1"
-                                    ],
-                                    "typemap_name": "three::Class1"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],
@@ -274,12 +278,13 @@
                                 "<FUNCTION>": "5 ****************************************",
                                 "ast": {
                                     "declarator": {
-                                        "name": "function1"
+                                        "metaattrs": {
+                                            "intent": "subroutine"
+                                        },
+                                        "name": "function1",
+                                        "params": [],
+                                        "typemap_name": "void"
                                     },
-                                    "metaattrs": {
-                                        "intent": "subroutine"
-                                    },
-                                    "params": [],
                                     "specifier": [
                                         "void"
                                     ],
@@ -383,28 +388,30 @@
                                 "<FUNCTION>": "2 ****************************************",
                                 "ast": {
                                     "declarator": {
-                                        "name": "method1"
+                                        "metaattrs": {
+                                            "intent": "subroutine"
+                                        },
+                                        "name": "method1",
+                                        "params": [
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "value": true
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "arg1",
+                                                    "typemap_name": "CustomType"
+                                                },
+                                                "specifier": [
+                                                    "CustomType"
+                                                ],
+                                                "typemap_name": "CustomType"
+                                            }
+                                        ],
+                                        "typemap_name": "void"
                                     },
-                                    "metaattrs": {
-                                        "intent": "subroutine"
-                                    },
-                                    "params": [
-                                        {
-                                            "attrs": {
-                                                "value": true
-                                            },
-                                            "declarator": {
-                                                "name": "arg1"
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "CustomType"
-                                            ],
-                                            "typemap_name": "CustomType"
-                                        }
-                                    ],
                                     "specifier": [
                                         "void"
                                     ],
@@ -549,12 +556,13 @@
                                 "<FUNCTION>": "3 ****************************************",
                                 "ast": {
                                     "declarator": {
-                                        "name": "method"
+                                        "metaattrs": {
+                                            "intent": "subroutine"
+                                        },
+                                        "name": "method",
+                                        "params": [],
+                                        "typemap_name": "void"
                                     },
-                                    "metaattrs": {
-                                        "intent": "subroutine"
-                                    },
-                                    "params": [],
                                     "specifier": [
                                         "void"
                                     ],
@@ -629,12 +637,13 @@
                         "<FUNCTION>": "6 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "outer_func"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "outer_func",
+                                "params": [],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [],
                             "specifier": [
                                 "void"
                             ],
@@ -711,12 +720,13 @@
                                 "<FUNCTION>": "4 ****************************************",
                                 "ast": {
                                     "declarator": {
-                                        "name": "method"
+                                        "metaattrs": {
+                                            "intent": "subroutine"
+                                        },
+                                        "name": "method",
+                                        "params": [],
+                                        "typemap_name": "void"
                                     },
-                                    "metaattrs": {
-                                        "intent": "subroutine"
-                                    },
-                                    "params": [],
                                     "specifier": [
                                         "void"
                                     ],
@@ -791,12 +801,13 @@
                         "<FUNCTION>": "7 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "outer_func"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "outer_func",
+                                "params": [],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [],
                             "specifier": [
                                 "void"
                             ],
@@ -868,7 +879,8 @@
                 "<TYPEDEF>": "****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "CustomType"
+                        "name": "CustomType",
+                        "typemap_name": "int"
                     },
                     "specifier": [
                         "int"

--- a/regression/reference/interface/interface.json
+++ b/regression/reference/interface/interface.json
@@ -17,12 +17,13 @@
                 "<FUNCTION>": "0 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "Function1"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "Function1",
+                        "params": [],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [],
                     "specifier": [
                         "void"
                     ],
@@ -61,43 +62,46 @@
                 "<FUNCTION>": "1 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "Function2"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "Function2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "double"
+                    },
                     "specifier": [
                         "double"
                     ],

--- a/regression/reference/interface/interface.json
+++ b/regression/reference/interface/interface.json
@@ -31,6 +31,7 @@
                 },
                 "decl": "void Function1()",
                 "declgen": "void Function1(void)",
+                "name": "Function1",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -109,6 +110,7 @@
                 },
                 "decl": "double Function2(double arg1, int arg2)",
                 "declgen": "double Function2(double arg1 +value, int arg2 +value)",
+                "name": "Function2",
                 "options": {},
                 "wrap": {
                     "c": true,

--- a/regression/reference/memdoc/memdoc.json
+++ b/regression/reference/memdoc/memdoc.json
@@ -42,6 +42,7 @@
                 },
                 "decl": "const std::string * getConstStringPtrAlloc() +owner(library)",
                 "declgen": "const std::string * getConstStringPtrAlloc(void) +owner(library)",
+                "name": "getConstStringPtrAlloc",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -134,6 +135,7 @@
                 },
                 "decl": "const std::string * getConstStringPtrAlloc() +owner(library)",
                 "declgen": "const std::string * getConstStringPtrAlloc(void) +owner(library)",
+                "name": "getConstStringPtrAlloc",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {

--- a/regression/reference/memdoc/memdoc.json
+++ b/regression/reference/memdoc/memdoc.json
@@ -17,23 +17,24 @@
                 ],
                 "_PTR_F_C_index": "1",
                 "ast": {
-                    "attrs": {
-                        "owner": "library"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "owner": "library"
+                        },
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
                         "name": "getConstStringPtrAlloc",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -107,24 +108,25 @@
                 "<FUNCTION>": "1 ****************************************",
                 "_generated": "arg_to_buffer",
                 "ast": {
-                    "attrs": {
-                        "owner": "library"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "owner": "library"
+                        },
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
                         "name": "getConstStringPtrAlloc",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],

--- a/regression/reference/names/names.json
+++ b/regression/reference/names/names.json
@@ -3192,6 +3192,7 @@
                                         "params": [],
                                         "typemap_name": "ns0::Names"
                                     },
+                                    "is_ctor": true,
                                     "specifier": [
                                         "Names"
                                     ],

--- a/regression/reference/names/names.json
+++ b/regression/reference/names/names.json
@@ -1845,9 +1845,10 @@
                                     "name": "arg1"
                                 },
                                 "specifier": [
-                                    "T"
+                                    "int"
                                 ],
-                                "template_argument": "T"
+                                "template_argument": "T",
+                                "typemap_name": "int"
                             },
                             {
                                 "declarator": {
@@ -1860,9 +1861,10 @@
                                     "name": "arg2"
                                 },
                                 "specifier": [
-                                    "U"
+                                    "long"
                                 ],
-                                "template_argument": "U"
+                                "template_argument": "U",
+                                "typemap_name": "long"
                             }
                         ],
                         "typemap_name": "void"
@@ -2091,9 +2093,10 @@
                                     "name": "arg1"
                                 },
                                 "specifier": [
-                                    "T"
+                                    "float"
                                 ],
-                                "template_argument": "T"
+                                "template_argument": "T",
+                                "typemap_name": "float"
                             },
                             {
                                 "declarator": {
@@ -2106,9 +2109,10 @@
                                     "name": "arg2"
                                 },
                                 "specifier": [
-                                    "U"
+                                    "double"
                                 ],
-                                "template_argument": "U"
+                                "template_argument": "U",
+                                "typemap_name": "double"
                             }
                         ],
                         "typemap_name": "void"

--- a/regression/reference/names/names.json
+++ b/regression/reference/names/names.json
@@ -2764,6 +2764,7 @@
                                     "metaattrs": {
                                         "intent": "in"
                                     },
+                                    "name": "alloc",
                                     "params": [
                                         {
                                             "declarator": {
@@ -2832,6 +2833,7 @@
                                     "metaattrs": {
                                         "intent": "in"
                                     },
+                                    "name": "afree",
                                     "params": [
                                         {
                                             "declarator": {
@@ -2879,6 +2881,7 @@
                                     "metaattrs": {
                                         "intent": "in"
                                     },
+                                    "name": "assoc",
                                     "params": [
                                         {
                                             "declarator": {

--- a/regression/reference/names/names.json
+++ b/regression/reference/names/names.json
@@ -3120,6 +3120,7 @@
                                         "_name": "ctor",
                                         "name": "defaultctor"
                                     },
+                                    "declarator": {},
                                     "metaattrs": {
                                         "api": "capptr",
                                         "intent": "ctor"

--- a/regression/reference/names/names.json
+++ b/regression/reference/names/names.json
@@ -437,6 +437,7 @@
                 },
                 "decl": "void getName(char *name +len(worklen) +len_trim(worktrim))",
                 "declgen": "void getName(char * name +len(worklen)+len_trim(worktrim))",
+                "name": "getName",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -562,6 +563,7 @@
                 },
                 "decl": "void getName(char *name +len(worklen) +len_trim(worktrim))",
                 "declgen": "void getName(char * name +len(worklen)+len_trim(worktrim))",
+                "name": "getName",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -638,6 +640,7 @@
                 },
                 "decl": "void function1()",
                 "declgen": "void function1(void)",
+                "name": "function1",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -685,6 +688,7 @@
                 },
                 "decl": "void function2()",
                 "declgen": "void function2(void)",
+                "name": "function2",
                 "options": {},
                 "user_fmt": {
                     "C_name": "c_name_special",
@@ -755,6 +759,7 @@
                 },
                 "decl": "void function3a(int i)",
                 "declgen": "void function3a(int i +value)",
+                "name": "function3a",
                 "options": {},
                 "user_fmt": {
                     "F_name_generic": "generic3",
@@ -881,6 +886,7 @@
                 },
                 "decl": "void function3a(long i)",
                 "declgen": "void function3a(long i +value)",
+                "name": "function3a",
                 "options": {},
                 "user_fmt": {
                     "F_name_generic": "generic3",
@@ -1013,6 +1019,7 @@
                 },
                 "decl": "int function4(const std::string &rv)",
                 "declgen": "int function4(const std::string & rv)",
+                "name": "function4",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -1183,6 +1190,7 @@
                 },
                 "decl": "int function4(const std::string &rv)",
                 "declgen": "int function4(const std::string & rv)",
+                "name": "function4",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -1289,6 +1297,7 @@
                 },
                 "decl": "void function5() +name(fiveplus)",
                 "declgen": "void function5(void) +name(fiveplus)",
+                "name": "fiveplus",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -1383,6 +1392,7 @@
                 "doxygen": {
                     "description": "Use std::string argument to get bufferified function.\n"
                 },
+                "name": "TestMultilineSplicer",
                 "options": {},
                 "splicer": {
                     "c": [
@@ -1595,6 +1605,7 @@
                 "doxygen": {
                     "description": "Use std::string argument to get bufferified function.\n"
                 },
+                "name": "TestMultilineSplicer",
                 "options": {},
                 "splicer": {
                     "c": [
@@ -1764,6 +1775,7 @@
                     "brief": "Function template with two template parameters."
                 },
                 "have_template_args": true,
+                "name": "FunctionTU",
                 "options": {},
                 "template_arguments": [
                     {
@@ -1880,6 +1892,7 @@
                     "brief": "Function template with two template parameters."
                 },
                 "have_template_args": true,
+                "name": "FunctionTU",
                 "options": {},
                 "template_arguments": [
                     {
@@ -2134,6 +2147,7 @@
                     "double"
                 ],
                 "have_template_args": true,
+                "name": "FunctionTU",
                 "options": {},
                 "template_arguments": [
                     {
@@ -2349,6 +2363,7 @@
                 "doxygen": {
                     "brief": "Function which uses a templated T in the implemetation."
                 },
+                "name": "UseImplWorker",
                 "options": {},
                 "template_arguments": [
                     {
@@ -2401,6 +2416,7 @@
                 "gen_headers_typedef": [
                     "internal::ImplWorker1"
                 ],
+                "name": "UseImplWorker",
                 "options": {},
                 "template_arguments": [
                     {
@@ -2537,6 +2553,7 @@
                 },
                 "decl": "int Cstruct_as_class_sum(const Cstruct_as_class *point +pass)",
                 "declgen": "int Cstruct_as_class_sum(const Cstruct_as_class * point +pass)",
+                "name": "Cstruct_as_class_sum",
                 "options": {
                     "class_method": "Cstruct_as_class"
                 },
@@ -2943,6 +2960,7 @@
                 },
                 "decl": "void external_funcs(const char *rdbase, const char *pkg, const char *name, void (*alloc)(double *arr+intent(inout), int *err+intent(out)), void (*afree)(double *arr+intent(inout)), void (*assoc)(double *arr+intent(in), int *err+intent(out)))",
                 "declgen": "void external_funcs(const char * rdbase, const char * pkg, const char * name, void ( * alloc)(double * arr +intent(inout), int * err +intent(out)) +value, void ( * afree)(double * arr +intent(inout)) +value, void ( * assoc)(double * arr +intent(in), int * err +intent(out)) +value)",
+                "name": "external_funcs",
                 "options": {
                     "wrap_python": false
                 },
@@ -3181,6 +3199,7 @@
                                 },
                                 "decl": "Names()         +name(defaultctor)",
                                 "declgen": "Names(void) +name(defaultctor)",
+                                "name": "defaultctor",
                                 "options": {
                                     "F_create_generic": true
                                 },
@@ -3287,6 +3306,7 @@
                                 },
                                 "decl": "void method1()",
                                 "declgen": "void method1(void)",
+                                "name": "method1",
                                 "options": {},
                                 "user_fmt": {
                                     "F_name_function": "type_method1"
@@ -3342,6 +3362,7 @@
                                 },
                                 "decl": "void method2()",
                                 "declgen": "void method2(void)",
+                                "name": "method2",
                                 "options": {},
                                 "user_fmt": {
                                     "CXX_this": "SH_this2",
@@ -3524,6 +3545,7 @@
                         },
                         "decl": "void init_ns1()",
                         "declgen": "void init_ns1(void)",
+                        "name": "init_ns1",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -4107,6 +4129,7 @@
                                 },
                                 "decl": "void Member1()",
                                 "declgen": "void Member1(void)",
+                                "name": "Member1",
                                 "options": {},
                                 "wrap": {
                                     "c": true,
@@ -4188,6 +4211,7 @@
                         },
                         "decl": "void Worker1()",
                         "declgen": "void Worker1(void)",
+                        "name": "Worker1",
                         "options": {},
                         "wrap": {
                             "c": true,

--- a/regression/reference/names/names.json
+++ b/regression/reference/names/names.json
@@ -400,34 +400,36 @@
                 "_PTR_F_C_index": "19",
                 "ast": {
                     "declarator": {
-                        "name": "getName"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getName",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "len": "worklen",
+                                        "len_trim": "worktrim"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "len": "worklen",
-                                "len_trim": "worktrim"
-                            },
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -522,35 +524,37 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "getName"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getName",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "len": "worklen",
+                                        "len_trim": "worktrim"
+                                    },
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "inout"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "len": "worklen",
-                                "len_trim": "worktrim"
-                            },
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -620,12 +624,13 @@
                 "<FUNCTION>": "5 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "function1"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "function1",
+                        "params": [],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [],
                     "specifier": [
                         "void"
                     ],
@@ -666,12 +671,13 @@
                 "<FUNCTION>": "6 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "function2"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "function2",
+                        "params": [],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [],
                     "specifier": [
                         "void"
                     ],
@@ -718,28 +724,30 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "function3a"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "function3a",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -842,28 +850,30 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "function3a"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "function3a",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "long"
+                                },
+                                "specifier": [
+                                    "long"
+                                ],
+                                "typemap_name": "long"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "long"
-                            ],
-                            "typemap_name": "long"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -969,31 +979,33 @@
                 "_PTR_F_C_index": "20",
                 "ast": {
                     "declarator": {
-                        "name": "function4"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "function4",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "rv",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "rv",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -1136,32 +1148,34 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "function4"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "function4",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "in"
+                                    },
+                                    "name": "rv",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "rv",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -1257,16 +1271,17 @@
             {
                 "<FUNCTION>": "10 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "name": "fiveplus"
-                    },
                     "declarator": {
-                        "name": "function5"
+                        "attrs": {
+                            "name": "fiveplus"
+                        },
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "function5",
+                        "params": [],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [],
                     "specifier": [
                         "void"
                     ],
@@ -1311,50 +1326,53 @@
                 "_PTR_F_C_index": "21",
                 "ast": {
                     "declarator": {
-                        "name": "TestMultilineSplicer"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                        "name": "TestMultilineSplicer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "value",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "value",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1519,51 +1537,54 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "TestMultilineSplicer"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                        "name": "TestMultilineSplicer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "inout"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "value",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "value",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1688,43 +1709,44 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "FunctionTU"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "T"
-                            ],
-                            "template_argument": "T"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "FunctionTU",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1"
+                                },
+                                "specifier": [
+                                    "T"
+                                ],
+                                "template_argument": "T"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "U"
-                            ],
-                            "template_argument": "U"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2"
+                                },
+                                "specifier": [
+                                    "U"
+                                ],
+                                "template_argument": "U"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1807,45 +1829,44 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "FunctionTU"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "template_argument": "T",
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "FunctionTU",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1"
+                                },
+                                "specifier": [
+                                    "T"
+                                ],
+                                "template_argument": "T"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "long"
-                            ],
-                            "template_argument": "U",
-                            "typemap_name": "long"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2"
+                                },
+                                "specifier": [
+                                    "U"
+                                ],
+                                "template_argument": "U"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2054,45 +2075,44 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "FunctionTU"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "float"
-                            ],
-                            "template_argument": "T",
-                            "typemap_name": "float"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "FunctionTU",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1"
+                                },
+                                "specifier": [
+                                    "T"
+                                ],
+                                "template_argument": "T"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "template_argument": "U",
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2"
+                                },
+                                "specifier": [
+                                    "U"
+                                ],
+                                "template_argument": "U"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2303,12 +2323,13 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UseImplWorker"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "UseImplWorker",
+                        "params": [],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -2356,12 +2377,13 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UseImplWorker"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "UseImplWorker",
+                        "params": [],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -2474,34 +2496,36 @@
                 "<FUNCTION>": "14 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "Cstruct_as_class_sum"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "Cstruct_as_class_sum",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "pass": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "point",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct_as_class"
+                                },
+                                "specifier": [
+                                    "Cstruct_as_class"
+                                ],
+                                "typemap_name": "Cstruct_as_class"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "pass": true
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "point",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct_as_class"
-                            ],
-                            "typemap_name": "Cstruct_as_class"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -2654,242 +2678,257 @@
                 "<FUNCTION>": "15 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "external_funcs"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "rdbase",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "ftrim_char_in": true,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "pkg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "ftrim_char_in": true,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        },
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "ftrim_char_in": true,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "func": {
-                                    "name": "alloc",
-                                    "pointer": [
-                                        {
-                                            "ptr": "*"
-                                        }
-                                    ]
-                                }
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "intent": "inout"
-                                    },
-                                    "declarator": {
-                                        "name": "arr",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
+                        "name": "external_funcs",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
                                     "metaattrs": {
-                                        "intent": "inout"
-                                    },
-                                    "specifier": [
-                                        "double"
-                                    ],
-                                    "typemap_name": "double"
-                                },
-                                {
-                                    "attrs": {
-                                        "intent": "out"
-                                    },
-                                    "declarator": {
-                                        "name": "err",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "out"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "func": {
-                                    "name": "afree",
-                                    "pointer": [
-                                        {
-                                            "ptr": "*"
-                                        }
-                                    ]
-                                }
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "intent": "inout"
-                                    },
-                                    "declarator": {
-                                        "name": "arr",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "inout"
-                                    },
-                                    "specifier": [
-                                        "double"
-                                    ],
-                                    "typemap_name": "double"
-                                }
-                            ],
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "func": {
-                                    "name": "assoc",
-                                    "pointer": [
-                                        {
-                                            "ptr": "*"
-                                        }
-                                    ]
-                                }
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
                                         "intent": "in"
                                     },
-                                    "declarator": {
-                                        "name": "arr",
+                                    "name": "rdbase",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "ftrim_char_in": true,
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            },
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "pkg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "ftrim_char_in": true,
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            },
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "ftrim_char_in": true,
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "func": {
+                                        "name": "alloc",
                                         "pointer": [
                                             {
                                                 "ptr": "*"
                                             }
-                                        ]
+                                        ],
+                                        "typemap_name": "void"
                                     },
                                     "metaattrs": {
                                         "intent": "in"
                                     },
-                                    "specifier": [
-                                        "double"
+                                    "params": [
+                                        {
+                                            "declarator": {
+                                                "attrs": {
+                                                    "intent": "inout"
+                                                },
+                                                "metaattrs": {
+                                                    "intent": "inout"
+                                                },
+                                                "name": "arr",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "double"
+                                            },
+                                            "specifier": [
+                                                "double"
+                                            ],
+                                            "typemap_name": "double"
+                                        },
+                                        {
+                                            "declarator": {
+                                                "attrs": {
+                                                    "intent": "out"
+                                                },
+                                                "metaattrs": {
+                                                    "intent": "out"
+                                                },
+                                                "name": "err",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            "specifier": [
+                                                "int"
+                                            ],
+                                            "typemap_name": "int"
+                                        }
                                     ],
-                                    "typemap_name": "double"
+                                    "typemap_name": "void"
                                 },
-                                {
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            },
+                            {
+                                "declarator": {
                                     "attrs": {
-                                        "intent": "out"
+                                        "value": true
                                     },
-                                    "declarator": {
-                                        "name": "err",
+                                    "func": {
+                                        "name": "afree",
                                         "pointer": [
                                             {
                                                 "ptr": "*"
                                             }
-                                        ]
+                                        ],
+                                        "typemap_name": "void"
                                     },
                                     "metaattrs": {
-                                        "intent": "out"
+                                        "intent": "in"
                                     },
-                                    "specifier": [
-                                        "int"
+                                    "params": [
+                                        {
+                                            "declarator": {
+                                                "attrs": {
+                                                    "intent": "inout"
+                                                },
+                                                "metaattrs": {
+                                                    "intent": "inout"
+                                                },
+                                                "name": "arr",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "double"
+                                            },
+                                            "specifier": [
+                                                "double"
+                                            ],
+                                            "typemap_name": "double"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "func": {
+                                        "name": "assoc",
+                                        "pointer": [
+                                            {
+                                                "ptr": "*"
+                                            }
+                                        ],
+                                        "typemap_name": "void"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "params": [
+                                        {
+                                            "declarator": {
+                                                "attrs": {
+                                                    "intent": "in"
+                                                },
+                                                "metaattrs": {
+                                                    "intent": "in"
+                                                },
+                                                "name": "arr",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "double"
+                                            },
+                                            "specifier": [
+                                                "double"
+                                            ],
+                                            "typemap_name": "double"
+                                        },
+                                        {
+                                            "declarator": {
+                                                "attrs": {
+                                                    "intent": "out"
+                                                },
+                                                "metaattrs": {
+                                                    "intent": "out"
+                                                },
+                                                "name": "err",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            "specifier": [
+                                                "int"
+                                            ],
+                                            "typemap_name": "int"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3115,17 +3154,19 @@
                                 "<FUNCTION>": "0 ****************************************",
                                 "_overloaded": true,
                                 "ast": {
-                                    "attrs": {
-                                        "_constructor": true,
-                                        "_name": "ctor",
-                                        "name": "defaultctor"
+                                    "declarator": {
+                                        "attrs": {
+                                            "_constructor": true,
+                                            "_name": "ctor",
+                                            "name": "defaultctor"
+                                        },
+                                        "metaattrs": {
+                                            "api": "capptr",
+                                            "intent": "ctor"
+                                        },
+                                        "params": [],
+                                        "typemap_name": "ns0::Names"
                                     },
-                                    "declarator": {},
-                                    "metaattrs": {
-                                        "api": "capptr",
-                                        "intent": "ctor"
-                                    },
-                                    "params": [],
                                     "specifier": [
                                         "Names"
                                     ],
@@ -3225,12 +3266,13 @@
                                 "<FUNCTION>": "1 ****************************************",
                                 "ast": {
                                     "declarator": {
-                                        "name": "method1"
+                                        "metaattrs": {
+                                            "intent": "subroutine"
+                                        },
+                                        "name": "method1",
+                                        "params": [],
+                                        "typemap_name": "void"
                                     },
-                                    "metaattrs": {
-                                        "intent": "subroutine"
-                                    },
-                                    "params": [],
                                     "specifier": [
                                         "void"
                                     ],
@@ -3279,12 +3321,13 @@
                                 "<FUNCTION>": "2 ****************************************",
                                 "ast": {
                                     "declarator": {
-                                        "name": "method2"
+                                        "metaattrs": {
+                                            "intent": "subroutine"
+                                        },
+                                        "name": "method2",
+                                        "params": [],
+                                        "typemap_name": "void"
                                     },
-                                    "metaattrs": {
-                                        "intent": "subroutine"
-                                    },
-                                    "params": [],
                                     "specifier": [
                                         "void"
                                     ],
@@ -3460,12 +3503,13 @@
                         "<FUNCTION>": "22 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "init_ns1"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "init_ns1",
+                                "params": [],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [],
                             "specifier": [
                                 "void"
                             ],
@@ -4042,12 +4086,13 @@
                                 "<FUNCTION>": "3 ****************************************",
                                 "ast": {
                                     "declarator": {
-                                        "name": "Member1"
+                                        "metaattrs": {
+                                            "intent": "subroutine"
+                                        },
+                                        "name": "Member1",
+                                        "params": [],
+                                        "typemap_name": "void"
                                     },
-                                    "metaattrs": {
-                                        "intent": "subroutine"
-                                    },
-                                    "params": [],
                                     "specifier": [
                                         "void"
                                     ],
@@ -4122,12 +4167,13 @@
                         "<FUNCTION>": "23 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "Worker1"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "Worker1",
+                                "params": [],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [],
                             "specifier": [
                                 "void"
                             ],

--- a/regression/reference/names2/names2.json
+++ b/regression/reference/names2/names2.json
@@ -14,12 +14,13 @@
                 "<FUNCTION>": "0 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "AFunction"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "AFunction",
+                        "params": [],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [],
                     "specifier": [
                         "void"
                     ],

--- a/regression/reference/names2/names2.json
+++ b/regression/reference/names2/names2.json
@@ -28,6 +28,7 @@
                 },
                 "decl": "void AFunction()",
                 "declgen": "void AFunction(void)",
+                "name": "AFunction",
                 "options": {},
                 "wrap": {
                     "c": true,

--- a/regression/reference/namespace/namespace.json
+++ b/regression/reference/namespace/namespace.json
@@ -46,6 +46,7 @@
                 },
                 "decl": "const std::string& LastFunctionCalled()",
                 "declgen": "const std::string & LastFunctionCalled(void)",
+                "name": "LastFunctionCalled",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -156,6 +157,7 @@
                 },
                 "decl": "const std::string& LastFunctionCalled()",
                 "declgen": "const std::string & LastFunctionCalled(void)",
+                "name": "LastFunctionCalled",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -222,6 +224,7 @@
                 },
                 "decl": "void One()",
                 "declgen": "void One(void)",
+                "name": "One",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -393,6 +396,7 @@
                                 },
                                 "decl": "Cstruct1_ctor",
                                 "declgen": "Cstruct1(int ifield, double dfield) +name(Cstruct1_ctor)",
+                                "name": "Cstruct1_ctor",
                                 "options": {
                                     "wrap_c": false,
                                     "wrap_fortran": false,
@@ -604,6 +608,7 @@
                         },
                         "decl": "void One()",
                         "declgen": "void One(void)",
+                        "name": "One",
                         "options": {},
                         "wrap": {
                             "c": true,

--- a/regression/reference/namespace/namespace.json
+++ b/regression/reference/namespace/namespace.json
@@ -389,6 +389,7 @@
                                         ],
                                         "typemap_name": "outer::Cstruct1"
                                     },
+                                    "is_ctor": true,
                                     "specifier": [
                                         "Cstruct1"
                                     ],

--- a/regression/reference/namespace/namespace.json
+++ b/regression/reference/namespace/namespace.json
@@ -347,6 +347,13 @@
                                 "_generated": "struct_as_class_ctor",
                                 "ast": {
                                     "declarator": {
+                                        "attrs": {
+                                            "_constructor": true,
+                                            "name": "Cstruct1_ctor"
+                                        },
+                                        "metaattrs": {
+                                            "intent": "ctor"
+                                        },
                                         "typemap_name": "outer::Cstruct1"
                                     },
                                     "specifier": [

--- a/regression/reference/namespace/namespace.json
+++ b/regression/reference/namespace/namespace.json
@@ -354,6 +354,36 @@
                                         "metaattrs": {
                                             "intent": "ctor"
                                         },
+                                        "params": [
+                                            {
+                                                "declarator": {
+                                                    "metaattrs": {
+                                                        "intent": "in",
+                                                        "struct_member": "ifield"
+                                                    },
+                                                    "name": "ifield",
+                                                    "typemap_name": "int"
+                                                },
+                                                "specifier": [
+                                                    "int"
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            {
+                                                "declarator": {
+                                                    "metaattrs": {
+                                                        "intent": "in",
+                                                        "struct_member": "dfield"
+                                                    },
+                                                    "name": "dfield",
+                                                    "typemap_name": "double"
+                                                },
+                                                "specifier": [
+                                                    "double"
+                                                ],
+                                                "typemap_name": "double"
+                                            }
+                                        ],
                                         "typemap_name": "outer::Cstruct1"
                                     },
                                     "specifier": [

--- a/regression/reference/namespace/namespace.json
+++ b/regression/reference/namespace/namespace.json
@@ -26,18 +26,19 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
                         "name": "LastFunctionCalled",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -134,19 +135,20 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
                         "name": "LastFunctionCalled",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -206,12 +208,13 @@
                 "<FUNCTION>": "2 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "One"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "One",
+                        "params": [],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [],
                     "specifier": [
                         "void"
                     ],
@@ -343,42 +346,9 @@
                                 "<FUNCTION>": "0 ****************************************",
                                 "_generated": "struct_as_class_ctor",
                                 "ast": {
-                                    "attrs": {
-                                        "_constructor": true,
-                                        "name": "Cstruct1_ctor"
+                                    "declarator": {
+                                        "typemap_name": "outer::Cstruct1"
                                     },
-                                    "declarator": {},
-                                    "metaattrs": {
-                                        "intent": "ctor"
-                                    },
-                                    "params": [
-                                        {
-                                            "declarator": {
-                                                "name": "ifield"
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in",
-                                                "struct_member": "ifield"
-                                            },
-                                            "specifier": [
-                                                "int"
-                                            ],
-                                            "typemap_name": "int"
-                                        },
-                                        {
-                                            "declarator": {
-                                                "name": "dfield"
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in",
-                                                "struct_member": "dfield"
-                                            },
-                                            "specifier": [
-                                                "double"
-                                            ],
-                                            "typemap_name": "double"
-                                        }
-                                    ],
                                     "specifier": [
                                         "Cstruct1"
                                     ],
@@ -486,7 +456,8 @@
                                 "<VARIABLE>": "****************************************",
                                 "ast": {
                                     "declarator": {
-                                        "name": "ifield"
+                                        "name": "ifield",
+                                        "typemap_name": "int"
                                     },
                                     "specifier": [
                                         "int"
@@ -516,7 +487,8 @@
                                 "<VARIABLE>": "****************************************",
                                 "ast": {
                                     "declarator": {
-                                        "name": "dfield"
+                                        "name": "dfield",
+                                        "typemap_name": "double"
                                     },
                                     "specifier": [
                                         "double"
@@ -581,12 +553,13 @@
                         "<FUNCTION>": "4 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "One"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "One",
+                                "params": [],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [],
                             "specifier": [
                                 "void"
                             ],

--- a/regression/reference/namespace/namespace.json
+++ b/regression/reference/namespace/namespace.json
@@ -347,6 +347,7 @@
                                         "_constructor": true,
                                         "name": "Cstruct1_ctor"
                                     },
+                                    "declarator": {},
                                     "metaattrs": {
                                         "intent": "ctor"
                                     },

--- a/regression/reference/namespacedoc/namespacedoc.json
+++ b/regression/reference/namespacedoc/namespacedoc.json
@@ -14,12 +14,13 @@
                 "<FUNCTION>": "0 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "worker3"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "worker3",
+                        "params": [],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [],
                     "specifier": [
                         "void"
                     ],
@@ -60,12 +61,13 @@
                 "<FUNCTION>": "1 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "worker"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "worker",
+                        "params": [],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [],
                     "specifier": [
                         "void"
                     ],
@@ -112,12 +114,13 @@
                         "<FUNCTION>": "2 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "worker"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "worker",
+                                "params": [],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [],
                             "specifier": [
                                 "void"
                             ],
@@ -192,12 +195,13 @@
                         "<FUNCTION>": "3 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "worker"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "worker",
+                                "params": [],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [],
                             "specifier": [
                                 "void"
                             ],
@@ -272,12 +276,13 @@
                         "<FUNCTION>": "4 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "worker4"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "worker4",
+                                "params": [],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [],
                             "specifier": [
                                 "void"
                             ],

--- a/regression/reference/namespacedoc/namespacedoc.json
+++ b/regression/reference/namespacedoc/namespacedoc.json
@@ -28,6 +28,7 @@
                 },
                 "decl": "void worker3();",
                 "declgen": "void worker3(void)",
+                "name": "worker3",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -75,6 +76,7 @@
                 },
                 "decl": "void worker();",
                 "declgen": "void worker(void)",
+                "name": "worker",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -128,6 +130,7 @@
                         },
                         "decl": "void worker();",
                         "declgen": "void worker(void)",
+                        "name": "worker",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -209,6 +212,7 @@
                         },
                         "decl": "void worker();",
                         "declgen": "void worker(void)",
+                        "name": "worker",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -290,6 +294,7 @@
                         },
                         "decl": "void worker4();",
                         "declgen": "void worker4(void)",
+                        "name": "worker4",
                         "options": {},
                         "wrap": {
                             "c": true,

--- a/regression/reference/ownership/ownership.json
+++ b/regression/reference/ownership/ownership.json
@@ -30,6 +30,7 @@
                         },
                         "decl": "~Class1()",
                         "declgen": "~Class1(void)",
+                        "name": "dtor",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -95,6 +96,7 @@
                         },
                         "decl": "int get_flag()",
                         "declgen": "int get_flag(void)",
+                        "name": "get_flag",
                         "options": {},
                         "user_fmt": {
                             "field_name": "m_flag",
@@ -288,6 +290,7 @@
                 },
                 "decl": "int * ReturnIntPtrRaw()",
                 "declgen": "int * ReturnIntPtrRaw(void) +deref(raw)",
+                "name": "ReturnIntPtrRaw",
                 "options": {
                     "wrap_fortran": false,
                     "wrap_lua": false,
@@ -363,6 +366,7 @@
                 },
                 "decl": "int * ReturnIntPtrScalar()",
                 "declgen": "int * ReturnIntPtrScalar(void) +deref(scalar)",
+                "name": "ReturnIntPtrScalar",
                 "options": {
                     "wrap_lua": false
                 },
@@ -473,6 +477,7 @@
                 },
                 "decl": "int * ReturnIntPtrPointer()",
                 "declgen": "int * ReturnIntPtrPointer(void) +deref(pointer)",
+                "name": "ReturnIntPtrPointer",
                 "options": {
                     "wrap_lua": false
                 },
@@ -583,6 +588,7 @@
                 },
                 "decl": "int * ReturnIntPtrPointer()",
                 "declgen": "int * ReturnIntPtrPointer(void) +deref(pointer)",
+                "name": "ReturnIntPtrPointer",
                 "options": {
                     "wrap_lua": false
                 },
@@ -681,6 +687,7 @@
                 },
                 "decl": "int * ReturnIntPtrDimRaw(int *len+intent(out))",
                 "declgen": "int * ReturnIntPtrDimRaw(int * len +intent(out)) +deref(raw)",
+                "name": "ReturnIntPtrDimRaw",
                 "options": {
                     "wrap_fortran": false,
                     "wrap_lua": false,
@@ -821,6 +828,7 @@
                 },
                 "decl": "int * ReturnIntPtrDimPointer(int *len+intent(out)+hidden)",
                 "declgen": "int * ReturnIntPtrDimPointer(int * len +hidden+intent(out)) +deref(pointer)+dimension(len)",
+                "name": "ReturnIntPtrDimPointer",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false
@@ -1025,6 +1033,7 @@
                 },
                 "decl": "int * ReturnIntPtrDimPointer(int *len+intent(out)+hidden)",
                 "declgen": "int * ReturnIntPtrDimPointer(int * len +hidden+intent(out)) +deref(pointer)+dimension(len)",
+                "name": "ReturnIntPtrDimPointer",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false
@@ -1174,6 +1183,7 @@
                 },
                 "decl": "int * ReturnIntPtrDimAlloc(int *len+intent(out)+hidden)",
                 "declgen": "int * ReturnIntPtrDimAlloc(int * len +hidden+intent(out)) +deref(allocatable)+dimension(len)",
+                "name": "ReturnIntPtrDimAlloc",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false
@@ -1378,6 +1388,7 @@
                 },
                 "decl": "int * ReturnIntPtrDimAlloc(int *len+intent(out)+hidden)",
                 "declgen": "int * ReturnIntPtrDimAlloc(int * len +hidden+intent(out)) +deref(allocatable)+dimension(len)",
+                "name": "ReturnIntPtrDimAlloc",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false
@@ -1526,6 +1537,7 @@
                 },
                 "decl": "int * ReturnIntPtrDimDefault(int *len+intent(out)+hidden)",
                 "declgen": "int * ReturnIntPtrDimDefault(int * len +hidden+intent(out)) +dimension(len)",
+                "name": "ReturnIntPtrDimDefault",
                 "options": {
                     "wrap_lua": false
                 },
@@ -1728,6 +1740,7 @@
                 },
                 "decl": "int * ReturnIntPtrDimDefault(int *len+intent(out)+hidden)",
                 "declgen": "int * ReturnIntPtrDimDefault(int * len +hidden+intent(out)) +dimension(len)",
+                "name": "ReturnIntPtrDimDefault",
                 "options": {
                     "wrap_lua": false
                 },
@@ -1873,6 +1886,7 @@
                 },
                 "decl": "int * ReturnIntPtrDimRawNew(int *len+intent(out)+hidden)",
                 "declgen": "int * ReturnIntPtrDimRawNew(int * len +hidden+intent(out)) +dimension(len)+owner(caller)",
+                "name": "ReturnIntPtrDimRawNew",
                 "options": {
                     "wrap_fortran": false,
                     "wrap_lua": false,
@@ -2021,6 +2035,7 @@
                 },
                 "decl": "int * ReturnIntPtrDimPointerNew(int *len+intent(out)+hidden)",
                 "declgen": "int * ReturnIntPtrDimPointerNew(int * len +hidden+intent(out)) +deref(pointer)+dimension(len)+owner(caller)",
+                "name": "ReturnIntPtrDimPointerNew",
                 "options": {
                     "wrap_lua": false
                 },
@@ -2228,6 +2243,7 @@
                 },
                 "decl": "int * ReturnIntPtrDimPointerNew(int *len+intent(out)+hidden)",
                 "declgen": "int * ReturnIntPtrDimPointerNew(int * len +hidden+intent(out)) +deref(pointer)+dimension(len)+owner(caller)",
+                "name": "ReturnIntPtrDimPointerNew",
                 "options": {
                     "wrap_lua": false
                 },
@@ -2375,6 +2391,7 @@
                 },
                 "decl": "int * ReturnIntPtrDimAllocNew(int *len+intent(out)+hidden)",
                 "declgen": "int * ReturnIntPtrDimAllocNew(int * len +hidden+intent(out)) +deref(allocatable)+dimension(len)+owner(caller)",
+                "name": "ReturnIntPtrDimAllocNew",
                 "options": {
                     "wrap_fortran": false,
                     "wrap_lua": false
@@ -2564,6 +2581,7 @@
                 },
                 "decl": "int * ReturnIntPtrDimDefaultNew(int *len+intent(out)+hidden)",
                 "declgen": "int * ReturnIntPtrDimDefaultNew(int * len +hidden+intent(out)) +dimension(len)+owner(caller)",
+                "name": "ReturnIntPtrDimDefaultNew",
                 "options": {
                     "wrap_lua": false
                 },
@@ -2770,6 +2788,7 @@
                 },
                 "decl": "int * ReturnIntPtrDimDefaultNew(int *len+intent(out)+hidden)",
                 "declgen": "int * ReturnIntPtrDimDefaultNew(int * len +hidden+intent(out)) +dimension(len)+owner(caller)",
+                "name": "ReturnIntPtrDimDefaultNew",
                 "options": {
                     "wrap_lua": false
                 },
@@ -2927,6 +2946,7 @@
                 },
                 "decl": "void IntPtrDimRaw(int **array, int *len+intent(out))",
                 "declgen": "void IntPtrDimRaw(int * * array +deref(raw)+intent(out)+owner(library), int * len +intent(out))",
+                "name": "IntPtrDimRaw",
                 "options": {
                     "wrap_c": false,
                     "wrap_fortran": false,
@@ -3013,6 +3033,7 @@
                 },
                 "decl": "void IntPtrDimPointer(int **array, int *len+intent(out)+hidden)",
                 "declgen": "void IntPtrDimPointer(int * * array +deref(pointer)+dimension(len)+intent(out)+owner(library), int * len +hidden+intent(out))",
+                "name": "IntPtrDimPointer",
                 "options": {
                     "wrap_c": false,
                     "wrap_fortran": false,
@@ -3099,6 +3120,7 @@
                 },
                 "decl": "void IntPtrDimAlloc(int **array, int *len+intent(out)+hidden)",
                 "declgen": "void IntPtrDimAlloc(int * * array +deref(allocatable)+dimension(len)+intent(out)+owner(library), int * len +hidden+intent(out))",
+                "name": "IntPtrDimAlloc",
                 "options": {
                     "wrap_c": false,
                     "wrap_fortran": false,
@@ -3184,6 +3206,7 @@
                 },
                 "decl": "void IntPtrDimDefault(int **array, int *len+intent(out)+hidden)",
                 "declgen": "void IntPtrDimDefault(int * * array +dimension(len)+intent(out)+owner(library), int * len +hidden+intent(out))",
+                "name": "IntPtrDimDefault",
                 "options": {
                     "wrap_c": false,
                     "wrap_fortran": false,
@@ -3264,6 +3287,7 @@
                 },
                 "decl": "void IntPtrDimRawNew(int **array, int *len+intent(out)+hidden)",
                 "declgen": "void IntPtrDimRawNew(int * * array +deref(raw)+intent(out)+owner(caller), int * len +hidden+intent(out))",
+                "name": "IntPtrDimRawNew",
                 "options": {
                     "wrap_c": false,
                     "wrap_fortran": false,
@@ -3350,6 +3374,7 @@
                 },
                 "decl": "void IntPtrDimPointerNew(int **array, int *len+intent(out)+hidden)",
                 "declgen": "void IntPtrDimPointerNew(int * * array +deref(pointer)+dimension(len)+intent(out)+owner(caller), int * len +hidden+intent(out))",
+                "name": "IntPtrDimPointerNew",
                 "options": {
                     "wrap_c": false,
                     "wrap_fortran": false,
@@ -3436,6 +3461,7 @@
                 },
                 "decl": "void IntPtrDimAllocNew(int **array, int *len+intent(out)+hidden)",
                 "declgen": "void IntPtrDimAllocNew(int * * array +deref(allocatable)+dimension(len)+intent(out)+owner(caller), int * len +hidden+intent(out))",
+                "name": "IntPtrDimAllocNew",
                 "options": {
                     "wrap_c": false,
                     "wrap_fortran": false,
@@ -3521,6 +3547,7 @@
                 },
                 "decl": "void IntPtrDimDefaultNew(int **array, int *len+intent(out)+hidden)",
                 "declgen": "void IntPtrDimDefaultNew(int * * array +dimension(len)+intent(out)+owner(caller), int * len +hidden+intent(out))",
+                "name": "IntPtrDimDefaultNew",
                 "options": {
                     "wrap_c": false,
                     "wrap_fortran": false,
@@ -3568,6 +3595,7 @@
                 },
                 "decl": "void createClassStatic(int flag)",
                 "declgen": "void createClassStatic(int flag +value)",
+                "name": "createClassStatic",
                 "options": {
                     "wrap_lua": false
                 },
@@ -3682,6 +3710,7 @@
                 },
                 "decl": "Class1 * getClassStatic() +owner(library)",
                 "declgen": "Class1 * getClassStatic(void) +owner(library)",
+                "name": "getClassStatic",
                 "options": {
                     "wrap_lua": false
                 },
@@ -3815,6 +3844,7 @@
                 "doxygen": {
                     "brief": "Return pointer to new Class1 instance."
                 },
+                "name": "getClassNew",
                 "options": {
                     "wrap_lua": false
                 },

--- a/regression/reference/ownership/ownership.json
+++ b/regression/reference/ownership/ownership.json
@@ -23,6 +23,7 @@
                                 "params": [],
                                 "typemap_name": "void"
                             },
+                            "is_dtor": "Class1",
                             "specifier": [
                                 "void"
                             ],

--- a/regression/reference/ownership/ownership.json
+++ b/regression/reference/ownership/ownership.json
@@ -12,15 +12,17 @@
                     {
                         "<FUNCTION>": "0 ****************************************",
                         "ast": {
-                            "attrs": {
-                                "_destructor": "Class1",
-                                "_name": "dtor"
+                            "declarator": {
+                                "attrs": {
+                                    "_destructor": "Class1",
+                                    "_name": "dtor"
+                                },
+                                "metaattrs": {
+                                    "intent": "dtor"
+                                },
+                                "params": [],
+                                "typemap_name": "void"
                             },
-                            "declarator": {},
-                            "metaattrs": {
-                                "intent": "dtor"
-                            },
-                            "params": [],
                             "specifier": [
                                 "void"
                             ],
@@ -79,12 +81,13 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "get_flag"
+                                "metaattrs": {
+                                    "intent": "getter"
+                                },
+                                "name": "get_flag",
+                                "params": [],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "getter"
-                            },
-                            "params": [],
                             "specifier": [
                                 "int"
                             ],
@@ -171,12 +174,13 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "name": "flag",
-                                "readonly": true
-                            },
                             "declarator": {
-                                "name": "m_flag"
+                                "attrs": {
+                                    "name": "flag",
+                                    "readonly": true
+                                },
+                                "name": "m_flag",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -260,22 +264,23 @@
             {
                 "<FUNCTION>": "2 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "deref": "raw"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "raw"
+                        },
+                        "metaattrs": {
+                            "deref": "raw",
+                            "intent": "function"
+                        },
                         "name": "ReturnIntPtrRaw",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "raw",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -334,22 +339,23 @@
             {
                 "<FUNCTION>": "3 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "deref": "scalar"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "scalar"
+                        },
+                        "metaattrs": {
+                            "deref": "scalar",
+                            "intent": "function"
+                        },
                         "name": "ReturnIntPtrScalar",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "scalar",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -443,22 +449,23 @@
                 ],
                 "_PTR_F_C_index": "24",
                 "ast": {
-                    "attrs": {
-                        "deref": "pointer"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "pointer"
+                        },
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "ReturnIntPtrPointer",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -551,23 +558,24 @@
                 "_PTR_C_CXX_index": "4",
                 "_generated": "arg_to_buffer",
                 "ast": {
-                    "attrs": {
-                        "deref": "pointer"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "pointer"
+                        },
+                        "metaattrs": {
+                            "api": "buf",
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "ReturnIntPtrPointer",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "api": "buf",
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -627,43 +635,45 @@
             {
                 "<FUNCTION>": "5 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "deref": "raw"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "raw"
+                        },
+                        "metaattrs": {
+                            "deref": "raw",
+                            "intent": "function"
+                        },
                         "name": "ReturnIntPtrDimRaw",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "len",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "raw",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "len",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -758,50 +768,52 @@
                 ],
                 "_PTR_F_C_index": "25",
                 "ast": {
-                    "attrs": {
-                        "deref": "pointer",
-                        "dimension": "len"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "pointer",
+                            "dimension": "len"
+                        },
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "name": "len"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "ReturnIntPtrDimPointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "len",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "name": "len"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "len",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -959,51 +971,53 @@
                 "_PTR_C_CXX_index": "6",
                 "_generated": "arg_to_buffer",
                 "ast": {
-                    "attrs": {
-                        "deref": "pointer",
-                        "dimension": "len"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "pointer",
+                            "dimension": "len"
+                        },
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "name": "len"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "ReturnIntPtrDimPointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "len",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "name": "len"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "len",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -1107,50 +1121,52 @@
                 ],
                 "_PTR_F_C_index": "26",
                 "ast": {
-                    "attrs": {
-                        "deref": "allocatable",
-                        "dimension": "len"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "allocatable",
+                            "dimension": "len"
+                        },
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "dimension": [
+                                {
+                                    "name": "len"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "ReturnIntPtrDimAlloc",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "len",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "dimension": [
-                            {
-                                "name": "len"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "len",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -1308,51 +1324,53 @@
                 "_PTR_C_CXX_index": "7",
                 "_generated": "arg_to_buffer",
                 "ast": {
-                    "attrs": {
-                        "deref": "allocatable",
-                        "dimension": "len"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "allocatable",
+                            "dimension": "len"
+                        },
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "deref": "allocatable",
+                            "dimension": [
+                                {
+                                    "name": "len"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "ReturnIntPtrDimAlloc",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "len",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "deref": "allocatable",
-                        "dimension": [
-                            {
-                                "name": "len"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "len",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -1456,49 +1474,51 @@
                 ],
                 "_PTR_F_C_index": "27",
                 "ast": {
-                    "attrs": {
-                        "dimension": "len"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "dimension": "len"
+                        },
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "name": "len"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "ReturnIntPtrDimDefault",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "len",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "name": "len"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "len",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -1655,50 +1675,52 @@
                 "_PTR_C_CXX_index": "8",
                 "_generated": "arg_to_buffer",
                 "ast": {
-                    "attrs": {
-                        "dimension": "len"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "dimension": "len"
+                        },
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "name": "len"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "ReturnIntPtrDimDefault",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "len",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "name": "len"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "len",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -1797,51 +1819,53 @@
             {
                 "<FUNCTION>": "9 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "dimension": "len",
-                        "owner": "caller"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "dimension": "len",
+                            "owner": "caller"
+                        },
+                        "metaattrs": {
+                            "capsule": true,
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "name": "len"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "ReturnIntPtrDimRawNew",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "len",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "capsule": true,
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "name": "len"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "len",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -1942,52 +1966,54 @@
                 ],
                 "_PTR_F_C_index": "28",
                 "ast": {
-                    "attrs": {
-                        "deref": "pointer",
-                        "dimension": "len",
-                        "owner": "caller"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "pointer",
+                            "dimension": "len",
+                            "owner": "caller"
+                        },
+                        "metaattrs": {
+                            "capsule": true,
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "name": "len"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "ReturnIntPtrDimPointerNew",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "len",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "capsule": true,
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "name": "len"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "len",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -2146,53 +2172,55 @@
                 "_PTR_C_CXX_index": "10",
                 "_generated": "arg_to_buffer",
                 "ast": {
-                    "attrs": {
-                        "deref": "pointer",
-                        "dimension": "len",
-                        "owner": "caller"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "pointer",
+                            "dimension": "len",
+                            "owner": "caller"
+                        },
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "capsule": true,
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "name": "len"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "ReturnIntPtrDimPointerNew",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "len",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "capsule": true,
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "name": "len"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "len",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -2293,51 +2321,53 @@
             {
                 "<FUNCTION>": "11 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "deref": "allocatable",
-                        "dimension": "len",
-                        "owner": "caller"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "allocatable",
+                            "dimension": "len",
+                            "owner": "caller"
+                        },
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "dimension": [
+                                {
+                                    "name": "len"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "ReturnIntPtrDimAllocNew",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "len",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "dimension": [
-                            {
-                                "name": "len"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "len",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -2480,51 +2510,53 @@
                 ],
                 "_PTR_F_C_index": "29",
                 "ast": {
-                    "attrs": {
-                        "dimension": "len",
-                        "owner": "caller"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "dimension": "len",
+                            "owner": "caller"
+                        },
+                        "metaattrs": {
+                            "capsule": true,
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "name": "len"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "ReturnIntPtrDimDefaultNew",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "len",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "capsule": true,
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "name": "len"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "len",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -2683,52 +2715,54 @@
                 "_PTR_C_CXX_index": "12",
                 "_generated": "arg_to_buffer",
                 "ast": {
-                    "attrs": {
-                        "dimension": "len",
-                        "owner": "caller"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "dimension": "len",
+                            "owner": "caller"
+                        },
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "capsule": true,
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "name": "len"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "ReturnIntPtrDimDefaultNew",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "len",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "capsule": true,
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "name": "len"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "len",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -2830,59 +2864,62 @@
                 "<FUNCTION>": "13 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "IntPtrDimRaw"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "raw",
-                                "intent": "out",
-                                "owner": "library"
-                            },
-                            "declarator": {
-                                "name": "array",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                        "name": "IntPtrDimRaw",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "raw",
+                                        "intent": "out",
+                                        "owner": "library"
+                                    },
+                                    "metaattrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
+                                    },
+                                    "name": "array",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "len",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "len",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2906,66 +2943,69 @@
                 "<FUNCTION>": "14 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "IntPtrDimPointer"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "pointer",
-                                "dimension": "len",
-                                "intent": "out",
-                                "owner": "library"
-                            },
-                            "declarator": {
-                                "name": "array",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "name": "len"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
+                        "name": "IntPtrDimPointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "pointer",
+                                        "dimension": "len",
+                                        "intent": "out",
+                                        "owner": "library"
+                                    },
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "name": "len"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "array",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "len",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "len",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2989,66 +3029,69 @@
                 "<FUNCTION>": "15 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "IntPtrDimAlloc"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "allocatable",
-                                "dimension": "len",
-                                "intent": "out",
-                                "owner": "library"
-                            },
-                            "declarator": {
-                                "name": "array",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "allocatable",
-                                "dimension": [
-                                    {
-                                        "name": "len"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
+                        "name": "IntPtrDimAlloc",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "allocatable",
+                                        "dimension": "len",
+                                        "intent": "out",
+                                        "owner": "library"
+                                    },
+                                    "metaattrs": {
+                                        "deref": "allocatable",
+                                        "dimension": [
+                                            {
+                                                "name": "len"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "array",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "len",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "len",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3072,65 +3115,68 @@
                 "<FUNCTION>": "16 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "IntPtrDimDefault"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "len",
-                                "intent": "out",
-                                "owner": "library"
-                            },
-                            "declarator": {
-                                "name": "array",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "name": "len"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
+                        "name": "IntPtrDimDefault",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "len",
+                                        "intent": "out",
+                                        "owner": "library"
+                                    },
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "name": "len"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "array",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "len",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "len",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3154,60 +3200,63 @@
                 "<FUNCTION>": "17 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "IntPtrDimRawNew"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "raw",
-                                "intent": "out",
-                                "owner": "caller"
-                            },
-                            "declarator": {
-                                "name": "array",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
+                        "name": "IntPtrDimRawNew",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "raw",
+                                        "intent": "out",
+                                        "owner": "caller"
+                                    },
+                                    "metaattrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
+                                    },
+                                    "name": "array",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "len",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "len",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3231,66 +3280,69 @@
                 "<FUNCTION>": "18 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "IntPtrDimPointerNew"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "pointer",
-                                "dimension": "len",
-                                "intent": "out",
-                                "owner": "caller"
-                            },
-                            "declarator": {
-                                "name": "array",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "name": "len"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
+                        "name": "IntPtrDimPointerNew",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "pointer",
+                                        "dimension": "len",
+                                        "intent": "out",
+                                        "owner": "caller"
+                                    },
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "name": "len"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "array",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "len",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "len",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3314,66 +3366,69 @@
                 "<FUNCTION>": "19 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "IntPtrDimAllocNew"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "allocatable",
-                                "dimension": "len",
-                                "intent": "out",
-                                "owner": "caller"
-                            },
-                            "declarator": {
-                                "name": "array",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "allocatable",
-                                "dimension": [
-                                    {
-                                        "name": "len"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
+                        "name": "IntPtrDimAllocNew",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "allocatable",
+                                        "dimension": "len",
+                                        "intent": "out",
+                                        "owner": "caller"
+                                    },
+                                    "metaattrs": {
+                                        "deref": "allocatable",
+                                        "dimension": [
+                                            {
+                                                "name": "len"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "array",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "len",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "len",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3397,65 +3452,68 @@
                 "<FUNCTION>": "20 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "IntPtrDimDefaultNew"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "len",
-                                "intent": "out",
-                                "owner": "caller"
-                            },
-                            "declarator": {
-                                "name": "array",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "name": "len"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
+                        "name": "IntPtrDimDefaultNew",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "len",
+                                        "intent": "out",
+                                        "owner": "caller"
+                                    },
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "name": "len"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "array",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "len",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "len",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3479,28 +3537,30 @@
                 "<FUNCTION>": "21 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "createClassStatic"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "createClassStatic",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "flag",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "flag"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -3598,22 +3658,23 @@
             {
                 "<FUNCTION>": "22 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "owner": "library"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "owner": "library"
+                        },
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
                         "name": "getClassStatic",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Class1"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "Class1"
                     ],
@@ -3710,38 +3771,40 @@
             {
                 "<FUNCTION>": "23 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "owner": "caller"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "owner": "caller"
+                        },
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
                         "name": "getClassNew",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "flag",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Class1"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "flag"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "Class1"
                     ],

--- a/regression/reference/ownership/ownership.json
+++ b/regression/reference/ownership/ownership.json
@@ -16,6 +16,7 @@
                                 "_destructor": "Class1",
                                 "_name": "dtor"
                             },
+                            "declarator": {},
                             "metaattrs": {
                                 "intent": "dtor"
                             },

--- a/regression/reference/pointers-c/pointers.json
+++ b/regression/reference/pointers-c/pointers.json
@@ -51,6 +51,7 @@
                 },
                 "decl": "void  intargs_in(const int *arg)",
                 "declgen": "void intargs_in(const int * arg)",
+                "name": "intargs_in",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -155,6 +156,7 @@
                 "doxygen": {
                     "description": "Argument is modified by library, defaults to intent(inout).\n"
                 },
+                "name": "intargs_inout",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -259,6 +261,7 @@
                 },
                 "decl": "void  intargs_out(int *arg +intent(out))",
                 "declgen": "void intargs_out(int * arg +intent(out))",
+                "name": "intargs_out",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -402,6 +405,7 @@
                 },
                 "decl": "void  intargs(const int argin      +intent(in), int * arginout +intent(inout), int * argout   +intent(out))",
                 "declgen": "void intargs(const int argin +intent(in)+value, int * arginout +intent(inout), int * argout +intent(out))",
+                "name": "intargs",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -626,6 +630,7 @@
                     "brief": "compute cos of IN and save in OUT",
                     "description": "allocate OUT same type as IN implied size of array"
                 },
+                "name": "cos_doubles",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -855,6 +860,7 @@
                     "brief": "truncate IN argument and save in OUT",
                     "description": "allocate OUT different type as IN\nimplied size of array\n"
                 },
+                "name": "truncate_to_int",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -1061,6 +1067,7 @@
                     "brief": "fill values into array",
                     "description": "The function knows how long the array must be.\nFortran will treat the dimension as assumed-length.\nThe Python wrapper will create a NumPy array or list so it must\nhave an explicit dimension (not assumed-length).\n"
                 },
+                "name": "get_values",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -1239,6 +1246,7 @@
                     "brief": "fill values into two arrays",
                     "description": "Test two intent(out) arguments.\nMake sure error handling works with C++.\n"
                 },
+                "name": "get_values2",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -1406,6 +1414,7 @@
                 },
                 "decl": "void iota_dimension (int nvar, int *values+intent(out)+dimension(nvar))",
                 "declgen": "void iota_dimension(int nvar +value, int * values +dimension(nvar)+intent(out))",
+                "name": "iota_dimension",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -1586,6 +1595,7 @@
                 },
                 "decl": "void Sum(int len +implied(size(values)), const int *values +rank(1), int *result +intent(out))",
                 "declgen": "void Sum(int len +implied(size(values))+value, const int * values +rank(1), int * result +intent(out))",
+                "name": "Sum",
                 "options": {
                     "wrap_lua": false
                 },
@@ -1768,6 +1778,7 @@
                 "doxygen": {
                     "description": "Return three values into memory the user provides.\n"
                 },
+                "name": "fillIntArray",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -1897,6 +1908,7 @@
                 "doxygen": {
                     "description": "Increment array in place using intent(INOUT).\n"
                 },
+                "name": "incrementIntArray",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2052,6 +2064,7 @@
                 },
                 "decl": "void fill_with_zeros(double* x+rank(1), int x_length+implied(size(x)));",
                 "declgen": "void fill_with_zeros(double * x +rank(1), int x_length +implied(size(x))+value)",
+                "name": "fill_with_zeros",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2208,6 +2221,7 @@
                 },
                 "decl": "int accumulate(const int *arr+rank(1), size_t len+implied(size(arr)));",
                 "declgen": "int accumulate(const int * arr +rank(1), size_t len +implied(size(arr))+value)",
+                "name": "accumulate",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2388,6 +2402,7 @@
                 "doxygen": {
                     "description": "Return strlen of the first index as a check.\n"
                 },
+                "name": "acceptCharArrayIn",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2532,6 +2547,7 @@
                 "doxygen": {
                     "description": "Return strlen of the first index as a check.\n"
                 },
+                "name": "acceptCharArrayIn",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -2658,6 +2674,7 @@
                 },
                 "decl": "void setGlobalInt(int value)",
                 "declgen": "void setGlobalInt(int value +value)",
+                "name": "setGlobalInt",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2743,6 +2760,7 @@
                 "doxygen": {
                     "description": "Used to test values global_array.\n"
                 },
+                "name": "sumFixedArray",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2849,6 +2867,7 @@
                 },
                 "decl": "void getPtrToScalar(int **nitems+intent(out))",
                 "declgen": "void getPtrToScalar(int * * nitems +intent(out))",
+                "name": "getPtrToScalar",
                 "options": {
                     "wrap_python": false
                 },
@@ -2957,6 +2976,7 @@
                 },
                 "decl": "void getPtrToScalar(int **nitems+intent(out))",
                 "declgen": "void getPtrToScalar(int * * nitems +intent(out))",
+                "name": "getPtrToScalar",
                 "options": {
                     "wrap_python": false
                 },
@@ -3075,6 +3095,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is always the same length.\n"
                 },
+                "name": "getPtrToFixedArray",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3194,6 +3215,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is always the same length.\n"
                 },
+                "name": "getPtrToFixedArray",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -3339,6 +3361,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is the length of\nthe argument ncount.\n"
                 },
+                "name": "getPtrToDynamicArray",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3509,6 +3532,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is the length of\nthe argument ncount.\n"
                 },
+                "name": "getPtrToDynamicArray",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -3662,6 +3686,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is the length\nis computed by C++ function getLen.\ngetLen will be called from C/C++ to compute the shape.\n"
                 },
+                "name": "getPtrToFuncArray",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3782,6 +3807,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is the length\nis computed by C++ function getLen.\ngetLen will be called from C/C++ to compute the shape.\n"
                 },
+                "name": "getPtrToFuncArray",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -3897,6 +3923,7 @@
                 },
                 "decl": "void getPtrToConstScalar( const int **nitems+intent(out))",
                 "declgen": "void getPtrToConstScalar(const int * * nitems +intent(out))",
+                "name": "getPtrToConstScalar",
                 "options": {
                     "wrap_python": false
                 },
@@ -4006,6 +4033,7 @@
                 },
                 "decl": "void getPtrToConstScalar( const int **nitems+intent(out))",
                 "declgen": "void getPtrToConstScalar(const int * * nitems +intent(out))",
+                "name": "getPtrToConstScalar",
                 "options": {
                     "wrap_python": false
                 },
@@ -4122,6 +4150,7 @@
                 },
                 "decl": "void getPtrToFixedConstArray( const int **count+intent(out)+dimension(10));",
                 "declgen": "void getPtrToFixedConstArray(const int * * count +dimension(10)+intent(out))",
+                "name": "getPtrToFixedConstArray",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -4239,6 +4268,7 @@
                 },
                 "decl": "void getPtrToFixedConstArray( const int **count+intent(out)+dimension(10));",
                 "declgen": "void getPtrToFixedConstArray(const int * * count +dimension(10)+intent(out))",
+                "name": "getPtrToFixedConstArray",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -4382,6 +4412,7 @@
                 },
                 "decl": "void getPtrToDynamicConstArray( const int **count+intent(out)+dimension(ncount), int *ncount+intent(out)+hidden)",
                 "declgen": "void getPtrToDynamicConstArray(const int * * count +dimension(ncount)+intent(out), int * ncount +hidden+intent(out))",
+                "name": "getPtrToDynamicConstArray",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -4550,6 +4581,7 @@
                 },
                 "decl": "void getPtrToDynamicConstArray( const int **count+intent(out)+dimension(ncount), int *ncount+intent(out)+hidden)",
                 "declgen": "void getPtrToDynamicConstArray(const int * * count +dimension(ncount)+intent(out), int * ncount +hidden+intent(out))",
+                "name": "getPtrToDynamicConstArray",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -4693,6 +4725,7 @@
                 "doxygen": {
                     "description": "Called directly via an interface in Fortran.\n"
                 },
+                "name": "getRawPtrToScalar",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -4805,6 +4838,7 @@
                 "doxygen": {
                     "description": "Create a Fortran wrapper.\n"
                 },
+                "name": "getRawPtrToScalarForce",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -4920,6 +4954,7 @@
                 "doxygen": {
                     "description": "Return a type(C_PTR) to an array which is always the same length.\nCalled directly via an interface in Fortran.\n# Uses +deref(raw) instead of +dimension(10) like getPtrToFixedArray.\n"
                 },
+                "name": "getRawPtrToFixedArray",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -5032,6 +5067,7 @@
                 "doxygen": {
                     "description": "Return a type(C_PTR) to an array which is always the same length.\nCreate a Fortran wrapper.\n"
                 },
+                "name": "getRawPtrToFixedArrayForce",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -5148,6 +5184,7 @@
                 "doxygen": {
                     "description": "Test multiple layers of indirection.\n"
                 },
+                "name": "getRawPtrToInt2d",
                 "options": {
                     "wrap_python": false
                 },
@@ -5260,6 +5297,7 @@
                 "doxygen": {
                     "description": "Check results of getRawPtrToInt2d.\n"
                 },
+                "name": "checkInt2d",
                 "options": {
                     "wrap_python": false
                 },
@@ -5409,6 +5447,7 @@
                 "doxygen": {
                     "description": "Test +dimension(10,20) +intent(in) together.\nThis will not use assumed-shape in the Fortran wrapper.\n"
                 },
+                "name": "DimensionIn",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -5538,6 +5577,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is always the same length.\n"
                 },
+                "name": "getAllocToFixedArray",
                 "options": {
                     "wrap_python": false
                 },
@@ -5660,6 +5700,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is always the same length.\n"
                 },
+                "name": "getAllocToFixedArray",
                 "options": {
                     "wrap_python": false
                 },
@@ -5768,6 +5809,7 @@
                 },
                 "decl": "void *returnAddress1(int flag)",
                 "declgen": "void * returnAddress1(int flag +value)",
+                "name": "returnAddress1",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -5902,6 +5944,7 @@
                 },
                 "decl": "void *returnAddress2(int flag)",
                 "declgen": "void * returnAddress2(int flag +value)",
+                "name": "returnAddress2",
                 "options": {
                     "F_force_wrapper": true
                 },
@@ -6041,6 +6084,7 @@
                 },
                 "decl": "void fetchVoidPtr(void **addr+intent(out))",
                 "declgen": "void fetchVoidPtr(void * * addr +intent(out))",
+                "name": "fetchVoidPtr",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -6147,6 +6191,7 @@
                 },
                 "decl": "void updateVoidPtr(void **addr+intent(inout))",
                 "declgen": "void updateVoidPtr(void * * addr +intent(inout))",
+                "name": "updateVoidPtr",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -6256,6 +6301,7 @@
                 },
                 "decl": "int VoidPtrArray(void **addr+rank(1))",
                 "declgen": "int VoidPtrArray(void * * addr +rank(1))",
+                "name": "VoidPtrArray",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -6385,6 +6431,7 @@
                 },
                 "decl": "int *returnIntPtrToScalar(void)",
                 "declgen": "int * returnIntPtrToScalar(void)",
+                "name": "returnIntPtrToScalar",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -6470,6 +6517,7 @@
                 },
                 "decl": "int *returnIntPtrToScalar(void)",
                 "declgen": "int * returnIntPtrToScalar(void)",
+                "name": "returnIntPtrToScalar",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -6553,6 +6601,7 @@
                 },
                 "decl": "int *returnIntPtrToFixedArray(void) +dimension(10)",
                 "declgen": "int * returnIntPtrToFixedArray(void) +dimension(10)",
+                "name": "returnIntPtrToFixedArray",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -6653,6 +6702,7 @@
                 },
                 "decl": "int *returnIntPtrToFixedArray(void) +dimension(10)",
                 "declgen": "int * returnIntPtrToFixedArray(void) +dimension(10)",
+                "name": "returnIntPtrToFixedArray",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -6736,6 +6786,7 @@
                 },
                 "decl": "const int *returnIntPtrToConstScalar(void)",
                 "declgen": "const int * returnIntPtrToConstScalar(void)",
+                "name": "returnIntPtrToConstScalar",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -6822,6 +6873,7 @@
                 },
                 "decl": "const int *returnIntPtrToConstScalar(void)",
                 "declgen": "const int * returnIntPtrToConstScalar(void)",
+                "name": "returnIntPtrToConstScalar",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -6906,6 +6958,7 @@
                 },
                 "decl": "const int *returnIntPtrToFixedConstArray(void) +dimension(10)",
                 "declgen": "const int * returnIntPtrToFixedConstArray(void) +dimension(10)",
+                "name": "returnIntPtrToFixedConstArray",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -7007,6 +7060,7 @@
                 },
                 "decl": "const int *returnIntPtrToFixedConstArray(void) +dimension(10)",
                 "declgen": "const int * returnIntPtrToFixedConstArray(void) +dimension(10)",
+                "name": "returnIntPtrToFixedConstArray",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -7088,6 +7142,7 @@
                 },
                 "decl": "int *returnIntScalar(void) +deref(scalar)",
                 "declgen": "int * returnIntScalar(void) +deref(scalar)",
+                "name": "returnIntScalar",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -7175,6 +7230,7 @@
                 "doxygen": {
                     "description": "Call directly via interface.\n"
                 },
+                "name": "returnIntRaw",
                 "options": {
                     "wrap_python": false
                 },
@@ -7286,6 +7342,7 @@
                 "doxygen": {
                     "description": "Like returnIntRaw but with another argument to force a wrapper.\nUses fc_statements f_function_native_*_raw.\n"
                 },
+                "name": "returnIntRawWithArgs",
                 "options": {
                     "wrap_python": false
                 },
@@ -7408,6 +7465,7 @@
                 "doxygen": {
                     "description": "Test multiple layers of indirection.\n# getRawPtrToInt2d\n"
                 },
+                "name": "returnRawPtrToInt2d",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -7506,6 +7564,7 @@
                 },
                 "decl": "int *returnIntAllocToFixedArray(void) +dimension(10)+deref(allocatable)",
                 "declgen": "int * returnIntAllocToFixedArray(void) +deref(allocatable)+dimension(10)",
+                "name": "returnIntAllocToFixedArray",
                 "options": {
                     "wrap_python": false
                 },
@@ -7609,6 +7668,7 @@
                 },
                 "decl": "int *returnIntAllocToFixedArray(void) +dimension(10)+deref(allocatable)",
                 "declgen": "int * returnIntAllocToFixedArray(void) +deref(allocatable)+dimension(10)",
+                "name": "returnIntAllocToFixedArray",
                 "options": {
                     "wrap_python": false
                 },

--- a/regression/reference/pointers-c/pointers.json
+++ b/regression/reference/pointers-c/pointers.json
@@ -17,31 +17,33 @@
                 "<FUNCTION>": "0 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "intargs_in"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "intargs_in",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -117,30 +119,32 @@
                 "<FUNCTION>": "1 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "intargs_inout"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "intargs_inout",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -219,33 +223,35 @@
                 "<FUNCTION>": "2 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "intargs_out"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "intargs_out",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -321,70 +327,74 @@
                 "<FUNCTION>": "3 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "intargs"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "value": true
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "argin"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "inout"
+                        "name": "intargs",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "argin",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "arginout",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arginout",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "argout",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "argout",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -526,81 +536,85 @@
                 "<FUNCTION>": "4 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "cos_doubles"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "in",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "size(in)",
-                                "intent": "out"
+                        "name": "cos_doubles",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "in",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "out",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "args": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "size(in)",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
                                             {
-                                                "name": "in"
+                                                "args": [
+                                                    {
+                                                        "name": "in"
+                                                    }
+                                                ],
+                                                "name": "size"
                                             }
                                         ],
-                                        "name": "size"
-                                    }
+                                        "intent": "out"
+                                    },
+                                    "name": "out",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "double"
                             },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(in)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "sizein"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(in)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "sizein",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -751,81 +765,85 @@
                 "<FUNCTION>": "5 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "truncate_to_int"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "in",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "size(in)",
-                                "intent": "out"
+                        "name": "truncate_to_int",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "in",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "out",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "args": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "size(in)",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
                                             {
-                                                "name": "in"
+                                                "args": [
+                                                    {
+                                                        "name": "in"
+                                                    }
+                                                ],
+                                                "name": "size"
                                             }
                                         ],
-                                        "name": "size"
-                                    }
+                                        "intent": "out"
+                                    },
+                                    "name": "out",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(in)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "sizein"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(in)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "sizein",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -976,59 +994,62 @@
                 "<FUNCTION>": "6 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "get_values"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "OUT"
-                            },
-                            "declarator": {
-                                "name": "nvalues",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "3",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "values",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "3"
-                                    }
+                        "name": "get_values",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "OUT"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "nvalues",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "3",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "3"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "values",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1145,65 +1166,68 @@
                 "<FUNCTION>": "7 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "get_values2"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "3",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "3"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "3",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg2",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "3"
-                                    }
+                        "name": "get_values2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "3",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "3"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "3",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "3"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "arg2",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1324,54 +1348,57 @@
                 "<FUNCTION>": "8 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "iota_dimension"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "nvar"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "nvar",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "values",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nvar"
-                                    }
+                        "name": "iota_dimension",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nvar",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "nvar",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "name": "nvar"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "values",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1484,70 +1511,74 @@
                 "<FUNCTION>": "9 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "Sum"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "implied": "size(values)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "len"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "rank": 1
+                        "name": "Sum",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(values)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "len",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "const": true,
-                            "declarator": {
-                                "name": "values",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "values",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "result",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "result",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1692,39 +1723,41 @@
                 "<FUNCTION>": "10 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "fillIntArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "3",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "out",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "3"
-                                    }
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "fillIntArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "3",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "3"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "out",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1807,50 +1840,53 @@
                 "<FUNCTION>": "11 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "incrementIntArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "array",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "size(array)",
-                                "value": true
+                        "name": "incrementIntArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "array",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "sizein"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(array)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "sizein",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1963,49 +1999,52 @@
                 "<FUNCTION>": "12 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "fill_with_zeros"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "x",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "size(x)",
-                                "value": true
+                        "name": "fill_with_zeros",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "x",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "x_length"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(x)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "x_length",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2115,50 +2154,53 @@
                 "<FUNCTION>": "13 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "accumulate"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "arr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "implied": "size(arr)",
-                                "value": true
+                        "name": "accumulate",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "len"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(arr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "len",
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -2303,37 +2345,39 @@
                 "_PTR_F_C_index": "46",
                 "ast": {
                     "declarator": {
-                        "name": "acceptCharArrayIn"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "names",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "acceptCharArrayIn",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "names",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -2444,38 +2488,40 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "acceptCharArrayIn"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "names",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "acceptCharArrayIn",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "in"
+                                    },
+                                    "name": "names",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -2581,28 +2627,30 @@
                 "<FUNCTION>": "15 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "setGlobalInt"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "setGlobalInt",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "value",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "value"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -2678,12 +2726,13 @@
                 "<FUNCTION>": "16 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "sumFixedArray"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "sumFixedArray",
+                        "params": [],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -2760,37 +2809,39 @@
                 "_PTR_F_C_index": "47",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToScalar"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToScalar",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2865,38 +2916,40 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToScalar"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToScalar",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "deref": "pointer",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "api": "cdesc",
+                                        "deref": "pointer",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2973,43 +3026,45 @@
                 "_PTR_F_C_index": "48",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToFixedArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "10",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToFixedArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "10",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "constant": "10"
-                                    }
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3089,44 +3144,46 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToFixedArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "10",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToFixedArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "10",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "constant": "10"
-                                    }
+                                    "metaattrs": {
+                                        "api": "cdesc",
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3211,64 +3268,67 @@
                 "_PTR_F_C_index": "49",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToDynamicArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "ncount",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "name": "ncount"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
+                        "name": "getPtrToDynamicArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "ncount",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "name": "ncount"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "ncount",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "ncount",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3377,65 +3437,68 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToDynamicArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "ncount",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "name": "ncount"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
+                        "name": "getPtrToDynamicArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "ncount",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "api": "cdesc",
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "name": "ncount"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "ncount",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "ncount",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3549,44 +3612,46 @@
                 "_PTR_F_C_index": "50",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToFuncArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "getLen()",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToFuncArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "getLen()",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "args": [],
-                                        "name": "getLen"
-                                    }
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "args": [],
+                                                "name": "getLen"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3666,45 +3731,47 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToFuncArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "getLen()",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToFuncArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "getLen()",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "args": [],
-                                        "name": "getLen"
-                                    }
+                                    "metaattrs": {
+                                        "api": "cdesc",
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "args": [],
+                                                "name": "getLen"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3789,38 +3856,40 @@
                 "_PTR_F_C_index": "51",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToConstScalar"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToConstScalar",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3895,39 +3964,41 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToConstScalar"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToConstScalar",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "deref": "pointer",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "api": "cdesc",
+                                        "deref": "pointer",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4004,44 +4075,46 @@
                 "_PTR_F_C_index": "52",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToFixedConstArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "10",
-                                "intent": "out"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToFixedConstArray",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "10",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "constant": "10"
-                                    }
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4118,45 +4191,47 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToFixedConstArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "10",
-                                "intent": "out"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToFixedConstArray",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "10",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "constant": "10"
-                                    }
+                                    "metaattrs": {
+                                        "api": "cdesc",
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4238,65 +4313,68 @@
                 "_PTR_F_C_index": "53",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToDynamicConstArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "ncount",
-                                "intent": "out"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "name": "ncount"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
+                        "name": "getPtrToDynamicConstArray",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "ncount",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "name": "ncount"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "ncount",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "ncount",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4402,66 +4480,69 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToDynamicConstArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "ncount",
-                                "intent": "out"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "name": "ncount"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
+                        "name": "getPtrToDynamicConstArray",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "ncount",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "api": "cdesc",
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "name": "ncount"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "ncount",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "ncount",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4568,38 +4649,40 @@
                 "<FUNCTION>": "24 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToScalar"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToScalar",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4678,38 +4761,40 @@
                 "<FUNCTION>": "25 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToScalarForce"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToScalarForce",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4791,38 +4876,40 @@
                 "<FUNCTION>": "26 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToFixedArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToFixedArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4901,38 +4988,40 @@
                 "<FUNCTION>": "27 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToFixedArrayForce"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToFixedArrayForce",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5014,39 +5103,41 @@
                 "<FUNCTION>": "28 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToInt2d"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToInt2d",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
+                                    "metaattrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5127,36 +5218,38 @@
                 "<FUNCTION>": "29 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "checkInt2d"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "checkInt2d",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -5268,42 +5361,44 @@
                 "<FUNCTION>": "30 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "DimensionIn"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "10,20"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "10"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "DimensionIn",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "10,20"
                                     },
-                                    {
-                                        "constant": "20"
-                                    }
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            },
+                                            {
+                                                "constant": "20"
+                                            }
+                                        ],
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5393,44 +5488,46 @@
                 "_PTR_F_C_index": "54",
                 "ast": {
                     "declarator": {
-                        "name": "getAllocToFixedArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "allocatable",
-                                "dimension": "10",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getAllocToFixedArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "allocatable",
+                                        "dimension": "10",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "allocatable",
-                                "dimension": [
-                                    {
-                                        "constant": "10"
-                                    }
+                                    "metaattrs": {
+                                        "deref": "allocatable",
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5512,45 +5609,47 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "getAllocToFixedArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "allocatable",
-                                "dimension": "10",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getAllocToFixedArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "allocatable",
+                                        "dimension": "10",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "deref": "allocatable",
-                                "dimension": [
-                                    {
-                                        "constant": "10"
-                                    }
+                                    "metaattrs": {
+                                        "api": "cdesc",
+                                        "deref": "allocatable",
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5633,33 +5732,35 @@
                 "<FUNCTION>": "32 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "intent": "function"
+                        },
                         "name": "returnAddress1",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "flag",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "flag"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -5765,33 +5866,35 @@
                 "<FUNCTION>": "33 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "intent": "function"
+                        },
                         "name": "returnAddress2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "flag",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "flag"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -5899,36 +6002,38 @@
                 "<FUNCTION>": "34 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "fetchVoidPtr"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "fetchVoidPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -6003,36 +6108,38 @@
                 "<FUNCTION>": "35 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "updateVoidPtr"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout"
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "updateVoidPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -6110,36 +6217,38 @@
                 "<FUNCTION>": "36 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "VoidPtrArray"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "VoidPtrArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -6256,18 +6365,19 @@
                 "_PTR_F_C_index": "55",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToScalar",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -6339,19 +6449,20 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "buf",
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToScalar",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "api": "buf",
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -6413,27 +6524,28 @@
                 ],
                 "_PTR_F_C_index": "56",
                 "ast": {
-                    "attrs": {
-                        "dimension": "10"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "dimension": "10"
+                        },
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "constant": "10"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToFixedArray",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "constant": "10"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -6511,28 +6623,29 @@
                 "_PTR_C_CXX_index": "38",
                 "_generated": "arg_to_buffer",
                 "ast": {
-                    "attrs": {
-                        "dimension": "10"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "dimension": "10"
+                        },
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "constant": "10"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToFixedArray",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "constant": "10"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -6603,18 +6716,19 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToConstScalar",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -6687,19 +6801,20 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "api": "buf",
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToConstScalar",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "api": "buf",
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -6761,28 +6876,29 @@
                 ],
                 "_PTR_F_C_index": "58",
                 "ast": {
-                    "attrs": {
-                        "dimension": "10"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "dimension": "10"
+                        },
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "constant": "10"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToFixedConstArray",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "constant": "10"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -6860,29 +6976,30 @@
                 "_PTR_C_CXX_index": "40",
                 "_generated": "arg_to_buffer",
                 "ast": {
-                    "attrs": {
-                        "dimension": "10"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "dimension": "10"
+                        },
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "constant": "10"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToFixedConstArray",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "constant": "10"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -6947,22 +7064,23 @@
             {
                 "<FUNCTION>": "41 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "deref": "scalar"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "scalar"
+                        },
+                        "metaattrs": {
+                            "deref": "scalar",
+                            "intent": "function"
+                        },
                         "name": "returnIntScalar",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "scalar",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -7030,22 +7148,23 @@
             {
                 "<FUNCTION>": "42 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "deref": "raw"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "raw"
+                        },
+                        "metaattrs": {
+                            "deref": "raw",
+                            "intent": "function"
+                        },
                         "name": "returnIntRaw",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "raw",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -7119,42 +7238,44 @@
             {
                 "<FUNCTION>": "43 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "deref": "raw"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "raw"
+                        },
+                        "metaattrs": {
+                            "deref": "raw",
+                            "intent": "function"
+                        },
                         "name": "returnIntRawWithArgs",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "ftrim_char_in": true,
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "raw",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "ftrim_char_in": true,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -7262,7 +7383,11 @@
                 "<FUNCTION>": "44 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "intent": "function"
+                        },
                         "name": "returnRawPtrToInt2d",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
@@ -7270,12 +7395,9 @@
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -7354,28 +7476,29 @@
                 ],
                 "_PTR_F_C_index": "59",
                 "ast": {
-                    "attrs": {
-                        "deref": "allocatable",
-                        "dimension": "10"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "allocatable",
+                            "dimension": "10"
+                        },
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "dimension": [
+                                {
+                                    "constant": "10"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "returnIntAllocToFixedArray",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "dimension": [
-                            {
-                                "constant": "10"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -7455,29 +7578,30 @@
                 "_PTR_C_CXX_index": "45",
                 "_generated": "arg_to_buffer",
                 "ast": {
-                    "attrs": {
-                        "deref": "allocatable",
-                        "dimension": "10"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "allocatable",
+                            "dimension": "10"
+                        },
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "deref": "allocatable",
+                            "dimension": [
+                                {
+                                    "constant": "10"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "returnIntAllocToFixedArray",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "deref": "allocatable",
-                        "dimension": [
-                            {
-                                "constant": "10"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],

--- a/regression/reference/pointers-cfi/pointers.json
+++ b/regression/reference/pointers-cfi/pointers.json
@@ -17,31 +17,33 @@
                 "<FUNCTION>": "0 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "intargs_in"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "intargs_in",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -117,30 +119,32 @@
                 "<FUNCTION>": "1 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "intargs_inout"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "intargs_inout",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -219,33 +223,35 @@
                 "<FUNCTION>": "2 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "intargs_out"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "intargs_out",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -321,70 +327,74 @@
                 "<FUNCTION>": "3 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "intargs"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "value": true
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "argin"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "inout"
+                        "name": "intargs",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "argin",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "arginout",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arginout",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "argout",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "argout",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -530,81 +540,85 @@
                 "_PTR_F_C_index": "46",
                 "ast": {
                     "declarator": {
-                        "name": "cos_doubles"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "in",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "size(in)",
-                                "intent": "out"
+                        "name": "cos_doubles",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "in",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "out",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "args": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "size(in)",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
                                             {
-                                                "name": "in"
+                                                "args": [
+                                                    {
+                                                        "name": "in"
+                                                    }
+                                                ],
+                                                "name": "size"
                                             }
                                         ],
-                                        "name": "size"
-                                    }
+                                        "intent": "out"
+                                    },
+                                    "name": "out",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "double"
                             },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(in)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "sizein"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(in)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "sizein",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -749,82 +763,86 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "cos_doubles"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "in",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "size(in)",
-                                "intent": "out"
+                        "name": "cos_doubles",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "in"
+                                    },
+                                    "name": "in",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "out",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "args": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "size(in)",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
                                             {
-                                                "name": "in"
+                                                "args": [
+                                                    {
+                                                        "name": "in"
+                                                    }
+                                                ],
+                                                "name": "size"
                                             }
                                         ],
-                                        "name": "size"
-                                    }
+                                        "intent": "out"
+                                    },
+                                    "name": "out",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "double"
                             },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(in)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "sizein"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(in)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "sizein",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -979,81 +997,85 @@
                 "_PTR_F_C_index": "47",
                 "ast": {
                     "declarator": {
-                        "name": "truncate_to_int"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "in",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "size(in)",
-                                "intent": "out"
+                        "name": "truncate_to_int",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "in",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "out",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "args": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "size(in)",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
                                             {
-                                                "name": "in"
+                                                "args": [
+                                                    {
+                                                        "name": "in"
+                                                    }
+                                                ],
+                                                "name": "size"
                                             }
                                         ],
-                                        "name": "size"
-                                    }
+                                        "intent": "out"
+                                    },
+                                    "name": "out",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(in)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "sizein"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(in)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "sizein",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1198,82 +1220,86 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "truncate_to_int"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "in",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "size(in)",
-                                "intent": "out"
+                        "name": "truncate_to_int",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "in"
+                                    },
+                                    "name": "in",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "out",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "args": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "size(in)",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
                                             {
-                                                "name": "in"
+                                                "args": [
+                                                    {
+                                                        "name": "in"
+                                                    }
+                                                ],
+                                                "name": "size"
                                             }
                                         ],
-                                        "name": "size"
-                                    }
+                                        "intent": "out"
+                                    },
+                                    "name": "out",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(in)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "sizein"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(in)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "sizein",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1424,59 +1450,62 @@
                 "<FUNCTION>": "6 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "get_values"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "OUT"
-                            },
-                            "declarator": {
-                                "name": "nvalues",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "3",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "values",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "3"
-                                    }
+                        "name": "get_values",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "OUT"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "nvalues",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "3",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "3"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "values",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1593,65 +1622,68 @@
                 "<FUNCTION>": "7 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "get_values2"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "3",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "3"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "3",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg2",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "3"
-                                    }
+                        "name": "get_values2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "3",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "3"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "3",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "3"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "arg2",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1772,54 +1804,57 @@
                 "<FUNCTION>": "8 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "iota_dimension"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "nvar"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "nvar",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "values",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nvar"
-                                    }
+                        "name": "iota_dimension",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nvar",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "nvar",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "name": "nvar"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "values",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1936,70 +1971,74 @@
                 "_PTR_F_C_index": "48",
                 "ast": {
                     "declarator": {
-                        "name": "Sum"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "implied": "size(values)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "len"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "rank": 1
+                        "name": "Sum",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(values)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "len",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "const": true,
-                            "declarator": {
-                                "name": "values",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "values",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "result",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "result",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2137,71 +2176,75 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "Sum"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "implied": "size(values)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "len"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "rank": 1
+                        "name": "Sum",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(values)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "len",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "const": true,
-                            "declarator": {
-                                "name": "values",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "in"
+                                    },
+                                    "name": "values",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "result",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "result",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2345,39 +2388,41 @@
                 "<FUNCTION>": "10 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "fillIntArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "3",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "out",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "3"
-                                    }
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "fillIntArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "3",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "3"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "out",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2464,50 +2509,53 @@
                 "_PTR_F_C_index": "49",
                 "ast": {
                     "declarator": {
-                        "name": "incrementIntArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "array",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "size(array)",
-                                "value": true
+                        "name": "incrementIntArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "array",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "sizein"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(array)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "sizein",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2618,51 +2666,54 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "incrementIntArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "array",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "size(array)",
-                                "value": true
+                        "name": "incrementIntArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "inout"
+                                    },
+                                    "name": "array",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "sizein"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(array)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "sizein",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2779,49 +2830,52 @@
                 "_PTR_F_C_index": "50",
                 "ast": {
                     "declarator": {
-                        "name": "fill_with_zeros"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "x",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "size(x)",
-                                "value": true
+                        "name": "fill_with_zeros",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "x",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "x_length"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(x)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "x_length",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2929,50 +2983,53 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "fill_with_zeros"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "x",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "size(x)",
-                                "value": true
+                        "name": "fill_with_zeros",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "inout"
+                                    },
+                                    "name": "x",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "x_length"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(x)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "x_length",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3086,50 +3143,53 @@
                 "_PTR_F_C_index": "51",
                 "ast": {
                     "declarator": {
-                        "name": "accumulate"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "arr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "implied": "size(arr)",
-                                "value": true
+                        "name": "accumulate",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "len"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(arr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "len",
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -3268,51 +3328,54 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "accumulate"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "arr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "implied": "size(arr)",
-                                "value": true
+                        "name": "accumulate",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "in"
+                                    },
+                                    "name": "arr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "len"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(arr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "len",
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -3453,37 +3516,39 @@
                 "_PTR_F_C_index": "52",
                 "ast": {
                     "declarator": {
-                        "name": "acceptCharArrayIn"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "names",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "acceptCharArrayIn",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "names",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -3596,38 +3661,40 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "acceptCharArrayIn"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "names",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "acceptCharArrayIn",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "in"
+                                    },
+                                    "name": "names",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -3737,28 +3804,30 @@
                 "<FUNCTION>": "15 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "setGlobalInt"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "setGlobalInt",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "value",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "value"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -3834,12 +3903,13 @@
                 "<FUNCTION>": "16 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "sumFixedArray"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "sumFixedArray",
+                        "params": [],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -3916,37 +3986,39 @@
                 "_PTR_F_C_index": "53",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToScalar"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToScalar",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4022,38 +4094,40 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToScalar"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToScalar",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "deref": "pointer",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "deref": "pointer",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4142,43 +4216,45 @@
                 "_PTR_F_C_index": "54",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToFixedArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "10",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToFixedArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "10",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "constant": "10"
-                                    }
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4260,44 +4336,46 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToFixedArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "10",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToFixedArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "10",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "constant": "10"
-                                    }
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4396,64 +4474,67 @@
                 "_PTR_F_C_index": "55",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToDynamicArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "ncount",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "name": "ncount"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
+                        "name": "getPtrToDynamicArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "ncount",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "name": "ncount"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "ncount",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "ncount",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4564,65 +4645,68 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToDynamicArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "ncount",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "name": "ncount"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
+                        "name": "getPtrToDynamicArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "ncount",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "name": "ncount"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "ncount",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "ncount",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4750,44 +4834,46 @@
                 "_PTR_F_C_index": "56",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToFuncArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "getLen()",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToFuncArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "getLen()",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "args": [],
-                                        "name": "getLen"
-                                    }
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "args": [],
+                                                "name": "getLen"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4869,45 +4955,47 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToFuncArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "getLen()",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToFuncArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "getLen()",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "args": [],
-                                        "name": "getLen"
-                                    }
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "args": [],
+                                                "name": "getLen"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5006,38 +5094,40 @@
                 "_PTR_F_C_index": "57",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToConstScalar"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToConstScalar",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5113,39 +5203,41 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToConstScalar"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToConstScalar",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "deref": "pointer",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "deref": "pointer",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5234,44 +5326,46 @@
                 "_PTR_F_C_index": "58",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToFixedConstArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "10",
-                                "intent": "out"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToFixedConstArray",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "10",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "constant": "10"
-                                    }
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5350,45 +5444,47 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToFixedConstArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "10",
-                                "intent": "out"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToFixedConstArray",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "10",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "constant": "10"
-                                    }
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5484,65 +5580,68 @@
                 "_PTR_F_C_index": "59",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToDynamicConstArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "ncount",
-                                "intent": "out"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "name": "ncount"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
+                        "name": "getPtrToDynamicConstArray",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "ncount",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "name": "ncount"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "ncount",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "ncount",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5650,66 +5749,69 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToDynamicConstArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "ncount",
-                                "intent": "out"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "name": "ncount"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
+                        "name": "getPtrToDynamicConstArray",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "ncount",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "name": "ncount"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "ncount",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "ncount",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5830,38 +5932,40 @@
                 "<FUNCTION>": "24 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToScalar"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToScalar",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5940,38 +6044,40 @@
                 "<FUNCTION>": "25 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToScalarForce"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToScalarForce",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -6053,38 +6159,40 @@
                 "<FUNCTION>": "26 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToFixedArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToFixedArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -6163,38 +6271,40 @@
                 "<FUNCTION>": "27 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToFixedArrayForce"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToFixedArrayForce",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -6276,39 +6386,41 @@
                 "<FUNCTION>": "28 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToInt2d"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToInt2d",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
+                                    "metaattrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -6389,36 +6501,38 @@
                 "<FUNCTION>": "29 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "checkInt2d"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "checkInt2d",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -6530,42 +6644,44 @@
                 "<FUNCTION>": "30 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "DimensionIn"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "10,20"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "10"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "DimensionIn",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "10,20"
                                     },
-                                    {
-                                        "constant": "20"
-                                    }
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            },
+                                            {
+                                                "constant": "20"
+                                            }
+                                        ],
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -6655,44 +6771,46 @@
                 "_PTR_F_C_index": "60",
                 "ast": {
                     "declarator": {
-                        "name": "getAllocToFixedArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "allocatable",
-                                "dimension": "10",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getAllocToFixedArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "allocatable",
+                                        "dimension": "10",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "allocatable",
-                                "dimension": [
-                                    {
-                                        "constant": "10"
-                                    }
+                                    "metaattrs": {
+                                        "deref": "allocatable",
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -6775,45 +6893,47 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "getAllocToFixedArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "allocatable",
-                                "dimension": "10",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getAllocToFixedArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "allocatable",
+                                        "dimension": "10",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "deref": "allocatable",
-                                "dimension": [
-                                    {
-                                        "constant": "10"
-                                    }
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "deref": "allocatable",
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -6901,33 +7021,35 @@
                 "<FUNCTION>": "32 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "intent": "function"
+                        },
                         "name": "returnAddress1",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "flag",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "flag"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -7033,33 +7155,35 @@
                 "<FUNCTION>": "33 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "intent": "function"
+                        },
                         "name": "returnAddress2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "flag",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "flag"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -7167,36 +7291,38 @@
                 "<FUNCTION>": "34 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "fetchVoidPtr"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "fetchVoidPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -7271,36 +7397,38 @@
                 "<FUNCTION>": "35 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "updateVoidPtr"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout"
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "updateVoidPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -7382,36 +7510,38 @@
                 "_PTR_F_C_index": "61",
                 "ast": {
                     "declarator": {
-                        "name": "VoidPtrArray"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "VoidPtrArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -7522,37 +7652,39 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "VoidPtrArray"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "VoidPtrArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "in"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -7658,18 +7790,19 @@
                 "_PTR_F_C_index": "62",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToScalar",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -7743,19 +7876,20 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "cfi",
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToScalar",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "api": "cfi",
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -7832,27 +7966,28 @@
                 ],
                 "_PTR_F_C_index": "63",
                 "ast": {
-                    "attrs": {
-                        "dimension": "10"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "dimension": "10"
+                        },
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "constant": "10"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToFixedArray",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "constant": "10"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -7929,28 +8064,29 @@
                 "_PTR_C_CXX_index": "38",
                 "_generated": "arg_to_cfi",
                 "ast": {
-                    "attrs": {
-                        "dimension": "10"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "dimension": "10"
+                        },
+                        "metaattrs": {
+                            "api": "cfi",
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "constant": "10"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToFixedArray",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "api": "cfi",
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "constant": "10"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -8037,18 +8173,19 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToConstScalar",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -8123,19 +8260,20 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "api": "cfi",
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToConstScalar",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "api": "cfi",
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -8212,28 +8350,29 @@
                 ],
                 "_PTR_F_C_index": "65",
                 "ast": {
-                    "attrs": {
-                        "dimension": "10"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "dimension": "10"
+                        },
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "constant": "10"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToFixedConstArray",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "constant": "10"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -8310,29 +8449,30 @@
                 "_PTR_C_CXX_index": "40",
                 "_generated": "arg_to_cfi",
                 "ast": {
-                    "attrs": {
-                        "dimension": "10"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "dimension": "10"
+                        },
+                        "metaattrs": {
+                            "api": "cfi",
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "constant": "10"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToFixedConstArray",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "api": "cfi",
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "constant": "10"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -8413,22 +8553,23 @@
             {
                 "<FUNCTION>": "41 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "deref": "scalar"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "scalar"
+                        },
+                        "metaattrs": {
+                            "deref": "scalar",
+                            "intent": "function"
+                        },
                         "name": "returnIntScalar",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "scalar",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -8496,22 +8637,23 @@
             {
                 "<FUNCTION>": "42 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "deref": "raw"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "raw"
+                        },
+                        "metaattrs": {
+                            "deref": "raw",
+                            "intent": "function"
+                        },
                         "name": "returnIntRaw",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "raw",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -8589,41 +8731,43 @@
                 ],
                 "_PTR_F_C_index": "66",
                 "ast": {
-                    "attrs": {
-                        "deref": "raw"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "raw"
+                        },
+                        "metaattrs": {
+                            "deref": "raw",
+                            "intent": "function"
+                        },
                         "name": "returnIntRawWithArgs",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "raw",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -8732,42 +8876,44 @@
                 "_PTR_C_CXX_index": "43",
                 "_generated": "arg_to_cfi",
                 "ast": {
-                    "attrs": {
-                        "deref": "raw"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "raw"
+                        },
+                        "metaattrs": {
+                            "deref": "raw",
+                            "intent": "function"
+                        },
                         "name": "returnIntRawWithArgs",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "raw",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -8870,7 +9016,11 @@
                 "<FUNCTION>": "44 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "intent": "function"
+                        },
                         "name": "returnRawPtrToInt2d",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
@@ -8878,12 +9028,9 @@
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -8962,28 +9109,29 @@
                 ],
                 "_PTR_F_C_index": "67",
                 "ast": {
-                    "attrs": {
-                        "deref": "allocatable",
-                        "dimension": "10"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "allocatable",
+                            "dimension": "10"
+                        },
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "dimension": [
+                                {
+                                    "constant": "10"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "returnIntAllocToFixedArray",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "dimension": [
-                            {
-                                "constant": "10"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -9061,29 +9209,30 @@
                 "_PTR_C_CXX_index": "45",
                 "_generated": "arg_to_cfi",
                 "ast": {
-                    "attrs": {
-                        "deref": "allocatable",
-                        "dimension": "10"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "allocatable",
+                            "dimension": "10"
+                        },
+                        "metaattrs": {
+                            "api": "cfi",
+                            "deref": "allocatable",
+                            "dimension": [
+                                {
+                                    "constant": "10"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "returnIntAllocToFixedArray",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "api": "cfi",
-                        "deref": "allocatable",
-                        "dimension": [
-                            {
-                                "constant": "10"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],

--- a/regression/reference/pointers-cfi/pointers.json
+++ b/regression/reference/pointers-cfi/pointers.json
@@ -51,6 +51,7 @@
                 },
                 "decl": "void  intargs_in(const int *arg)",
                 "declgen": "void intargs_in(const int * arg)",
+                "name": "intargs_in",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -155,6 +156,7 @@
                 "doxygen": {
                     "description": "Argument is modified by library, defaults to intent(inout).\n"
                 },
+                "name": "intargs_inout",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -259,6 +261,7 @@
                 },
                 "decl": "void  intargs_out(int *arg +intent(out))",
                 "declgen": "void intargs_out(int * arg +intent(out))",
+                "name": "intargs_out",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -402,6 +405,7 @@
                 },
                 "decl": "void  intargs(const int argin      +intent(in), int * arginout +intent(inout), int * argout   +intent(out))",
                 "declgen": "void intargs(const int argin +intent(in)+value, int * arginout +intent(inout), int * argout +intent(out))",
+                "name": "intargs",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -630,6 +634,7 @@
                     "brief": "compute cos of IN and save in OUT",
                     "description": "allocate OUT same type as IN implied size of array"
                 },
+                "name": "cos_doubles",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -854,6 +859,7 @@
                     "brief": "compute cos of IN and save in OUT",
                     "description": "allocate OUT same type as IN implied size of array"
                 },
+                "name": "cos_doubles",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -1087,6 +1093,7 @@
                     "brief": "truncate IN argument and save in OUT",
                     "description": "allocate OUT different type as IN\nimplied size of array\n"
                 },
+                "name": "truncate_to_int",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -1311,6 +1318,7 @@
                     "brief": "truncate IN argument and save in OUT",
                     "description": "allocate OUT different type as IN\nimplied size of array\n"
                 },
+                "name": "truncate_to_int",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -1517,6 +1525,7 @@
                     "brief": "fill values into array",
                     "description": "The function knows how long the array must be.\nFortran will treat the dimension as assumed-length.\nThe Python wrapper will create a NumPy array or list so it must\nhave an explicit dimension (not assumed-length).\n"
                 },
+                "name": "get_values",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -1695,6 +1704,7 @@
                     "brief": "fill values into two arrays",
                     "description": "Test two intent(out) arguments.\nMake sure error handling works with C++.\n"
                 },
+                "name": "get_values2",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -1862,6 +1872,7 @@
                 },
                 "decl": "void iota_dimension (int nvar, int *values+intent(out)+dimension(nvar))",
                 "declgen": "void iota_dimension(int nvar +value, int * values +dimension(nvar)+intent(out))",
+                "name": "iota_dimension",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2046,6 +2057,7 @@
                 },
                 "decl": "void Sum(int len +implied(size(values)), const int *values +rank(1), int *result +intent(out))",
                 "declgen": "void Sum(int len +implied(size(values))+value, const int * values +rank(1), int * result +intent(out))",
+                "name": "Sum",
                 "options": {
                     "wrap_fortran": false,
                     "wrap_lua": false
@@ -2252,6 +2264,7 @@
                 },
                 "decl": "void Sum(int len +implied(size(values)), const int *values +rank(1), int *result +intent(out))",
                 "declgen": "void Sum(int len +implied(size(values))+value, const int * values +rank(1), int * result +intent(out))",
+                "name": "Sum",
                 "options": {
                     "wrap_fortran": false,
                     "wrap_lua": false
@@ -2433,6 +2446,7 @@
                 "doxygen": {
                     "description": "Return three values into memory the user provides.\n"
                 },
+                "name": "fillIntArray",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2566,6 +2580,7 @@
                 "doxygen": {
                     "description": "Increment array in place using intent(INOUT).\n"
                 },
+                "name": "incrementIntArray",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -2724,6 +2739,7 @@
                 "doxygen": {
                     "description": "Increment array in place using intent(INOUT).\n"
                 },
+                "name": "incrementIntArray",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -2883,6 +2899,7 @@
                 },
                 "decl": "void fill_with_zeros(double* x+rank(1), int x_length+implied(size(x)));",
                 "declgen": "void fill_with_zeros(double * x +rank(1), int x_length +implied(size(x))+value)",
+                "name": "fill_with_zeros",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -3037,6 +3054,7 @@
                 },
                 "decl": "void fill_with_zeros(double* x+rank(1), int x_length+implied(size(x)));",
                 "declgen": "void fill_with_zeros(double * x +rank(1), int x_length +implied(size(x))+value)",
+                "name": "fill_with_zeros",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -3197,6 +3215,7 @@
                 },
                 "decl": "int accumulate(const int *arr+rank(1), size_t len+implied(size(arr)));",
                 "declgen": "int accumulate(const int * arr +rank(1), size_t len +implied(size(arr))+value)",
+                "name": "accumulate",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -3383,6 +3402,7 @@
                 },
                 "decl": "int accumulate(const int *arr+rank(1), size_t len+implied(size(arr)));",
                 "declgen": "int accumulate(const int * arr +rank(1), size_t len +implied(size(arr))+value)",
+                "name": "accumulate",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -3559,6 +3579,7 @@
                 "doxygen": {
                     "description": "Return strlen of the first index as a check.\n"
                 },
+                "name": "acceptCharArrayIn",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -3705,6 +3726,7 @@
                 "doxygen": {
                     "description": "Return strlen of the first index as a check.\n"
                 },
+                "name": "acceptCharArrayIn",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -3835,6 +3857,7 @@
                 },
                 "decl": "void setGlobalInt(int value)",
                 "declgen": "void setGlobalInt(int value +value)",
+                "name": "setGlobalInt",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3920,6 +3943,7 @@
                 "doxygen": {
                     "description": "Used to test values global_array.\n"
                 },
+                "name": "sumFixedArray",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -4026,6 +4050,7 @@
                 },
                 "decl": "void getPtrToScalar(int **nitems+intent(out))",
                 "declgen": "void getPtrToScalar(int * * nitems +intent(out))",
+                "name": "getPtrToScalar",
                 "options": {
                     "wrap_fortran": false,
                     "wrap_python": false
@@ -4135,6 +4160,7 @@
                 },
                 "decl": "void getPtrToScalar(int **nitems+intent(out))",
                 "declgen": "void getPtrToScalar(int * * nitems +intent(out))",
+                "name": "getPtrToScalar",
                 "options": {
                     "wrap_fortran": false,
                     "wrap_python": false
@@ -4265,6 +4291,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is always the same length.\n"
                 },
+                "name": "getPtrToFixedArray",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -4386,6 +4413,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is always the same length.\n"
                 },
+                "name": "getPtrToFixedArray",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -4545,6 +4573,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is the length of\nthe argument ncount.\n"
                 },
+                "name": "getPtrToDynamicArray",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -4717,6 +4746,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is the length of\nthe argument ncount.\n"
                 },
+                "name": "getPtrToDynamicArray",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -4884,6 +4914,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is the length\nis computed by C++ function getLen.\ngetLen will be called from C/C++ to compute the shape.\n"
                 },
+                "name": "getPtrToFuncArray",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -5006,6 +5037,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is the length\nis computed by C++ function getLen.\ngetLen will be called from C/C++ to compute the shape.\n"
                 },
+                "name": "getPtrToFuncArray",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -5135,6 +5167,7 @@
                 },
                 "decl": "void getPtrToConstScalar( const int **nitems+intent(out))",
                 "declgen": "void getPtrToConstScalar(const int * * nitems +intent(out))",
+                "name": "getPtrToConstScalar",
                 "options": {
                     "wrap_fortran": false,
                     "wrap_python": false
@@ -5245,6 +5278,7 @@
                 },
                 "decl": "void getPtrToConstScalar( const int **nitems+intent(out))",
                 "declgen": "void getPtrToConstScalar(const int * * nitems +intent(out))",
+                "name": "getPtrToConstScalar",
                 "options": {
                     "wrap_fortran": false,
                     "wrap_python": false
@@ -5373,6 +5407,7 @@
                 },
                 "decl": "void getPtrToFixedConstArray( const int **count+intent(out)+dimension(10));",
                 "declgen": "void getPtrToFixedConstArray(const int * * count +dimension(10)+intent(out))",
+                "name": "getPtrToFixedConstArray",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -5492,6 +5527,7 @@
                 },
                 "decl": "void getPtrToFixedConstArray( const int **count+intent(out)+dimension(10));",
                 "declgen": "void getPtrToFixedConstArray(const int * * count +dimension(10)+intent(out))",
+                "name": "getPtrToFixedConstArray",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -5649,6 +5685,7 @@
                 },
                 "decl": "void getPtrToDynamicConstArray( const int **count+intent(out)+dimension(ncount), int *ncount+intent(out)+hidden)",
                 "declgen": "void getPtrToDynamicConstArray(const int * * count +dimension(ncount)+intent(out), int * ncount +hidden+intent(out))",
+                "name": "getPtrToDynamicConstArray",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -5819,6 +5856,7 @@
                 },
                 "decl": "void getPtrToDynamicConstArray( const int **count+intent(out)+dimension(ncount), int *ncount+intent(out)+hidden)",
                 "declgen": "void getPtrToDynamicConstArray(const int * * count +dimension(ncount)+intent(out), int * ncount +hidden+intent(out))",
+                "name": "getPtrToDynamicConstArray",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -5976,6 +6014,7 @@
                 "doxygen": {
                     "description": "Called directly via an interface in Fortran.\n"
                 },
+                "name": "getRawPtrToScalar",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -6088,6 +6127,7 @@
                 "doxygen": {
                     "description": "Create a Fortran wrapper.\n"
                 },
+                "name": "getRawPtrToScalarForce",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -6203,6 +6243,7 @@
                 "doxygen": {
                     "description": "Return a type(C_PTR) to an array which is always the same length.\nCalled directly via an interface in Fortran.\n# Uses +deref(raw) instead of +dimension(10) like getPtrToFixedArray.\n"
                 },
+                "name": "getRawPtrToFixedArray",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -6315,6 +6356,7 @@
                 "doxygen": {
                     "description": "Return a type(C_PTR) to an array which is always the same length.\nCreate a Fortran wrapper.\n"
                 },
+                "name": "getRawPtrToFixedArrayForce",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -6431,6 +6473,7 @@
                 "doxygen": {
                     "description": "Test multiple layers of indirection.\n"
                 },
+                "name": "getRawPtrToInt2d",
                 "options": {
                     "wrap_python": false
                 },
@@ -6543,6 +6586,7 @@
                 "doxygen": {
                     "description": "Check results of getRawPtrToInt2d.\n"
                 },
+                "name": "checkInt2d",
                 "options": {
                     "wrap_python": false
                 },
@@ -6692,6 +6736,7 @@
                 "doxygen": {
                     "description": "Test +dimension(10,20) +intent(in) together.\nThis will not use assumed-shape in the Fortran wrapper.\n"
                 },
+                "name": "DimensionIn",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -6821,6 +6866,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is always the same length.\n"
                 },
+                "name": "getAllocToFixedArray",
                 "options": {
                     "wrap_fortran": false,
                     "wrap_python": false
@@ -6944,6 +6990,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is always the same length.\n"
                 },
+                "name": "getAllocToFixedArray",
                 "options": {
                     "wrap_fortran": false,
                     "wrap_python": false
@@ -7057,6 +7104,7 @@
                 },
                 "decl": "void *returnAddress1(int flag)",
                 "declgen": "void * returnAddress1(int flag +value)",
+                "name": "returnAddress1",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -7191,6 +7239,7 @@
                 },
                 "decl": "void *returnAddress2(int flag)",
                 "declgen": "void * returnAddress2(int flag +value)",
+                "name": "returnAddress2",
                 "options": {
                     "F_force_wrapper": true
                 },
@@ -7330,6 +7379,7 @@
                 },
                 "decl": "void fetchVoidPtr(void **addr+intent(out))",
                 "declgen": "void fetchVoidPtr(void * * addr +intent(out))",
+                "name": "fetchVoidPtr",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -7436,6 +7486,7 @@
                 },
                 "decl": "void updateVoidPtr(void **addr+intent(inout))",
                 "declgen": "void updateVoidPtr(void * * addr +intent(inout))",
+                "name": "updateVoidPtr",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -7549,6 +7600,7 @@
                 },
                 "decl": "int VoidPtrArray(void **addr+rank(1))",
                 "declgen": "int VoidPtrArray(void * * addr +rank(1))",
+                "name": "VoidPtrArray",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_fortran": false,
@@ -7692,6 +7744,7 @@
                 },
                 "decl": "int VoidPtrArray(void **addr+rank(1))",
                 "declgen": "int VoidPtrArray(void * * addr +rank(1))",
+                "name": "VoidPtrArray",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_fortran": false,
@@ -7810,6 +7863,7 @@
                 },
                 "decl": "int *returnIntPtrToScalar(void)",
                 "declgen": "int * returnIntPtrToScalar(void)",
+                "name": "returnIntPtrToScalar",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -7897,6 +7951,7 @@
                 },
                 "decl": "int *returnIntPtrToScalar(void)",
                 "declgen": "int * returnIntPtrToScalar(void)",
+                "name": "returnIntPtrToScalar",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -7995,6 +8050,7 @@
                 },
                 "decl": "int *returnIntPtrToFixedArray(void) +dimension(10)",
                 "declgen": "int * returnIntPtrToFixedArray(void) +dimension(10)",
+                "name": "returnIntPtrToFixedArray",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -8094,6 +8150,7 @@
                 },
                 "decl": "int *returnIntPtrToFixedArray(void) +dimension(10)",
                 "declgen": "int * returnIntPtrToFixedArray(void) +dimension(10)",
+                "name": "returnIntPtrToFixedArray",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -8193,6 +8250,7 @@
                 },
                 "decl": "const int *returnIntPtrToConstScalar(void)",
                 "declgen": "const int * returnIntPtrToConstScalar(void)",
+                "name": "returnIntPtrToConstScalar",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -8281,6 +8339,7 @@
                 },
                 "decl": "const int *returnIntPtrToConstScalar(void)",
                 "declgen": "const int * returnIntPtrToConstScalar(void)",
+                "name": "returnIntPtrToConstScalar",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -8380,6 +8439,7 @@
                 },
                 "decl": "const int *returnIntPtrToFixedConstArray(void) +dimension(10)",
                 "declgen": "const int * returnIntPtrToFixedConstArray(void) +dimension(10)",
+                "name": "returnIntPtrToFixedConstArray",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -8480,6 +8540,7 @@
                 },
                 "decl": "const int *returnIntPtrToFixedConstArray(void) +dimension(10)",
                 "declgen": "const int * returnIntPtrToFixedConstArray(void) +dimension(10)",
+                "name": "returnIntPtrToFixedConstArray",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -8577,6 +8638,7 @@
                 },
                 "decl": "int *returnIntScalar(void) +deref(scalar)",
                 "declgen": "int * returnIntScalar(void) +deref(scalar)",
+                "name": "returnIntScalar",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -8664,6 +8726,7 @@
                 "doxygen": {
                     "description": "Call directly via interface.\n"
                 },
+                "name": "returnIntRaw",
                 "options": {
                     "wrap_python": false
                 },
@@ -8778,6 +8841,7 @@
                 "doxygen": {
                     "description": "Like returnIntRaw but with another argument to force a wrapper.\nUses fc_statements f_function_native_*_raw.\n"
                 },
+                "name": "returnIntRawWithArgs",
                 "options": {
                     "wrap_fortran": false,
                     "wrap_python": false
@@ -8924,6 +8988,7 @@
                 "doxygen": {
                     "description": "Like returnIntRaw but with another argument to force a wrapper.\nUses fc_statements f_function_native_*_raw.\n"
                 },
+                "name": "returnIntRawWithArgs",
                 "options": {
                     "wrap_fortran": false,
                     "wrap_python": false
@@ -9041,6 +9106,7 @@
                 "doxygen": {
                     "description": "Test multiple layers of indirection.\n# getRawPtrToInt2d\n"
                 },
+                "name": "returnRawPtrToInt2d",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -9139,6 +9205,7 @@
                 },
                 "decl": "int *returnIntAllocToFixedArray(void) +dimension(10)+deref(allocatable)",
                 "declgen": "int * returnIntAllocToFixedArray(void) +deref(allocatable)+dimension(10)",
+                "name": "returnIntAllocToFixedArray",
                 "options": {
                     "wrap_fortran": false,
                     "wrap_python": false
@@ -9240,6 +9307,7 @@
                 },
                 "decl": "int *returnIntAllocToFixedArray(void) +dimension(10)+deref(allocatable)",
                 "declgen": "int * returnIntAllocToFixedArray(void) +deref(allocatable)+dimension(10)",
+                "name": "returnIntAllocToFixedArray",
                 "options": {
                     "wrap_fortran": false,
                     "wrap_python": false

--- a/regression/reference/pointers-cxx/pointers.json
+++ b/regression/reference/pointers-cxx/pointers.json
@@ -51,6 +51,7 @@
                 },
                 "decl": "void  intargs_in(const int *arg)",
                 "declgen": "void intargs_in(const int * arg)",
+                "name": "intargs_in",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -155,6 +156,7 @@
                 "doxygen": {
                     "description": "Argument is modified by library, defaults to intent(inout).\n"
                 },
+                "name": "intargs_inout",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -259,6 +261,7 @@
                 },
                 "decl": "void  intargs_out(int *arg +intent(out))",
                 "declgen": "void intargs_out(int * arg +intent(out))",
+                "name": "intargs_out",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -402,6 +405,7 @@
                 },
                 "decl": "void  intargs(const int argin      +intent(in), int * arginout +intent(inout), int * argout   +intent(out))",
                 "declgen": "void intargs(const int argin +intent(in)+value, int * arginout +intent(inout), int * argout +intent(out))",
+                "name": "intargs",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -626,6 +630,7 @@
                     "brief": "compute cos of IN and save in OUT",
                     "description": "allocate OUT same type as IN implied size of array"
                 },
+                "name": "cos_doubles",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -855,6 +860,7 @@
                     "brief": "truncate IN argument and save in OUT",
                     "description": "allocate OUT different type as IN\nimplied size of array\n"
                 },
+                "name": "truncate_to_int",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -1061,6 +1067,7 @@
                     "brief": "fill values into array",
                     "description": "The function knows how long the array must be.\nFortran will treat the dimension as assumed-length.\nThe Python wrapper will create a NumPy array or list so it must\nhave an explicit dimension (not assumed-length).\n"
                 },
+                "name": "get_values",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -1239,6 +1246,7 @@
                     "brief": "fill values into two arrays",
                     "description": "Test two intent(out) arguments.\nMake sure error handling works with C++.\n"
                 },
+                "name": "get_values2",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -1406,6 +1414,7 @@
                 },
                 "decl": "void iota_dimension (int nvar, int *values+intent(out)+dimension(nvar))",
                 "declgen": "void iota_dimension(int nvar +value, int * values +dimension(nvar)+intent(out))",
+                "name": "iota_dimension",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -1586,6 +1595,7 @@
                 },
                 "decl": "void Sum(int len +implied(size(values)), const int *values +rank(1), int *result +intent(out))",
                 "declgen": "void Sum(int len +implied(size(values))+value, const int * values +rank(1), int * result +intent(out))",
+                "name": "Sum",
                 "options": {
                     "wrap_lua": false
                 },
@@ -1768,6 +1778,7 @@
                 "doxygen": {
                     "description": "Return three values into memory the user provides.\n"
                 },
+                "name": "fillIntArray",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -1897,6 +1908,7 @@
                 "doxygen": {
                     "description": "Increment array in place using intent(INOUT).\n"
                 },
+                "name": "incrementIntArray",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2052,6 +2064,7 @@
                 },
                 "decl": "void fill_with_zeros(double* x+rank(1), int x_length+implied(size(x)));",
                 "declgen": "void fill_with_zeros(double * x +rank(1), int x_length +implied(size(x))+value)",
+                "name": "fill_with_zeros",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2208,6 +2221,7 @@
                 },
                 "decl": "int accumulate(const int *arr+rank(1), size_t len+implied(size(arr)));",
                 "declgen": "int accumulate(const int * arr +rank(1), size_t len +implied(size(arr))+value)",
+                "name": "accumulate",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2388,6 +2402,7 @@
                 "doxygen": {
                     "description": "Return strlen of the first index as a check.\n"
                 },
+                "name": "acceptCharArrayIn",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2532,6 +2547,7 @@
                 "doxygen": {
                     "description": "Return strlen of the first index as a check.\n"
                 },
+                "name": "acceptCharArrayIn",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -2658,6 +2674,7 @@
                 },
                 "decl": "void setGlobalInt(int value)",
                 "declgen": "void setGlobalInt(int value +value)",
+                "name": "setGlobalInt",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2743,6 +2760,7 @@
                 "doxygen": {
                     "description": "Used to test values global_array.\n"
                 },
+                "name": "sumFixedArray",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2849,6 +2867,7 @@
                 },
                 "decl": "void getPtrToScalar(int **nitems+intent(out))",
                 "declgen": "void getPtrToScalar(int * * nitems +intent(out))",
+                "name": "getPtrToScalar",
                 "options": {
                     "wrap_python": false
                 },
@@ -2957,6 +2976,7 @@
                 },
                 "decl": "void getPtrToScalar(int **nitems+intent(out))",
                 "declgen": "void getPtrToScalar(int * * nitems +intent(out))",
+                "name": "getPtrToScalar",
                 "options": {
                     "wrap_python": false
                 },
@@ -3075,6 +3095,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is always the same length.\n"
                 },
+                "name": "getPtrToFixedArray",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3194,6 +3215,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is always the same length.\n"
                 },
+                "name": "getPtrToFixedArray",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -3339,6 +3361,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is the length of\nthe argument ncount.\n"
                 },
+                "name": "getPtrToDynamicArray",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3509,6 +3532,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is the length of\nthe argument ncount.\n"
                 },
+                "name": "getPtrToDynamicArray",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -3662,6 +3686,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is the length\nis computed by C++ function getLen.\ngetLen will be called from C/C++ to compute the shape.\n"
                 },
+                "name": "getPtrToFuncArray",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3782,6 +3807,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is the length\nis computed by C++ function getLen.\ngetLen will be called from C/C++ to compute the shape.\n"
                 },
+                "name": "getPtrToFuncArray",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -3897,6 +3923,7 @@
                 },
                 "decl": "void getPtrToConstScalar( const int **nitems+intent(out))",
                 "declgen": "void getPtrToConstScalar(const int * * nitems +intent(out))",
+                "name": "getPtrToConstScalar",
                 "options": {
                     "wrap_python": false
                 },
@@ -4006,6 +4033,7 @@
                 },
                 "decl": "void getPtrToConstScalar( const int **nitems+intent(out))",
                 "declgen": "void getPtrToConstScalar(const int * * nitems +intent(out))",
+                "name": "getPtrToConstScalar",
                 "options": {
                     "wrap_python": false
                 },
@@ -4122,6 +4150,7 @@
                 },
                 "decl": "void getPtrToFixedConstArray( const int **count+intent(out)+dimension(10));",
                 "declgen": "void getPtrToFixedConstArray(const int * * count +dimension(10)+intent(out))",
+                "name": "getPtrToFixedConstArray",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -4239,6 +4268,7 @@
                 },
                 "decl": "void getPtrToFixedConstArray( const int **count+intent(out)+dimension(10));",
                 "declgen": "void getPtrToFixedConstArray(const int * * count +dimension(10)+intent(out))",
+                "name": "getPtrToFixedConstArray",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -4382,6 +4412,7 @@
                 },
                 "decl": "void getPtrToDynamicConstArray( const int **count+intent(out)+dimension(ncount), int *ncount+intent(out)+hidden)",
                 "declgen": "void getPtrToDynamicConstArray(const int * * count +dimension(ncount)+intent(out), int * ncount +hidden+intent(out))",
+                "name": "getPtrToDynamicConstArray",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -4550,6 +4581,7 @@
                 },
                 "decl": "void getPtrToDynamicConstArray( const int **count+intent(out)+dimension(ncount), int *ncount+intent(out)+hidden)",
                 "declgen": "void getPtrToDynamicConstArray(const int * * count +dimension(ncount)+intent(out), int * ncount +hidden+intent(out))",
+                "name": "getPtrToDynamicConstArray",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -4693,6 +4725,7 @@
                 "doxygen": {
                     "description": "Called directly via an interface in Fortran.\n"
                 },
+                "name": "getRawPtrToScalar",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -4805,6 +4838,7 @@
                 "doxygen": {
                     "description": "Create a Fortran wrapper.\n"
                 },
+                "name": "getRawPtrToScalarForce",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -4920,6 +4954,7 @@
                 "doxygen": {
                     "description": "Return a type(C_PTR) to an array which is always the same length.\nCalled directly via an interface in Fortran.\n# Uses +deref(raw) instead of +dimension(10) like getPtrToFixedArray.\n"
                 },
+                "name": "getRawPtrToFixedArray",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -5032,6 +5067,7 @@
                 "doxygen": {
                     "description": "Return a type(C_PTR) to an array which is always the same length.\nCreate a Fortran wrapper.\n"
                 },
+                "name": "getRawPtrToFixedArrayForce",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -5148,6 +5184,7 @@
                 "doxygen": {
                     "description": "Test multiple layers of indirection.\n"
                 },
+                "name": "getRawPtrToInt2d",
                 "options": {
                     "wrap_python": false
                 },
@@ -5260,6 +5297,7 @@
                 "doxygen": {
                     "description": "Check results of getRawPtrToInt2d.\n"
                 },
+                "name": "checkInt2d",
                 "options": {
                     "wrap_python": false
                 },
@@ -5409,6 +5447,7 @@
                 "doxygen": {
                     "description": "Test +dimension(10,20) +intent(in) together.\nThis will not use assumed-shape in the Fortran wrapper.\n"
                 },
+                "name": "DimensionIn",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -5538,6 +5577,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is always the same length.\n"
                 },
+                "name": "getAllocToFixedArray",
                 "options": {
                     "wrap_python": false
                 },
@@ -5660,6 +5700,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is always the same length.\n"
                 },
+                "name": "getAllocToFixedArray",
                 "options": {
                     "wrap_python": false
                 },
@@ -5768,6 +5809,7 @@
                 },
                 "decl": "void *returnAddress1(int flag)",
                 "declgen": "void * returnAddress1(int flag +value)",
+                "name": "returnAddress1",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -5902,6 +5944,7 @@
                 },
                 "decl": "void *returnAddress2(int flag)",
                 "declgen": "void * returnAddress2(int flag +value)",
+                "name": "returnAddress2",
                 "options": {
                     "F_force_wrapper": true
                 },
@@ -6041,6 +6084,7 @@
                 },
                 "decl": "void fetchVoidPtr(void **addr+intent(out))",
                 "declgen": "void fetchVoidPtr(void * * addr +intent(out))",
+                "name": "fetchVoidPtr",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -6147,6 +6191,7 @@
                 },
                 "decl": "void updateVoidPtr(void **addr+intent(inout))",
                 "declgen": "void updateVoidPtr(void * * addr +intent(inout))",
+                "name": "updateVoidPtr",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -6256,6 +6301,7 @@
                 },
                 "decl": "int VoidPtrArray(void **addr+rank(1))",
                 "declgen": "int VoidPtrArray(void * * addr +rank(1))",
+                "name": "VoidPtrArray",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -6385,6 +6431,7 @@
                 },
                 "decl": "int *returnIntPtrToScalar(void)",
                 "declgen": "int * returnIntPtrToScalar(void)",
+                "name": "returnIntPtrToScalar",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -6470,6 +6517,7 @@
                 },
                 "decl": "int *returnIntPtrToScalar(void)",
                 "declgen": "int * returnIntPtrToScalar(void)",
+                "name": "returnIntPtrToScalar",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -6553,6 +6601,7 @@
                 },
                 "decl": "int *returnIntPtrToFixedArray(void) +dimension(10)",
                 "declgen": "int * returnIntPtrToFixedArray(void) +dimension(10)",
+                "name": "returnIntPtrToFixedArray",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -6653,6 +6702,7 @@
                 },
                 "decl": "int *returnIntPtrToFixedArray(void) +dimension(10)",
                 "declgen": "int * returnIntPtrToFixedArray(void) +dimension(10)",
+                "name": "returnIntPtrToFixedArray",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -6736,6 +6786,7 @@
                 },
                 "decl": "const int *returnIntPtrToConstScalar(void)",
                 "declgen": "const int * returnIntPtrToConstScalar(void)",
+                "name": "returnIntPtrToConstScalar",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -6822,6 +6873,7 @@
                 },
                 "decl": "const int *returnIntPtrToConstScalar(void)",
                 "declgen": "const int * returnIntPtrToConstScalar(void)",
+                "name": "returnIntPtrToConstScalar",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -6906,6 +6958,7 @@
                 },
                 "decl": "const int *returnIntPtrToFixedConstArray(void) +dimension(10)",
                 "declgen": "const int * returnIntPtrToFixedConstArray(void) +dimension(10)",
+                "name": "returnIntPtrToFixedConstArray",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -7007,6 +7060,7 @@
                 },
                 "decl": "const int *returnIntPtrToFixedConstArray(void) +dimension(10)",
                 "declgen": "const int * returnIntPtrToFixedConstArray(void) +dimension(10)",
+                "name": "returnIntPtrToFixedConstArray",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -7088,6 +7142,7 @@
                 },
                 "decl": "int *returnIntScalar(void) +deref(scalar)",
                 "declgen": "int * returnIntScalar(void) +deref(scalar)",
+                "name": "returnIntScalar",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -7175,6 +7230,7 @@
                 "doxygen": {
                     "description": "Call directly via interface.\n"
                 },
+                "name": "returnIntRaw",
                 "options": {
                     "wrap_python": false
                 },
@@ -7286,6 +7342,7 @@
                 "doxygen": {
                     "description": "Like returnIntRaw but with another argument to force a wrapper.\nUses fc_statements f_function_native_*_raw.\n"
                 },
+                "name": "returnIntRawWithArgs",
                 "options": {
                     "wrap_python": false
                 },
@@ -7408,6 +7465,7 @@
                 "doxygen": {
                     "description": "Test multiple layers of indirection.\n# getRawPtrToInt2d\n"
                 },
+                "name": "returnRawPtrToInt2d",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -7506,6 +7564,7 @@
                 },
                 "decl": "int *returnIntAllocToFixedArray(void) +dimension(10)+deref(allocatable)",
                 "declgen": "int * returnIntAllocToFixedArray(void) +deref(allocatable)+dimension(10)",
+                "name": "returnIntAllocToFixedArray",
                 "options": {
                     "wrap_python": false
                 },
@@ -7609,6 +7668,7 @@
                 },
                 "decl": "int *returnIntAllocToFixedArray(void) +dimension(10)+deref(allocatable)",
                 "declgen": "int * returnIntAllocToFixedArray(void) +deref(allocatable)+dimension(10)",
+                "name": "returnIntAllocToFixedArray",
                 "options": {
                     "wrap_python": false
                 },

--- a/regression/reference/pointers-cxx/pointers.json
+++ b/regression/reference/pointers-cxx/pointers.json
@@ -17,31 +17,33 @@
                 "<FUNCTION>": "0 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "intargs_in"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "intargs_in",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -117,30 +119,32 @@
                 "<FUNCTION>": "1 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "intargs_inout"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "intargs_inout",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -219,33 +223,35 @@
                 "<FUNCTION>": "2 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "intargs_out"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "intargs_out",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -321,70 +327,74 @@
                 "<FUNCTION>": "3 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "intargs"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "value": true
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "argin"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "inout"
+                        "name": "intargs",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "argin",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "arginout",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arginout",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "argout",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "argout",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -526,81 +536,85 @@
                 "<FUNCTION>": "4 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "cos_doubles"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "in",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "size(in)",
-                                "intent": "out"
+                        "name": "cos_doubles",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "in",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "out",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "args": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "size(in)",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
                                             {
-                                                "name": "in"
+                                                "args": [
+                                                    {
+                                                        "name": "in"
+                                                    }
+                                                ],
+                                                "name": "size"
                                             }
                                         ],
-                                        "name": "size"
-                                    }
+                                        "intent": "out"
+                                    },
+                                    "name": "out",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "double"
                             },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(in)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "sizein"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(in)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "sizein",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -751,81 +765,85 @@
                 "<FUNCTION>": "5 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "truncate_to_int"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "in",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "size(in)",
-                                "intent": "out"
+                        "name": "truncate_to_int",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "in",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "out",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "args": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "size(in)",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
                                             {
-                                                "name": "in"
+                                                "args": [
+                                                    {
+                                                        "name": "in"
+                                                    }
+                                                ],
+                                                "name": "size"
                                             }
                                         ],
-                                        "name": "size"
-                                    }
+                                        "intent": "out"
+                                    },
+                                    "name": "out",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(in)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "sizein"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(in)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "sizein",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -976,59 +994,62 @@
                 "<FUNCTION>": "6 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "get_values"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "OUT"
-                            },
-                            "declarator": {
-                                "name": "nvalues",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "3",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "values",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "3"
-                                    }
+                        "name": "get_values",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "OUT"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "nvalues",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "3",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "3"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "values",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1145,65 +1166,68 @@
                 "<FUNCTION>": "7 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "get_values2"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "3",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "3"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "3",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg2",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "3"
-                                    }
+                        "name": "get_values2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "3",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "3"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "3",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "3"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "arg2",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1324,54 +1348,57 @@
                 "<FUNCTION>": "8 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "iota_dimension"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "nvar"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "nvar",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "values",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nvar"
-                                    }
+                        "name": "iota_dimension",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nvar",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "nvar",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "name": "nvar"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "values",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1484,70 +1511,74 @@
                 "<FUNCTION>": "9 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "Sum"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "implied": "size(values)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "len"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "rank": 1
+                        "name": "Sum",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(values)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "len",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "const": true,
-                            "declarator": {
-                                "name": "values",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "values",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "result",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "result",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1692,39 +1723,41 @@
                 "<FUNCTION>": "10 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "fillIntArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "3",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "out",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "3"
-                                    }
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "fillIntArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "3",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "3"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "out",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1807,50 +1840,53 @@
                 "<FUNCTION>": "11 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "incrementIntArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "array",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "size(array)",
-                                "value": true
+                        "name": "incrementIntArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "array",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "sizein"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(array)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "sizein",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1963,49 +1999,52 @@
                 "<FUNCTION>": "12 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "fill_with_zeros"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "x",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "size(x)",
-                                "value": true
+                        "name": "fill_with_zeros",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "x",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "x_length"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(x)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "x_length",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2115,50 +2154,53 @@
                 "<FUNCTION>": "13 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "accumulate"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "arr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "implied": "size(arr)",
-                                "value": true
+                        "name": "accumulate",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "len"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(arr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "len",
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -2303,37 +2345,39 @@
                 "_PTR_F_C_index": "46",
                 "ast": {
                     "declarator": {
-                        "name": "acceptCharArrayIn"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "names",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "acceptCharArrayIn",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "names",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -2444,38 +2488,40 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "acceptCharArrayIn"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "names",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "acceptCharArrayIn",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "in"
+                                    },
+                                    "name": "names",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -2581,28 +2627,30 @@
                 "<FUNCTION>": "15 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "setGlobalInt"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "setGlobalInt",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "value",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "value"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -2678,12 +2726,13 @@
                 "<FUNCTION>": "16 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "sumFixedArray"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "sumFixedArray",
+                        "params": [],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -2760,37 +2809,39 @@
                 "_PTR_F_C_index": "47",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToScalar"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToScalar",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2865,38 +2916,40 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToScalar"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToScalar",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "deref": "pointer",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "api": "cdesc",
+                                        "deref": "pointer",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2973,43 +3026,45 @@
                 "_PTR_F_C_index": "48",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToFixedArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "10",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToFixedArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "10",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "constant": "10"
-                                    }
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3089,44 +3144,46 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToFixedArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "10",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToFixedArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "10",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "constant": "10"
-                                    }
+                                    "metaattrs": {
+                                        "api": "cdesc",
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3211,64 +3268,67 @@
                 "_PTR_F_C_index": "49",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToDynamicArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "ncount",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "name": "ncount"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
+                        "name": "getPtrToDynamicArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "ncount",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "name": "ncount"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "ncount",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "ncount",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3377,65 +3437,68 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToDynamicArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "ncount",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "name": "ncount"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
+                        "name": "getPtrToDynamicArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "ncount",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "api": "cdesc",
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "name": "ncount"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "ncount",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "ncount",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3549,44 +3612,46 @@
                 "_PTR_F_C_index": "50",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToFuncArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "getLen()",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToFuncArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "getLen()",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "args": [],
-                                        "name": "getLen"
-                                    }
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "args": [],
+                                                "name": "getLen"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3666,45 +3731,47 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToFuncArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "getLen()",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToFuncArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "getLen()",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "args": [],
-                                        "name": "getLen"
-                                    }
+                                    "metaattrs": {
+                                        "api": "cdesc",
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "args": [],
+                                                "name": "getLen"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3789,38 +3856,40 @@
                 "_PTR_F_C_index": "51",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToConstScalar"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToConstScalar",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3895,39 +3964,41 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToConstScalar"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToConstScalar",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "deref": "pointer",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "api": "cdesc",
+                                        "deref": "pointer",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4004,44 +4075,46 @@
                 "_PTR_F_C_index": "52",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToFixedConstArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "10",
-                                "intent": "out"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToFixedConstArray",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "10",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "constant": "10"
-                                    }
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4118,45 +4191,47 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToFixedConstArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "10",
-                                "intent": "out"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToFixedConstArray",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "10",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "constant": "10"
-                                    }
+                                    "metaattrs": {
+                                        "api": "cdesc",
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4238,65 +4313,68 @@
                 "_PTR_F_C_index": "53",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToDynamicConstArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "ncount",
-                                "intent": "out"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "name": "ncount"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
+                        "name": "getPtrToDynamicConstArray",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "ncount",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "name": "ncount"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "ncount",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "ncount",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4402,66 +4480,69 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToDynamicConstArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "ncount",
-                                "intent": "out"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "name": "ncount"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
+                        "name": "getPtrToDynamicConstArray",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "ncount",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "api": "cdesc",
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "name": "ncount"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "ncount",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "ncount",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4568,38 +4649,40 @@
                 "<FUNCTION>": "24 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToScalar"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToScalar",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4678,38 +4761,40 @@
                 "<FUNCTION>": "25 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToScalarForce"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToScalarForce",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4791,38 +4876,40 @@
                 "<FUNCTION>": "26 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToFixedArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToFixedArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -4901,38 +4988,40 @@
                 "<FUNCTION>": "27 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToFixedArrayForce"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToFixedArrayForce",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5014,39 +5103,41 @@
                 "<FUNCTION>": "28 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToInt2d"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToInt2d",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
+                                    "metaattrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5127,36 +5218,38 @@
                 "<FUNCTION>": "29 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "checkInt2d"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "checkInt2d",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -5268,42 +5361,44 @@
                 "<FUNCTION>": "30 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "DimensionIn"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "10,20"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "10"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "DimensionIn",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "10,20"
                                     },
-                                    {
-                                        "constant": "20"
-                                    }
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            },
+                                            {
+                                                "constant": "20"
+                                            }
+                                        ],
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5393,44 +5488,46 @@
                 "_PTR_F_C_index": "54",
                 "ast": {
                     "declarator": {
-                        "name": "getAllocToFixedArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "allocatable",
-                                "dimension": "10",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getAllocToFixedArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "allocatable",
+                                        "dimension": "10",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "allocatable",
-                                "dimension": [
-                                    {
-                                        "constant": "10"
-                                    }
+                                    "metaattrs": {
+                                        "deref": "allocatable",
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5512,45 +5609,47 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "getAllocToFixedArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "allocatable",
-                                "dimension": "10",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getAllocToFixedArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "allocatable",
+                                        "dimension": "10",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "deref": "allocatable",
-                                "dimension": [
-                                    {
-                                        "constant": "10"
-                                    }
+                                    "metaattrs": {
+                                        "api": "cdesc",
+                                        "deref": "allocatable",
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5633,33 +5732,35 @@
                 "<FUNCTION>": "32 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "intent": "function"
+                        },
                         "name": "returnAddress1",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "flag",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "flag"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -5765,33 +5866,35 @@
                 "<FUNCTION>": "33 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "intent": "function"
+                        },
                         "name": "returnAddress2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "flag",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "flag"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -5899,36 +6002,38 @@
                 "<FUNCTION>": "34 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "fetchVoidPtr"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "fetchVoidPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -6003,36 +6108,38 @@
                 "<FUNCTION>": "35 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "updateVoidPtr"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout"
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "updateVoidPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -6110,36 +6217,38 @@
                 "<FUNCTION>": "36 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "VoidPtrArray"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "VoidPtrArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -6256,18 +6365,19 @@
                 "_PTR_F_C_index": "55",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToScalar",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -6339,19 +6449,20 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "buf",
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToScalar",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "api": "buf",
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -6413,27 +6524,28 @@
                 ],
                 "_PTR_F_C_index": "56",
                 "ast": {
-                    "attrs": {
-                        "dimension": "10"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "dimension": "10"
+                        },
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "constant": "10"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToFixedArray",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "constant": "10"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -6511,28 +6623,29 @@
                 "_PTR_C_CXX_index": "38",
                 "_generated": "arg_to_buffer",
                 "ast": {
-                    "attrs": {
-                        "dimension": "10"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "dimension": "10"
+                        },
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "constant": "10"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToFixedArray",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "constant": "10"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -6603,18 +6716,19 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToConstScalar",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -6687,19 +6801,20 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "api": "buf",
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToConstScalar",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "api": "buf",
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -6761,28 +6876,29 @@
                 ],
                 "_PTR_F_C_index": "58",
                 "ast": {
-                    "attrs": {
-                        "dimension": "10"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "dimension": "10"
+                        },
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "constant": "10"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToFixedConstArray",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "constant": "10"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -6860,29 +6976,30 @@
                 "_PTR_C_CXX_index": "40",
                 "_generated": "arg_to_buffer",
                 "ast": {
-                    "attrs": {
-                        "dimension": "10"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "dimension": "10"
+                        },
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "constant": "10"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToFixedConstArray",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "constant": "10"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -6947,22 +7064,23 @@
             {
                 "<FUNCTION>": "41 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "deref": "scalar"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "scalar"
+                        },
+                        "metaattrs": {
+                            "deref": "scalar",
+                            "intent": "function"
+                        },
                         "name": "returnIntScalar",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "scalar",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -7030,22 +7148,23 @@
             {
                 "<FUNCTION>": "42 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "deref": "raw"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "raw"
+                        },
+                        "metaattrs": {
+                            "deref": "raw",
+                            "intent": "function"
+                        },
                         "name": "returnIntRaw",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "raw",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -7119,42 +7238,44 @@
             {
                 "<FUNCTION>": "43 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "deref": "raw"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "raw"
+                        },
+                        "metaattrs": {
+                            "deref": "raw",
+                            "intent": "function"
+                        },
                         "name": "returnIntRawWithArgs",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "ftrim_char_in": true,
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "raw",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "ftrim_char_in": true,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -7262,7 +7383,11 @@
                 "<FUNCTION>": "44 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "intent": "function"
+                        },
                         "name": "returnRawPtrToInt2d",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
@@ -7270,12 +7395,9 @@
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -7354,28 +7476,29 @@
                 ],
                 "_PTR_F_C_index": "59",
                 "ast": {
-                    "attrs": {
-                        "deref": "allocatable",
-                        "dimension": "10"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "allocatable",
+                            "dimension": "10"
+                        },
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "dimension": [
+                                {
+                                    "constant": "10"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "returnIntAllocToFixedArray",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "dimension": [
-                            {
-                                "constant": "10"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -7455,29 +7578,30 @@
                 "_PTR_C_CXX_index": "45",
                 "_generated": "arg_to_buffer",
                 "ast": {
-                    "attrs": {
-                        "deref": "allocatable",
-                        "dimension": "10"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "allocatable",
+                            "dimension": "10"
+                        },
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "deref": "allocatable",
+                            "dimension": [
+                                {
+                                    "constant": "10"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "returnIntAllocToFixedArray",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "deref": "allocatable",
-                        "dimension": [
-                            {
-                                "constant": "10"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],

--- a/regression/reference/pointers-list-c/pointers.json
+++ b/regression/reference/pointers-list-c/pointers.json
@@ -17,31 +17,33 @@
                 "<FUNCTION>": "0 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "intargs_in"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "intargs_in",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -87,30 +89,32 @@
                 "<FUNCTION>": "1 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "intargs_inout"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "intargs_inout",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -159,33 +163,35 @@
                 "<FUNCTION>": "2 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "intargs_out"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "intargs_out",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -231,70 +237,74 @@
                 "<FUNCTION>": "3 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "intargs"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "value": true
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "argin"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "inout"
+                        "name": "intargs",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "argin",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "arginout",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arginout",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "argout",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "argout",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -383,81 +393,85 @@
                 "<FUNCTION>": "4 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "cos_doubles"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "in",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "size(in)",
-                                "intent": "out"
+                        "name": "cos_doubles",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "in",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "out",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "args": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "size(in)",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
                                             {
-                                                "name": "in"
+                                                "args": [
+                                                    {
+                                                        "name": "in"
+                                                    }
+                                                ],
+                                                "name": "size"
                                             }
                                         ],
-                                        "name": "size"
-                                    }
+                                        "intent": "out"
+                                    },
+                                    "name": "out",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "double"
                             },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(in)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "sizein"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(in)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "sizein",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -557,81 +571,85 @@
                 "<FUNCTION>": "5 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "truncate_to_int"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "in",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "size(in)",
-                                "intent": "out"
+                        "name": "truncate_to_int",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "in",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "out",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "args": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "size(in)",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
                                             {
-                                                "name": "in"
+                                                "args": [
+                                                    {
+                                                        "name": "in"
+                                                    }
+                                                ],
+                                                "name": "size"
                                             }
                                         ],
-                                        "name": "size"
-                                    }
+                                        "intent": "out"
+                                    },
+                                    "name": "out",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(in)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "sizein"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(in)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "sizein",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -731,59 +749,62 @@
                 "<FUNCTION>": "6 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "get_values"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "OUT"
-                            },
-                            "declarator": {
-                                "name": "nvalues",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "3",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "values",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "3"
-                                    }
+                        "name": "get_values",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "OUT"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "nvalues",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "3",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "3"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "values",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -861,65 +882,68 @@
                 "<FUNCTION>": "7 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "get_values2"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "3",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "3"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "3",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg2",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "3"
-                                    }
+                        "name": "get_values2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "3",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "3"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "3",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "3"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "arg2",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1003,54 +1027,57 @@
                 "<FUNCTION>": "8 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "iota_dimension"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "nvar"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "nvar",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "values",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nvar"
-                                    }
+                        "name": "iota_dimension",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nvar",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "nvar",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "name": "nvar"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "values",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1123,70 +1150,74 @@
                 "<FUNCTION>": "9 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "Sum"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "implied": "size(values)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "len"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "rank": 1
+                        "name": "Sum",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(values)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "len",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "const": true,
-                            "declarator": {
-                                "name": "values",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "values",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "result",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "result",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1278,39 +1309,41 @@
                 "<FUNCTION>": "10 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "fillIntArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "3",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "out",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "3"
-                                    }
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "fillIntArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "3",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "3"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "out",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1365,50 +1398,53 @@
                 "<FUNCTION>": "11 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "incrementIntArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "array",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "size(array)",
-                                "value": true
+                        "name": "incrementIntArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "array",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "sizein"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(array)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "sizein",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1480,49 +1516,52 @@
                 "<FUNCTION>": "12 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "fill_with_zeros"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "x",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "size(x)",
-                                "value": true
+                        "name": "fill_with_zeros",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "x",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "x_length"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(x)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "x_length",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1591,50 +1630,53 @@
                 "<FUNCTION>": "13 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "accumulate"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "arr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "implied": "size(arr)",
-                                "value": true
+                        "name": "accumulate",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "len"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(arr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "len",
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -1721,37 +1763,39 @@
                 "<FUNCTION>": "14 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptCharArrayIn"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "names",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "acceptCharArrayIn",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "names",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -1821,28 +1865,30 @@
                 "<FUNCTION>": "15 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "setGlobalInt"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "setGlobalInt",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "value",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "value"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -1887,12 +1933,13 @@
                 "<FUNCTION>": "16 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "sumFixedArray"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "sumFixedArray",
+                        "params": [],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -1936,37 +1983,39 @@
                 "<FUNCTION>": "17 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToScalar"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToScalar",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1987,43 +2036,45 @@
                 "<FUNCTION>": "18 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToFixedArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "10",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToFixedArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "10",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "constant": "10"
-                                    }
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2078,64 +2129,67 @@
                 "<FUNCTION>": "19 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToDynamicArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "ncount",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "name": "ncount"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
+                        "name": "getPtrToDynamicArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "ncount",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "name": "ncount"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "ncount",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "ncount",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2212,44 +2266,46 @@
                 "<FUNCTION>": "20 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToFuncArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "getLen()",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToFuncArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "getLen()",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "args": [],
-                                        "name": "getLen"
-                                    }
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "args": [],
+                                                "name": "getLen"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2304,38 +2360,40 @@
                 "<FUNCTION>": "21 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToConstScalar"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToConstScalar",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2356,44 +2414,46 @@
                 "<FUNCTION>": "22 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToFixedConstArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "10",
-                                "intent": "out"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToFixedConstArray",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "10",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "constant": "10"
-                                    }
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2445,65 +2505,68 @@
                 "<FUNCTION>": "23 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToDynamicConstArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "ncount",
-                                "intent": "out"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "name": "ncount"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
+                        "name": "getPtrToDynamicConstArray",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "ncount",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "name": "ncount"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "ncount",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "ncount",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2577,38 +2640,40 @@
                 "<FUNCTION>": "24 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToScalar"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToScalar",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2657,38 +2722,40 @@
                 "<FUNCTION>": "25 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToScalarForce"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToScalarForce",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2713,38 +2780,40 @@
                 "<FUNCTION>": "26 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToFixedArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToFixedArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2793,38 +2862,40 @@
                 "<FUNCTION>": "27 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToFixedArrayForce"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToFixedArrayForce",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2849,39 +2920,41 @@
                 "<FUNCTION>": "28 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToInt2d"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToInt2d",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
+                                    "metaattrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2905,36 +2978,38 @@
                 "<FUNCTION>": "29 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "checkInt2d"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "checkInt2d",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -2958,42 +3033,44 @@
                 "<FUNCTION>": "30 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "DimensionIn"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "10,20"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "10"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "DimensionIn",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "10,20"
                                     },
-                                    {
-                                        "constant": "20"
-                                    }
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            },
+                                            {
+                                                "constant": "20"
+                                            }
+                                        ],
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3018,44 +3095,46 @@
                 "<FUNCTION>": "31 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getAllocToFixedArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "allocatable",
-                                "dimension": "10",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getAllocToFixedArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "allocatable",
+                                        "dimension": "10",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "allocatable",
-                                "dimension": [
-                                    {
-                                        "constant": "10"
-                                    }
+                                    "metaattrs": {
+                                        "deref": "allocatable",
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3079,33 +3158,35 @@
                 "<FUNCTION>": "32 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "intent": "function"
+                        },
                         "name": "returnAddress1",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "flag",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "flag"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -3170,33 +3251,35 @@
                 "<FUNCTION>": "33 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "intent": "function"
+                        },
                         "name": "returnAddress2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "flag",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "flag"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -3263,36 +3346,38 @@
                 "<FUNCTION>": "34 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "fetchVoidPtr"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "fetchVoidPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3338,36 +3423,38 @@
                 "<FUNCTION>": "35 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "updateVoidPtr"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout"
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "updateVoidPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3389,36 +3476,38 @@
                 "<FUNCTION>": "36 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "VoidPtrArray"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "VoidPtrArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -3440,18 +3529,19 @@
                 "<FUNCTION>": "37 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToScalar",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -3493,27 +3583,28 @@
             {
                 "<FUNCTION>": "38 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "dimension": "10"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "dimension": "10"
+                        },
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "constant": "10"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToFixedArray",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "constant": "10"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -3562,18 +3653,19 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToConstScalar",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -3615,28 +3707,29 @@
             {
                 "<FUNCTION>": "40 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "dimension": "10"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "dimension": "10"
+                        },
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "constant": "10"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToFixedConstArray",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "constant": "10"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -3683,22 +3776,23 @@
             {
                 "<FUNCTION>": "41 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "deref": "scalar"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "scalar"
+                        },
+                        "metaattrs": {
+                            "deref": "scalar",
+                            "intent": "function"
+                        },
                         "name": "returnIntScalar",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "scalar",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -3739,22 +3833,23 @@
             {
                 "<FUNCTION>": "42 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "deref": "raw"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "raw"
+                        },
+                        "metaattrs": {
+                            "deref": "raw",
+                            "intent": "function"
+                        },
                         "name": "returnIntRaw",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "raw",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -3777,42 +3872,44 @@
             {
                 "<FUNCTION>": "43 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "deref": "raw"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "raw"
+                        },
+                        "metaattrs": {
+                            "deref": "raw",
+                            "intent": "function"
+                        },
                         "name": "returnIntRawWithArgs",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "ftrim_char_in": true,
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "raw",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "ftrim_char_in": true,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -3836,7 +3933,11 @@
                 "<FUNCTION>": "44 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "intent": "function"
+                        },
                         "name": "returnRawPtrToInt2d",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
@@ -3844,12 +3945,9 @@
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -3873,28 +3971,29 @@
             {
                 "<FUNCTION>": "45 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "deref": "allocatable",
-                        "dimension": "10"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "allocatable",
+                            "dimension": "10"
+                        },
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "dimension": [
+                                {
+                                    "constant": "10"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "returnIntAllocToFixedArray",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "dimension": [
-                            {
-                                "constant": "10"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],

--- a/regression/reference/pointers-list-c/pointers.json
+++ b/regression/reference/pointers-list-c/pointers.json
@@ -51,6 +51,7 @@
                 },
                 "decl": "void  intargs_in(const int *arg)",
                 "declgen": "void intargs_in(const int * arg)",
+                "name": "intargs_in",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -125,6 +126,7 @@
                 "doxygen": {
                     "description": "Argument is modified by library, defaults to intent(inout).\n"
                 },
+                "name": "intargs_inout",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -199,6 +201,7 @@
                 },
                 "decl": "void  intargs_out(int *arg +intent(out))",
                 "declgen": "void intargs_out(int * arg +intent(out))",
+                "name": "intargs_out",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -312,6 +315,7 @@
                 },
                 "decl": "void  intargs(const int argin      +intent(in), int * arginout +intent(inout), int * argout   +intent(out))",
                 "declgen": "void intargs(const int argin +intent(in)+value, int * arginout +intent(inout), int * argout +intent(out))",
+                "name": "intargs",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -483,6 +487,7 @@
                     "brief": "compute cos of IN and save in OUT",
                     "description": "allocate OUT same type as IN implied size of array"
                 },
+                "name": "cos_doubles",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -661,6 +666,7 @@
                     "brief": "truncate IN argument and save in OUT",
                     "description": "allocate OUT different type as IN\nimplied size of array\n"
                 },
+                "name": "truncate_to_int",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -816,6 +822,7 @@
                     "brief": "fill values into array",
                     "description": "The function knows how long the array must be.\nFortran will treat the dimension as assumed-length.\nThe Python wrapper will create a NumPy array or list so it must\nhave an explicit dimension (not assumed-length).\n"
                 },
+                "name": "get_values",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -955,6 +962,7 @@
                     "brief": "fill values into two arrays",
                     "description": "Test two intent(out) arguments.\nMake sure error handling works with C++.\n"
                 },
+                "name": "get_values2",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1085,6 +1093,7 @@
                 },
                 "decl": "void iota_dimension (int nvar, int *values+intent(out)+dimension(nvar))",
                 "declgen": "void iota_dimension(int nvar +value, int * values +dimension(nvar)+intent(out))",
+                "name": "iota_dimension",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1225,6 +1234,7 @@
                 },
                 "decl": "void Sum(int len +implied(size(values)), const int *values +rank(1), int *result +intent(out))",
                 "declgen": "void Sum(int len +implied(size(values))+value, const int * values +rank(1), int * result +intent(out))",
+                "name": "Sum",
                 "options": {
                     "wrap_lua": false
                 },
@@ -1354,6 +1364,7 @@
                 "doxygen": {
                     "description": "Return three values into memory the user provides.\n"
                 },
+                "name": "fillIntArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1455,6 +1466,7 @@
                 "doxygen": {
                     "description": "Increment array in place using intent(INOUT).\n"
                 },
+                "name": "incrementIntArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1569,6 +1581,7 @@
                 },
                 "decl": "void fill_with_zeros(double* x+rank(1), int x_length+implied(size(x)));",
                 "declgen": "void fill_with_zeros(double * x +rank(1), int x_length +implied(size(x))+value)",
+                "name": "fill_with_zeros",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1684,6 +1697,7 @@
                 },
                 "decl": "int accumulate(const int *arr+rank(1), size_t len+implied(size(arr)));",
                 "declgen": "int accumulate(const int * arr +rank(1), size_t len +implied(size(arr))+value)",
+                "name": "accumulate",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1806,6 +1820,7 @@
                 "doxygen": {
                     "description": "Return strlen of the first index as a check.\n"
                 },
+                "name": "acceptCharArrayIn",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1896,6 +1911,7 @@
                 },
                 "decl": "void setGlobalInt(int value)",
                 "declgen": "void setGlobalInt(int value +value)",
+                "name": "setGlobalInt",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1950,6 +1966,7 @@
                 "doxygen": {
                     "description": "Used to test values global_array.\n"
                 },
+                "name": "sumFixedArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2023,6 +2040,7 @@
                 },
                 "decl": "void getPtrToScalar(int **nitems+intent(out))",
                 "declgen": "void getPtrToScalar(int * * nitems +intent(out))",
+                "name": "getPtrToScalar",
                 "options": {
                     "wrap_python": false
                 },
@@ -2085,6 +2103,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is always the same length.\n"
                 },
+                "name": "getPtrToFixedArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2200,6 +2219,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is the length of\nthe argument ncount.\n"
                 },
+                "name": "getPtrToDynamicArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2316,6 +2336,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is the length\nis computed by C++ function getLen.\ngetLen will be called from C/C++ to compute the shape.\n"
                 },
+                "name": "getPtrToFuncArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2401,6 +2422,7 @@
                 },
                 "decl": "void getPtrToConstScalar( const int **nitems+intent(out))",
                 "declgen": "void getPtrToConstScalar(const int * * nitems +intent(out))",
+                "name": "getPtrToConstScalar",
                 "options": {
                     "wrap_python": false
                 },
@@ -2461,6 +2483,7 @@
                 },
                 "decl": "void getPtrToFixedConstArray( const int **count+intent(out)+dimension(10));",
                 "declgen": "void getPtrToFixedConstArray(const int * * count +dimension(10)+intent(out))",
+                "name": "getPtrToFixedConstArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2574,6 +2597,7 @@
                 },
                 "decl": "void getPtrToDynamicConstArray( const int **count+intent(out)+dimension(ncount), int *ncount+intent(out)+hidden)",
                 "declgen": "void getPtrToDynamicConstArray(const int * * count +dimension(ncount)+intent(out), int * ncount +hidden+intent(out))",
+                "name": "getPtrToDynamicConstArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2684,6 +2708,7 @@
                 "doxygen": {
                     "description": "Called directly via an interface in Fortran.\n"
                 },
+                "name": "getRawPtrToScalar",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2766,6 +2791,7 @@
                 "doxygen": {
                     "description": "Create a Fortran wrapper.\n"
                 },
+                "name": "getRawPtrToScalarForce",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -2824,6 +2850,7 @@
                 "doxygen": {
                     "description": "Return a type(C_PTR) to an array which is always the same length.\nCalled directly via an interface in Fortran.\n# Uses +deref(raw) instead of +dimension(10) like getPtrToFixedArray.\n"
                 },
+                "name": "getRawPtrToFixedArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2906,6 +2933,7 @@
                 "doxygen": {
                     "description": "Return a type(C_PTR) to an array which is always the same length.\nCreate a Fortran wrapper.\n"
                 },
+                "name": "getRawPtrToFixedArrayForce",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -2965,6 +2993,7 @@
                 "doxygen": {
                     "description": "Test multiple layers of indirection.\n"
                 },
+                "name": "getRawPtrToInt2d",
                 "options": {
                     "wrap_python": false
                 },
@@ -3020,6 +3049,7 @@
                 "doxygen": {
                     "description": "Check results of getRawPtrToInt2d.\n"
                 },
+                "name": "checkInt2d",
                 "options": {
                     "wrap_python": false
                 },
@@ -3081,6 +3111,7 @@
                 "doxygen": {
                     "description": "Test +dimension(10,20) +intent(in) together.\nThis will not use assumed-shape in the Fortran wrapper.\n"
                 },
+                "name": "DimensionIn",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -3145,6 +3176,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is always the same length.\n"
                 },
+                "name": "getAllocToFixedArray",
                 "options": {
                     "wrap_python": false
                 },
@@ -3194,6 +3226,7 @@
                 },
                 "decl": "void *returnAddress1(int flag)",
                 "declgen": "void * returnAddress1(int flag +value)",
+                "name": "returnAddress1",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3287,6 +3320,7 @@
                 },
                 "decl": "void *returnAddress2(int flag)",
                 "declgen": "void * returnAddress2(int flag +value)",
+                "name": "returnAddress2",
                 "options": {
                     "F_force_wrapper": true
                 },
@@ -3385,6 +3419,7 @@
                 },
                 "decl": "void fetchVoidPtr(void **addr+intent(out))",
                 "declgen": "void fetchVoidPtr(void * * addr +intent(out))",
+                "name": "fetchVoidPtr",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3462,6 +3497,7 @@
                 },
                 "decl": "void updateVoidPtr(void **addr+intent(inout))",
                 "declgen": "void updateVoidPtr(void * * addr +intent(inout))",
+                "name": "updateVoidPtr",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -3515,6 +3551,7 @@
                 },
                 "decl": "int VoidPtrArray(void **addr+rank(1))",
                 "declgen": "int VoidPtrArray(void * * addr +rank(1))",
+                "name": "VoidPtrArray",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -3549,6 +3586,7 @@
                 },
                 "decl": "int *returnIntPtrToScalar(void)",
                 "declgen": "int * returnIntPtrToScalar(void)",
+                "name": "returnIntPtrToScalar",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3612,6 +3650,7 @@
                 },
                 "decl": "int *returnIntPtrToFixedArray(void) +dimension(10)",
                 "declgen": "int * returnIntPtrToFixedArray(void) +dimension(10)",
+                "name": "returnIntPtrToFixedArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3673,6 +3712,7 @@
                 },
                 "decl": "const int *returnIntPtrToConstScalar(void)",
                 "declgen": "const int * returnIntPtrToConstScalar(void)",
+                "name": "returnIntPtrToConstScalar",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3737,6 +3777,7 @@
                 },
                 "decl": "const int *returnIntPtrToFixedConstArray(void) +dimension(10)",
                 "declgen": "const int * returnIntPtrToFixedConstArray(void) +dimension(10)",
+                "name": "returnIntPtrToFixedConstArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3800,6 +3841,7 @@
                 },
                 "decl": "int *returnIntScalar(void) +deref(scalar)",
                 "declgen": "int * returnIntScalar(void) +deref(scalar)",
+                "name": "returnIntScalar",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3860,6 +3902,7 @@
                 "doxygen": {
                     "description": "Call directly via interface.\n"
                 },
+                "name": "returnIntRaw",
                 "options": {
                     "wrap_python": false
                 },
@@ -3920,6 +3963,7 @@
                 "doxygen": {
                     "description": "Like returnIntRaw but with another argument to force a wrapper.\nUses fc_statements f_function_native_*_raw.\n"
                 },
+                "name": "returnIntRawWithArgs",
                 "options": {
                     "wrap_python": false
                 },
@@ -3958,6 +4002,7 @@
                 "doxygen": {
                     "description": "Test multiple layers of indirection.\n# getRawPtrToInt2d\n"
                 },
+                "name": "returnRawPtrToInt2d",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -4001,6 +4046,7 @@
                 },
                 "decl": "int *returnIntAllocToFixedArray(void) +dimension(10)+deref(allocatable)",
                 "declgen": "int * returnIntAllocToFixedArray(void) +deref(allocatable)+dimension(10)",
+                "name": "returnIntAllocToFixedArray",
                 "options": {
                     "wrap_python": false
                 },

--- a/regression/reference/pointers-list-cxx/pointers.json
+++ b/regression/reference/pointers-list-cxx/pointers.json
@@ -17,31 +17,33 @@
                 "<FUNCTION>": "0 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "intargs_in"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "intargs_in",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -87,30 +89,32 @@
                 "<FUNCTION>": "1 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "intargs_inout"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "intargs_inout",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -159,33 +163,35 @@
                 "<FUNCTION>": "2 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "intargs_out"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "intargs_out",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -231,70 +237,74 @@
                 "<FUNCTION>": "3 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "intargs"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "value": true
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "argin"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "inout"
+                        "name": "intargs",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "argin",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "arginout",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arginout",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "argout",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "argout",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -383,81 +393,85 @@
                 "<FUNCTION>": "4 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "cos_doubles"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "in",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "size(in)",
-                                "intent": "out"
+                        "name": "cos_doubles",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "in",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "out",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "args": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "size(in)",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
                                             {
-                                                "name": "in"
+                                                "args": [
+                                                    {
+                                                        "name": "in"
+                                                    }
+                                                ],
+                                                "name": "size"
                                             }
                                         ],
-                                        "name": "size"
-                                    }
+                                        "intent": "out"
+                                    },
+                                    "name": "out",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "double"
                             },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(in)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "sizein"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(in)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "sizein",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -557,81 +571,85 @@
                 "<FUNCTION>": "5 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "truncate_to_int"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "in",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "size(in)",
-                                "intent": "out"
+                        "name": "truncate_to_int",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "in",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "out",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "args": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "size(in)",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
                                             {
-                                                "name": "in"
+                                                "args": [
+                                                    {
+                                                        "name": "in"
+                                                    }
+                                                ],
+                                                "name": "size"
                                             }
                                         ],
-                                        "name": "size"
-                                    }
+                                        "intent": "out"
+                                    },
+                                    "name": "out",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(in)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "sizein"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(in)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "sizein",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -731,59 +749,62 @@
                 "<FUNCTION>": "6 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "get_values"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "OUT"
-                            },
-                            "declarator": {
-                                "name": "nvalues",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "3",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "values",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "3"
-                                    }
+                        "name": "get_values",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "OUT"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "nvalues",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "3",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "3"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "values",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -861,65 +882,68 @@
                 "<FUNCTION>": "7 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "get_values2"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "3",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "3"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "3",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg2",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "3"
-                                    }
+                        "name": "get_values2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "3",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "3"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "3",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "3"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "arg2",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1003,54 +1027,57 @@
                 "<FUNCTION>": "8 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "iota_dimension"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "nvar"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "nvar",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "values",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nvar"
-                                    }
+                        "name": "iota_dimension",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nvar",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "nvar",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "name": "nvar"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "values",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1123,70 +1150,74 @@
                 "<FUNCTION>": "9 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "Sum"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "implied": "size(values)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "len"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "rank": 1
+                        "name": "Sum",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(values)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "len",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "const": true,
-                            "declarator": {
-                                "name": "values",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "values",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "result",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "result",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1278,39 +1309,41 @@
                 "<FUNCTION>": "10 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "fillIntArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "3",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "out",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "3"
-                                    }
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "fillIntArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "3",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "3"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "out",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1365,50 +1398,53 @@
                 "<FUNCTION>": "11 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "incrementIntArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "array",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "size(array)",
-                                "value": true
+                        "name": "incrementIntArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "array",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "sizein"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(array)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "sizein",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1480,49 +1516,52 @@
                 "<FUNCTION>": "12 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "fill_with_zeros"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "x",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "size(x)",
-                                "value": true
+                        "name": "fill_with_zeros",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "x",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "x_length"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(x)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "x_length",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1591,50 +1630,53 @@
                 "<FUNCTION>": "13 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "accumulate"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "arr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "implied": "size(arr)",
-                                "value": true
+                        "name": "accumulate",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "len"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(arr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "len",
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -1721,37 +1763,39 @@
                 "<FUNCTION>": "14 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptCharArrayIn"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "names",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "acceptCharArrayIn",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "names",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -1821,28 +1865,30 @@
                 "<FUNCTION>": "15 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "setGlobalInt"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "setGlobalInt",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "value",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "value"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -1887,12 +1933,13 @@
                 "<FUNCTION>": "16 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "sumFixedArray"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "sumFixedArray",
+                        "params": [],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -1936,37 +1983,39 @@
                 "<FUNCTION>": "17 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToScalar"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToScalar",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1987,43 +2036,45 @@
                 "<FUNCTION>": "18 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToFixedArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "10",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToFixedArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "10",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "constant": "10"
-                                    }
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2078,64 +2129,67 @@
                 "<FUNCTION>": "19 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToDynamicArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "ncount",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "name": "ncount"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
+                        "name": "getPtrToDynamicArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "ncount",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "name": "ncount"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "ncount",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "ncount",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2212,44 +2266,46 @@
                 "<FUNCTION>": "20 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToFuncArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "getLen()",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToFuncArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "getLen()",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "args": [],
-                                        "name": "getLen"
-                                    }
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "args": [],
+                                                "name": "getLen"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2304,38 +2360,40 @@
                 "<FUNCTION>": "21 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToConstScalar"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToConstScalar",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2356,44 +2414,46 @@
                 "<FUNCTION>": "22 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToFixedConstArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "10",
-                                "intent": "out"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToFixedConstArray",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "10",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "constant": "10"
-                                    }
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2445,65 +2505,68 @@
                 "<FUNCTION>": "23 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToDynamicConstArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "ncount",
-                                "intent": "out"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "name": "ncount"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
+                        "name": "getPtrToDynamicConstArray",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "ncount",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "name": "ncount"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "ncount",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "ncount",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2577,38 +2640,40 @@
                 "<FUNCTION>": "24 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToScalar"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToScalar",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2657,38 +2722,40 @@
                 "<FUNCTION>": "25 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToScalarForce"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToScalarForce",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2713,38 +2780,40 @@
                 "<FUNCTION>": "26 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToFixedArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToFixedArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2793,38 +2862,40 @@
                 "<FUNCTION>": "27 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToFixedArrayForce"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToFixedArrayForce",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2849,39 +2920,41 @@
                 "<FUNCTION>": "28 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToInt2d"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToInt2d",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
+                                    "metaattrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2905,36 +2978,38 @@
                 "<FUNCTION>": "29 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "checkInt2d"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "checkInt2d",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -2958,42 +3033,44 @@
                 "<FUNCTION>": "30 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "DimensionIn"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "10,20"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "10"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "DimensionIn",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "10,20"
                                     },
-                                    {
-                                        "constant": "20"
-                                    }
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            },
+                                            {
+                                                "constant": "20"
+                                            }
+                                        ],
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3018,44 +3095,46 @@
                 "<FUNCTION>": "31 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getAllocToFixedArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "allocatable",
-                                "dimension": "10",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getAllocToFixedArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "allocatable",
+                                        "dimension": "10",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "allocatable",
-                                "dimension": [
-                                    {
-                                        "constant": "10"
-                                    }
+                                    "metaattrs": {
+                                        "deref": "allocatable",
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3079,33 +3158,35 @@
                 "<FUNCTION>": "32 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "intent": "function"
+                        },
                         "name": "returnAddress1",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "flag",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "flag"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -3170,33 +3251,35 @@
                 "<FUNCTION>": "33 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "intent": "function"
+                        },
                         "name": "returnAddress2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "flag",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "flag"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -3263,36 +3346,38 @@
                 "<FUNCTION>": "34 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "fetchVoidPtr"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "fetchVoidPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3338,36 +3423,38 @@
                 "<FUNCTION>": "35 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "updateVoidPtr"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout"
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "updateVoidPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3389,36 +3476,38 @@
                 "<FUNCTION>": "36 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "VoidPtrArray"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "VoidPtrArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -3440,18 +3529,19 @@
                 "<FUNCTION>": "37 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToScalar",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -3493,27 +3583,28 @@
             {
                 "<FUNCTION>": "38 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "dimension": "10"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "dimension": "10"
+                        },
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "constant": "10"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToFixedArray",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "constant": "10"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -3562,18 +3653,19 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToConstScalar",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -3615,28 +3707,29 @@
             {
                 "<FUNCTION>": "40 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "dimension": "10"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "dimension": "10"
+                        },
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "constant": "10"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToFixedConstArray",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "constant": "10"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -3683,22 +3776,23 @@
             {
                 "<FUNCTION>": "41 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "deref": "scalar"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "scalar"
+                        },
+                        "metaattrs": {
+                            "deref": "scalar",
+                            "intent": "function"
+                        },
                         "name": "returnIntScalar",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "scalar",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -3739,22 +3833,23 @@
             {
                 "<FUNCTION>": "42 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "deref": "raw"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "raw"
+                        },
+                        "metaattrs": {
+                            "deref": "raw",
+                            "intent": "function"
+                        },
                         "name": "returnIntRaw",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "raw",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -3777,42 +3872,44 @@
             {
                 "<FUNCTION>": "43 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "deref": "raw"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "raw"
+                        },
+                        "metaattrs": {
+                            "deref": "raw",
+                            "intent": "function"
+                        },
                         "name": "returnIntRawWithArgs",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "ftrim_char_in": true,
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "raw",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "ftrim_char_in": true,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -3836,7 +3933,11 @@
                 "<FUNCTION>": "44 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "intent": "function"
+                        },
                         "name": "returnRawPtrToInt2d",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
@@ -3844,12 +3945,9 @@
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -3873,28 +3971,29 @@
             {
                 "<FUNCTION>": "45 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "deref": "allocatable",
-                        "dimension": "10"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "allocatable",
+                            "dimension": "10"
+                        },
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "dimension": [
+                                {
+                                    "constant": "10"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "returnIntAllocToFixedArray",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "dimension": [
-                            {
-                                "constant": "10"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],

--- a/regression/reference/pointers-list-cxx/pointers.json
+++ b/regression/reference/pointers-list-cxx/pointers.json
@@ -51,6 +51,7 @@
                 },
                 "decl": "void  intargs_in(const int *arg)",
                 "declgen": "void intargs_in(const int * arg)",
+                "name": "intargs_in",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -125,6 +126,7 @@
                 "doxygen": {
                     "description": "Argument is modified by library, defaults to intent(inout).\n"
                 },
+                "name": "intargs_inout",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -199,6 +201,7 @@
                 },
                 "decl": "void  intargs_out(int *arg +intent(out))",
                 "declgen": "void intargs_out(int * arg +intent(out))",
+                "name": "intargs_out",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -312,6 +315,7 @@
                 },
                 "decl": "void  intargs(const int argin      +intent(in), int * arginout +intent(inout), int * argout   +intent(out))",
                 "declgen": "void intargs(const int argin +intent(in)+value, int * arginout +intent(inout), int * argout +intent(out))",
+                "name": "intargs",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -483,6 +487,7 @@
                     "brief": "compute cos of IN and save in OUT",
                     "description": "allocate OUT same type as IN implied size of array"
                 },
+                "name": "cos_doubles",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -661,6 +666,7 @@
                     "brief": "truncate IN argument and save in OUT",
                     "description": "allocate OUT different type as IN\nimplied size of array\n"
                 },
+                "name": "truncate_to_int",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -816,6 +822,7 @@
                     "brief": "fill values into array",
                     "description": "The function knows how long the array must be.\nFortran will treat the dimension as assumed-length.\nThe Python wrapper will create a NumPy array or list so it must\nhave an explicit dimension (not assumed-length).\n"
                 },
+                "name": "get_values",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -955,6 +962,7 @@
                     "brief": "fill values into two arrays",
                     "description": "Test two intent(out) arguments.\nMake sure error handling works with C++.\n"
                 },
+                "name": "get_values2",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1085,6 +1093,7 @@
                 },
                 "decl": "void iota_dimension (int nvar, int *values+intent(out)+dimension(nvar))",
                 "declgen": "void iota_dimension(int nvar +value, int * values +dimension(nvar)+intent(out))",
+                "name": "iota_dimension",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1225,6 +1234,7 @@
                 },
                 "decl": "void Sum(int len +implied(size(values)), const int *values +rank(1), int *result +intent(out))",
                 "declgen": "void Sum(int len +implied(size(values))+value, const int * values +rank(1), int * result +intent(out))",
+                "name": "Sum",
                 "options": {
                     "wrap_lua": false
                 },
@@ -1354,6 +1364,7 @@
                 "doxygen": {
                     "description": "Return three values into memory the user provides.\n"
                 },
+                "name": "fillIntArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1455,6 +1466,7 @@
                 "doxygen": {
                     "description": "Increment array in place using intent(INOUT).\n"
                 },
+                "name": "incrementIntArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1569,6 +1581,7 @@
                 },
                 "decl": "void fill_with_zeros(double* x+rank(1), int x_length+implied(size(x)));",
                 "declgen": "void fill_with_zeros(double * x +rank(1), int x_length +implied(size(x))+value)",
+                "name": "fill_with_zeros",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1684,6 +1697,7 @@
                 },
                 "decl": "int accumulate(const int *arr+rank(1), size_t len+implied(size(arr)));",
                 "declgen": "int accumulate(const int * arr +rank(1), size_t len +implied(size(arr))+value)",
+                "name": "accumulate",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1806,6 +1820,7 @@
                 "doxygen": {
                     "description": "Return strlen of the first index as a check.\n"
                 },
+                "name": "acceptCharArrayIn",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1896,6 +1911,7 @@
                 },
                 "decl": "void setGlobalInt(int value)",
                 "declgen": "void setGlobalInt(int value +value)",
+                "name": "setGlobalInt",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1950,6 +1966,7 @@
                 "doxygen": {
                     "description": "Used to test values global_array.\n"
                 },
+                "name": "sumFixedArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2023,6 +2040,7 @@
                 },
                 "decl": "void getPtrToScalar(int **nitems+intent(out))",
                 "declgen": "void getPtrToScalar(int * * nitems +intent(out))",
+                "name": "getPtrToScalar",
                 "options": {
                     "wrap_python": false
                 },
@@ -2085,6 +2103,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is always the same length.\n"
                 },
+                "name": "getPtrToFixedArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2200,6 +2219,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is the length of\nthe argument ncount.\n"
                 },
+                "name": "getPtrToDynamicArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2316,6 +2336,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is the length\nis computed by C++ function getLen.\ngetLen will be called from C/C++ to compute the shape.\n"
                 },
+                "name": "getPtrToFuncArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2401,6 +2422,7 @@
                 },
                 "decl": "void getPtrToConstScalar( const int **nitems+intent(out))",
                 "declgen": "void getPtrToConstScalar(const int * * nitems +intent(out))",
+                "name": "getPtrToConstScalar",
                 "options": {
                     "wrap_python": false
                 },
@@ -2461,6 +2483,7 @@
                 },
                 "decl": "void getPtrToFixedConstArray( const int **count+intent(out)+dimension(10));",
                 "declgen": "void getPtrToFixedConstArray(const int * * count +dimension(10)+intent(out))",
+                "name": "getPtrToFixedConstArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2574,6 +2597,7 @@
                 },
                 "decl": "void getPtrToDynamicConstArray( const int **count+intent(out)+dimension(ncount), int *ncount+intent(out)+hidden)",
                 "declgen": "void getPtrToDynamicConstArray(const int * * count +dimension(ncount)+intent(out), int * ncount +hidden+intent(out))",
+                "name": "getPtrToDynamicConstArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2684,6 +2708,7 @@
                 "doxygen": {
                     "description": "Called directly via an interface in Fortran.\n"
                 },
+                "name": "getRawPtrToScalar",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2766,6 +2791,7 @@
                 "doxygen": {
                     "description": "Create a Fortran wrapper.\n"
                 },
+                "name": "getRawPtrToScalarForce",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -2824,6 +2850,7 @@
                 "doxygen": {
                     "description": "Return a type(C_PTR) to an array which is always the same length.\nCalled directly via an interface in Fortran.\n# Uses +deref(raw) instead of +dimension(10) like getPtrToFixedArray.\n"
                 },
+                "name": "getRawPtrToFixedArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2906,6 +2933,7 @@
                 "doxygen": {
                     "description": "Return a type(C_PTR) to an array which is always the same length.\nCreate a Fortran wrapper.\n"
                 },
+                "name": "getRawPtrToFixedArrayForce",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -2965,6 +2993,7 @@
                 "doxygen": {
                     "description": "Test multiple layers of indirection.\n"
                 },
+                "name": "getRawPtrToInt2d",
                 "options": {
                     "wrap_python": false
                 },
@@ -3020,6 +3049,7 @@
                 "doxygen": {
                     "description": "Check results of getRawPtrToInt2d.\n"
                 },
+                "name": "checkInt2d",
                 "options": {
                     "wrap_python": false
                 },
@@ -3081,6 +3111,7 @@
                 "doxygen": {
                     "description": "Test +dimension(10,20) +intent(in) together.\nThis will not use assumed-shape in the Fortran wrapper.\n"
                 },
+                "name": "DimensionIn",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -3145,6 +3176,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is always the same length.\n"
                 },
+                "name": "getAllocToFixedArray",
                 "options": {
                     "wrap_python": false
                 },
@@ -3194,6 +3226,7 @@
                 },
                 "decl": "void *returnAddress1(int flag)",
                 "declgen": "void * returnAddress1(int flag +value)",
+                "name": "returnAddress1",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3287,6 +3320,7 @@
                 },
                 "decl": "void *returnAddress2(int flag)",
                 "declgen": "void * returnAddress2(int flag +value)",
+                "name": "returnAddress2",
                 "options": {
                     "F_force_wrapper": true
                 },
@@ -3385,6 +3419,7 @@
                 },
                 "decl": "void fetchVoidPtr(void **addr+intent(out))",
                 "declgen": "void fetchVoidPtr(void * * addr +intent(out))",
+                "name": "fetchVoidPtr",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3462,6 +3497,7 @@
                 },
                 "decl": "void updateVoidPtr(void **addr+intent(inout))",
                 "declgen": "void updateVoidPtr(void * * addr +intent(inout))",
+                "name": "updateVoidPtr",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -3515,6 +3551,7 @@
                 },
                 "decl": "int VoidPtrArray(void **addr+rank(1))",
                 "declgen": "int VoidPtrArray(void * * addr +rank(1))",
+                "name": "VoidPtrArray",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -3549,6 +3586,7 @@
                 },
                 "decl": "int *returnIntPtrToScalar(void)",
                 "declgen": "int * returnIntPtrToScalar(void)",
+                "name": "returnIntPtrToScalar",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3612,6 +3650,7 @@
                 },
                 "decl": "int *returnIntPtrToFixedArray(void) +dimension(10)",
                 "declgen": "int * returnIntPtrToFixedArray(void) +dimension(10)",
+                "name": "returnIntPtrToFixedArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3673,6 +3712,7 @@
                 },
                 "decl": "const int *returnIntPtrToConstScalar(void)",
                 "declgen": "const int * returnIntPtrToConstScalar(void)",
+                "name": "returnIntPtrToConstScalar",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3737,6 +3777,7 @@
                 },
                 "decl": "const int *returnIntPtrToFixedConstArray(void) +dimension(10)",
                 "declgen": "const int * returnIntPtrToFixedConstArray(void) +dimension(10)",
+                "name": "returnIntPtrToFixedConstArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3800,6 +3841,7 @@
                 },
                 "decl": "int *returnIntScalar(void) +deref(scalar)",
                 "declgen": "int * returnIntScalar(void) +deref(scalar)",
+                "name": "returnIntScalar",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3860,6 +3902,7 @@
                 "doxygen": {
                     "description": "Call directly via interface.\n"
                 },
+                "name": "returnIntRaw",
                 "options": {
                     "wrap_python": false
                 },
@@ -3920,6 +3963,7 @@
                 "doxygen": {
                     "description": "Like returnIntRaw but with another argument to force a wrapper.\nUses fc_statements f_function_native_*_raw.\n"
                 },
+                "name": "returnIntRawWithArgs",
                 "options": {
                     "wrap_python": false
                 },
@@ -3958,6 +4002,7 @@
                 "doxygen": {
                     "description": "Test multiple layers of indirection.\n# getRawPtrToInt2d\n"
                 },
+                "name": "returnRawPtrToInt2d",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -4001,6 +4046,7 @@
                 },
                 "decl": "int *returnIntAllocToFixedArray(void) +dimension(10)+deref(allocatable)",
                 "declgen": "int * returnIntAllocToFixedArray(void) +deref(allocatable)+dimension(10)",
+                "name": "returnIntAllocToFixedArray",
                 "options": {
                     "wrap_python": false
                 },

--- a/regression/reference/pointers-numpy-c/pointers.json
+++ b/regression/reference/pointers-numpy-c/pointers.json
@@ -51,6 +51,7 @@
                 },
                 "decl": "void  intargs_in(const int *arg)",
                 "declgen": "void intargs_in(const int * arg)",
+                "name": "intargs_in",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -125,6 +126,7 @@
                 "doxygen": {
                     "description": "Argument is modified by library, defaults to intent(inout).\n"
                 },
+                "name": "intargs_inout",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -199,6 +201,7 @@
                 },
                 "decl": "void  intargs_out(int *arg +intent(out))",
                 "declgen": "void intargs_out(int * arg +intent(out))",
+                "name": "intargs_out",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -312,6 +315,7 @@
                 },
                 "decl": "void  intargs(const int argin      +intent(in), int * arginout +intent(inout), int * argout   +intent(out))",
                 "declgen": "void intargs(const int argin +intent(in)+value, int * arginout +intent(inout), int * argout +intent(out))",
+                "name": "intargs",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -483,6 +487,7 @@
                     "brief": "compute cos of IN and save in OUT",
                     "description": "allocate OUT same type as IN implied size of array"
                 },
+                "name": "cos_doubles",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -659,6 +664,7 @@
                     "brief": "truncate IN argument and save in OUT",
                     "description": "allocate OUT different type as IN\nimplied size of array\n"
                 },
+                "name": "truncate_to_int",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -812,6 +818,7 @@
                     "brief": "fill values into array",
                     "description": "The function knows how long the array must be.\nFortran will treat the dimension as assumed-length.\nThe Python wrapper will create a NumPy array or list so it must\nhave an explicit dimension (not assumed-length).\n"
                 },
+                "name": "get_values",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -950,6 +957,7 @@
                     "brief": "fill values into two arrays",
                     "description": "Test two intent(out) arguments.\nMake sure error handling works with C++.\n"
                 },
+                "name": "get_values2",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1078,6 +1086,7 @@
                 },
                 "decl": "void iota_dimension (int nvar, int *values+intent(out)+dimension(nvar))",
                 "declgen": "void iota_dimension(int nvar +value, int * values +dimension(nvar)+intent(out))",
+                "name": "iota_dimension",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1217,6 +1226,7 @@
                 },
                 "decl": "void Sum(int len +implied(size(values)), const int *values +rank(1), int *result +intent(out))",
                 "declgen": "void Sum(int len +implied(size(values))+value, const int * values +rank(1), int * result +intent(out))",
+                "name": "Sum",
                 "options": {
                     "wrap_lua": false
                 },
@@ -1345,6 +1355,7 @@
                 "doxygen": {
                     "description": "Return three values into memory the user provides.\n"
                 },
+                "name": "fillIntArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1445,6 +1456,7 @@
                 "doxygen": {
                     "description": "Increment array in place using intent(INOUT).\n"
                 },
+                "name": "incrementIntArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1557,6 +1569,7 @@
                 },
                 "decl": "void fill_with_zeros(double* x+rank(1), int x_length+implied(size(x)));",
                 "declgen": "void fill_with_zeros(double * x +rank(1), int x_length +implied(size(x))+value)",
+                "name": "fill_with_zeros",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1670,6 +1683,7 @@
                 },
                 "decl": "int accumulate(const int *arr+rank(1), size_t len+implied(size(arr)));",
                 "declgen": "int accumulate(const int * arr +rank(1), size_t len +implied(size(arr))+value)",
+                "name": "accumulate",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1791,6 +1805,7 @@
                 "doxygen": {
                     "description": "Return strlen of the first index as a check.\n"
                 },
+                "name": "acceptCharArrayIn",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1881,6 +1896,7 @@
                 },
                 "decl": "void setGlobalInt(int value)",
                 "declgen": "void setGlobalInt(int value +value)",
+                "name": "setGlobalInt",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1935,6 +1951,7 @@
                 "doxygen": {
                     "description": "Used to test values global_array.\n"
                 },
+                "name": "sumFixedArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2008,6 +2025,7 @@
                 },
                 "decl": "void getPtrToScalar(int **nitems+intent(out))",
                 "declgen": "void getPtrToScalar(int * * nitems +intent(out))",
+                "name": "getPtrToScalar",
                 "options": {
                     "wrap_python": false
                 },
@@ -2070,6 +2088,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is always the same length.\n"
                 },
+                "name": "getPtrToFixedArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2184,6 +2203,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is the length of\nthe argument ncount.\n"
                 },
+                "name": "getPtrToDynamicArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2299,6 +2319,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is the length\nis computed by C++ function getLen.\ngetLen will be called from C/C++ to compute the shape.\n"
                 },
+                "name": "getPtrToFuncArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2383,6 +2404,7 @@
                 },
                 "decl": "void getPtrToConstScalar( const int **nitems+intent(out))",
                 "declgen": "void getPtrToConstScalar(const int * * nitems +intent(out))",
+                "name": "getPtrToConstScalar",
                 "options": {
                     "wrap_python": false
                 },
@@ -2443,6 +2465,7 @@
                 },
                 "decl": "void getPtrToFixedConstArray( const int **count+intent(out)+dimension(10));",
                 "declgen": "void getPtrToFixedConstArray(const int * * count +dimension(10)+intent(out))",
+                "name": "getPtrToFixedConstArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2555,6 +2578,7 @@
                 },
                 "decl": "void getPtrToDynamicConstArray( const int **count+intent(out)+dimension(ncount), int *ncount+intent(out)+hidden)",
                 "declgen": "void getPtrToDynamicConstArray(const int * * count +dimension(ncount)+intent(out), int * ncount +hidden+intent(out))",
+                "name": "getPtrToDynamicConstArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2664,6 +2688,7 @@
                 "doxygen": {
                     "description": "Called directly via an interface in Fortran.\n"
                 },
+                "name": "getRawPtrToScalar",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2746,6 +2771,7 @@
                 "doxygen": {
                     "description": "Create a Fortran wrapper.\n"
                 },
+                "name": "getRawPtrToScalarForce",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -2804,6 +2830,7 @@
                 "doxygen": {
                     "description": "Return a type(C_PTR) to an array which is always the same length.\nCalled directly via an interface in Fortran.\n# Uses +deref(raw) instead of +dimension(10) like getPtrToFixedArray.\n"
                 },
+                "name": "getRawPtrToFixedArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2886,6 +2913,7 @@
                 "doxygen": {
                     "description": "Return a type(C_PTR) to an array which is always the same length.\nCreate a Fortran wrapper.\n"
                 },
+                "name": "getRawPtrToFixedArrayForce",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -2945,6 +2973,7 @@
                 "doxygen": {
                     "description": "Test multiple layers of indirection.\n"
                 },
+                "name": "getRawPtrToInt2d",
                 "options": {
                     "wrap_python": false
                 },
@@ -3000,6 +3029,7 @@
                 "doxygen": {
                     "description": "Check results of getRawPtrToInt2d.\n"
                 },
+                "name": "checkInt2d",
                 "options": {
                     "wrap_python": false
                 },
@@ -3061,6 +3091,7 @@
                 "doxygen": {
                     "description": "Test +dimension(10,20) +intent(in) together.\nThis will not use assumed-shape in the Fortran wrapper.\n"
                 },
+                "name": "DimensionIn",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -3125,6 +3156,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is always the same length.\n"
                 },
+                "name": "getAllocToFixedArray",
                 "options": {
                     "wrap_python": false
                 },
@@ -3174,6 +3206,7 @@
                 },
                 "decl": "void *returnAddress1(int flag)",
                 "declgen": "void * returnAddress1(int flag +value)",
+                "name": "returnAddress1",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3267,6 +3300,7 @@
                 },
                 "decl": "void *returnAddress2(int flag)",
                 "declgen": "void * returnAddress2(int flag +value)",
+                "name": "returnAddress2",
                 "options": {
                     "F_force_wrapper": true
                 },
@@ -3365,6 +3399,7 @@
                 },
                 "decl": "void fetchVoidPtr(void **addr+intent(out))",
                 "declgen": "void fetchVoidPtr(void * * addr +intent(out))",
+                "name": "fetchVoidPtr",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3442,6 +3477,7 @@
                 },
                 "decl": "void updateVoidPtr(void **addr+intent(inout))",
                 "declgen": "void updateVoidPtr(void * * addr +intent(inout))",
+                "name": "updateVoidPtr",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -3495,6 +3531,7 @@
                 },
                 "decl": "int VoidPtrArray(void **addr+rank(1))",
                 "declgen": "int VoidPtrArray(void * * addr +rank(1))",
+                "name": "VoidPtrArray",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -3529,6 +3566,7 @@
                 },
                 "decl": "int *returnIntPtrToScalar(void)",
                 "declgen": "int * returnIntPtrToScalar(void)",
+                "name": "returnIntPtrToScalar",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3591,6 +3629,7 @@
                 },
                 "decl": "int *returnIntPtrToFixedArray(void) +dimension(10)",
                 "declgen": "int * returnIntPtrToFixedArray(void) +dimension(10)",
+                "name": "returnIntPtrToFixedArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3651,6 +3690,7 @@
                 },
                 "decl": "const int *returnIntPtrToConstScalar(void)",
                 "declgen": "const int * returnIntPtrToConstScalar(void)",
+                "name": "returnIntPtrToConstScalar",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3714,6 +3754,7 @@
                 },
                 "decl": "const int *returnIntPtrToFixedConstArray(void) +dimension(10)",
                 "declgen": "const int * returnIntPtrToFixedConstArray(void) +dimension(10)",
+                "name": "returnIntPtrToFixedConstArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3776,6 +3817,7 @@
                 },
                 "decl": "int *returnIntScalar(void) +deref(scalar)",
                 "declgen": "int * returnIntScalar(void) +deref(scalar)",
+                "name": "returnIntScalar",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3836,6 +3878,7 @@
                 "doxygen": {
                     "description": "Call directly via interface.\n"
                 },
+                "name": "returnIntRaw",
                 "options": {
                     "wrap_python": false
                 },
@@ -3896,6 +3939,7 @@
                 "doxygen": {
                     "description": "Like returnIntRaw but with another argument to force a wrapper.\nUses fc_statements f_function_native_*_raw.\n"
                 },
+                "name": "returnIntRawWithArgs",
                 "options": {
                     "wrap_python": false
                 },
@@ -3934,6 +3978,7 @@
                 "doxygen": {
                     "description": "Test multiple layers of indirection.\n# getRawPtrToInt2d\n"
                 },
+                "name": "returnRawPtrToInt2d",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -3977,6 +4022,7 @@
                 },
                 "decl": "int *returnIntAllocToFixedArray(void) +dimension(10)+deref(allocatable)",
                 "declgen": "int * returnIntAllocToFixedArray(void) +deref(allocatable)+dimension(10)",
+                "name": "returnIntAllocToFixedArray",
                 "options": {
                     "wrap_python": false
                 },

--- a/regression/reference/pointers-numpy-c/pointers.json
+++ b/regression/reference/pointers-numpy-c/pointers.json
@@ -17,31 +17,33 @@
                 "<FUNCTION>": "0 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "intargs_in"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "intargs_in",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -87,30 +89,32 @@
                 "<FUNCTION>": "1 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "intargs_inout"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "intargs_inout",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -159,33 +163,35 @@
                 "<FUNCTION>": "2 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "intargs_out"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "intargs_out",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -231,70 +237,74 @@
                 "<FUNCTION>": "3 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "intargs"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "value": true
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "argin"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "inout"
+                        "name": "intargs",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "argin",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "arginout",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arginout",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "argout",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "argout",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -383,81 +393,85 @@
                 "<FUNCTION>": "4 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "cos_doubles"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "in",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "size(in)",
-                                "intent": "out"
+                        "name": "cos_doubles",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "in",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "out",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "args": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "size(in)",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
                                             {
-                                                "name": "in"
+                                                "args": [
+                                                    {
+                                                        "name": "in"
+                                                    }
+                                                ],
+                                                "name": "size"
                                             }
                                         ],
-                                        "name": "size"
-                                    }
+                                        "intent": "out"
+                                    },
+                                    "name": "out",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "double"
                             },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(in)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "sizein"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(in)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "sizein",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -555,81 +569,85 @@
                 "<FUNCTION>": "5 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "truncate_to_int"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "in",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "size(in)",
-                                "intent": "out"
+                        "name": "truncate_to_int",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "in",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "out",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "args": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "size(in)",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
                                             {
-                                                "name": "in"
+                                                "args": [
+                                                    {
+                                                        "name": "in"
+                                                    }
+                                                ],
+                                                "name": "size"
                                             }
                                         ],
-                                        "name": "size"
-                                    }
+                                        "intent": "out"
+                                    },
+                                    "name": "out",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(in)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "sizein"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(in)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "sizein",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -727,59 +745,62 @@
                 "<FUNCTION>": "6 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "get_values"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "OUT"
-                            },
-                            "declarator": {
-                                "name": "nvalues",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "3",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "values",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "3"
-                                    }
+                        "name": "get_values",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "OUT"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "nvalues",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "3",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "3"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "values",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -856,65 +877,68 @@
                 "<FUNCTION>": "7 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "get_values2"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "3",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "3"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "3",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg2",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "3"
-                                    }
+                        "name": "get_values2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "3",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "3"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "3",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "3"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "arg2",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -996,54 +1020,57 @@
                 "<FUNCTION>": "8 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "iota_dimension"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "nvar"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "nvar",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "values",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nvar"
-                                    }
+                        "name": "iota_dimension",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nvar",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "nvar",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "name": "nvar"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "values",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1115,70 +1142,74 @@
                 "<FUNCTION>": "9 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "Sum"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "implied": "size(values)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "len"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "rank": 1
+                        "name": "Sum",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(values)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "len",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "const": true,
-                            "declarator": {
-                                "name": "values",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "values",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "result",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "result",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1269,39 +1300,41 @@
                 "<FUNCTION>": "10 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "fillIntArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "3",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "out",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "3"
-                                    }
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "fillIntArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "3",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "3"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "out",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1355,50 +1388,53 @@
                 "<FUNCTION>": "11 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "incrementIntArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "array",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "size(array)",
-                                "value": true
+                        "name": "incrementIntArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "array",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "sizein"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(array)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "sizein",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1468,49 +1504,52 @@
                 "<FUNCTION>": "12 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "fill_with_zeros"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "x",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "size(x)",
-                                "value": true
+                        "name": "fill_with_zeros",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "x",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "x_length"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(x)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "x_length",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1577,50 +1616,53 @@
                 "<FUNCTION>": "13 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "accumulate"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "arr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "implied": "size(arr)",
-                                "value": true
+                        "name": "accumulate",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "len"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(arr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "len",
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -1706,37 +1748,39 @@
                 "<FUNCTION>": "14 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptCharArrayIn"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "names",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "acceptCharArrayIn",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "names",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -1806,28 +1850,30 @@
                 "<FUNCTION>": "15 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "setGlobalInt"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "setGlobalInt",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "value",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "value"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -1872,12 +1918,13 @@
                 "<FUNCTION>": "16 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "sumFixedArray"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "sumFixedArray",
+                        "params": [],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -1921,37 +1968,39 @@
                 "<FUNCTION>": "17 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToScalar"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToScalar",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1972,43 +2021,45 @@
                 "<FUNCTION>": "18 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToFixedArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "10",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToFixedArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "10",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "constant": "10"
-                                    }
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2062,64 +2113,67 @@
                 "<FUNCTION>": "19 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToDynamicArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "ncount",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "name": "ncount"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
+                        "name": "getPtrToDynamicArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "ncount",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "name": "ncount"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "ncount",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "ncount",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2195,44 +2249,46 @@
                 "<FUNCTION>": "20 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToFuncArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "getLen()",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToFuncArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "getLen()",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "args": [],
-                                        "name": "getLen"
-                                    }
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "args": [],
+                                                "name": "getLen"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2286,38 +2342,40 @@
                 "<FUNCTION>": "21 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToConstScalar"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToConstScalar",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2338,44 +2396,46 @@
                 "<FUNCTION>": "22 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToFixedConstArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "10",
-                                "intent": "out"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToFixedConstArray",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "10",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "constant": "10"
-                                    }
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2426,65 +2486,68 @@
                 "<FUNCTION>": "23 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToDynamicConstArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "ncount",
-                                "intent": "out"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "name": "ncount"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
+                        "name": "getPtrToDynamicConstArray",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "ncount",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "name": "ncount"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "ncount",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "ncount",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2557,38 +2620,40 @@
                 "<FUNCTION>": "24 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToScalar"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToScalar",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2637,38 +2702,40 @@
                 "<FUNCTION>": "25 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToScalarForce"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToScalarForce",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2693,38 +2760,40 @@
                 "<FUNCTION>": "26 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToFixedArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToFixedArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2773,38 +2842,40 @@
                 "<FUNCTION>": "27 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToFixedArrayForce"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToFixedArrayForce",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2829,39 +2900,41 @@
                 "<FUNCTION>": "28 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToInt2d"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToInt2d",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
+                                    "metaattrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2885,36 +2958,38 @@
                 "<FUNCTION>": "29 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "checkInt2d"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "checkInt2d",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -2938,42 +3013,44 @@
                 "<FUNCTION>": "30 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "DimensionIn"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "10,20"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "10"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "DimensionIn",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "10,20"
                                     },
-                                    {
-                                        "constant": "20"
-                                    }
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            },
+                                            {
+                                                "constant": "20"
+                                            }
+                                        ],
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2998,44 +3075,46 @@
                 "<FUNCTION>": "31 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getAllocToFixedArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "allocatable",
-                                "dimension": "10",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getAllocToFixedArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "allocatable",
+                                        "dimension": "10",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "allocatable",
-                                "dimension": [
-                                    {
-                                        "constant": "10"
-                                    }
+                                    "metaattrs": {
+                                        "deref": "allocatable",
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3059,33 +3138,35 @@
                 "<FUNCTION>": "32 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "intent": "function"
+                        },
                         "name": "returnAddress1",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "flag",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "flag"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -3150,33 +3231,35 @@
                 "<FUNCTION>": "33 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "intent": "function"
+                        },
                         "name": "returnAddress2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "flag",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "flag"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -3243,36 +3326,38 @@
                 "<FUNCTION>": "34 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "fetchVoidPtr"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "fetchVoidPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3318,36 +3403,38 @@
                 "<FUNCTION>": "35 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "updateVoidPtr"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout"
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "updateVoidPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3369,36 +3456,38 @@
                 "<FUNCTION>": "36 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "VoidPtrArray"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "VoidPtrArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -3420,18 +3509,19 @@
                 "<FUNCTION>": "37 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToScalar",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -3472,27 +3562,28 @@
             {
                 "<FUNCTION>": "38 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "dimension": "10"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "dimension": "10"
+                        },
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "constant": "10"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToFixedArray",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "constant": "10"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -3540,18 +3631,19 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToConstScalar",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -3592,28 +3684,29 @@
             {
                 "<FUNCTION>": "40 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "dimension": "10"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "dimension": "10"
+                        },
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "constant": "10"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToFixedConstArray",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "constant": "10"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -3659,22 +3752,23 @@
             {
                 "<FUNCTION>": "41 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "deref": "scalar"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "scalar"
+                        },
+                        "metaattrs": {
+                            "deref": "scalar",
+                            "intent": "function"
+                        },
                         "name": "returnIntScalar",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "scalar",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -3715,22 +3809,23 @@
             {
                 "<FUNCTION>": "42 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "deref": "raw"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "raw"
+                        },
+                        "metaattrs": {
+                            "deref": "raw",
+                            "intent": "function"
+                        },
                         "name": "returnIntRaw",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "raw",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -3753,42 +3848,44 @@
             {
                 "<FUNCTION>": "43 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "deref": "raw"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "raw"
+                        },
+                        "metaattrs": {
+                            "deref": "raw",
+                            "intent": "function"
+                        },
                         "name": "returnIntRawWithArgs",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "ftrim_char_in": true,
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "raw",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "ftrim_char_in": true,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -3812,7 +3909,11 @@
                 "<FUNCTION>": "44 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "intent": "function"
+                        },
                         "name": "returnRawPtrToInt2d",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
@@ -3820,12 +3921,9 @@
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -3849,28 +3947,29 @@
             {
                 "<FUNCTION>": "45 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "deref": "allocatable",
-                        "dimension": "10"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "allocatable",
+                            "dimension": "10"
+                        },
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "dimension": [
+                                {
+                                    "constant": "10"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "returnIntAllocToFixedArray",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "dimension": [
-                            {
-                                "constant": "10"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],

--- a/regression/reference/pointers-numpy-cxx/pointers.json
+++ b/regression/reference/pointers-numpy-cxx/pointers.json
@@ -51,6 +51,7 @@
                 },
                 "decl": "void  intargs_in(const int *arg)",
                 "declgen": "void intargs_in(const int * arg)",
+                "name": "intargs_in",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -125,6 +126,7 @@
                 "doxygen": {
                     "description": "Argument is modified by library, defaults to intent(inout).\n"
                 },
+                "name": "intargs_inout",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -199,6 +201,7 @@
                 },
                 "decl": "void  intargs_out(int *arg +intent(out))",
                 "declgen": "void intargs_out(int * arg +intent(out))",
+                "name": "intargs_out",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -312,6 +315,7 @@
                 },
                 "decl": "void  intargs(const int argin      +intent(in), int * arginout +intent(inout), int * argout   +intent(out))",
                 "declgen": "void intargs(const int argin +intent(in)+value, int * arginout +intent(inout), int * argout +intent(out))",
+                "name": "intargs",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -483,6 +487,7 @@
                     "brief": "compute cos of IN and save in OUT",
                     "description": "allocate OUT same type as IN implied size of array"
                 },
+                "name": "cos_doubles",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -659,6 +664,7 @@
                     "brief": "truncate IN argument and save in OUT",
                     "description": "allocate OUT different type as IN\nimplied size of array\n"
                 },
+                "name": "truncate_to_int",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -812,6 +818,7 @@
                     "brief": "fill values into array",
                     "description": "The function knows how long the array must be.\nFortran will treat the dimension as assumed-length.\nThe Python wrapper will create a NumPy array or list so it must\nhave an explicit dimension (not assumed-length).\n"
                 },
+                "name": "get_values",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -950,6 +957,7 @@
                     "brief": "fill values into two arrays",
                     "description": "Test two intent(out) arguments.\nMake sure error handling works with C++.\n"
                 },
+                "name": "get_values2",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1078,6 +1086,7 @@
                 },
                 "decl": "void iota_dimension (int nvar, int *values+intent(out)+dimension(nvar))",
                 "declgen": "void iota_dimension(int nvar +value, int * values +dimension(nvar)+intent(out))",
+                "name": "iota_dimension",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1217,6 +1226,7 @@
                 },
                 "decl": "void Sum(int len +implied(size(values)), const int *values +rank(1), int *result +intent(out))",
                 "declgen": "void Sum(int len +implied(size(values))+value, const int * values +rank(1), int * result +intent(out))",
+                "name": "Sum",
                 "options": {
                     "wrap_lua": false
                 },
@@ -1345,6 +1355,7 @@
                 "doxygen": {
                     "description": "Return three values into memory the user provides.\n"
                 },
+                "name": "fillIntArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1445,6 +1456,7 @@
                 "doxygen": {
                     "description": "Increment array in place using intent(INOUT).\n"
                 },
+                "name": "incrementIntArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1557,6 +1569,7 @@
                 },
                 "decl": "void fill_with_zeros(double* x+rank(1), int x_length+implied(size(x)));",
                 "declgen": "void fill_with_zeros(double * x +rank(1), int x_length +implied(size(x))+value)",
+                "name": "fill_with_zeros",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1670,6 +1683,7 @@
                 },
                 "decl": "int accumulate(const int *arr+rank(1), size_t len+implied(size(arr)));",
                 "declgen": "int accumulate(const int * arr +rank(1), size_t len +implied(size(arr))+value)",
+                "name": "accumulate",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1791,6 +1805,7 @@
                 "doxygen": {
                     "description": "Return strlen of the first index as a check.\n"
                 },
+                "name": "acceptCharArrayIn",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1881,6 +1896,7 @@
                 },
                 "decl": "void setGlobalInt(int value)",
                 "declgen": "void setGlobalInt(int value +value)",
+                "name": "setGlobalInt",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1935,6 +1951,7 @@
                 "doxygen": {
                     "description": "Used to test values global_array.\n"
                 },
+                "name": "sumFixedArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2008,6 +2025,7 @@
                 },
                 "decl": "void getPtrToScalar(int **nitems+intent(out))",
                 "declgen": "void getPtrToScalar(int * * nitems +intent(out))",
+                "name": "getPtrToScalar",
                 "options": {
                     "wrap_python": false
                 },
@@ -2070,6 +2088,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is always the same length.\n"
                 },
+                "name": "getPtrToFixedArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2184,6 +2203,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is the length of\nthe argument ncount.\n"
                 },
+                "name": "getPtrToDynamicArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2299,6 +2319,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is the length\nis computed by C++ function getLen.\ngetLen will be called from C/C++ to compute the shape.\n"
                 },
+                "name": "getPtrToFuncArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2383,6 +2404,7 @@
                 },
                 "decl": "void getPtrToConstScalar( const int **nitems+intent(out))",
                 "declgen": "void getPtrToConstScalar(const int * * nitems +intent(out))",
+                "name": "getPtrToConstScalar",
                 "options": {
                     "wrap_python": false
                 },
@@ -2443,6 +2465,7 @@
                 },
                 "decl": "void getPtrToFixedConstArray( const int **count+intent(out)+dimension(10));",
                 "declgen": "void getPtrToFixedConstArray(const int * * count +dimension(10)+intent(out))",
+                "name": "getPtrToFixedConstArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2555,6 +2578,7 @@
                 },
                 "decl": "void getPtrToDynamicConstArray( const int **count+intent(out)+dimension(ncount), int *ncount+intent(out)+hidden)",
                 "declgen": "void getPtrToDynamicConstArray(const int * * count +dimension(ncount)+intent(out), int * ncount +hidden+intent(out))",
+                "name": "getPtrToDynamicConstArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2664,6 +2688,7 @@
                 "doxygen": {
                     "description": "Called directly via an interface in Fortran.\n"
                 },
+                "name": "getRawPtrToScalar",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2746,6 +2771,7 @@
                 "doxygen": {
                     "description": "Create a Fortran wrapper.\n"
                 },
+                "name": "getRawPtrToScalarForce",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -2804,6 +2830,7 @@
                 "doxygen": {
                     "description": "Return a type(C_PTR) to an array which is always the same length.\nCalled directly via an interface in Fortran.\n# Uses +deref(raw) instead of +dimension(10) like getPtrToFixedArray.\n"
                 },
+                "name": "getRawPtrToFixedArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2886,6 +2913,7 @@
                 "doxygen": {
                     "description": "Return a type(C_PTR) to an array which is always the same length.\nCreate a Fortran wrapper.\n"
                 },
+                "name": "getRawPtrToFixedArrayForce",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -2945,6 +2973,7 @@
                 "doxygen": {
                     "description": "Test multiple layers of indirection.\n"
                 },
+                "name": "getRawPtrToInt2d",
                 "options": {
                     "wrap_python": false
                 },
@@ -3000,6 +3029,7 @@
                 "doxygen": {
                     "description": "Check results of getRawPtrToInt2d.\n"
                 },
+                "name": "checkInt2d",
                 "options": {
                     "wrap_python": false
                 },
@@ -3061,6 +3091,7 @@
                 "doxygen": {
                     "description": "Test +dimension(10,20) +intent(in) together.\nThis will not use assumed-shape in the Fortran wrapper.\n"
                 },
+                "name": "DimensionIn",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -3125,6 +3156,7 @@
                 "doxygen": {
                     "description": "Return a Fortran pointer to an array which is always the same length.\n"
                 },
+                "name": "getAllocToFixedArray",
                 "options": {
                     "wrap_python": false
                 },
@@ -3174,6 +3206,7 @@
                 },
                 "decl": "void *returnAddress1(int flag)",
                 "declgen": "void * returnAddress1(int flag +value)",
+                "name": "returnAddress1",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3267,6 +3300,7 @@
                 },
                 "decl": "void *returnAddress2(int flag)",
                 "declgen": "void * returnAddress2(int flag +value)",
+                "name": "returnAddress2",
                 "options": {
                     "F_force_wrapper": true
                 },
@@ -3365,6 +3399,7 @@
                 },
                 "decl": "void fetchVoidPtr(void **addr+intent(out))",
                 "declgen": "void fetchVoidPtr(void * * addr +intent(out))",
+                "name": "fetchVoidPtr",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3442,6 +3477,7 @@
                 },
                 "decl": "void updateVoidPtr(void **addr+intent(inout))",
                 "declgen": "void updateVoidPtr(void * * addr +intent(inout))",
+                "name": "updateVoidPtr",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -3495,6 +3531,7 @@
                 },
                 "decl": "int VoidPtrArray(void **addr+rank(1))",
                 "declgen": "int VoidPtrArray(void * * addr +rank(1))",
+                "name": "VoidPtrArray",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -3529,6 +3566,7 @@
                 },
                 "decl": "int *returnIntPtrToScalar(void)",
                 "declgen": "int * returnIntPtrToScalar(void)",
+                "name": "returnIntPtrToScalar",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3591,6 +3629,7 @@
                 },
                 "decl": "int *returnIntPtrToFixedArray(void) +dimension(10)",
                 "declgen": "int * returnIntPtrToFixedArray(void) +dimension(10)",
+                "name": "returnIntPtrToFixedArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3651,6 +3690,7 @@
                 },
                 "decl": "const int *returnIntPtrToConstScalar(void)",
                 "declgen": "const int * returnIntPtrToConstScalar(void)",
+                "name": "returnIntPtrToConstScalar",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3714,6 +3754,7 @@
                 },
                 "decl": "const int *returnIntPtrToFixedConstArray(void) +dimension(10)",
                 "declgen": "const int * returnIntPtrToFixedConstArray(void) +dimension(10)",
+                "name": "returnIntPtrToFixedConstArray",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3776,6 +3817,7 @@
                 },
                 "decl": "int *returnIntScalar(void) +deref(scalar)",
                 "declgen": "int * returnIntScalar(void) +deref(scalar)",
+                "name": "returnIntScalar",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3836,6 +3878,7 @@
                 "doxygen": {
                     "description": "Call directly via interface.\n"
                 },
+                "name": "returnIntRaw",
                 "options": {
                     "wrap_python": false
                 },
@@ -3896,6 +3939,7 @@
                 "doxygen": {
                     "description": "Like returnIntRaw but with another argument to force a wrapper.\nUses fc_statements f_function_native_*_raw.\n"
                 },
+                "name": "returnIntRawWithArgs",
                 "options": {
                     "wrap_python": false
                 },
@@ -3934,6 +3978,7 @@
                 "doxygen": {
                     "description": "Test multiple layers of indirection.\n# getRawPtrToInt2d\n"
                 },
+                "name": "returnRawPtrToInt2d",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -3977,6 +4022,7 @@
                 },
                 "decl": "int *returnIntAllocToFixedArray(void) +dimension(10)+deref(allocatable)",
                 "declgen": "int * returnIntAllocToFixedArray(void) +deref(allocatable)+dimension(10)",
+                "name": "returnIntAllocToFixedArray",
                 "options": {
                     "wrap_python": false
                 },

--- a/regression/reference/pointers-numpy-cxx/pointers.json
+++ b/regression/reference/pointers-numpy-cxx/pointers.json
@@ -17,31 +17,33 @@
                 "<FUNCTION>": "0 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "intargs_in"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "intargs_in",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -87,30 +89,32 @@
                 "<FUNCTION>": "1 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "intargs_inout"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "intargs_inout",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -159,33 +163,35 @@
                 "<FUNCTION>": "2 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "intargs_out"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "intargs_out",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -231,70 +237,74 @@
                 "<FUNCTION>": "3 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "intargs"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "value": true
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "argin"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "inout"
+                        "name": "intargs",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "argin",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "arginout",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arginout",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "argout",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "argout",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -383,81 +393,85 @@
                 "<FUNCTION>": "4 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "cos_doubles"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "in",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "size(in)",
-                                "intent": "out"
+                        "name": "cos_doubles",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "in",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "out",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "args": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "size(in)",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
                                             {
-                                                "name": "in"
+                                                "args": [
+                                                    {
+                                                        "name": "in"
+                                                    }
+                                                ],
+                                                "name": "size"
                                             }
                                         ],
-                                        "name": "size"
-                                    }
+                                        "intent": "out"
+                                    },
+                                    "name": "out",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "double"
                             },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(in)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "sizein"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(in)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "sizein",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -555,81 +569,85 @@
                 "<FUNCTION>": "5 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "truncate_to_int"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "in",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "size(in)",
-                                "intent": "out"
+                        "name": "truncate_to_int",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "in",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "out",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "args": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "size(in)",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
                                             {
-                                                "name": "in"
+                                                "args": [
+                                                    {
+                                                        "name": "in"
+                                                    }
+                                                ],
+                                                "name": "size"
                                             }
                                         ],
-                                        "name": "size"
-                                    }
+                                        "intent": "out"
+                                    },
+                                    "name": "out",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "implied": "size(in)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "sizein"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(in)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "sizein",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -727,59 +745,62 @@
                 "<FUNCTION>": "6 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "get_values"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "OUT"
-                            },
-                            "declarator": {
-                                "name": "nvalues",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "3",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "values",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "3"
-                                    }
+                        "name": "get_values",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "OUT"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "nvalues",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "3",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "3"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "values",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -856,65 +877,68 @@
                 "<FUNCTION>": "7 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "get_values2"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "3",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "3"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "3",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg2",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "3"
-                                    }
+                        "name": "get_values2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "3",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "3"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "3",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "3"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "arg2",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -996,54 +1020,57 @@
                 "<FUNCTION>": "8 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "iota_dimension"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "nvar"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "dimension": "nvar",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "values",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nvar"
-                                    }
+                        "name": "iota_dimension",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "nvar",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
+                                "typemap_name": "int"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "nvar",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "name": "nvar"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "values",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1115,70 +1142,74 @@
                 "<FUNCTION>": "9 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "Sum"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "implied": "size(values)",
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "len"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "rank": 1
+                        "name": "Sum",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(values)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "len",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "const": true,
-                            "declarator": {
-                                "name": "values",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "values",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "result",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "result",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1269,39 +1300,41 @@
                 "<FUNCTION>": "10 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "fillIntArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "3",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "out",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "3"
-                                    }
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "fillIntArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "3",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "3"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "out",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1355,50 +1388,53 @@
                 "<FUNCTION>": "11 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "incrementIntArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "array",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "size(array)",
-                                "value": true
+                        "name": "incrementIntArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "array",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "sizein"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(array)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "sizein",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1468,49 +1504,52 @@
                 "<FUNCTION>": "12 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "fill_with_zeros"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "x",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "implied": "size(x)",
-                                "value": true
+                        "name": "fill_with_zeros",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "x",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "x_length"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(x)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "x_length",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1577,50 +1616,53 @@
                 "<FUNCTION>": "13 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "accumulate"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "arr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "implied": "size(arr)",
-                                "value": true
+                        "name": "accumulate",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "len"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(arr)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "len",
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -1706,37 +1748,39 @@
                 "<FUNCTION>": "14 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptCharArrayIn"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "names",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "acceptCharArrayIn",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "names",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -1806,28 +1850,30 @@
                 "<FUNCTION>": "15 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "setGlobalInt"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "setGlobalInt",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "value",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "value"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -1872,12 +1918,13 @@
                 "<FUNCTION>": "16 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "sumFixedArray"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "sumFixedArray",
+                        "params": [],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -1921,37 +1968,39 @@
                 "<FUNCTION>": "17 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToScalar"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToScalar",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1972,43 +2021,45 @@
                 "<FUNCTION>": "18 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToFixedArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "10",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToFixedArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "10",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "constant": "10"
-                                    }
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2062,64 +2113,67 @@
                 "<FUNCTION>": "19 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToDynamicArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "ncount",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "name": "ncount"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
+                        "name": "getPtrToDynamicArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "ncount",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "name": "ncount"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "ncount",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "ncount",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2195,44 +2249,46 @@
                 "<FUNCTION>": "20 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToFuncArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "getLen()",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToFuncArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "getLen()",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "args": [],
-                                        "name": "getLen"
-                                    }
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "args": [],
+                                                "name": "getLen"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2286,38 +2342,40 @@
                 "<FUNCTION>": "21 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToConstScalar"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToConstScalar",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2338,44 +2396,46 @@
                 "<FUNCTION>": "22 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToFixedConstArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "10",
-                                "intent": "out"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getPtrToFixedConstArray",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "10",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "constant": "10"
-                                    }
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2426,65 +2486,68 @@
                 "<FUNCTION>": "23 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getPtrToDynamicConstArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "ncount",
-                                "intent": "out"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "name": "ncount"
-                                    }
-                                ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "hidden": true,
-                                "intent": "out"
+                        "name": "getPtrToDynamicConstArray",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "ncount",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "deref": "pointer",
+                                        "dimension": [
+                                            {
+                                                "name": "ncount"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "ncount",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "hidden": true,
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "ncount",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2557,38 +2620,40 @@
                 "<FUNCTION>": "24 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToScalar"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToScalar",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2637,38 +2702,40 @@
                 "<FUNCTION>": "25 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToScalarForce"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "nitems",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToScalarForce",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
+                                    },
+                                    "name": "nitems",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2693,38 +2760,40 @@
                 "<FUNCTION>": "26 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToFixedArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToFixedArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2773,38 +2842,40 @@
                 "<FUNCTION>": "27 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToFixedArrayForce"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToFixedArrayForce",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "raw",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "deref": "raw",
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2829,39 +2900,41 @@
                 "<FUNCTION>": "28 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getRawPtrToInt2d"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getRawPtrToInt2d",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
+                                    "metaattrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2885,36 +2958,38 @@
                 "<FUNCTION>": "29 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "checkInt2d"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "checkInt2d",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -2938,42 +3013,44 @@
                 "<FUNCTION>": "30 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "DimensionIn"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "dimension": "10,20"
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "constant": "10"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "DimensionIn",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "dimension": "10,20"
                                     },
-                                    {
-                                        "constant": "20"
-                                    }
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            },
+                                            {
+                                                "constant": "20"
+                                            }
+                                        ],
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2998,44 +3075,46 @@
                 "<FUNCTION>": "31 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getAllocToFixedArray"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "allocatable",
-                                "dimension": "10",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getAllocToFixedArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "allocatable",
+                                        "dimension": "10",
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "allocatable",
-                                "dimension": [
-                                    {
-                                        "constant": "10"
-                                    }
+                                    "metaattrs": {
+                                        "deref": "allocatable",
+                                        "dimension": [
+                                            {
+                                                "constant": "10"
+                                            }
+                                        ],
+                                        "intent": "out"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
                                 ],
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3059,33 +3138,35 @@
                 "<FUNCTION>": "32 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "intent": "function"
+                        },
                         "name": "returnAddress1",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "flag",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "flag"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -3150,33 +3231,35 @@
                 "<FUNCTION>": "33 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "intent": "function"
+                        },
                         "name": "returnAddress2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "flag",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "flag"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -3243,36 +3326,38 @@
                 "<FUNCTION>": "34 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "fetchVoidPtr"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "fetchVoidPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3318,36 +3403,38 @@
                 "<FUNCTION>": "35 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "updateVoidPtr"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout"
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "updateVoidPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout"
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3369,36 +3456,38 @@
                 "<FUNCTION>": "36 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "VoidPtrArray"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "VoidPtrArray",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
                                     },
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
-                        }
-                    ],
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        },
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -3420,18 +3509,19 @@
                 "<FUNCTION>": "37 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToScalar",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -3472,27 +3562,28 @@
             {
                 "<FUNCTION>": "38 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "dimension": "10"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "dimension": "10"
+                        },
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "constant": "10"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToFixedArray",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "constant": "10"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -3540,18 +3631,19 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToConstScalar",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -3592,28 +3684,29 @@
             {
                 "<FUNCTION>": "40 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "dimension": "10"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "dimension": "10"
+                        },
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "constant": "10"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "returnIntPtrToFixedConstArray",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "constant": "10"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -3659,22 +3752,23 @@
             {
                 "<FUNCTION>": "41 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "deref": "scalar"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "scalar"
+                        },
+                        "metaattrs": {
+                            "deref": "scalar",
+                            "intent": "function"
+                        },
                         "name": "returnIntScalar",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "scalar",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -3715,22 +3809,23 @@
             {
                 "<FUNCTION>": "42 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "deref": "raw"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "raw"
+                        },
+                        "metaattrs": {
+                            "deref": "raw",
+                            "intent": "function"
+                        },
                         "name": "returnIntRaw",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "raw",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -3753,42 +3848,44 @@
             {
                 "<FUNCTION>": "43 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "deref": "raw"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "raw"
+                        },
+                        "metaattrs": {
+                            "deref": "raw",
+                            "intent": "function"
+                        },
                         "name": "returnIntRawWithArgs",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "ftrim_char_in": true,
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "deref": "raw",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "ftrim_char_in": true,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -3812,7 +3909,11 @@
                 "<FUNCTION>": "44 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "intent": "function"
+                        },
                         "name": "returnRawPtrToInt2d",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
@@ -3820,12 +3921,9 @@
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -3849,28 +3947,29 @@
             {
                 "<FUNCTION>": "45 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "deref": "allocatable",
-                        "dimension": "10"
-                    },
                     "declarator": {
+                        "attrs": {
+                            "deref": "allocatable",
+                            "dimension": "10"
+                        },
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "dimension": [
+                                {
+                                    "constant": "10"
+                                }
+                            ],
+                            "intent": "function"
+                        },
                         "name": "returnIntAllocToFixedArray",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "dimension": [
-                            {
-                                "constant": "10"
-                            }
                         ],
-                        "intent": "function"
+                        "typemap_name": "int"
                     },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],

--- a/regression/reference/preprocess/preprocess.json
+++ b/regression/reference/preprocess/preprocess.json
@@ -28,6 +28,7 @@
                         },
                         "decl": "void method1()",
                         "declgen": "void method1(void)",
+                        "name": "method1",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -80,6 +81,7 @@
                         },
                         "decl": "void method2()",
                         "declgen": "void method2(void)",
+                        "name": "method2",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -137,6 +139,7 @@
                         },
                         "decl": "void method3def(int i=0)",
                         "declgen": "void method3def(void)",
+                        "name": "method3def",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -215,6 +218,7 @@
                         },
                         "decl": "void method3def(int i=0)",
                         "declgen": "void method3def(int i=0 +value)",
+                        "name": "method3def",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -369,6 +373,7 @@
                         },
                         "decl": "void exfunc()",
                         "declgen": "void exfunc(void)",
+                        "name": "exfunc",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -440,6 +445,7 @@
                         },
                         "decl": "void exfunc(int flag)",
                         "declgen": "void exfunc(int flag +value)",
+                        "name": "exfunc",
                         "options": {},
                         "wrap": {
                             "c": true,

--- a/regression/reference/preprocess/preprocess.json
+++ b/regression/reference/preprocess/preprocess.json
@@ -14,12 +14,13 @@
                         "<FUNCTION>": "0 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "method1"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "method1",
+                                "params": [],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [],
                             "specifier": [
                                 "void"
                             ],
@@ -65,12 +66,13 @@
                         "<FUNCTION>": "1 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "method2"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "method2",
+                                "params": [],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [],
                             "specifier": [
                                 "void"
                             ],
@@ -121,12 +123,13 @@
                         "_overloaded": true,
                         "ast": {
                             "declarator": {
-                                "name": "method3def"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "method3def",
+                                "params": [],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [],
                             "specifier": [
                                 "void"
                             ],
@@ -180,29 +183,31 @@
                         "_overloaded": true,
                         "ast": {
                             "declarator": {
-                                "name": "method3def"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "method3def",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "value": true
+                                            },
+                                            "init": 0,
+                                            "metaattrs": {
+                                                "intent": "in"
+                                            },
+                                            "name": "i",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "i"
-                                    },
-                                    "init": 0,
-                                    "metaattrs": {
-                                        "intent": "in"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],
@@ -350,12 +355,13 @@
                         "_overloaded": true,
                         "ast": {
                             "declarator": {
-                                "name": "exfunc"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "exfunc",
+                                "params": [],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [],
                             "specifier": [
                                 "void"
                             ],
@@ -403,28 +409,30 @@
                         "_overloaded": true,
                         "ast": {
                             "declarator": {
-                                "name": "exfunc"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "exfunc",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "in"
+                                            },
+                                            "name": "flag",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "flag"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],

--- a/regression/reference/python-only/tutorial.json
+++ b/regression/reference/python-only/tutorial.json
@@ -2154,6 +2154,7 @@
                                     "metaattrs": {
                                         "intent": "in"
                                     },
+                                    "name": "incr",
                                     "params": [
                                         {
                                             "declarator": {

--- a/regression/reference/python-only/tutorial.json
+++ b/regression/reference/python-only/tutorial.json
@@ -2116,6 +2116,7 @@
                                     "attrs": {
                                         "value": true
                                     },
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],

--- a/regression/reference/python-only/tutorial.json
+++ b/regression/reference/python-only/tutorial.json
@@ -93,6 +93,7 @@
                 },
                 "decl": "void NoReturnNoArguments()",
                 "declgen": "void NoReturnNoArguments(void)",
+                "name": "NoReturnNoArguments",
                 "options": {
                     "literalinclude": true
                 },
@@ -156,6 +157,7 @@
                 },
                 "decl": "double PassByValue(double arg1, int arg2)",
                 "declgen": "double PassByValue(double arg1 +value, int arg2 +value)",
+                "name": "PassByValue",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -291,6 +293,7 @@
                 "doxygen": {
                     "description": "Note that since a reference is returned, no intermediate string\nis allocated.  It is assumed +owner(library).\n"
                 },
+                "name": "ConcatenateStrings",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -425,6 +428,7 @@
                     "_arg1",
                     "_arg1_arg2"
                 ],
+                "name": "UseDefaultArguments",
                 "options": {
                     "literalinclude": true
                 },
@@ -542,6 +546,7 @@
                 },
                 "decl": "void OverloadedFunction(const std::string& name)",
                 "declgen": "void OverloadedFunction(const std::string & name)",
+                "name": "OverloadedFunction",
                 "options": {},
                 "user_fmt": {
                     "function_suffix": "_from_name"
@@ -616,6 +621,7 @@
                 },
                 "decl": "void OverloadedFunction(int indx)",
                 "declgen": "void OverloadedFunction(int indx +value)",
+                "name": "OverloadedFunction",
                 "options": {},
                 "user_fmt": {
                     "function_suffix": "_from_index"
@@ -695,6 +701,7 @@
                 "decl": "template<typename ArgType>\nvoid TemplateArgument(ArgType arg)\n",
                 "declgen": "void TemplateArgument(ArgType arg +value)",
                 "have_template_args": true,
+                "name": "TemplateArgument",
                 "options": {},
                 "template_arguments": [
                     {
@@ -767,6 +774,7 @@
                 "decl": "template<typename ArgType>\nvoid TemplateArgument(ArgType arg)\n",
                 "declgen": "void TemplateArgument(int arg +value)",
                 "have_template_args": true,
+                "name": "TemplateArgument",
                 "options": {},
                 "template_arguments": [
                     {
@@ -871,6 +879,7 @@
                     "double"
                 ],
                 "have_template_args": true,
+                "name": "TemplateArgument",
                 "options": {},
                 "template_arguments": [
                     {
@@ -958,6 +967,7 @@
                 "decl": "template<typename RetType> RetType TemplateReturn()",
                 "declgen": "RetType TemplateReturn(void)",
                 "have_template_args": true,
+                "name": "TemplateReturn",
                 "options": {
                     "wrap_lua": false,
                     "wrap_python": false
@@ -1016,6 +1026,7 @@
                 "decl": "template<typename RetType> RetType TemplateReturn()",
                 "declgen": "int TemplateReturn(void)",
                 "have_template_args": true,
+                "name": "TemplateReturn",
                 "options": {
                     "F_create_generic": false,
                     "wrap_lua": false,
@@ -1081,6 +1092,7 @@
                     "double"
                 ],
                 "have_template_args": true,
+                "name": "TemplateReturn",
                 "options": {
                     "F_create_generic": false,
                     "wrap_lua": false,
@@ -1140,6 +1152,7 @@
                 },
                 "decl": "void FortranGenericOverloaded()",
                 "declgen": "void FortranGenericOverloaded(void)",
+                "name": "FortranGenericOverloaded",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1290,6 +1303,7 @@
                         "generic": "(double arg2)"
                     }
                 ],
+                "name": "FortranGenericOverloaded",
                 "options": {
                     "F_string_len_trim": true
                 },
@@ -1424,6 +1438,7 @@
                     "_num_offset",
                     "_num_offset_stride"
                 ],
+                "name": "UseDefaultOverload",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1607,6 +1622,7 @@
                 },
                 "decl": "int UseDefaultOverload(double type, int num, int offset = 0, int stride = 1)",
                 "declgen": "int UseDefaultOverload(double type +value, int num +value, int offset=0 +value, int stride=1 +value)",
+                "name": "UseDefaultOverload",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1759,6 +1775,7 @@
                 },
                 "decl": "TypeID typefunc(TypeID arg)",
                 "declgen": "TypeID typefunc(TypeID arg +value)",
+                "name": "typefunc",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1846,6 +1863,7 @@
                 },
                 "decl": "EnumTypeID enumfunc(EnumTypeID arg)",
                 "declgen": "EnumTypeID enumfunc(EnumTypeID arg +value)",
+                "name": "enumfunc",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1935,6 +1953,7 @@
                 },
                 "decl": "Color colorfunc(Color arg);",
                 "declgen": "Color colorfunc(Color arg +value)",
+                "name": "colorfunc",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2053,6 +2072,7 @@
                 "doxygen": {
                     "brief": "Pass in reference to scalar"
                 },
+                "name": "getMinMax",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false
@@ -2189,6 +2209,7 @@
                 "doxygen": {
                     "brief": "Test function pointer"
                 },
+                "name": "callback1",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false,
@@ -2228,6 +2249,7 @@
                 },
                 "decl": "const std::string& LastFunctionCalled() +len(30)",
                 "declgen": "const std::string & LastFunctionCalled(void) +len(30)",
+                "name": "LastFunctionCalled",
                 "options": {},
                 "wrap": {
                     "python": true

--- a/regression/reference/python-only/tutorial.json
+++ b/regression/reference/python-only/tutorial.json
@@ -751,9 +751,10 @@
                                     "name": "arg"
                                 },
                                 "specifier": [
-                                    "ArgType"
+                                    "int"
                                 ],
-                                "template_argument": "ArgType"
+                                "template_argument": "ArgType",
+                                "typemap_name": "int"
                             }
                         ],
                         "typemap_name": "void"
@@ -850,9 +851,10 @@
                                     "name": "arg"
                                 },
                                 "specifier": [
-                                    "ArgType"
+                                    "double"
                                 ],
-                                "template_argument": "ArgType"
+                                "template_argument": "ArgType",
+                                "typemap_name": "double"
                             }
                         ],
                         "typemap_name": "void"

--- a/regression/reference/python-only/tutorial.json
+++ b/regression/reference/python-only/tutorial.json
@@ -79,12 +79,13 @@
                 "<FUNCTION>": "0 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "NoReturnNoArguments"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "NoReturnNoArguments",
+                        "params": [],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [],
                     "specifier": [
                         "void"
                     ],
@@ -108,43 +109,46 @@
                 "<FUNCTION>": "1 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "PassByValue"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "PassByValue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "double"
+                    },
                     "specifier": [
                         "double"
                     ],
@@ -230,50 +234,53 @@
                 "ast": {
                     "const": true,
                     "declarator": {
-                        "name": "ConcatenateStrings"
-                    },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "intent": "function"
                         },
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg2",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
+                        "name": "ConcatenateStrings",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "std::string"
+                    },
                     "specifier": [
                         "std::string"
                     ],
@@ -364,45 +371,48 @@
                 "_has_default_arg": true,
                 "ast": {
                     "declarator": {
-                        "name": "UseDefaultArguments"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "init": 3.1415,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "UseDefaultArguments",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 3.1415,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "init": "true",
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "bool"
-                            ],
-                            "typemap_name": "bool"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": "true",
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "bool"
+                                },
+                                "specifier": [
+                                    "bool"
+                                ],
+                                "typemap_name": "bool"
+                            }
+                        ],
+                        "typemap_name": "double"
+                    },
                     "specifier": [
                         "double"
                     ],
@@ -498,31 +508,33 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "OverloadedFunction"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "OverloadedFunction",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -573,28 +585,30 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "OverloadedFunction"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "OverloadedFunction",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "indx",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "indx"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -644,28 +658,29 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "TemplateArgument"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "TemplateArgument",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg"
+                                },
+                                "specifier": [
+                                    "ArgType"
+                                ],
+                                "template_argument": "ArgType"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "ArgType"
-                            ],
-                            "template_argument": "ArgType"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -720,29 +735,29 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "TemplateArgument"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "TemplateArgument",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg"
+                                },
+                                "specifier": [
+                                    "ArgType"
+                                ],
+                                "template_argument": "ArgType"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "template_argument": "ArgType",
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -819,29 +834,29 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "TemplateArgument"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "TemplateArgument",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg"
+                                },
+                                "specifier": [
+                                    "ArgType"
+                                ],
+                                "template_argument": "ArgType"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "template_argument": "ArgType",
-                            "typemap_name": "double"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -921,12 +936,12 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "TemplateReturn"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "TemplateReturn",
+                        "params": []
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "RetType"
                     ],
@@ -984,12 +999,12 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "TemplateReturn"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "TemplateReturn",
+                        "params": []
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -1045,12 +1060,12 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "TemplateReturn"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "TemplateReturn",
+                        "params": []
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "double"
                     ],
@@ -1109,12 +1124,13 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "FortranGenericOverloaded"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "FortranGenericOverloaded",
+                        "params": [],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [],
                     "specifier": [
                         "void"
                     ],
@@ -1138,46 +1154,49 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "FortranGenericOverloaded"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "FortranGenericOverloaded",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1191,15 +1210,16 @@
                             {
                                 "const": true,
                                 "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
                                     "name": "name",
                                     "pointer": [
                                         {
                                             "ptr": "&"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    ],
+                                    "typemap_name": "std::string"
                                 },
                                 "specifier": [
                                     "std::string"
@@ -1207,14 +1227,15 @@
                                 "typemap_name": "std::string"
                             },
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "arg2"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
                                     "float"
@@ -1230,15 +1251,16 @@
                             {
                                 "const": true,
                                 "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
                                     "name": "name",
                                     "pointer": [
                                         {
                                             "ptr": "&"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    ],
+                                    "typemap_name": "std::string"
                                 },
                                 "specifier": [
                                     "std::string"
@@ -1246,14 +1268,15 @@
                                 "typemap_name": "std::string"
                             },
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "arg2"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "double"
                                 },
                                 "specifier": [
                                     "double"
@@ -1329,60 +1352,64 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UseDefaultOverload"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "num"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "UseDefaultOverload",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "num",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "offset"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 0,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "offset",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "init": 0,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "stride"
-                            },
-                            "init": 1,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 1,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "stride",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -1497,75 +1524,80 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UseDefaultOverload"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "UseDefaultOverload",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "num",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 0,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "offset",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 1,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "stride",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "type"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "num"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "offset"
-                            },
-                            "init": 0,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "stride"
-                            },
-                            "init": 1,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -1694,28 +1726,30 @@
                 "<FUNCTION>": "12 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "typefunc"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "typefunc",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "tutorial::TypeID"
+                                },
+                                "specifier": [
+                                    "TypeID"
+                                ],
+                                "typemap_name": "tutorial::TypeID"
+                            }
+                        ],
+                        "typemap_name": "tutorial::TypeID"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "TypeID"
-                            ],
-                            "typemap_name": "tutorial::TypeID"
-                        }
-                    ],
                     "specifier": [
                         "TypeID"
                     ],
@@ -1779,28 +1813,30 @@
                 "<FUNCTION>": "13 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "enumfunc"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "enumfunc",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "tutorial::EnumTypeID"
+                                },
+                                "specifier": [
+                                    "EnumTypeID"
+                                ],
+                                "typemap_name": "tutorial::EnumTypeID"
+                            }
+                        ],
+                        "typemap_name": "tutorial::EnumTypeID"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "EnumTypeID"
-                            ],
-                            "typemap_name": "tutorial::EnumTypeID"
-                        }
-                    ],
                     "specifier": [
                         "EnumTypeID"
                     ],
@@ -1866,28 +1902,30 @@
                 "<FUNCTION>": "14 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "colorfunc"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "colorfunc",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "tutorial::Color"
+                                },
+                                "specifier": [
+                                    "Color"
+                                ],
+                                "typemap_name": "tutorial::Color"
+                            }
+                        ],
+                        "typemap_name": "tutorial::Color"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Color"
-                            ],
-                            "typemap_name": "tutorial::Color"
-                        }
-                    ],
                     "specifier": [
                         "Color"
                     ],
@@ -1953,53 +1991,56 @@
                 "<FUNCTION>": "15 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getMinMax"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "min",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                        "name": "getMinMax",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "min",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "max",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "max",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2073,62 +2114,68 @@
                 "<FUNCTION>": "16 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "callback1"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "in"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "func": {
-                                    "name": "incr",
-                                    "pointer": [
-                                        {
-                                            "ptr": "*"
-                                        }
-                                    ]
-                                }
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "params": [
-                                {
+                        "name": "callback1",
+                        "params": [
+                            {
+                                "declarator": {
                                     "attrs": {
                                         "value": true
                                     },
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "in",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "func": {
+                                        "name": "incr",
+                                        "pointer": [
+                                            {
+                                                "ptr": "*"
+                                            }
+                                        ],
+                                        "typemap_name": "int"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "params": [
+                                        {
+                                            "declarator": {
+                                                "attrs": {
+                                                    "value": true
+                                                },
+                                                "typemap_name": "int"
+                                            },
+                                            "specifier": [
+                                                "int"
+                                            ],
+                                            "typemap_name": "int"
+                                        }
                                     ],
                                     "typemap_name": "int"
-                                }
-                            ],
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -2153,23 +2200,24 @@
             {
                 "<FUNCTION>": "17 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "len": "30"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "len": "30"
+                        },
+                        "metaattrs": {
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "LastFunctionCalled",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -2217,7 +2265,8 @@
                 "<TYPEDEF>": "****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "TypeID"
+                        "name": "TypeID",
+                        "typemap_name": "int"
                     },
                     "specifier": [
                         "int"
@@ -2248,7 +2297,8 @@
                 "<TYPEDEF>": "****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "EnumTypeID"
+                        "name": "EnumTypeID",
+                        "typemap_name": "int"
                     },
                     "specifier": [
                         "int"
@@ -2285,7 +2335,8 @@
                 "<VARIABLE>": "****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "global_flag"
+                        "name": "global_flag",
+                        "typemap_name": "int"
                     },
                     "specifier": [
                         "int"
@@ -2313,7 +2364,8 @@
                 "<VARIABLE>": "****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "tutorial_flag"
+                        "name": "tutorial_flag",
+                        "typemap_name": "int"
                     },
                     "specifier": [
                         "int"

--- a/regression/reference/scope/scope.json
+++ b/regression/reference/scope/scope.json
@@ -559,6 +559,7 @@
                 },
                 "decl": "int * DataPointer_get_items(ns3::DataPointer *SH_this)",
                 "declgen": "int * DataPointer_get_items(ns3::DataPointer * SH_this)",
+                "name": "DataPointer_get_items",
                 "options": {},
                 "user_fmt": {
                     "field_name": "items",
@@ -657,6 +658,7 @@
                 },
                 "decl": "int * DataPointer_get_items(ns3::DataPointer *SH_this)",
                 "declgen": "int * DataPointer_get_items(ns3::DataPointer * SH_this)",
+                "name": "DataPointer_get_items",
                 "options": {},
                 "splicer_group": "buf",
                 "user_fmt": {
@@ -823,6 +825,7 @@
                 },
                 "decl": "void DataPointer_set_items(ns3::DataPointer *SH_this,int * val)",
                 "declgen": "void DataPointer_set_items(ns3::DataPointer * SH_this, int * val +intent(in)+rank(1))",
+                "name": "DataPointer_set_items",
                 "options": {},
                 "user_fmt": {
                     "field_name": "items",
@@ -1162,6 +1165,7 @@
                         },
                         "decl": "int * DataPointer_get_items(ns1::DataPointer *SH_this)",
                         "declgen": "int * DataPointer_get_items(ns1::DataPointer * SH_this)",
+                        "name": "DataPointer_get_items",
                         "options": {},
                         "user_fmt": {
                             "field_name": "items",
@@ -1261,6 +1265,7 @@
                         },
                         "decl": "int * DataPointer_get_items(ns1::DataPointer *SH_this)",
                         "declgen": "int * DataPointer_get_items(ns1::DataPointer * SH_this)",
+                        "name": "DataPointer_get_items",
                         "options": {},
                         "splicer_group": "buf",
                         "user_fmt": {
@@ -1427,6 +1432,7 @@
                         },
                         "decl": "void DataPointer_set_items(ns1::DataPointer *SH_this,int * val)",
                         "declgen": "void DataPointer_set_items(ns1::DataPointer * SH_this, int * val +intent(in)+rank(1))",
+                        "name": "DataPointer_set_items",
                         "options": {},
                         "user_fmt": {
                             "field_name": "items",
@@ -1791,6 +1797,7 @@
                         },
                         "decl": "int * DataPointer_get_items(ns2::DataPointer *SH_this)",
                         "declgen": "int * DataPointer_get_items(ns2::DataPointer * SH_this)",
+                        "name": "DataPointer_get_items",
                         "options": {},
                         "user_fmt": {
                             "field_name": "items",
@@ -1890,6 +1897,7 @@
                         },
                         "decl": "int * DataPointer_get_items(ns2::DataPointer *SH_this)",
                         "declgen": "int * DataPointer_get_items(ns2::DataPointer * SH_this)",
+                        "name": "DataPointer_get_items",
                         "options": {},
                         "splicer_group": "buf",
                         "user_fmt": {
@@ -2056,6 +2064,7 @@
                         },
                         "decl": "void DataPointer_set_items(ns2::DataPointer *SH_this,int * val)",
                         "declgen": "void DataPointer_set_items(ns2::DataPointer * SH_this, int * val +intent(in)+rank(1))",
+                        "name": "DataPointer_set_items",
                         "options": {},
                         "user_fmt": {
                             "field_name": "items",

--- a/regression/reference/scope/scope.json
+++ b/regression/reference/scope/scope.json
@@ -22,7 +22,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "nitems"
+                                "name": "nitems",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -47,23 +48,24 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "name": "nitems"
+                                        }
+                                    ]
+                                },
                                 "name": "items",
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nitems"
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -511,43 +513,45 @@
                 "_generated": "getter/setter",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "name": "nitems"
+                                }
+                            ],
+                            "intent": "getter",
+                            "struct": "ns3_DataPointer"
+                        },
                         "name": "DataPointer_get_items",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in",
+                                        "struct": "ns3_DataPointer"
+                                    },
+                                    "name": "SH_this",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "ns3::DataPointer"
+                                },
+                                "specifier": [
+                                    "ns3::DataPointer"
+                                ],
+                                "typemap_name": "ns3::DataPointer"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "name": "nitems"
-                            }
                         ],
-                        "intent": "getter",
-                        "struct": "ns3_DataPointer"
+                        "typemap_name": "int"
                     },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "SH_this",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in",
-                                "struct": "ns3_DataPointer"
-                            },
-                            "specifier": [
-                                "ns3::DataPointer"
-                            ],
-                            "typemap_name": "ns3::DataPointer"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -606,44 +610,46 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "name": "nitems"
+                                }
+                            ],
+                            "intent": "getter",
+                            "struct": "ns3_DataPointer"
+                        },
                         "name": "DataPointer_get_items",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in",
+                                        "struct": "ns3_DataPointer"
+                                    },
+                                    "name": "SH_this",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "ns3::DataPointer"
+                                },
+                                "specifier": [
+                                    "ns3::DataPointer"
+                                ],
+                                "typemap_name": "ns3::DataPointer"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "name": "nitems"
-                            }
                         ],
-                        "intent": "getter",
-                        "struct": "ns3_DataPointer"
+                        "typemap_name": "int"
                     },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "SH_this",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in",
-                                "struct": "ns3_DataPointer"
-                            },
-                            "specifier": [
-                                "ns3::DataPointer"
-                            ],
-                            "typemap_name": "ns3::DataPointer"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -756,57 +762,60 @@
                 "_generated": "getter/setter",
                 "ast": {
                     "declarator": {
-                        "name": "DataPointer_set_items"
-                    },
-                    "metaattrs": {
-                        "intent": "setter"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "SH_this",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout",
-                                "struct": "ns3_DataPointer"
-                            },
-                            "specifier": [
-                                "ns3::DataPointer"
-                            ],
-                            "typemap_name": "ns3::DataPointer"
+                        "metaattrs": {
+                            "intent": "setter"
                         },
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "val",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nitems"
-                                    }
+                        "name": "DataPointer_set_items",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout",
+                                        "struct": "ns3_DataPointer"
+                                    },
+                                    "name": "SH_this",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "ns3::DataPointer"
+                                },
+                                "specifier": [
+                                    "ns3::DataPointer"
                                 ],
-                                "intent": "setter"
+                                "typemap_name": "ns3::DataPointer"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "name": "nitems"
+                                            }
+                                        ],
+                                        "intent": "setter"
+                                    },
+                                    "name": "val",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -943,7 +952,8 @@
                                 "<VARIABLE>": "****************************************",
                                 "ast": {
                                     "declarator": {
-                                        "name": "nitems"
+                                        "name": "nitems",
+                                        "typemap_name": "int"
                                     },
                                     "specifier": [
                                         "int"
@@ -968,23 +978,24 @@
                             {
                                 "<VARIABLE>": "****************************************",
                                 "ast": {
-                                    "attrs": {
-                                        "dimension": "nitems"
-                                    },
                                     "declarator": {
+                                        "attrs": {
+                                            "dimension": "nitems"
+                                        },
+                                        "metaattrs": {
+                                            "dimension": [
+                                                {
+                                                    "name": "nitems"
+                                                }
+                                            ]
+                                        },
                                         "name": "items",
                                         "pointer": [
                                             {
                                                 "ptr": "*"
                                             }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "dimension": [
-                                            {
-                                                "name": "nitems"
-                                            }
-                                        ]
+                                        ],
+                                        "typemap_name": "int"
                                     },
                                     "specifier": [
                                         "int"
@@ -1105,43 +1116,45 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
+                                "metaattrs": {
+                                    "deref": "pointer",
+                                    "dimension": [
+                                        {
+                                            "name": "nitems"
+                                        }
+                                    ],
+                                    "intent": "getter",
+                                    "struct": "ns1_DataPointer"
+                                },
                                 "name": "DataPointer_get_items",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "metaattrs": {
+                                                "intent": "in",
+                                                "struct": "ns1_DataPointer"
+                                            },
+                                            "name": "SH_this",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "ns1::DataPointer"
+                                        },
+                                        "specifier": [
+                                            "ns1::DataPointer"
+                                        ],
+                                        "typemap_name": "ns1::DataPointer"
+                                    }
+                                ],
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "name": "nitems"
-                                    }
                                 ],
-                                "intent": "getter",
-                                "struct": "ns1_DataPointer"
+                                "typemap_name": "int"
                             },
-                            "params": [
-                                {
-                                    "declarator": {
-                                        "name": "SH_this",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in",
-                                        "struct": "ns1_DataPointer"
-                                    },
-                                    "specifier": [
-                                        "ns1::DataPointer"
-                                    ],
-                                    "typemap_name": "ns1::DataPointer"
-                                }
-                            ],
                             "specifier": [
                                 "int"
                             ],
@@ -1201,44 +1214,46 @@
                         "_generated": "arg_to_buffer",
                         "ast": {
                             "declarator": {
+                                "metaattrs": {
+                                    "api": "cdesc",
+                                    "deref": "pointer",
+                                    "dimension": [
+                                        {
+                                            "name": "nitems"
+                                        }
+                                    ],
+                                    "intent": "getter",
+                                    "struct": "ns1_DataPointer"
+                                },
                                 "name": "DataPointer_get_items",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "metaattrs": {
+                                                "intent": "in",
+                                                "struct": "ns1_DataPointer"
+                                            },
+                                            "name": "SH_this",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "ns1::DataPointer"
+                                        },
+                                        "specifier": [
+                                            "ns1::DataPointer"
+                                        ],
+                                        "typemap_name": "ns1::DataPointer"
+                                    }
+                                ],
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "name": "nitems"
-                                    }
                                 ],
-                                "intent": "getter",
-                                "struct": "ns1_DataPointer"
+                                "typemap_name": "int"
                             },
-                            "params": [
-                                {
-                                    "declarator": {
-                                        "name": "SH_this",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in",
-                                        "struct": "ns1_DataPointer"
-                                    },
-                                    "specifier": [
-                                        "ns1::DataPointer"
-                                    ],
-                                    "typemap_name": "ns1::DataPointer"
-                                }
-                            ],
                             "specifier": [
                                 "int"
                             ],
@@ -1351,57 +1366,60 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "DataPointer_set_items"
-                            },
-                            "metaattrs": {
-                                "intent": "setter"
-                            },
-                            "params": [
-                                {
-                                    "declarator": {
-                                        "name": "SH_this",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "inout",
-                                        "struct": "ns1_DataPointer"
-                                    },
-                                    "specifier": [
-                                        "ns1::DataPointer"
-                                    ],
-                                    "typemap_name": "ns1::DataPointer"
+                                "metaattrs": {
+                                    "intent": "setter"
                                 },
-                                {
-                                    "attrs": {
-                                        "intent": "in",
-                                        "rank": 1
-                                    },
-                                    "declarator": {
-                                        "name": "val",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "dimension": [
-                                            {
-                                                "name": "nitems"
-                                            }
+                                "name": "DataPointer_set_items",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "metaattrs": {
+                                                "intent": "inout",
+                                                "struct": "ns1_DataPointer"
+                                            },
+                                            "name": "SH_this",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "ns1::DataPointer"
+                                        },
+                                        "specifier": [
+                                            "ns1::DataPointer"
                                         ],
-                                        "intent": "setter"
+                                        "typemap_name": "ns1::DataPointer"
                                     },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "intent": "in",
+                                                "rank": 1
+                                            },
+                                            "metaattrs": {
+                                                "dimension": [
+                                                    {
+                                                        "name": "nitems"
+                                                    }
+                                                ],
+                                                "intent": "setter"
+                                            },
+                                            "name": "val",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "void"
+                            },
                             "specifier": [
                                 "void"
                             ],
@@ -1563,7 +1581,8 @@
                                 "<VARIABLE>": "****************************************",
                                 "ast": {
                                     "declarator": {
-                                        "name": "nitems"
+                                        "name": "nitems",
+                                        "typemap_name": "int"
                                     },
                                     "specifier": [
                                         "int"
@@ -1588,23 +1607,24 @@
                             {
                                 "<VARIABLE>": "****************************************",
                                 "ast": {
-                                    "attrs": {
-                                        "dimension": "nitems"
-                                    },
                                     "declarator": {
+                                        "attrs": {
+                                            "dimension": "nitems"
+                                        },
+                                        "metaattrs": {
+                                            "dimension": [
+                                                {
+                                                    "name": "nitems"
+                                                }
+                                            ]
+                                        },
                                         "name": "items",
                                         "pointer": [
                                             {
                                                 "ptr": "*"
                                             }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "dimension": [
-                                            {
-                                                "name": "nitems"
-                                            }
-                                        ]
+                                        ],
+                                        "typemap_name": "int"
                                     },
                                     "specifier": [
                                         "int"
@@ -1725,43 +1745,45 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
+                                "metaattrs": {
+                                    "deref": "pointer",
+                                    "dimension": [
+                                        {
+                                            "name": "nitems"
+                                        }
+                                    ],
+                                    "intent": "getter",
+                                    "struct": "ns2_DataPointer"
+                                },
                                 "name": "DataPointer_get_items",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "metaattrs": {
+                                                "intent": "in",
+                                                "struct": "ns2_DataPointer"
+                                            },
+                                            "name": "SH_this",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "ns2::DataPointer"
+                                        },
+                                        "specifier": [
+                                            "ns2::DataPointer"
+                                        ],
+                                        "typemap_name": "ns2::DataPointer"
+                                    }
+                                ],
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "name": "nitems"
-                                    }
                                 ],
-                                "intent": "getter",
-                                "struct": "ns2_DataPointer"
+                                "typemap_name": "int"
                             },
-                            "params": [
-                                {
-                                    "declarator": {
-                                        "name": "SH_this",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in",
-                                        "struct": "ns2_DataPointer"
-                                    },
-                                    "specifier": [
-                                        "ns2::DataPointer"
-                                    ],
-                                    "typemap_name": "ns2::DataPointer"
-                                }
-                            ],
                             "specifier": [
                                 "int"
                             ],
@@ -1821,44 +1843,46 @@
                         "_generated": "arg_to_buffer",
                         "ast": {
                             "declarator": {
+                                "metaattrs": {
+                                    "api": "cdesc",
+                                    "deref": "pointer",
+                                    "dimension": [
+                                        {
+                                            "name": "nitems"
+                                        }
+                                    ],
+                                    "intent": "getter",
+                                    "struct": "ns2_DataPointer"
+                                },
                                 "name": "DataPointer_get_items",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "metaattrs": {
+                                                "intent": "in",
+                                                "struct": "ns2_DataPointer"
+                                            },
+                                            "name": "SH_this",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "ns2::DataPointer"
+                                        },
+                                        "specifier": [
+                                            "ns2::DataPointer"
+                                        ],
+                                        "typemap_name": "ns2::DataPointer"
+                                    }
+                                ],
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "deref": "pointer",
-                                "dimension": [
-                                    {
-                                        "name": "nitems"
-                                    }
                                 ],
-                                "intent": "getter",
-                                "struct": "ns2_DataPointer"
+                                "typemap_name": "int"
                             },
-                            "params": [
-                                {
-                                    "declarator": {
-                                        "name": "SH_this",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in",
-                                        "struct": "ns2_DataPointer"
-                                    },
-                                    "specifier": [
-                                        "ns2::DataPointer"
-                                    ],
-                                    "typemap_name": "ns2::DataPointer"
-                                }
-                            ],
                             "specifier": [
                                 "int"
                             ],
@@ -1971,57 +1995,60 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "DataPointer_set_items"
-                            },
-                            "metaattrs": {
-                                "intent": "setter"
-                            },
-                            "params": [
-                                {
-                                    "declarator": {
-                                        "name": "SH_this",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "inout",
-                                        "struct": "ns2_DataPointer"
-                                    },
-                                    "specifier": [
-                                        "ns2::DataPointer"
-                                    ],
-                                    "typemap_name": "ns2::DataPointer"
+                                "metaattrs": {
+                                    "intent": "setter"
                                 },
-                                {
-                                    "attrs": {
-                                        "intent": "in",
-                                        "rank": 1
-                                    },
-                                    "declarator": {
-                                        "name": "val",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "dimension": [
-                                            {
-                                                "name": "nitems"
-                                            }
+                                "name": "DataPointer_set_items",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "metaattrs": {
+                                                "intent": "inout",
+                                                "struct": "ns2_DataPointer"
+                                            },
+                                            "name": "SH_this",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "ns2::DataPointer"
+                                        },
+                                        "specifier": [
+                                            "ns2::DataPointer"
                                         ],
-                                        "intent": "setter"
+                                        "typemap_name": "ns2::DataPointer"
                                     },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "intent": "in",
+                                                "rank": 1
+                                            },
+                                            "metaattrs": {
+                                                "dimension": [
+                                                    {
+                                                        "name": "nitems"
+                                                    }
+                                                ],
+                                                "intent": "setter"
+                                            },
+                                            "name": "val",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "void"
+                            },
                             "specifier": [
                                 "void"
                             ],

--- a/regression/reference/statement/statement.json
+++ b/regression/reference/statement/statement.json
@@ -16,16 +16,17 @@
             {
                 "<FUNCTION>": "0 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "pure": true
-                    },
                     "declarator": {
-                        "name": "GetNameLength"
+                        "attrs": {
+                            "pure": true
+                        },
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "GetNameLength",
+                        "params": [],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -109,23 +110,24 @@
                 "PY_error_pattern": "PY_invalid_name",
                 "_PTR_F_C_index": "2",
                 "ast": {
-                    "attrs": {
-                        "len": "get_name_length()"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "len": "get_name_length()"
+                        },
+                        "metaattrs": {
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "getNameErrorPattern",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "string"
                     ],
@@ -200,24 +202,25 @@
                 "_PTR_C_CXX_index": "1",
                 "_generated": "arg_to_buffer",
                 "ast": {
-                    "attrs": {
-                        "len": "get_name_length()"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "len": "get_name_length()"
+                        },
+                        "metaattrs": {
+                            "api": "buf",
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "getNameErrorPattern",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "buf",
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "string"
                     ],

--- a/regression/reference/statement/statement.json
+++ b/regression/reference/statement/statement.json
@@ -37,6 +37,7 @@
                 "doxygen": {
                     "brief": "helper function for Fortran to get length of name."
                 },
+                "name": "GetNameLength",
                 "options": {},
                 "splicer": {
                     "c": [
@@ -135,6 +136,7 @@
                 },
                 "decl": "const string& getNameErrorPattern()",
                 "declgen": "const string & getNameErrorPattern(void) +len(get_name_length())",
+                "name": "getNameErrorPattern",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -228,6 +230,7 @@
                 },
                 "decl": "const string& getNameErrorPattern()",
                 "declgen": "const string & getNameErrorPattern(void) +len(get_name_length())",
+                "name": "getNameErrorPattern",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {

--- a/regression/reference/strings-cfi/strings.json
+++ b/regression/reference/strings-cfi/strings.json
@@ -55,6 +55,7 @@
                 "doxygen": {
                     "brief": "pass a single char argument as a scalar."
                 },
+                "name": "passChar",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -157,6 +158,7 @@
                 "doxygen": {
                     "description": "By default no Fortran wrapper is created.\nForce one so it can be tested.\n"
                 },
+                "name": "passCharForce",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -245,6 +247,7 @@
                 "doxygen": {
                     "brief": "return a char argument (non-pointer)"
                 },
+                "name": "returnChar",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -370,6 +373,7 @@
                     "brief": "strcpy like behavior",
                     "description": "dest is marked intent(OUT) to override the intent(INOUT) default\nThis avoid a copy-in on dest.\nIn Python, src must not be over 40 characters, defined by charlen.\n"
                 },
+                "name": "passCharPtr",
                 "options": {
                     "literalinclude": true,
                     "wrap_fortran": false,
@@ -530,6 +534,7 @@
                     "brief": "strcpy like behavior",
                     "description": "dest is marked intent(OUT) to override the intent(INOUT) default\nThis avoid a copy-in on dest.\nIn Python, src must not be over 40 characters, defined by charlen.\n"
                 },
+                "name": "passCharPtr",
                 "options": {
                     "literalinclude": true,
                     "wrap_fortran": false,
@@ -675,6 +680,7 @@
                     "brief": "toupper",
                     "description": "Change a string in-place.\nFor Python, return a new string since strings are immutable.\n"
                 },
+                "name": "passCharPtrInOut",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -783,6 +789,7 @@
                     "brief": "toupper",
                     "description": "Change a string in-place.\nFor Python, return a new string since strings are immutable.\n"
                 },
+                "name": "passCharPtrInOut",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -875,6 +882,7 @@
                 "doxygen": {
                     "brief": "return a 'const char *' as character(*)"
                 },
+                "name": "getCharPtr1",
                 "options": {
                     "literalinclude": true,
                     "wrap_fortran": false
@@ -967,6 +975,7 @@
                 "doxygen": {
                     "brief": "return a 'const char *' as character(*)"
                 },
+                "name": "getCharPtr1",
                 "options": {
                     "literalinclude": true,
                     "wrap_fortran": false
@@ -1053,6 +1062,7 @@
                 "doxygen": {
                     "brief": "return 'const char *' with fixed size (len=30)"
                 },
+                "name": "getCharPtr2",
                 "options": {
                     "literalinclude": true,
                     "wrap_fortran": false
@@ -1147,6 +1157,7 @@
                 "doxygen": {
                     "brief": "return 'const char *' with fixed size (len=30)"
                 },
+                "name": "getCharPtr2",
                 "options": {
                     "literalinclude": true,
                     "wrap_fortran": false
@@ -1225,6 +1236,7 @@
                 "doxygen": {
                     "brief": "return a 'const char *' as argument"
                 },
+                "name": "getCharPtr3",
                 "options": {
                     "literalinclude": true,
                     "wrap_fortran": false
@@ -1321,6 +1333,7 @@
                 "doxygen": {
                     "brief": "return a 'const char *' as argument"
                 },
+                "name": "getCharPtr3",
                 "options": {
                     "literalinclude": true,
                     "wrap_fortran": false
@@ -1450,6 +1463,7 @@
                 "doxygen": {
                     "brief": "return a 'const char *' as argument"
                 },
+                "name": "getCharPtr3",
                 "options": {
                     "literalinclude": true,
                     "wrap_fortran": false
@@ -1510,6 +1524,7 @@
                 "doxygen": {
                     "brief": "return a 'const char *' as type(C_PTR)"
                 },
+                "name": "getCharPtr4",
                 "options": {
                     "wrap_python": false
                 },
@@ -1605,6 +1620,7 @@
                 "doxygen": {
                     "brief": "return a 'const char *' as character(:) pointer"
                 },
+                "name": "getCharPtr5",
                 "options": {
                     "wrap_fortran": false,
                     "wrap_python": false
@@ -1700,6 +1716,7 @@
                 "doxygen": {
                     "brief": "return a 'const char *' as character(:) pointer"
                 },
+                "name": "getCharPtr5",
                 "options": {
                     "wrap_fortran": false,
                     "wrap_python": false
@@ -1789,6 +1806,7 @@
                 "doxygen": {
                     "brief": "return an ALLOCATABLE CHARACTER from std::string"
                 },
+                "name": "getConstStringResult",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -1850,6 +1868,7 @@
                 "doxygen": {
                     "brief": "return an ALLOCATABLE CHARACTER from std::string"
                 },
+                "name": "getConstStringResult",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -1931,6 +1950,7 @@
                 "doxygen": {
                     "brief": "return a 'const string' as argument"
                 },
+                "name": "getConstStringLen",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -1995,6 +2015,7 @@
                 "doxygen": {
                     "brief": "return a 'const string' as argument"
                 },
+                "name": "getConstStringLen",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -2068,6 +2089,7 @@
                 "doxygen": {
                     "brief": "return a 'const string' as argument"
                 },
+                "name": "getConstStringAsArg",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -2127,6 +2149,7 @@
                 "doxygen": {
                     "brief": "return a 'const string' as argument"
                 },
+                "name": "getConstStringAsArg",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -2256,6 +2279,7 @@
                 "doxygen": {
                     "brief": "return a 'const string' as argument"
                 },
+                "name": "getConstStringAsArg",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -2308,6 +2332,7 @@
                 },
                 "decl": "const std::string getConstStringAlloc()",
                 "declgen": "const std::string getConstStringAlloc(void)",
+                "name": "getConstStringAlloc",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -2365,6 +2390,7 @@
                 },
                 "decl": "const std::string getConstStringAlloc()",
                 "declgen": "const std::string getConstStringAlloc(void)",
+                "name": "getConstStringAlloc",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -2447,6 +2473,7 @@
                 "doxygen": {
                     "brief": "return a 'const string&' as ALLOCATABLE character"
                 },
+                "name": "getConstStringRefPure",
                 "options": {
                     "literalinclude": true,
                     "wrap_fortran": false
@@ -2540,6 +2567,7 @@
                 "doxygen": {
                     "brief": "return a 'const string&' as ALLOCATABLE character"
                 },
+                "name": "getConstStringRefPure",
                 "options": {
                     "literalinclude": true,
                     "wrap_fortran": false
@@ -2628,6 +2656,7 @@
                     "brief": "return 'const string&' with fixed size (len=30)",
                     "description": "Since +len(30) is provided, the result of the function\nwill be copied directly into memory provided by Fortran.\nThe function will not be ALLOCATABLE.\n"
                 },
+                "name": "getConstStringRefLen",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -2725,6 +2754,7 @@
                     "brief": "return 'const string&' with fixed size (len=30)",
                     "description": "Since +len(30) is provided, the result of the function\nwill be copied directly into memory provided by Fortran.\nThe function will not be ALLOCATABLE.\n"
                 },
+                "name": "getConstStringRefLen",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -2804,6 +2834,7 @@
                     "brief": "return a 'const string&' as argument",
                     "description": "Pass an additional argument which will be used as the return value.\nThe length of the output variable is declared by the caller.\n"
                 },
+                "name": "getConstStringRefAsArg",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -2902,6 +2933,7 @@
                     "brief": "return a 'const string&' as argument",
                     "description": "Pass an additional argument which will be used as the return value.\nThe length of the output variable is declared by the caller.\n"
                 },
+                "name": "getConstStringRefAsArg",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -3032,6 +3064,7 @@
                     "brief": "return a 'const string&' as argument",
                     "description": "Pass an additional argument which will be used as the return value.\nThe length of the output variable is declared by the caller.\n"
                 },
+                "name": "getConstStringRefAsArg",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -3096,6 +3129,7 @@
                 "doxygen": {
                     "brief": "Test returning empty string reference"
                 },
+                "name": "getConstStringRefLenEmpty",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -3192,6 +3226,7 @@
                 "doxygen": {
                     "brief": "Test returning empty string reference"
                 },
+                "name": "getConstStringRefLenEmpty",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -3271,6 +3306,7 @@
                 },
                 "decl": "const std::string& getConstStringRefAlloc()",
                 "declgen": "const std::string & getConstStringRefAlloc(void)",
+                "name": "getConstStringRefAlloc",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -3360,6 +3396,7 @@
                 },
                 "decl": "const std::string& getConstStringRefAlloc()",
                 "declgen": "const std::string & getConstStringRefAlloc(void)",
+                "name": "getConstStringRefAlloc",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -3453,6 +3490,7 @@
                         ]
                     }
                 },
+                "name": "getConstStringPtrLen",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -3556,6 +3594,7 @@
                         ]
                     }
                 },
+                "name": "getConstStringPtrLen",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -3638,6 +3677,7 @@
                 },
                 "decl": "const std::string * getConstStringPtrAlloc() +owner(library)",
                 "declgen": "const std::string * getConstStringPtrAlloc(void) +owner(library)",
+                "name": "getConstStringPtrAlloc",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -3730,6 +3770,7 @@
                 },
                 "decl": "const std::string * getConstStringPtrAlloc() +owner(library)",
                 "declgen": "const std::string * getConstStringPtrAlloc(void) +owner(library)",
+                "name": "getConstStringPtrAlloc",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -3815,6 +3856,7 @@
                 "doxygen": {
                     "description": "It is the caller's responsibility to release the string\ncreated by the C++ library.\nThis is accomplished +owner(caller) which sets idtor.\nThe contents are copied by Fortran so they must outlast\nthe return from the C wrapper.\n"
                 },
+                "name": "getConstStringPtrOwnsAlloc",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -3910,6 +3952,7 @@
                 "doxygen": {
                     "description": "It is the caller's responsibility to release the string\ncreated by the C++ library.\nThis is accomplished +owner(caller) which sets idtor.\nThe contents are copied by Fortran so they must outlast\nthe return from the C wrapper.\n"
                 },
+                "name": "getConstStringPtrOwnsAlloc",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -3996,6 +4039,7 @@
                 "doxygen": {
                     "description": "Similar to getConstStringPtrOwnsAlloc, but uses pattern to release memory.\n"
                 },
+                "name": "getConstStringPtrOwnsAllocPattern",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -4092,6 +4136,7 @@
                 "doxygen": {
                     "description": "Similar to getConstStringPtrOwnsAlloc, but uses pattern to release memory.\n"
                 },
+                "name": "getConstStringPtrOwnsAllocPattern",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -4175,6 +4220,7 @@
                 },
                 "decl": "const std::string * getConstStringPtrPointer() +deref(pointer)+owner(library)",
                 "declgen": "const std::string * getConstStringPtrPointer(void) +deref(pointer)+owner(library)",
+                "name": "getConstStringPtrPointer",
                 "options": {
                     "wrap_fortran": false,
                     "wrap_python": false
@@ -4269,6 +4315,7 @@
                 },
                 "decl": "const std::string * getConstStringPtrPointer() +deref(pointer)+owner(library)",
                 "declgen": "const std::string * getConstStringPtrPointer(void) +deref(pointer)+owner(library)",
+                "name": "getConstStringPtrPointer",
                 "options": {
                     "wrap_fortran": false,
                     "wrap_python": false
@@ -4376,6 +4423,7 @@
                     "brief": "Accept a const string reference",
                     "description": "Save contents of arg1.\narg1 is assumed to be intent(IN) since it is const\nWill copy in.\n"
                 },
+                "name": "acceptStringConstReference",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -4482,6 +4530,7 @@
                     "brief": "Accept a const string reference",
                     "description": "Save contents of arg1.\narg1 is assumed to be intent(IN) since it is const\nWill copy in.\n"
                 },
+                "name": "acceptStringConstReference",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -4592,6 +4641,7 @@
                     "brief": "Accept a string reference",
                     "description": "Set out to a constant string.\narg1 is intent(OUT)\nMust copy out.\n"
                 },
+                "name": "acceptStringReferenceOut",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -4700,6 +4750,7 @@
                     "brief": "Accept a string reference",
                     "description": "Set out to a constant string.\narg1 is intent(OUT)\nMust copy out.\n"
                 },
+                "name": "acceptStringReferenceOut",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -4805,6 +4856,7 @@
                     "brief": "Accept a string reference",
                     "description": "Append \"dog\" to the end of arg1.\narg1 is assumed to be intent(INOUT)\nMust copy in and copy out.\n"
                 },
+                "name": "acceptStringReference",
                 "options": {
                     "literalinclude": true,
                     "wrap_fortran": false
@@ -4911,6 +4963,7 @@
                     "brief": "Accept a string reference",
                     "description": "Append \"dog\" to the end of arg1.\narg1 is assumed to be intent(INOUT)\nMust copy in and copy out.\n"
                 },
+                "name": "acceptStringReference",
                 "options": {
                     "literalinclude": true,
                     "wrap_fortran": false
@@ -5019,6 +5072,7 @@
                 "doxygen": {
                     "brief": "Accept a const string pointer - intent(in)"
                 },
+                "name": "acceptStringPointerConst",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -5124,6 +5178,7 @@
                 "doxygen": {
                     "brief": "Accept a const string pointer - intent(in)"
                 },
+                "name": "acceptStringPointerConst",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -5230,6 +5285,7 @@
                 "doxygen": {
                     "brief": "Accept a string pointer - intent(inout)"
                 },
+                "name": "acceptStringPointer",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -5334,6 +5390,7 @@
                 "doxygen": {
                     "brief": "Accept a string pointer - intent(inout)"
                 },
+                "name": "acceptStringPointer",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -5444,6 +5501,7 @@
                     "brief": "Accept a string pointer - intent(out)",
                     "description": "Return global_str.\n"
                 },
+                "name": "fetchStringPointer",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -5552,6 +5610,7 @@
                     "brief": "Accept a string pointer - intent(out)",
                     "description": "Return global_str.\n"
                 },
+                "name": "fetchStringPointer",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -5678,6 +5737,7 @@
                     "brief": "Accept a string pointer - intent(inout)",
                     "description": "Test return tuple with two arguments.\nMust rename argument to nlen to avoid conflict with intrinsic len.\n"
                 },
+                "name": "acceptStringPointerLen",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -5833,6 +5893,7 @@
                     "brief": "Accept a string pointer - intent(inout)",
                     "description": "Test return tuple with two arguments.\nMust rename argument to nlen to avoid conflict with intrinsic len.\n"
                 },
+                "name": "acceptStringPointerLen",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -5997,6 +6058,7 @@
                     "brief": "Accept a string pointer - intent(out)",
                     "description": "Return global_str.\nTest return tuple with two arguments.\nMust rename argument to nlen to avoid conflict with intrinsic len.\n"
                 },
+                "name": "fetchStringPointerLen",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -6155,6 +6217,7 @@
                     "brief": "Accept a string pointer - intent(out)",
                     "description": "Return global_str.\nTest return tuple with two arguments.\nMust rename argument to nlen to avoid conflict with intrinsic len.\n"
                 },
+                "name": "fetchStringPointerLen",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -6290,6 +6353,7 @@
                 "doxygen": {
                     "brief": "Accept a string instance"
                 },
+                "name": "acceptStringInstance",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -6423,6 +6487,7 @@
                 "doxygen": {
                     "brief": "Accept a string instance"
                 },
+                "name": "acceptStringInstance",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -6576,6 +6641,7 @@
                 "doxygen": {
                     "brief": "Test Python returning multiple std::string arguments."
                 },
+                "name": "returnStrings",
                 "options": {
                     "wrap_c": false,
                     "wrap_fortran": false
@@ -6629,6 +6695,7 @@
                 "doxygen": {
                     "description": "Test Py_BuildValue with multiple values.\n"
                 },
+                "name": "returnMany",
                 "options": {
                     "wrap_c": false,
                     "wrap_fortran": false,
@@ -6685,6 +6752,7 @@
                 },
                 "decl": "void explicit1(char * name+len_trim(AAlen)+intent(in))",
                 "declgen": "void explicit1(char * name +intent(in)+len_trim(AAlen))",
+                "name": "explicit1",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -6794,6 +6862,7 @@
                 },
                 "decl": "void explicit1(char * name+len_trim(AAlen)+intent(in))",
                 "declgen": "void explicit1(char * name +intent(in)+len_trim(AAlen))",
+                "name": "explicit1",
                 "options": {
                     "wrap_fortran": false
                 },
@@ -6903,6 +6972,7 @@
                 },
                 "decl": "void explicit2(char * name+len(AAtrim)+intent(out))",
                 "declgen": "void explicit2(char * name +intent(out)+len(AAtrim))",
+                "name": "explicit2",
                 "options": {
                     "wrap_fortran": false,
                     "wrap_lua": false,
@@ -7010,6 +7080,7 @@
                 },
                 "decl": "void explicit2(char * name+len(AAtrim)+intent(out))",
                 "declgen": "void explicit2(char * name +intent(out)+len(AAtrim))",
+                "name": "explicit2",
                 "options": {
                     "wrap_fortran": false,
                     "wrap_lua": false,
@@ -7110,6 +7181,7 @@
                 "doxygen": {
                     "brief": "pass a single char argument as a scalar, extern \"C\""
                 },
+                "name": "CpassChar",
                 "options": {
                     "C_extern_C": true
                 },
@@ -7197,6 +7269,7 @@
                 "doxygen": {
                     "brief": "return a char argument (non-pointer), extern \"C\""
                 },
+                "name": "CreturnChar",
                 "options": {
                     "C_extern_C": true
                 },
@@ -7327,6 +7400,7 @@
                     "brief": "strcpy like behavior",
                     "description": "dest is marked intent(OUT) to override the intent(INOUT) default\nThis avoid a copy-in on dest.\nextern \"C\"\nIf src is a blank string, pass a NULL pointer to C library function.\n"
                 },
+                "name": "CpassCharPtr",
                 "options": {
                     "C_extern_C": true,
                     "wrap_fortran": false,
@@ -7492,6 +7566,7 @@
                     "brief": "strcpy like behavior",
                     "description": "dest is marked intent(OUT) to override the intent(INOUT) default\nThis avoid a copy-in on dest.\nextern \"C\"\nIf src is a blank string, pass a NULL pointer to C library function.\n"
                 },
+                "name": "CpassCharPtr",
                 "options": {
                     "C_extern_C": true,
                     "wrap_fortran": false,
@@ -7658,6 +7733,7 @@
                 "doxygen": {
                     "brief": "Test F_blanknull option"
                 },
+                "name": "CpassCharPtrBlank",
                 "options": {
                     "F_blanknull": true,
                     "wrap_fortran": false,
@@ -7819,6 +7895,7 @@
                 "doxygen": {
                     "brief": "Test F_blanknull option"
                 },
+                "name": "CpassCharPtrBlank",
                 "options": {
                     "F_blanknull": true,
                     "wrap_fortran": false,
@@ -7984,6 +8061,7 @@
                 "doxygen": {
                     "description": "Test post_declare.\nThe std::string in py_string_inout must be declared before the\ngoto added by py_native_*_in_pointer_list to avoid\n\"jump to label 'fail' crosses initialization of\" error.\n"
                 },
+                "name": "PostDeclare",
                 "options": {
                     "PY_array_arg": "list",
                     "wrap_fortran": false
@@ -8145,6 +8223,7 @@
                 "doxygen": {
                     "description": "Test post_declare.\nThe std::string in py_string_inout must be declared before the\ngoto added by py_native_*_in_pointer_list to avoid\n\"jump to label 'fail' crosses initialization of\" error.\n"
                 },
+                "name": "PostDeclare",
                 "options": {
                     "PY_array_arg": "list",
                     "wrap_fortran": false
@@ -8296,6 +8375,7 @@
                 "doxygen": {
                     "brief": "NULL terminate input string in C, not in Fortran."
                 },
+                "name": "CpassCharPtrNotrim",
                 "options": {
                     "F_trim_char_in": false,
                     "wrap_fortran": false,
@@ -8434,6 +8514,7 @@
                 "doxygen": {
                     "brief": "NULL terminate input string in C, not in Fortran."
                 },
+                "name": "CpassCharPtrNotrim",
                 "options": {
                     "F_trim_char_in": false,
                     "wrap_fortran": false,
@@ -8590,6 +8671,7 @@
                     "brief": "Do not NULL terminate input string",
                     "description": "The C library function should get the same address\nfor addr and src.\nUsed when the C function needs the true address of the argument.\nSkips null-termination. Useful to create an interface for\na function which is already callable by Fortran.\nFor example, the length is passed explicitly.\nThis example will not create a Fortran wrapper since C can be\ncalled directly.\n"
                 },
+                "name": "CpassCharPtrCAPI",
                 "options": {
                     "wrap_python": false
                 },
@@ -8787,6 +8869,7 @@
                 "doxygen": {
                     "brief": "Mix api(buf) and api(capi)"
                 },
+                "name": "CpassCharPtrCAPI2",
                 "options": {
                     "wrap_fortran": false,
                     "wrap_python": false
@@ -8976,6 +9059,7 @@
                 "doxygen": {
                     "brief": "Mix api(buf) and api(capi)"
                 },
+                "name": "CpassCharPtrCAPI2",
                 "options": {
                     "wrap_fortran": false,
                     "wrap_python": false

--- a/regression/reference/strings-cfi/strings.json
+++ b/regression/reference/strings-cfi/strings.json
@@ -1296,7 +1296,6 @@
                                         "is_result": true
                                     },
                                     "name": "output",
-                                    "params": [],
                                     "pointer": [
                                         {
                                             "ptr": "*"
@@ -1426,7 +1425,6 @@
                                         "is_result": true
                                     },
                                     "name": "output",
-                                    "params": [],
                                     "pointer": [
                                         {
                                             "ptr": "*"
@@ -2104,7 +2102,6 @@
                                         "is_result": true
                                     },
                                     "name": "output",
-                                    "params": [],
                                     "pointer": [
                                         {
                                             "ptr": "*"
@@ -2234,7 +2231,6 @@
                                         "is_result": true
                                     },
                                     "name": "output",
-                                    "params": [],
                                     "pointer": [
                                         {
                                             "ptr": "*"
@@ -2880,7 +2876,6 @@
                                         "is_result": true
                                     },
                                     "name": "output",
-                                    "params": [],
                                     "pointer": [
                                         {
                                             "ptr": "&"
@@ -3011,7 +3006,6 @@
                                         "is_result": true
                                     },
                                     "name": "output",
-                                    "params": [],
                                     "pointer": [
                                         {
                                             "ptr": "&"

--- a/regression/reference/strings-cfi/strings.json
+++ b/regression/reference/strings-cfi/strings.json
@@ -21,28 +21,30 @@
                 "<FUNCTION>": "0 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passChar"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "passChar",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "status",
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "status"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -121,28 +123,30 @@
                 "<FUNCTION>": "1 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passCharForce"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "passCharForce",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "status",
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "status"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -224,12 +228,13 @@
                 "<FUNCTION>": "2 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "returnChar"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "returnChar",
+                        "params": [],
+                        "typemap_name": "char"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "char"
                     ],
@@ -305,52 +310,55 @@
                 "_PTR_F_C_index": "45",
                 "ast": {
                     "declarator": {
-                        "name": "passCharPtr"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "charlen": "40",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "dest",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "src",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                        "name": "passCharPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "charlen": "40",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "dest",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "src",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -460,54 +468,57 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "passCharPtr"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "charlen": "40",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "dest",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "src",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                        "name": "passCharPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "charlen": "40",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "out"
+                                    },
+                                    "name": "dest",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
                             },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "in"
+                                    },
+                                    "name": "src",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -624,33 +635,35 @@
                 "_PTR_F_C_index": "46",
                 "ast": {
                     "declarator": {
-                        "name": "passCharPtrInOut"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "passCharPtrInOut",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "s",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout"
-                            },
-                            "declarator": {
-                                "name": "s",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -729,34 +742,36 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "passCharPtrInOut"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "passCharPtrInOut",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout"
+                                    },
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "inout"
+                                    },
+                                    "name": "s",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout"
-                            },
-                            "declarator": {
-                                "name": "s",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -837,18 +852,19 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
                         "name": "getCharPtr1",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "char"
                     },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "char"
                     ],
@@ -927,19 +943,20 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "api": "cfi",
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
                         "name": "getCharPtr1",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "char"
                     },
-                    "metaattrs": {
-                        "api": "cfi",
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "char"
                     ],
@@ -1008,23 +1025,24 @@
                 ],
                 "_PTR_F_C_index": "48",
                 "ast": {
-                    "attrs": {
-                        "len": "30"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "len": "30"
+                        },
+                        "metaattrs": {
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "getCharPtr2",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "char"
                     },
-                    "metaattrs": {
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "char"
                     ],
@@ -1100,24 +1118,25 @@
                 "_PTR_C_CXX_index": "6",
                 "_generated": "arg_to_cfi",
                 "ast": {
-                    "attrs": {
-                        "len": "30"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "len": "30"
+                        },
+                        "metaattrs": {
+                            "api": "cfi",
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "getCharPtr2",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "char"
                     },
-                    "metaattrs": {
-                        "api": "cfi",
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "char"
                     ],
@@ -1184,17 +1203,18 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "intent": "function"
+                        },
                         "name": "getCharPtr3",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "char"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "char"
                     ],
@@ -1262,33 +1282,35 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "getCharPtr3"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getCharPtr3",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "deref": "allocatable",
+                                        "intent": "function"
+                                    },
+                                    "name": "output",
+                                    "params": [],
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "char"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "output",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "deref": "result",
-                                "intent": "out",
-                                "is_result": true
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -1389,33 +1411,35 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "getCharPtr3"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getCharPtr3",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "deref": "allocatable",
+                                        "intent": "function"
+                                    },
+                                    "name": "output",
+                                    "params": [],
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "char"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "output",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "deref": "result",
-                                "intent": "out",
-                                "is_result": true
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -1458,23 +1482,24 @@
             {
                 "<FUNCTION>": "8 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "deref": "raw"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "deref": "raw"
+                        },
+                        "metaattrs": {
+                            "deref": "raw",
+                            "intent": "function"
+                        },
                         "name": "getCharPtr4",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "char"
                     },
-                    "metaattrs": {
-                        "deref": "raw",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "char"
                     ],
@@ -1552,23 +1577,24 @@
                 ],
                 "_PTR_F_C_index": "51",
                 "ast": {
-                    "attrs": {
-                        "deref": "pointer"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "deref": "pointer"
+                        },
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "getCharPtr5",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "char"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "char"
                     ],
@@ -1645,24 +1671,25 @@
                 "_PTR_C_CXX_index": "9",
                 "_generated": "arg_to_cfi",
                 "ast": {
-                    "attrs": {
-                        "deref": "pointer"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "deref": "pointer"
+                        },
+                        "metaattrs": {
+                            "api": "cfi",
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "getCharPtr5",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "char"
                     },
-                    "metaattrs": {
-                        "api": "cfi",
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "char"
                     ],
@@ -1744,13 +1771,14 @@
                 "ast": {
                     "const": true,
                     "declarator": {
-                        "name": "getConstStringResult"
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
+                        "name": "getConstStringResult",
+                        "params": [],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "string"
                     ],
@@ -1803,14 +1831,15 @@
                 "ast": {
                     "const": true,
                     "declarator": {
-                        "name": "getConstStringResult"
+                        "metaattrs": {
+                            "api": "cfi",
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
+                        "name": "getConstStringResult",
+                        "params": [],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "cfi",
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "string"
                     ],
@@ -1879,18 +1908,19 @@
                 ],
                 "_PTR_F_C_index": "53",
                 "ast": {
-                    "attrs": {
-                        "len": 30
-                    },
                     "const": true,
                     "declarator": {
-                        "name": "getConstStringLen"
+                        "attrs": {
+                            "len": 30
+                        },
+                        "metaattrs": {
+                            "deref": "copy",
+                            "intent": "function"
+                        },
+                        "name": "getConstStringLen",
+                        "params": [],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "string"
                     ],
@@ -1941,19 +1971,20 @@
                 "_PTR_C_CXX_index": "11",
                 "_generated": "arg_to_cfi",
                 "ast": {
-                    "attrs": {
-                        "len": 30
-                    },
                     "const": true,
                     "declarator": {
-                        "name": "getConstStringLen"
+                        "attrs": {
+                            "len": 30
+                        },
+                        "metaattrs": {
+                            "api": "cfi",
+                            "deref": "copy",
+                            "intent": "function"
+                        },
+                        "name": "getConstStringLen",
+                        "params": [],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "cfi",
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "string"
                     ],
@@ -2020,12 +2051,13 @@
                 "ast": {
                     "const": true,
                     "declarator": {
-                        "name": "getConstStringAsArg"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "getConstStringAsArg",
+                        "params": [],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "string"
                     ],
@@ -2056,33 +2088,35 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "getConstStringAsArg"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getConstStringAsArg",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "deref": "allocatable",
+                                        "intent": "function"
+                                    },
+                                    "name": "output",
+                                    "params": [],
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "output",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "deref": "result",
-                                "intent": "out",
-                                "is_result": true
-                            },
-                            "specifier": [
-                                "string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -2183,33 +2217,35 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "getConstStringAsArg"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getConstStringAsArg",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "deref": "allocatable",
+                                        "intent": "function"
+                                    },
+                                    "name": "output",
+                                    "params": [],
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "output",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "deref": "result",
-                                "intent": "out",
-                                "is_result": true
-                            },
-                            "specifier": [
-                                "string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -2257,13 +2293,14 @@
                 "ast": {
                     "const": true,
                     "declarator": {
-                        "name": "getConstStringAlloc"
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
+                        "name": "getConstStringAlloc",
+                        "params": [],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -2312,14 +2349,15 @@
                 "ast": {
                     "const": true,
                     "declarator": {
-                        "name": "getConstStringAlloc"
+                        "metaattrs": {
+                            "api": "cfi",
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
+                        "name": "getConstStringAlloc",
+                        "params": [],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "cfi",
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -2386,18 +2424,19 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
                         "name": "getConstStringRefPure",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "string"
                     ],
@@ -2477,19 +2516,20 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "api": "cfi",
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
                         "name": "getConstStringRefPure",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "cfi",
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "string"
                     ],
@@ -2559,23 +2599,24 @@
                 ],
                 "_PTR_F_C_index": "58",
                 "ast": {
-                    "attrs": {
-                        "len": 30
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "len": 30
+                        },
+                        "metaattrs": {
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "getConstStringRefLen",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "string"
                     ],
@@ -2654,24 +2695,25 @@
                 "_PTR_C_CXX_index": "15",
                 "_generated": "arg_to_cfi",
                 "ast": {
-                    "attrs": {
-                        "len": 30
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "len": 30
+                        },
+                        "metaattrs": {
+                            "api": "cfi",
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "getConstStringRefLen",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "cfi",
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "string"
                     ],
@@ -2739,17 +2781,18 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "intent": "function"
+                        },
                         "name": "getConstStringRefAsArg",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "string"
                     ],
@@ -2819,33 +2862,35 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "getConstStringRefAsArg"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getConstStringRefAsArg",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "deref": "allocatable",
+                                        "intent": "function"
+                                    },
+                                    "name": "output",
+                                    "params": [],
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "output",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "deref": "result",
-                                "intent": "out",
-                                "is_result": true
-                            },
-                            "specifier": [
-                                "string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -2947,33 +2992,35 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "getConstStringRefAsArg"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getConstStringRefAsArg",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "deref": "allocatable",
+                                        "intent": "function"
+                                    },
+                                    "name": "output",
+                                    "params": [],
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "output",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "deref": "result",
-                                "intent": "out",
-                                "is_result": true
-                            },
-                            "specifier": [
-                                "string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -3021,23 +3068,24 @@
                 ],
                 "_PTR_F_C_index": "61",
                 "ast": {
-                    "attrs": {
-                        "len": 30
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "len": 30
+                        },
+                        "metaattrs": {
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "getConstStringRefLenEmpty",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "string"
                     ],
@@ -3115,24 +3163,25 @@
                 "_PTR_C_CXX_index": "17",
                 "_generated": "arg_to_cfi",
                 "ast": {
-                    "attrs": {
-                        "len": 30
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "len": 30
+                        },
+                        "metaattrs": {
+                            "api": "cfi",
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "getConstStringRefLenEmpty",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "cfi",
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "string"
                     ],
@@ -3202,18 +3251,19 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
                         "name": "getConstStringRefAlloc",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -3289,19 +3339,20 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "api": "cfi",
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
                         "name": "getConstStringRefAlloc",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "cfi",
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -3366,23 +3417,24 @@
                 ],
                 "_PTR_F_C_index": "63",
                 "ast": {
-                    "attrs": {
-                        "len": 30
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "len": 30
+                        },
+                        "metaattrs": {
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "getConstStringPtrLen",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "string"
                     ],
@@ -3467,24 +3519,25 @@
                 "_PTR_C_CXX_index": "19",
                 "_generated": "arg_to_cfi",
                 "ast": {
-                    "attrs": {
-                        "len": 30
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "len": 30
+                        },
+                        "metaattrs": {
+                            "api": "cfi",
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "getConstStringPtrLen",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "cfi",
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "string"
                     ],
@@ -3560,23 +3613,24 @@
                 ],
                 "_PTR_F_C_index": "64",
                 "ast": {
-                    "attrs": {
-                        "owner": "library"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "owner": "library"
+                        },
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
                         "name": "getConstStringPtrAlloc",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -3650,24 +3704,25 @@
                 "_PTR_C_CXX_index": "20",
                 "_generated": "arg_to_cfi",
                 "ast": {
-                    "attrs": {
-                        "owner": "library"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "owner": "library"
+                        },
+                        "metaattrs": {
+                            "api": "cfi",
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
                         "name": "getConstStringPtrAlloc",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "cfi",
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -3732,23 +3787,24 @@
                 ],
                 "_PTR_F_C_index": "65",
                 "ast": {
-                    "attrs": {
-                        "owner": "caller"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "owner": "caller"
+                        },
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
                         "name": "getConstStringPtrOwnsAlloc",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -3825,24 +3881,25 @@
                 "_PTR_C_CXX_index": "21",
                 "_generated": "arg_to_cfi",
                 "ast": {
-                    "attrs": {
-                        "owner": "caller"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "owner": "caller"
+                        },
+                        "metaattrs": {
+                            "api": "cfi",
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
                         "name": "getConstStringPtrOwnsAlloc",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "cfi",
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -3910,24 +3967,25 @@
                 ],
                 "_PTR_F_C_index": "66",
                 "ast": {
-                    "attrs": {
-                        "free_pattern": "C_string_free",
-                        "owner": "caller"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "free_pattern": "C_string_free",
+                            "owner": "caller"
+                        },
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
                         "name": "getConstStringPtrOwnsAllocPattern",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -4004,25 +4062,26 @@
                 "_PTR_C_CXX_index": "22",
                 "_generated": "arg_to_cfi",
                 "ast": {
-                    "attrs": {
-                        "free_pattern": "C_string_free",
-                        "owner": "caller"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "free_pattern": "C_string_free",
+                            "owner": "caller"
+                        },
+                        "metaattrs": {
+                            "api": "cfi",
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
                         "name": "getConstStringPtrOwnsAllocPattern",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "cfi",
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -4090,24 +4149,25 @@
                 ],
                 "_PTR_F_C_index": "67",
                 "ast": {
-                    "attrs": {
-                        "deref": "pointer",
-                        "owner": "library"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "deref": "pointer",
+                            "owner": "library"
+                        },
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "getConstStringPtrPointer",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -4182,25 +4242,26 @@
                 "_PTR_C_CXX_index": "23",
                 "_generated": "arg_to_cfi",
                 "ast": {
-                    "attrs": {
-                        "deref": "pointer",
-                        "owner": "library"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "deref": "pointer",
+                            "owner": "library"
+                        },
+                        "metaattrs": {
+                            "api": "cfi",
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "getConstStringPtrPointer",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "cfi",
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -4277,31 +4338,33 @@
                 "_PTR_F_C_index": "68",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStringConstReference"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptStringConstReference",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -4380,32 +4443,34 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStringConstReference"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptStringConstReference",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -4487,33 +4552,35 @@
                 "_PTR_F_C_index": "69",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStringReferenceOut"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptStringReferenceOut",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -4592,34 +4659,36 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStringReferenceOut"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptStringReferenceOut",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "out"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -4699,30 +4768,32 @@
                 "_PTR_F_C_index": "70",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStringReference"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptStringReference",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -4802,31 +4873,33 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStringReference"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptStringReference",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -4909,31 +4982,33 @@
                 "_PTR_F_C_index": "71",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStringPointerConst"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptStringPointerConst",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -5011,32 +5086,34 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStringPointerConst"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptStringPointerConst",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -5117,30 +5194,32 @@
                 "_PTR_F_C_index": "72",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStringPointer"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptStringPointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -5218,31 +5297,33 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStringPointer"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptStringPointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -5323,33 +5404,35 @@
                 "_PTR_F_C_index": "73",
                 "ast": {
                     "declarator": {
-                        "name": "fetchStringPointer"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "fetchStringPointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -5428,34 +5511,36 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "fetchStringPointer"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "fetchStringPointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "out"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -5535,50 +5620,53 @@
                 "_PTR_F_C_index": "74",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStringPointerLen"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                        "name": "acceptStringPointerLen",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "nlen",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "nlen",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5686,51 +5774,54 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStringPointerLen"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                        "name": "acceptStringPointerLen",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "nlen",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "nlen",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5845,53 +5936,56 @@
                 "_PTR_F_C_index": "75",
                 "ast": {
                     "declarator": {
-                        "name": "fetchStringPointerLen"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                        "name": "fetchStringPointerLen",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "nlen",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "nlen",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5999,54 +6093,57 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "fetchStringPointerLen"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                        "name": "fetchStringPointerLen",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "out"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "nlen",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "nlen",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -6159,28 +6256,30 @@
                 "_PTR_F_C_index": "76",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStringInstance"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "acceptStringInstance",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -6289,29 +6388,31 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStringInstance"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "acceptStringInstance",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -6415,53 +6516,56 @@
                 "<FUNCTION>": "33 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "returnStrings"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                        "name": "returnStrings",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "arg2",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg2",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -6486,33 +6590,35 @@
                 "<FUNCTION>": "34 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "returnMany"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "returnMany",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "char"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "char"
                     ],
@@ -6542,34 +6648,36 @@
                 "_PTR_F_C_index": "77",
                 "ast": {
                     "declarator": {
-                        "name": "explicit1"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "explicit1",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "len_trim": "AAlen"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "len_trim": "AAlen"
-                            },
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -6648,35 +6756,37 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "explicit1"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "explicit1",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "len_trim": "AAlen"
+                                    },
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "len_trim": "AAlen"
-                            },
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -6756,34 +6866,36 @@
                 "_PTR_F_C_index": "78",
                 "ast": {
                     "declarator": {
-                        "name": "explicit2"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "explicit2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out",
+                                        "len": "AAtrim"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out",
-                                "len": "AAtrim"
-                            },
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -6860,35 +6972,37 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "explicit2"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "explicit2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out",
+                                        "len": "AAtrim"
+                                    },
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "out"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out",
-                                "len": "AAtrim"
-                            },
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -6962,28 +7076,30 @@
                 "<FUNCTION>": "37 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "CpassChar"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "CpassChar",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "status",
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "status"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -7064,12 +7180,13 @@
                 "<FUNCTION>": "38 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "CreturnChar"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "CreturnChar",
+                        "params": [],
+                        "typemap_name": "char"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "char"
                     ],
@@ -7147,55 +7264,58 @@
                 "_PTR_F_C_index": "79",
                 "ast": {
                     "declarator": {
-                        "name": "CpassCharPtr"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "dest",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "blanknull": true
+                        "name": "CpassCharPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "dest",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
                             },
-                            "blanknull": true,
-                            "const": true,
-                            "declarator": {
-                                "name": "src",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "blanknull": true,
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "blanknull": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "src",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -7307,57 +7427,60 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "CpassCharPtr"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "dest",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "blanknull": true
+                        "name": "CpassCharPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "out"
+                                    },
+                                    "name": "dest",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
                             },
-                            "blanknull": true,
-                            "const": true,
-                            "declarator": {
-                                "name": "src",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "blanknull": true,
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "blanknull": true
+                                    },
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "in"
+                                    },
+                                    "name": "src",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -7476,52 +7599,55 @@
                 "_PTR_F_C_index": "80",
                 "ast": {
                     "declarator": {
-                        "name": "CpassCharPtrBlank"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "dest",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "blanknull": true,
-                            "const": true,
-                            "declarator": {
-                                "name": "src",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                        "name": "CpassCharPtrBlank",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "dest",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "blanknull": true,
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "src",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -7632,54 +7758,57 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "CpassCharPtrBlank"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "dest",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "blanknull": true,
-                            "const": true,
-                            "declarator": {
-                                "name": "src",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                        "name": "CpassCharPtrBlank",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "out"
+                                    },
+                                    "name": "dest",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
                             },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "blanknull": true,
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "in"
+                                    },
+                                    "name": "src",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -7797,51 +7926,54 @@
                 "_PTR_F_C_index": "81",
                 "ast": {
                     "declarator": {
-                        "name": "PostDeclare"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
+                        "name": "PostDeclare",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -7953,53 +8085,56 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "PostDeclare"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
+                        "name": "PostDeclare",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "in"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "inout"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -8124,31 +8259,33 @@
                 "_PTR_F_C_index": "82",
                 "ast": {
                     "declarator": {
-                        "name": "CpassCharPtrNotrim"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "CpassCharPtrNotrim",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "src",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "src",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -8259,32 +8396,34 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "CpassCharPtrNotrim"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "CpassCharPtrNotrim",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "in"
+                                    },
+                                    "name": "src",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "src",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -8388,55 +8527,58 @@
                 "<FUNCTION>": "43 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "CpassCharPtrCAPI"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "api": "capi"
+                        "name": "CpassCharPtrCAPI",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "const": true,
-                            "declarator": {
-                                "name": "src",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "capi",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "api": "capi"
+                                    },
+                                    "metaattrs": {
+                                        "api": "capi",
+                                        "intent": "in"
+                                    },
+                                    "name": "src",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -8585,53 +8727,56 @@
                 "_PTR_F_C_index": "83",
                 "ast": {
                     "declarator": {
-                        "name": "CpassCharPtrCAPI2"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "in",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "api": "capi"
+                        "name": "CpassCharPtrCAPI2",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "in",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
                             },
-                            "const": true,
-                            "declarator": {
-                                "name": "src",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "capi",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "api": "capi"
+                                    },
+                                    "metaattrs": {
+                                        "api": "capi",
+                                        "intent": "in"
+                                    },
+                                    "name": "src",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -8770,54 +8915,57 @@
                 "_generated": "arg_to_cfi",
                 "ast": {
                     "declarator": {
-                        "name": "CpassCharPtrCAPI2"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "in",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cfi",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "api": "capi"
+                        "name": "CpassCharPtrCAPI2",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "cfi",
+                                        "intent": "in"
+                                    },
+                                    "name": "in",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
                             },
-                            "const": true,
-                            "declarator": {
-                                "name": "src",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "capi",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "api": "capi"
+                                    },
+                                    "metaattrs": {
+                                        "api": "capi",
+                                        "intent": "in"
+                                    },
+                                    "name": "src",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],

--- a/regression/reference/strings-cfi/strings.json
+++ b/regression/reference/strings-cfi/strings.json
@@ -1291,8 +1291,9 @@
                                 "declarator": {
                                     "metaattrs": {
                                         "api": "cfi",
-                                        "deref": "allocatable",
-                                        "intent": "function"
+                                        "deref": "result",
+                                        "intent": "out",
+                                        "is_result": true
                                     },
                                     "name": "output",
                                     "params": [],
@@ -1309,7 +1310,7 @@
                                 "typemap_name": "char"
                             }
                         ],
-                        "typemap_name": "char"
+                        "typemap_name": "void"
                     },
                     "specifier": [
                         "void"
@@ -1420,8 +1421,9 @@
                                 "declarator": {
                                     "metaattrs": {
                                         "api": "cfi",
-                                        "deref": "allocatable",
-                                        "intent": "function"
+                                        "deref": "result",
+                                        "intent": "out",
+                                        "is_result": true
                                     },
                                     "name": "output",
                                     "params": [],
@@ -1438,7 +1440,7 @@
                                 "typemap_name": "char"
                             }
                         ],
-                        "typemap_name": "char"
+                        "typemap_name": "void"
                     },
                     "specifier": [
                         "void"
@@ -2097,8 +2099,9 @@
                                 "declarator": {
                                     "metaattrs": {
                                         "api": "cfi",
-                                        "deref": "allocatable",
-                                        "intent": "function"
+                                        "deref": "result",
+                                        "intent": "out",
+                                        "is_result": true
                                     },
                                     "name": "output",
                                     "params": [],
@@ -2115,7 +2118,7 @@
                                 "typemap_name": "std::string"
                             }
                         ],
-                        "typemap_name": "std::string"
+                        "typemap_name": "void"
                     },
                     "specifier": [
                         "void"
@@ -2226,8 +2229,9 @@
                                 "declarator": {
                                     "metaattrs": {
                                         "api": "cfi",
-                                        "deref": "allocatable",
-                                        "intent": "function"
+                                        "deref": "result",
+                                        "intent": "out",
+                                        "is_result": true
                                     },
                                     "name": "output",
                                     "params": [],
@@ -2244,7 +2248,7 @@
                                 "typemap_name": "std::string"
                             }
                         ],
-                        "typemap_name": "std::string"
+                        "typemap_name": "void"
                     },
                     "specifier": [
                         "void"
@@ -2871,8 +2875,9 @@
                                 "declarator": {
                                     "metaattrs": {
                                         "api": "cfi",
-                                        "deref": "allocatable",
-                                        "intent": "function"
+                                        "deref": "result",
+                                        "intent": "out",
+                                        "is_result": true
                                     },
                                     "name": "output",
                                     "params": [],
@@ -2889,7 +2894,7 @@
                                 "typemap_name": "std::string"
                             }
                         ],
-                        "typemap_name": "std::string"
+                        "typemap_name": "void"
                     },
                     "specifier": [
                         "void"
@@ -3001,8 +3006,9 @@
                                 "declarator": {
                                     "metaattrs": {
                                         "api": "cfi",
-                                        "deref": "allocatable",
-                                        "intent": "function"
+                                        "deref": "result",
+                                        "intent": "out",
+                                        "is_result": true
                                     },
                                     "name": "output",
                                     "params": [],
@@ -3019,7 +3025,7 @@
                                 "typemap_name": "std::string"
                             }
                         ],
-                        "typemap_name": "std::string"
+                        "typemap_name": "void"
                     },
                     "specifier": [
                         "void"

--- a/regression/reference/strings/strings.json
+++ b/regression/reference/strings/strings.json
@@ -1450,7 +1450,6 @@
                                         "is_result": true
                                     },
                                     "name": "output",
-                                    "params": [],
                                     "pointer": [
                                         {
                                             "ptr": "*"
@@ -1579,7 +1578,6 @@
                                         "is_result": true
                                     },
                                     "name": "output",
-                                    "params": [],
                                     "pointer": [
                                         {
                                             "ptr": "*"
@@ -2301,7 +2299,6 @@
                                         "is_result": true
                                     },
                                     "name": "output",
-                                    "params": [],
                                     "pointer": [
                                         {
                                             "ptr": "*"
@@ -2429,7 +2426,6 @@
                                         "is_result": true
                                     },
                                     "name": "output",
-                                    "params": [],
                                     "pointer": [
                                         {
                                             "ptr": "*"
@@ -3147,7 +3143,6 @@
                                         "is_result": true
                                     },
                                     "name": "output",
-                                    "params": [],
                                     "pointer": [
                                         {
                                             "ptr": "&"
@@ -3276,7 +3271,6 @@
                                         "is_result": true
                                     },
                                     "name": "output",
-                                    "params": [],
                                     "pointer": [
                                         {
                                             "ptr": "&"

--- a/regression/reference/strings/strings.json
+++ b/regression/reference/strings/strings.json
@@ -21,28 +21,30 @@
                 "<FUNCTION>": "0 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passChar"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "passChar",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "status",
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "status"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -143,28 +145,30 @@
                 "<FUNCTION>": "1 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passCharForce"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "passCharForce",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "status",
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "status"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -246,12 +250,13 @@
                 "<FUNCTION>": "2 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "returnChar"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "returnChar",
+                        "params": [],
+                        "typemap_name": "char"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "char"
                     ],
@@ -346,53 +351,56 @@
                 "_PTR_F_C_index": "45",
                 "ast": {
                     "declarator": {
-                        "name": "passCharPtr"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "charlen": "40",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "dest",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "src",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                        "name": "passCharPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "charlen": "40",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "dest",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
                             },
-                            "ftrim_char_in": true,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "src",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "ftrim_char_in": true,
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -544,54 +552,57 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "passCharPtr"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "charlen": "40",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "dest",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "src",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                        "name": "passCharPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "charlen": "40",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "out"
+                                    },
+                                    "name": "dest",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
                             },
-                            "ftrim_char_in": true,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "src",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "ftrim_char_in": true,
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -701,33 +712,35 @@
                 "_PTR_F_C_index": "46",
                 "ast": {
                     "declarator": {
-                        "name": "passCharPtrInOut"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "passCharPtrInOut",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "s",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout"
-                            },
-                            "declarator": {
-                                "name": "s",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -826,34 +839,36 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "passCharPtrInOut"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "passCharPtrInOut",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout"
+                                    },
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "inout"
+                                    },
+                                    "name": "s",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout"
-                            },
-                            "declarator": {
-                                "name": "s",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -932,18 +947,19 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
                         "name": "getCharPtr1",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "char"
                     },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "char"
                     ],
@@ -1044,19 +1060,20 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
                         "name": "getCharPtr1",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "char"
                     },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "char"
                     ],
@@ -1124,23 +1141,24 @@
                 ],
                 "_PTR_F_C_index": "48",
                 "ast": {
-                    "attrs": {
-                        "len": "30"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "len": "30"
+                        },
+                        "metaattrs": {
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "getCharPtr2",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "char"
                     },
-                    "metaattrs": {
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "char"
                     ],
@@ -1236,24 +1254,25 @@
                 "_PTR_C_CXX_index": "6",
                 "_generated": "arg_to_buffer",
                 "ast": {
-                    "attrs": {
-                        "len": "30"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "len": "30"
+                        },
+                        "metaattrs": {
+                            "api": "buf",
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "getCharPtr2",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "char"
                     },
-                    "metaattrs": {
-                        "api": "buf",
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "char"
                     ],
@@ -1319,17 +1338,18 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "intent": "function"
+                        },
                         "name": "getCharPtr3",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "char"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "char"
                     ],
@@ -1416,33 +1436,35 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "getCharPtr3"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getCharPtr3",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "cdesc",
+                                        "deref": "allocatable",
+                                        "intent": "function"
+                                    },
+                                    "name": "output",
+                                    "params": [],
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "char"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "output",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "deref": "result",
-                                "intent": "out",
-                                "is_result": true
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -1542,33 +1564,35 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "getCharPtr3"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getCharPtr3",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "cdesc",
+                                        "deref": "allocatable",
+                                        "intent": "function"
+                                    },
+                                    "name": "output",
+                                    "params": [],
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "char"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "output",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "deref": "result",
-                                "intent": "out",
-                                "is_result": true
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -1610,23 +1634,24 @@
             {
                 "<FUNCTION>": "8 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "deref": "raw"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "deref": "raw"
+                        },
+                        "metaattrs": {
+                            "deref": "raw",
+                            "intent": "function"
+                        },
                         "name": "getCharPtr4",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "char"
                     },
-                    "metaattrs": {
-                        "deref": "raw",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "char"
                     ],
@@ -1704,23 +1729,24 @@
                 ],
                 "_PTR_F_C_index": "51",
                 "ast": {
-                    "attrs": {
-                        "deref": "pointer"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "deref": "pointer"
+                        },
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "getCharPtr5",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "char"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "char"
                     ],
@@ -1799,24 +1825,25 @@
                 "_PTR_C_CXX_index": "9",
                 "_generated": "arg_to_buffer",
                 "ast": {
-                    "attrs": {
-                        "deref": "pointer"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "deref": "pointer"
+                        },
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "getCharPtr5",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "char"
                     },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "char"
                     ],
@@ -1887,13 +1914,14 @@
                 "ast": {
                     "const": true,
                     "declarator": {
-                        "name": "getConstStringResult"
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
+                        "name": "getConstStringResult",
+                        "params": [],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "string"
                     ],
@@ -1966,14 +1994,15 @@
                 "ast": {
                     "const": true,
                     "declarator": {
-                        "name": "getConstStringResult"
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
+                        "name": "getConstStringResult",
+                        "params": [],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "string"
                     ],
@@ -2040,18 +2069,19 @@
                 ],
                 "_PTR_F_C_index": "53",
                 "ast": {
-                    "attrs": {
-                        "len": 30
-                    },
                     "const": true,
                     "declarator": {
-                        "name": "getConstStringLen"
+                        "attrs": {
+                            "len": 30
+                        },
+                        "metaattrs": {
+                            "deref": "copy",
+                            "intent": "function"
+                        },
+                        "name": "getConstStringLen",
+                        "params": [],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "string"
                     ],
@@ -2120,19 +2150,20 @@
                 "_PTR_C_CXX_index": "11",
                 "_generated": "arg_to_buffer",
                 "ast": {
-                    "attrs": {
-                        "len": 30
-                    },
                     "const": true,
                     "declarator": {
-                        "name": "getConstStringLen"
+                        "attrs": {
+                            "len": 30
+                        },
+                        "metaattrs": {
+                            "api": "buf",
+                            "deref": "copy",
+                            "intent": "function"
+                        },
+                        "name": "getConstStringLen",
+                        "params": [],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "buf",
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "string"
                     ],
@@ -2197,12 +2228,13 @@
                 "ast": {
                     "const": true,
                     "declarator": {
-                        "name": "getConstStringAsArg"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "getConstStringAsArg",
+                        "params": [],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "string"
                     ],
@@ -2253,33 +2285,35 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "getConstStringAsArg"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getConstStringAsArg",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "cdesc",
+                                        "deref": "allocatable",
+                                        "intent": "function"
+                                    },
+                                    "name": "output",
+                                    "params": [],
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "output",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "deref": "result",
-                                "intent": "out",
-                                "is_result": true
-                            },
-                            "specifier": [
-                                "string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -2378,33 +2412,35 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "getConstStringAsArg"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getConstStringAsArg",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "cdesc",
+                                        "deref": "allocatable",
+                                        "intent": "function"
+                                    },
+                                    "name": "output",
+                                    "params": [],
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "output",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "deref": "result",
-                                "intent": "out",
-                                "is_result": true
-                            },
-                            "specifier": [
-                                "string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -2450,13 +2486,14 @@
                 "ast": {
                     "const": true,
                     "declarator": {
-                        "name": "getConstStringAlloc"
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
+                        "name": "getConstStringAlloc",
+                        "params": [],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -2525,14 +2562,15 @@
                 "ast": {
                     "const": true,
                     "declarator": {
-                        "name": "getConstStringAlloc"
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
+                        "name": "getConstStringAlloc",
+                        "params": [],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -2597,18 +2635,19 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
                         "name": "getConstStringRefPure",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "string"
                     ],
@@ -2710,19 +2749,20 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
                         "name": "getConstStringRefPure",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "string"
                     ],
@@ -2791,23 +2831,24 @@
                 ],
                 "_PTR_F_C_index": "58",
                 "ast": {
-                    "attrs": {
-                        "len": 30
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "len": 30
+                        },
+                        "metaattrs": {
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "getConstStringRefLen",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "string"
                     ],
@@ -2905,24 +2946,25 @@
                 "_PTR_C_CXX_index": "15",
                 "_generated": "arg_to_buffer",
                 "ast": {
-                    "attrs": {
-                        "len": 30
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "len": 30
+                        },
+                        "metaattrs": {
+                            "api": "buf",
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "getConstStringRefLen",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "buf",
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "string"
                     ],
@@ -2988,17 +3030,18 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "intent": "function"
+                        },
                         "name": "getConstStringRefAsArg",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "string"
                     ],
@@ -3086,33 +3129,35 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "getConstStringRefAsArg"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getConstStringRefAsArg",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "cdesc",
+                                        "deref": "allocatable",
+                                        "intent": "function"
+                                    },
+                                    "name": "output",
+                                    "params": [],
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "output",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "deref": "result",
-                                "intent": "out",
-                                "is_result": true
-                            },
-                            "specifier": [
-                                "string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -3212,33 +3257,35 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "getConstStringRefAsArg"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "getConstStringRefAsArg",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "cdesc",
+                                        "deref": "allocatable",
+                                        "intent": "function"
+                                    },
+                                    "name": "output",
+                                    "params": [],
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "output",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "deref": "result",
-                                "intent": "out",
-                                "is_result": true
-                            },
-                            "specifier": [
-                                "string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -3284,23 +3331,24 @@
                 ],
                 "_PTR_F_C_index": "61",
                 "ast": {
-                    "attrs": {
-                        "len": 30
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "len": 30
+                        },
+                        "metaattrs": {
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "getConstStringRefLenEmpty",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "string"
                     ],
@@ -3397,24 +3445,25 @@
                 "_PTR_C_CXX_index": "17",
                 "_generated": "arg_to_buffer",
                 "ast": {
-                    "attrs": {
-                        "len": 30
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "len": 30
+                        },
+                        "metaattrs": {
+                            "api": "buf",
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "getConstStringRefLenEmpty",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "buf",
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "string"
                     ],
@@ -3482,18 +3531,19 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
                         "name": "getConstStringRefAlloc",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -3590,19 +3640,20 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
                         "name": "getConstStringRefAlloc",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -3665,23 +3716,24 @@
                 ],
                 "_PTR_F_C_index": "63",
                 "ast": {
-                    "attrs": {
-                        "len": 30
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "len": 30
+                        },
+                        "metaattrs": {
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "getConstStringPtrLen",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "string"
                     ],
@@ -3785,24 +3837,25 @@
                 "_PTR_C_CXX_index": "19",
                 "_generated": "arg_to_buffer",
                 "ast": {
-                    "attrs": {
-                        "len": 30
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "len": 30
+                        },
+                        "metaattrs": {
+                            "api": "buf",
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "getConstStringPtrLen",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "buf",
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "string"
                     ],
@@ -3876,23 +3929,24 @@
                 ],
                 "_PTR_F_C_index": "64",
                 "ast": {
-                    "attrs": {
-                        "owner": "library"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "owner": "library"
+                        },
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
                         "name": "getConstStringPtrAlloc",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -3987,24 +4041,25 @@
                 "_PTR_C_CXX_index": "20",
                 "_generated": "arg_to_buffer",
                 "ast": {
-                    "attrs": {
-                        "owner": "library"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "owner": "library"
+                        },
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
                         "name": "getConstStringPtrAlloc",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -4067,23 +4122,24 @@
                 ],
                 "_PTR_F_C_index": "65",
                 "ast": {
-                    "attrs": {
-                        "owner": "caller"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "owner": "caller"
+                        },
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
                         "name": "getConstStringPtrOwnsAlloc",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -4181,24 +4237,25 @@
                 "_PTR_C_CXX_index": "21",
                 "_generated": "arg_to_buffer",
                 "ast": {
-                    "attrs": {
-                        "owner": "caller"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "owner": "caller"
+                        },
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
                         "name": "getConstStringPtrOwnsAlloc",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -4264,24 +4321,25 @@
                 ],
                 "_PTR_F_C_index": "66",
                 "ast": {
-                    "attrs": {
-                        "free_pattern": "C_string_free",
-                        "owner": "caller"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "free_pattern": "C_string_free",
+                            "owner": "caller"
+                        },
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
                         "name": "getConstStringPtrOwnsAllocPattern",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -4379,25 +4437,26 @@
                 "_PTR_C_CXX_index": "22",
                 "_generated": "arg_to_buffer",
                 "ast": {
-                    "attrs": {
-                        "free_pattern": "C_string_free",
-                        "owner": "caller"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "free_pattern": "C_string_free",
+                            "owner": "caller"
+                        },
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
                         "name": "getConstStringPtrOwnsAllocPattern",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -4463,24 +4522,25 @@
                 ],
                 "_PTR_F_C_index": "67",
                 "ast": {
-                    "attrs": {
-                        "deref": "pointer",
-                        "owner": "library"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "deref": "pointer",
+                            "owner": "library"
+                        },
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "getConstStringPtrPointer",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -4557,25 +4617,26 @@
                 "_PTR_C_CXX_index": "23",
                 "_generated": "arg_to_buffer",
                 "ast": {
-                    "attrs": {
-                        "deref": "pointer",
-                        "owner": "library"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "deref": "pointer",
+                            "owner": "library"
+                        },
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "getConstStringPtrPointer",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -4641,31 +4702,33 @@
                 "_PTR_F_C_index": "68",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStringConstReference"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptStringConstReference",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -4764,32 +4827,34 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStringConstReference"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptStringConstReference",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -4867,33 +4932,35 @@
                 "_PTR_F_C_index": "69",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStringReferenceOut"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptStringReferenceOut",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -4992,34 +5059,36 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStringReferenceOut"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptStringReferenceOut",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "out"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -5097,30 +5166,32 @@
                 "_PTR_F_C_index": "70",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStringReference"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptStringReference",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -5221,31 +5292,33 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStringReference"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptStringReference",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -5325,31 +5398,33 @@
                 "_PTR_F_C_index": "71",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStringPointerConst"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptStringPointerConst",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -5447,32 +5522,34 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStringPointerConst"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptStringPointerConst",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -5549,30 +5626,32 @@
                 "_PTR_F_C_index": "72",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStringPointer"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptStringPointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -5670,31 +5749,33 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStringPointer"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptStringPointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -5771,33 +5852,35 @@
                 "_PTR_F_C_index": "73",
                 "ast": {
                     "declarator": {
-                        "name": "fetchStringPointer"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "fetchStringPointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -5896,34 +5979,36 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "fetchStringPointer"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "fetchStringPointer",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "out"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -6001,50 +6086,53 @@
                 "_PTR_F_C_index": "74",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStringPointerLen"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                        "name": "acceptStringPointerLen",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "nlen",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "nlen",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -6192,51 +6280,54 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStringPointerLen"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                        "name": "acceptStringPointerLen",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "nlen",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "nlen",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -6347,53 +6438,56 @@
                 "_PTR_F_C_index": "75",
                 "ast": {
                     "declarator": {
-                        "name": "fetchStringPointerLen"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                        "name": "fetchStringPointerLen",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "nlen",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "nlen",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -6541,54 +6635,57 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "fetchStringPointerLen"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                        "name": "fetchStringPointerLen",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "out"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "nlen",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "nlen",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -6699,28 +6796,30 @@
                 "_PTR_F_C_index": "76",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStringInstance"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "acceptStringInstance",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -6865,29 +6964,31 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStringInstance"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "acceptStringInstance",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -6989,53 +7090,56 @@
                 "<FUNCTION>": "33 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "returnStrings"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                        "name": "returnStrings",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "arg2",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg2",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -7109,33 +7213,35 @@
                 "<FUNCTION>": "34 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "returnMany"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "returnMany",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "char"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "char"
                     ],
@@ -7161,35 +7267,37 @@
                 "<FUNCTION>": "35 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "explicit1"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "explicit1",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "len_trim": "AAlen"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "ftrim_char_in": true,
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "len_trim": "AAlen"
-                            },
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "ftrim_char_in": true,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -7291,34 +7399,36 @@
                 "_PTR_F_C_index": "77",
                 "ast": {
                     "declarator": {
-                        "name": "explicit2"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "explicit2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out",
+                                        "len": "AAtrim"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out",
-                                "len": "AAtrim"
-                            },
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -7394,35 +7504,37 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "explicit2"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "explicit2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out",
+                                        "len": "AAtrim"
+                                    },
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "out"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out",
-                                "len": "AAtrim"
-                            },
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -7495,28 +7607,30 @@
                 "<FUNCTION>": "37 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "CpassChar"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "CpassChar",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "status",
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "status"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -7619,12 +7733,13 @@
                 "<FUNCTION>": "38 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "CreturnChar"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "CreturnChar",
+                        "params": [],
+                        "typemap_name": "char"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "char"
                     ],
@@ -7721,55 +7836,58 @@
                 "_PTR_F_C_index": "78",
                 "ast": {
                     "declarator": {
-                        "name": "CpassCharPtr"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "dest",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "blanknull": true
+                        "name": "CpassCharPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "dest",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
                             },
-                            "blanknull": true,
-                            "const": true,
-                            "declarator": {
-                                "name": "src",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "blanknull": true,
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "blanknull": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "src",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -7880,57 +7998,60 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "CpassCharPtr"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "dest",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "blanknull": true
+                        "name": "CpassCharPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "out"
+                                    },
+                                    "name": "dest",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
                             },
-                            "blanknull": true,
-                            "const": true,
-                            "declarator": {
-                                "name": "src",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "blanknull": true,
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "blanknull": true
+                                    },
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "in"
+                                    },
+                                    "name": "src",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -8048,52 +8169,55 @@
                 "_PTR_F_C_index": "79",
                 "ast": {
                     "declarator": {
-                        "name": "CpassCharPtrBlank"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "dest",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "blanknull": true,
-                            "const": true,
-                            "declarator": {
-                                "name": "src",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                        "name": "CpassCharPtrBlank",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "dest",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "blanknull": true,
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "src",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -8203,54 +8327,57 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "CpassCharPtrBlank"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "dest",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "blanknull": true,
-                            "const": true,
-                            "declarator": {
-                                "name": "src",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
+                        "name": "CpassCharPtrBlank",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "out"
+                                    },
+                                    "name": "dest",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
                             },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "blanknull": true,
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "in"
+                                    },
+                                    "name": "src",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -8367,51 +8494,54 @@
                 "_PTR_F_C_index": "80",
                 "ast": {
                     "declarator": {
-                        "name": "PostDeclare"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
+                        "name": "PostDeclare",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -8566,52 +8696,55 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "PostDeclare"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "count",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
+                        "name": "PostDeclare",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "count",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "inout"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -8727,31 +8860,33 @@
                 "_PTR_F_C_index": "81",
                 "ast": {
                     "declarator": {
-                        "name": "CpassCharPtrNotrim"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "CpassCharPtrNotrim",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "src",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "src",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -8861,32 +8996,34 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "CpassCharPtrNotrim"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "CpassCharPtrNotrim",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "in"
+                                    },
+                                    "name": "src",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "src",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -8989,55 +9126,58 @@
                 "<FUNCTION>": "43 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "CpassCharPtrCAPI"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "addr",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "void"
-                            ],
-                            "typemap_name": "void"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "api": "capi"
+                        "name": "CpassCharPtrCAPI",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "addr",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "void"
+                                },
+                                "specifier": [
+                                    "void"
+                                ],
+                                "typemap_name": "void"
                             },
-                            "const": true,
-                            "declarator": {
-                                "name": "src",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "capi",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "api": "capi"
+                                    },
+                                    "metaattrs": {
+                                        "api": "capi",
+                                        "intent": "in"
+                                    },
+                                    "name": "src",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -9182,54 +9322,57 @@
                 "<FUNCTION>": "44 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "CpassCharPtrCAPI2"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "in",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "ftrim_char_in": true,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "api": "capi"
+                        "name": "CpassCharPtrCAPI2",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "in",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "ftrim_char_in": true,
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
                             },
-                            "const": true,
-                            "declarator": {
-                                "name": "src",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "capi",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "api": "capi"
+                                    },
+                                    "metaattrs": {
+                                        "api": "capi",
+                                        "intent": "in"
+                                    },
+                                    "name": "src",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],

--- a/regression/reference/strings/strings.json
+++ b/regression/reference/strings/strings.json
@@ -55,6 +55,7 @@
                 "doxygen": {
                     "brief": "pass a single char argument as a scalar."
                 },
+                "name": "passChar",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -179,6 +180,7 @@
                 "doxygen": {
                     "description": "By default no Fortran wrapper is created.\nForce one so it can be tested.\n"
                 },
+                "name": "passCharForce",
                 "options": {
                     "F_force_wrapper": true,
                     "wrap_python": false
@@ -267,6 +269,7 @@
                 "doxygen": {
                     "brief": "return a char argument (non-pointer)"
                 },
+                "name": "returnChar",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -412,6 +415,7 @@
                     "brief": "strcpy like behavior",
                     "description": "dest is marked intent(OUT) to override the intent(INOUT) default\nThis avoid a copy-in on dest.\nIn Python, src must not be over 40 characters, defined by charlen.\n"
                 },
+                "name": "passCharPtr",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false
@@ -614,6 +618,7 @@
                     "brief": "strcpy like behavior",
                     "description": "dest is marked intent(OUT) to override the intent(INOUT) default\nThis avoid a copy-in on dest.\nIn Python, src must not be over 40 characters, defined by charlen.\n"
                 },
+                "name": "passCharPtr",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false
@@ -752,6 +757,7 @@
                     "brief": "toupper",
                     "description": "Change a string in-place.\nFor Python, return a new string since strings are immutable.\n"
                 },
+                "name": "passCharPtrInOut",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -880,6 +886,7 @@
                     "brief": "toupper",
                     "description": "Change a string in-place.\nFor Python, return a new string since strings are immutable.\n"
                 },
+                "name": "passCharPtrInOut",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -970,6 +977,7 @@
                 "doxygen": {
                     "brief": "return a 'const char *' as character(*)"
                 },
+                "name": "getCharPtr1",
                 "options": {
                     "literalinclude": true
                 },
@@ -1084,6 +1092,7 @@
                 "doxygen": {
                     "brief": "return a 'const char *' as character(*)"
                 },
+                "name": "getCharPtr1",
                 "options": {
                     "literalinclude": true
                 },
@@ -1169,6 +1178,7 @@
                 "doxygen": {
                     "brief": "return 'const char *' with fixed size (len=30)"
                 },
+                "name": "getCharPtr2",
                 "options": {
                     "literalinclude": true
                 },
@@ -1283,6 +1293,7 @@
                 "doxygen": {
                     "brief": "return 'const char *' with fixed size (len=30)"
                 },
+                "name": "getCharPtr2",
                 "options": {
                     "literalinclude": true
                 },
@@ -1360,6 +1371,7 @@
                 "doxygen": {
                     "brief": "return a 'const char *' as argument"
                 },
+                "name": "getCharPtr3",
                 "options": {
                     "literalinclude": true
                 },
@@ -1475,6 +1487,7 @@
                 "doxygen": {
                     "brief": "return a 'const char *' as argument"
                 },
+                "name": "getCharPtr3",
                 "options": {
                     "literalinclude": true
                 },
@@ -1603,6 +1616,7 @@
                 "doxygen": {
                     "brief": "return a 'const char *' as argument"
                 },
+                "name": "getCharPtr3",
                 "options": {
                     "literalinclude": true
                 },
@@ -1662,6 +1676,7 @@
                 "doxygen": {
                     "brief": "return a 'const char *' as type(C_PTR)"
                 },
+                "name": "getCharPtr4",
                 "options": {
                     "wrap_python": false
                 },
@@ -1757,6 +1772,7 @@
                 "doxygen": {
                     "brief": "return a 'const char *' as character(:) pointer"
                 },
+                "name": "getCharPtr5",
                 "options": {
                     "wrap_python": false
                 },
@@ -1854,6 +1870,7 @@
                 "doxygen": {
                     "brief": "return a 'const char *' as character(:) pointer"
                 },
+                "name": "getCharPtr5",
                 "options": {
                     "wrap_python": false
                 },
@@ -1932,6 +1949,7 @@
                 "doxygen": {
                     "brief": "return an ALLOCATABLE CHARACTER from std::string"
                 },
+                "name": "getConstStringResult",
                 "options": {},
                 "wrap": {
                     "fortran": true,
@@ -2013,6 +2031,7 @@
                 "doxygen": {
                     "brief": "return an ALLOCATABLE CHARACTER from std::string"
                 },
+                "name": "getConstStringResult",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -2092,6 +2111,7 @@
                 "doxygen": {
                     "brief": "return a 'const string' as argument"
                 },
+                "name": "getConstStringLen",
                 "options": {},
                 "wrap": {
                     "fortran": true,
@@ -2174,6 +2194,7 @@
                 "doxygen": {
                     "brief": "return a 'const string' as argument"
                 },
+                "name": "getConstStringLen",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -2245,6 +2266,7 @@
                 "doxygen": {
                     "brief": "return a 'const string' as argument"
                 },
+                "name": "getConstStringAsArg",
                 "options": {},
                 "user_fmt": {
                     "F_string_result_as_arg": "output"
@@ -2324,6 +2346,7 @@
                 "doxygen": {
                     "brief": "return a 'const string' as argument"
                 },
+                "name": "getConstStringAsArg",
                 "options": {},
                 "splicer_group": "buf",
                 "user_fmt": {
@@ -2451,6 +2474,7 @@
                 "doxygen": {
                     "brief": "return a 'const string' as argument"
                 },
+                "name": "getConstStringAsArg",
                 "options": {},
                 "splicer_group": "buf",
                 "user_fmt": {
@@ -2501,6 +2525,7 @@
                 },
                 "decl": "const std::string getConstStringAlloc()",
                 "declgen": "const std::string getConstStringAlloc(void)",
+                "name": "getConstStringAlloc",
                 "options": {},
                 "wrap": {
                     "fortran": true,
@@ -2578,6 +2603,7 @@
                 },
                 "decl": "const std::string getConstStringAlloc()",
                 "declgen": "const std::string getConstStringAlloc(void)",
+                "name": "getConstStringAlloc",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -2658,6 +2684,7 @@
                 "doxygen": {
                     "brief": "return a 'const string&' as ALLOCATABLE character"
                 },
+                "name": "getConstStringRefPure",
                 "options": {
                     "literalinclude": true
                 },
@@ -2773,6 +2800,7 @@
                 "doxygen": {
                     "brief": "return a 'const string&' as ALLOCATABLE character"
                 },
+                "name": "getConstStringRefPure",
                 "options": {
                     "literalinclude": true
                 },
@@ -2860,6 +2888,7 @@
                     "brief": "return 'const string&' with fixed size (len=30)",
                     "description": "Since +len(30) is provided, the result of the function\nwill be copied directly into memory provided by Fortran.\nThe function will not be ALLOCATABLE.\n"
                 },
+                "name": "getConstStringRefLen",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2976,6 +3005,7 @@
                     "brief": "return 'const string&' with fixed size (len=30)",
                     "description": "Since +len(30) is provided, the result of the function\nwill be copied directly into memory provided by Fortran.\nThe function will not be ALLOCATABLE.\n"
                 },
+                "name": "getConstStringRefLen",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -3053,6 +3083,7 @@
                     "brief": "return a 'const string&' as argument",
                     "description": "Pass an additional argument which will be used as the return value.\nThe length of the output variable is declared by the caller.\n"
                 },
+                "name": "getConstStringRefAsArg",
                 "options": {},
                 "user_fmt": {
                     "F_string_result_as_arg": "output"
@@ -3169,6 +3200,7 @@
                     "brief": "return a 'const string&' as argument",
                     "description": "Pass an additional argument which will be used as the return value.\nThe length of the output variable is declared by the caller.\n"
                 },
+                "name": "getConstStringRefAsArg",
                 "options": {},
                 "splicer_group": "buf",
                 "user_fmt": {
@@ -3297,6 +3329,7 @@
                     "brief": "return a 'const string&' as argument",
                     "description": "Pass an additional argument which will be used as the return value.\nThe length of the output variable is declared by the caller.\n"
                 },
+                "name": "getConstStringRefAsArg",
                 "options": {},
                 "splicer_group": "buf",
                 "user_fmt": {
@@ -3359,6 +3392,7 @@
                 "doxygen": {
                     "brief": "Test returning empty string reference"
                 },
+                "name": "getConstStringRefLenEmpty",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3474,6 +3508,7 @@
                 "doxygen": {
                     "brief": "Test returning empty string reference"
                 },
+                "name": "getConstStringRefLenEmpty",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -3551,6 +3586,7 @@
                 },
                 "decl": "const std::string& getConstStringRefAlloc()",
                 "declgen": "const std::string & getConstStringRefAlloc(void)",
+                "name": "getConstStringRefAlloc",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3661,6 +3697,7 @@
                 },
                 "decl": "const std::string& getConstStringRefAlloc()",
                 "declgen": "const std::string & getConstStringRefAlloc(void)",
+                "name": "getConstStringRefAlloc",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -3752,6 +3789,7 @@
                         ]
                     }
                 },
+                "name": "getConstStringPtrLen",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3874,6 +3912,7 @@
                         ]
                     }
                 },
+                "name": "getConstStringPtrLen",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -3954,6 +3993,7 @@
                 },
                 "decl": "const std::string * getConstStringPtrAlloc() +owner(library)",
                 "declgen": "const std::string * getConstStringPtrAlloc(void) +owner(library)",
+                "name": "getConstStringPtrAlloc",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -4067,6 +4107,7 @@
                 },
                 "decl": "const std::string * getConstStringPtrAlloc() +owner(library)",
                 "declgen": "const std::string * getConstStringPtrAlloc(void) +owner(library)",
+                "name": "getConstStringPtrAlloc",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -4150,6 +4191,7 @@
                 "doxygen": {
                     "description": "It is the caller's responsibility to release the string\ncreated by the C++ library.\nThis is accomplished +owner(caller) which sets idtor.\nThe contents are copied by Fortran so they must outlast\nthe return from the C wrapper.\n"
                 },
+                "name": "getConstStringPtrOwnsAlloc",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -4266,6 +4308,7 @@
                 "doxygen": {
                     "description": "It is the caller's responsibility to release the string\ncreated by the C++ library.\nThis is accomplished +owner(caller) which sets idtor.\nThe contents are copied by Fortran so they must outlast\nthe return from the C wrapper.\n"
                 },
+                "name": "getConstStringPtrOwnsAlloc",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -4350,6 +4393,7 @@
                 "doxygen": {
                     "description": "Similar to getConstStringPtrOwnsAlloc, but uses pattern to release memory.\n"
                 },
+                "name": "getConstStringPtrOwnsAllocPattern",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -4467,6 +4511,7 @@
                 "doxygen": {
                     "description": "Similar to getConstStringPtrOwnsAlloc, but uses pattern to release memory.\n"
                 },
+                "name": "getConstStringPtrOwnsAllocPattern",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -4548,6 +4593,7 @@
                 },
                 "decl": "const std::string * getConstStringPtrPointer() +deref(pointer)+owner(library)",
                 "declgen": "const std::string * getConstStringPtrPointer(void) +deref(pointer)+owner(library)",
+                "name": "getConstStringPtrPointer",
                 "options": {
                     "wrap_python": false
                 },
@@ -4644,6 +4690,7 @@
                 },
                 "decl": "const std::string * getConstStringPtrPointer() +deref(pointer)+owner(library)",
                 "declgen": "const std::string * getConstStringPtrPointer(void) +deref(pointer)+owner(library)",
+                "name": "getConstStringPtrPointer",
                 "options": {
                     "wrap_python": false
                 },
@@ -4740,6 +4787,7 @@
                     "brief": "Accept a const string reference",
                     "description": "Save contents of arg1.\narg1 is assumed to be intent(IN) since it is const\nWill copy in.\n"
                 },
+                "name": "acceptStringConstReference",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -4866,6 +4914,7 @@
                     "brief": "Accept a const string reference",
                     "description": "Save contents of arg1.\narg1 is assumed to be intent(IN) since it is const\nWill copy in.\n"
                 },
+                "name": "acceptStringConstReference",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -4972,6 +5021,7 @@
                     "brief": "Accept a string reference",
                     "description": "Set out to a constant string.\narg1 is intent(OUT)\nMust copy out.\n"
                 },
+                "name": "acceptStringReferenceOut",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -5100,6 +5150,7 @@
                     "brief": "Accept a string reference",
                     "description": "Set out to a constant string.\narg1 is intent(OUT)\nMust copy out.\n"
                 },
+                "name": "acceptStringReferenceOut",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -5203,6 +5254,7 @@
                     "brief": "Accept a string reference",
                     "description": "Append \"dog\" to the end of arg1.\narg1 is assumed to be intent(INOUT)\nMust copy in and copy out.\n"
                 },
+                "name": "acceptStringReference",
                 "options": {
                     "literalinclude": true
                 },
@@ -5330,6 +5382,7 @@
                     "brief": "Accept a string reference",
                     "description": "Append \"dog\" to the end of arg1.\narg1 is assumed to be intent(INOUT)\nMust copy in and copy out.\n"
                 },
+                "name": "acceptStringReference",
                 "options": {
                     "literalinclude": true
                 },
@@ -5435,6 +5488,7 @@
                 "doxygen": {
                     "brief": "Accept a const string pointer - intent(in)"
                 },
+                "name": "acceptStringPointerConst",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -5560,6 +5614,7 @@
                 "doxygen": {
                     "brief": "Accept a const string pointer - intent(in)"
                 },
+                "name": "acceptStringPointerConst",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -5662,6 +5717,7 @@
                 "doxygen": {
                     "brief": "Accept a string pointer - intent(inout)"
                 },
+                "name": "acceptStringPointer",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -5786,6 +5842,7 @@
                 "doxygen": {
                     "brief": "Accept a string pointer - intent(inout)"
                 },
+                "name": "acceptStringPointer",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -5892,6 +5949,7 @@
                     "brief": "Accept a string pointer - intent(out)",
                     "description": "Return global_str.\n"
                 },
+                "name": "fetchStringPointer",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -6020,6 +6078,7 @@
                     "brief": "Accept a string pointer - intent(out)",
                     "description": "Return global_str.\n"
                 },
+                "name": "fetchStringPointer",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -6144,6 +6203,7 @@
                     "brief": "Accept a string pointer - intent(inout)",
                     "description": "Test return tuple with two arguments.\nMust rename argument to nlen to avoid conflict with intrinsic len.\n"
                 },
+                "name": "acceptStringPointerLen",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -6339,6 +6399,7 @@
                     "brief": "Accept a string pointer - intent(inout)",
                     "description": "Test return tuple with two arguments.\nMust rename argument to nlen to avoid conflict with intrinsic len.\n"
                 },
+                "name": "acceptStringPointerLen",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -6499,6 +6560,7 @@
                     "brief": "Accept a string pointer - intent(out)",
                     "description": "Return global_str.\nTest return tuple with two arguments.\nMust rename argument to nlen to avoid conflict with intrinsic len.\n"
                 },
+                "name": "fetchStringPointerLen",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -6697,6 +6759,7 @@
                     "brief": "Accept a string pointer - intent(out)",
                     "description": "Return global_str.\nTest return tuple with two arguments.\nMust rename argument to nlen to avoid conflict with intrinsic len.\n"
                 },
+                "name": "fetchStringPointerLen",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -6830,6 +6893,7 @@
                 "doxygen": {
                     "brief": "Accept a string instance"
                 },
+                "name": "acceptStringInstance",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -6999,6 +7063,7 @@
                 "doxygen": {
                     "brief": "Accept a string instance"
                 },
+                "name": "acceptStringInstance",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -7150,6 +7215,7 @@
                 "doxygen": {
                     "brief": "Test Python returning multiple std::string arguments."
                 },
+                "name": "returnStrings",
                 "options": {
                     "wrap_c": false,
                     "wrap_fortran": false
@@ -7252,6 +7318,7 @@
                 "doxygen": {
                     "description": "Test Py_BuildValue with multiple values.\n"
                 },
+                "name": "returnMany",
                 "options": {
                     "wrap_c": false,
                     "wrap_fortran": false,
@@ -7305,6 +7372,7 @@
                 },
                 "decl": "void explicit1(char * name+len_trim(AAlen)+intent(in))",
                 "declgen": "void explicit1(char * name +intent(in)+len_trim(AAlen))",
+                "name": "explicit1",
                 "options": {},
                 "user_fmt": {
                     "C_bufferify_suffix": "_BUFFER"
@@ -7436,6 +7504,7 @@
                 },
                 "decl": "void explicit2(char * name+len(AAtrim)+intent(out))",
                 "declgen": "void explicit2(char * name +intent(out)+len(AAtrim))",
+                "name": "explicit2",
                 "options": {
                     "wrap_lua": false,
                     "wrap_python": false
@@ -7542,6 +7611,7 @@
                 },
                 "decl": "void explicit2(char * name+len(AAtrim)+intent(out))",
                 "declgen": "void explicit2(char * name +intent(out)+len(AAtrim))",
+                "name": "explicit2",
                 "options": {
                     "wrap_lua": false,
                     "wrap_python": false
@@ -7641,6 +7711,7 @@
                 "doxygen": {
                     "brief": "pass a single char argument as a scalar, extern \"C\""
                 },
+                "name": "CpassChar",
                 "options": {
                     "C_extern_C": true
                 },
@@ -7750,6 +7821,7 @@
                 "doxygen": {
                     "brief": "return a char argument (non-pointer), extern \"C\""
                 },
+                "name": "CreturnChar",
                 "options": {
                     "C_extern_C": true
                 },
@@ -7899,6 +7971,7 @@
                     "brief": "strcpy like behavior",
                     "description": "dest is marked intent(OUT) to override the intent(INOUT) default\nThis avoid a copy-in on dest.\nextern \"C\"\nIf src is a blank string, pass a NULL pointer to C library function.\n"
                 },
+                "name": "CpassCharPtr",
                 "options": {
                     "C_extern_C": true,
                     "wrap_lua": false,
@@ -8063,6 +8136,7 @@
                     "brief": "strcpy like behavior",
                     "description": "dest is marked intent(OUT) to override the intent(INOUT) default\nThis avoid a copy-in on dest.\nextern \"C\"\nIf src is a blank string, pass a NULL pointer to C library function.\n"
                 },
+                "name": "CpassCharPtr",
                 "options": {
                     "C_extern_C": true,
                     "wrap_lua": false,
@@ -8228,6 +8302,7 @@
                 "doxygen": {
                     "brief": "Test F_blanknull option"
                 },
+                "name": "CpassCharPtrBlank",
                 "options": {
                     "F_blanknull": true,
                     "wrap_lua": false,
@@ -8388,6 +8463,7 @@
                 "doxygen": {
                     "brief": "Test F_blanknull option"
                 },
+                "name": "CpassCharPtrBlank",
                 "options": {
                     "F_blanknull": true,
                     "wrap_lua": false,
@@ -8552,6 +8628,7 @@
                 "doxygen": {
                     "description": "Test post_declare.\nThe std::string in py_string_inout must be declared before the\ngoto added by py_native_*_in_pointer_list to avoid\n\"jump to label 'fail' crosses initialization of\" error.\n"
                 },
+                "name": "PostDeclare",
                 "options": {
                     "PY_array_arg": "list"
                 },
@@ -8755,6 +8832,7 @@
                 "doxygen": {
                     "description": "Test post_declare.\nThe std::string in py_string_inout must be declared before the\ngoto added by py_native_*_in_pointer_list to avoid\n\"jump to label 'fail' crosses initialization of\" error.\n"
                 },
+                "name": "PostDeclare",
                 "options": {
                     "PY_array_arg": "list"
                 },
@@ -8897,6 +8975,7 @@
                 "doxygen": {
                     "brief": "NULL terminate input string in C, not in Fortran."
                 },
+                "name": "CpassCharPtrNotrim",
                 "options": {
                     "F_trim_char_in": false,
                     "wrap_python": false
@@ -9034,6 +9113,7 @@
                 "doxygen": {
                     "brief": "NULL terminate input string in C, not in Fortran."
                 },
+                "name": "CpassCharPtrNotrim",
                 "options": {
                     "F_trim_char_in": false,
                     "wrap_python": false
@@ -9189,6 +9269,7 @@
                     "brief": "Do not NULL terminate input string",
                     "description": "The C library function should get the same address\nfor addr and src.\nUsed when the C function needs the true address of the argument.\nSkips null-termination. Useful to create an interface for\na function which is already callable by Fortran.\nFor example, the length is passed explicitly.\nThis example will not create a Fortran wrapper since C can be\ncalled directly.\n"
                 },
+                "name": "CpassCharPtrCAPI",
                 "options": {
                     "wrap_python": false
                 },
@@ -9383,6 +9464,7 @@
                 "doxygen": {
                     "brief": "Mix api(buf) and api(capi)"
                 },
+                "name": "CpassCharPtrCAPI2",
                 "options": {
                     "wrap_python": false
                 },

--- a/regression/reference/strings/strings.json
+++ b/regression/reference/strings/strings.json
@@ -1444,9 +1444,10 @@
                             {
                                 "declarator": {
                                     "metaattrs": {
-                                        "api": "cdesc",
-                                        "deref": "allocatable",
-                                        "intent": "function"
+                                        "api": "buf",
+                                        "deref": "result",
+                                        "intent": "out",
+                                        "is_result": true
                                     },
                                     "name": "output",
                                     "params": [],
@@ -1463,7 +1464,7 @@
                                 "typemap_name": "char"
                             }
                         ],
-                        "typemap_name": "char"
+                        "typemap_name": "void"
                     },
                     "specifier": [
                         "void"
@@ -1572,9 +1573,10 @@
                             {
                                 "declarator": {
                                     "metaattrs": {
-                                        "api": "cdesc",
-                                        "deref": "allocatable",
-                                        "intent": "function"
+                                        "api": "buf",
+                                        "deref": "result",
+                                        "intent": "out",
+                                        "is_result": true
                                     },
                                     "name": "output",
                                     "params": [],
@@ -1591,7 +1593,7 @@
                                 "typemap_name": "char"
                             }
                         ],
-                        "typemap_name": "char"
+                        "typemap_name": "void"
                     },
                     "specifier": [
                         "void"
@@ -2293,9 +2295,10 @@
                             {
                                 "declarator": {
                                     "metaattrs": {
-                                        "api": "cdesc",
-                                        "deref": "allocatable",
-                                        "intent": "function"
+                                        "api": "buf",
+                                        "deref": "result",
+                                        "intent": "out",
+                                        "is_result": true
                                     },
                                     "name": "output",
                                     "params": [],
@@ -2312,7 +2315,7 @@
                                 "typemap_name": "std::string"
                             }
                         ],
-                        "typemap_name": "std::string"
+                        "typemap_name": "void"
                     },
                     "specifier": [
                         "void"
@@ -2420,9 +2423,10 @@
                             {
                                 "declarator": {
                                     "metaattrs": {
-                                        "api": "cdesc",
-                                        "deref": "allocatable",
-                                        "intent": "function"
+                                        "api": "buf",
+                                        "deref": "result",
+                                        "intent": "out",
+                                        "is_result": true
                                     },
                                     "name": "output",
                                     "params": [],
@@ -2439,7 +2443,7 @@
                                 "typemap_name": "std::string"
                             }
                         ],
-                        "typemap_name": "std::string"
+                        "typemap_name": "void"
                     },
                     "specifier": [
                         "void"
@@ -3137,9 +3141,10 @@
                             {
                                 "declarator": {
                                     "metaattrs": {
-                                        "api": "cdesc",
-                                        "deref": "allocatable",
-                                        "intent": "function"
+                                        "api": "buf",
+                                        "deref": "result",
+                                        "intent": "out",
+                                        "is_result": true
                                     },
                                     "name": "output",
                                     "params": [],
@@ -3156,7 +3161,7 @@
                                 "typemap_name": "std::string"
                             }
                         ],
-                        "typemap_name": "std::string"
+                        "typemap_name": "void"
                     },
                     "specifier": [
                         "void"
@@ -3265,9 +3270,10 @@
                             {
                                 "declarator": {
                                     "metaattrs": {
-                                        "api": "cdesc",
-                                        "deref": "allocatable",
-                                        "intent": "function"
+                                        "api": "buf",
+                                        "deref": "result",
+                                        "intent": "out",
+                                        "is_result": true
                                     },
                                     "name": "output",
                                     "params": [],
@@ -3284,7 +3290,7 @@
                                 "typemap_name": "std::string"
                             }
                         ],
-                        "typemap_name": "std::string"
+                        "typemap_name": "void"
                     },
                     "specifier": [
                         "void"

--- a/regression/reference/struct-c/struct.json
+++ b/regression/reference/struct-c/struct.json
@@ -26,7 +26,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "ifield"
+                                "name": "ifield",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -52,7 +53,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "dfield"
+                                "name": "dfield",
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -116,7 +118,8 @@
                                     {
                                         "ptr": "*"
                                     }
-                                ]
+                                ],
+                                "typemap_name": "char"
                             },
                             "specifier": [
                                 "char"
@@ -148,7 +151,8 @@
                                     {
                                         "ptr": "*"
                                     }
-                                ]
+                                ],
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -209,7 +213,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "nitems"
+                                "name": "nitems",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -234,29 +239,30 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems+nitems"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems+nitems"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "left": {
+                                                "name": "nitems"
+                                            },
+                                            "op": "+",
+                                            "right": {
+                                                "name": "nitems"
+                                            }
+                                        }
+                                    ]
+                                },
                                 "name": "ivalue",
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "left": {
-                                            "name": "nitems"
-                                        },
-                                        "op": "+",
-                                        "right": {
-                                            "name": "nitems"
-                                        }
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -281,29 +287,30 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems*TWO"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems*TWO"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "left": {
+                                                "name": "nitems"
+                                            },
+                                            "op": "*",
+                                            "right": {
+                                                "name": "TWO"
+                                            }
+                                        }
+                                    ]
+                                },
                                 "name": "dvalue",
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "left": {
-                                            "name": "nitems"
-                                        },
-                                        "op": "*",
-                                        "right": {
-                                            "name": "TWO"
-                                        }
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -328,10 +335,17 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "name": "nitems"
+                                        }
+                                    ]
+                                },
                                 "name": "svalue",
                                 "pointer": [
                                     {
@@ -340,14 +354,8 @@
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nitems"
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "char"
                             },
                             "specifier": [
                                 "char"
@@ -409,7 +417,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "nitems"
+                                "name": "nitems",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -434,23 +443,24 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "name": "nitems"
+                                        }
+                                    ]
+                                },
                                 "name": "ivalue",
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nitems"
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -475,23 +485,24 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "name": "nitems"
+                                        }
+                                    ]
+                                },
                                 "name": "dvalue",
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nitems"
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -551,13 +562,14 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "array": [
-                                {
-                                    "constant": "20"
-                                }
-                            ],
                             "declarator": {
-                                "name": "name"
+                                "array": [
+                                    {
+                                        "constant": "20"
+                                    }
+                                ],
+                                "name": "name",
+                                "typemap_name": "char"
                             },
                             "specifier": [
                                 "char"
@@ -582,13 +594,14 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "array": [
-                                {
-                                    "constant": "10"
-                                }
-                            ],
                             "declarator": {
-                                "name": "count"
+                                "array": [
+                                    {
+                                        "constant": "10"
+                                    }
+                                ],
+                                "name": "count",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -646,12 +659,13 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "get_x1"
+                                "metaattrs": {
+                                    "intent": "getter"
+                                },
+                                "name": "get_x1",
+                                "params": [],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "getter"
-                            },
-                            "params": [],
                             "specifier": [
                                 "int"
                             ],
@@ -736,29 +750,31 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "set_x1"
+                                "metaattrs": {
+                                    "intent": "setter"
+                                },
+                                "name": "set_x1",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "intent": "in",
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "setter"
+                                            },
+                                            "name": "val",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "setter"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "intent": "in",
-                                        "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "val"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "setter"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],
@@ -850,12 +866,13 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "get_y1"
+                                "metaattrs": {
+                                    "intent": "getter"
+                                },
+                                "name": "get_y1",
+                                "params": [],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "getter"
-                            },
-                            "params": [],
                             "specifier": [
                                 "int"
                             ],
@@ -940,29 +957,31 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "set_y1"
+                                "metaattrs": {
+                                    "intent": "setter"
+                                },
+                                "name": "set_y1",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "intent": "in",
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "setter"
+                                            },
+                                            "name": "val",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "setter"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "intent": "in",
-                                        "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "val"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "setter"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],
@@ -1061,7 +1080,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "x1"
+                                "name": "x1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -1087,7 +1107,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "y1"
+                                "name": "y1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -1149,12 +1170,13 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "get_x1"
+                                "metaattrs": {
+                                    "intent": "getter"
+                                },
+                                "name": "get_x1",
+                                "params": [],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "getter"
-                            },
-                            "params": [],
                             "specifier": [
                                 "int"
                             ],
@@ -1239,29 +1261,31 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "set_x1"
+                                "metaattrs": {
+                                    "intent": "setter"
+                                },
+                                "name": "set_x1",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "intent": "in",
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "setter"
+                                            },
+                                            "name": "val",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "setter"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "intent": "in",
-                                        "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "val"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "setter"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],
@@ -1353,12 +1377,13 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "get_y1"
+                                "metaattrs": {
+                                    "intent": "getter"
+                                },
+                                "name": "get_y1",
+                                "params": [],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "getter"
-                            },
-                            "params": [],
                             "specifier": [
                                 "int"
                             ],
@@ -1443,29 +1468,31 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "set_y1"
+                                "metaattrs": {
+                                    "intent": "setter"
+                                },
+                                "name": "set_y1",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "intent": "in",
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "setter"
+                                            },
+                                            "name": "val",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "setter"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "intent": "in",
-                                        "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "val"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "setter"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],
@@ -1557,12 +1584,13 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "get_z1"
+                                "metaattrs": {
+                                    "intent": "getter"
+                                },
+                                "name": "get_z1",
+                                "params": [],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "getter"
-                            },
-                            "params": [],
                             "specifier": [
                                 "int"
                             ],
@@ -1647,29 +1675,31 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "set_z1"
+                                "metaattrs": {
+                                    "intent": "setter"
+                                },
+                                "name": "set_z1",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "intent": "in",
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "setter"
+                                            },
+                                            "name": "val",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "setter"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "intent": "in",
-                                        "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "val"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "setter"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],
@@ -1769,7 +1799,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "x1"
+                                "name": "x1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -1795,7 +1826,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "y1"
+                                "name": "y1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -1821,7 +1853,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "z1"
+                                "name": "z1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -1889,28 +1922,30 @@
                 "<FUNCTION>": "10 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passStructByValue"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "passStructByValue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -2018,31 +2053,33 @@
                 "<FUNCTION>": "11 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passStruct1"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "passStruct1",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -2154,52 +2191,55 @@
                 "_PTR_F_C_index": "30",
                 "ast": {
                     "declarator": {
-                        "name": "passStruct2"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "s1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "charlen": "LENOUTBUF",
-                                "intent": "out"
+                        "name": "passStruct2",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "s1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
                             },
-                            "declarator": {
-                                "name": "outbuf",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "charlen": "LENOUTBUF",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "outbuf",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -2334,53 +2374,56 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "passStruct2"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "s1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "charlen": "LENOUTBUF",
-                                "intent": "out"
+                        "name": "passStruct2",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "s1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
                             },
-                            "declarator": {
-                                "name": "outbuf",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "charlen": "LENOUTBUF",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "out"
+                                    },
+                                    "name": "outbuf",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -2512,33 +2555,35 @@
                 "<FUNCTION>": "13 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStructInPtr"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "acceptStructInPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -2644,63 +2689,67 @@
                 "<FUNCTION>": "14 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStructOutPtr"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "acceptStructOutPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
                             },
-                            "declarator": {
-                                "name": "i"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2844,33 +2893,35 @@
                 "<FUNCTION>": "15 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStructInOutPtr"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptStructInOutPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -2945,43 +2996,46 @@
                 "<FUNCTION>": "16 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "returnStructByValue"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "returnStructByValue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "Cstruct1"
+                    },
                     "specifier": [
                         "Cstruct1"
                     ],
@@ -3124,49 +3178,52 @@
                 "_PTR_F_C_index": "31",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnStructPtr1",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct1"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct1"
                     ],
@@ -3303,50 +3360,53 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "buf",
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnStructPtr1",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct1"
                     },
-                    "metaattrs": {
-                        "api": "buf",
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct1"
                     ],
@@ -3481,70 +3541,74 @@
                 "_PTR_F_C_index": "32",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnStructPtr2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "charlen": "LENOUTBUF",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "outbuf",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct1"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        },
-                        {
-                            "attrs": {
-                                "charlen": "LENOUTBUF",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "outbuf",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct1"
                     ],
@@ -3710,72 +3774,76 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "buf",
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnStructPtr2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "charlen": "LENOUTBUF",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "out"
+                                    },
+                                    "name": "outbuf",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct1"
                     },
-                    "metaattrs": {
-                        "api": "buf",
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        },
-                        {
-                            "attrs": {
-                                "charlen": "LENOUTBUF",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "outbuf",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct1"
                     ],
@@ -3945,18 +4013,19 @@
                 "_PTR_F_C_index": "33",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "get_global_struct_list",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct_list"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "Cstruct_list"
                     ],
@@ -4027,19 +4096,20 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "buf",
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "get_global_struct_list",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct_list"
                     },
-                    "metaattrs": {
-                        "api": "buf",
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "Cstruct_list"
                     ],
@@ -4097,18 +4167,19 @@
                 "<FUNCTION>": "20 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
                         "name": "Create_Cstruct_as_class",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct_as_class"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "Cstruct_as_class"
                     ],
@@ -4185,49 +4256,52 @@
                 "<FUNCTION>": "21 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
                         "name": "Create_Cstruct_as_class_args",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "x",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "y",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct_as_class"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "x"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "y"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct_as_class"
                     ],
@@ -4372,34 +4446,36 @@
                 "<FUNCTION>": "22 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "Cstruct_as_class_sum"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "Cstruct_as_class_sum",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "pass": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "point",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct_as_class"
+                                },
+                                "specifier": [
+                                    "Cstruct_as_class"
+                                ],
+                                "typemap_name": "Cstruct_as_class"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "pass": true
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "point",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct_as_class"
-                            ],
-                            "typemap_name": "Cstruct_as_class"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -4513,64 +4589,68 @@
                 "<FUNCTION>": "23 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
                         "name": "Create_Cstruct_as_subclass_args",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "x",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "y",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "z",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct_as_subclass"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "x"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "y"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "z"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct_as_subclass"
                     ],
@@ -4755,38 +4835,40 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "getter",
+                            "struct": "Cstruct_ptr"
+                        },
                         "name": "Cstruct_ptr_get_const_dvalue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in",
+                                        "struct": "Cstruct_ptr"
+                                    },
+                                    "name": "SH_this",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct_ptr"
+                                },
+                                "specifier": [
+                                    "Cstruct_ptr"
+                                ],
+                                "typemap_name": "Cstruct_ptr"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "double"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "getter",
-                        "struct": "Cstruct_ptr"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "SH_this",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in",
-                                "struct": "Cstruct_ptr"
-                            },
-                            "specifier": [
-                                "Cstruct_ptr"
-                            ],
-                            "typemap_name": "Cstruct_ptr"
-                        }
-                    ],
                     "specifier": [
                         "double"
                     ],
@@ -4841,39 +4923,41 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "api": "buf",
+                            "deref": "pointer",
+                            "intent": "getter",
+                            "struct": "Cstruct_ptr"
+                        },
                         "name": "Cstruct_ptr_get_const_dvalue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in",
+                                        "struct": "Cstruct_ptr"
+                                    },
+                                    "name": "SH_this",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct_ptr"
+                                },
+                                "specifier": [
+                                    "Cstruct_ptr"
+                                ],
+                                "typemap_name": "Cstruct_ptr"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "double"
                     },
-                    "metaattrs": {
-                        "api": "buf",
-                        "deref": "pointer",
-                        "intent": "getter",
-                        "struct": "Cstruct_ptr"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "SH_this",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in",
-                                "struct": "Cstruct_ptr"
-                            },
-                            "specifier": [
-                                "Cstruct_ptr"
-                            ],
-                            "typemap_name": "Cstruct_ptr"
-                        }
-                    ],
                     "specifier": [
                         "double"
                     ],
@@ -4978,52 +5062,55 @@
                 "_generated": "getter/setter",
                 "ast": {
                     "declarator": {
-                        "name": "Cstruct_ptr_set_const_dvalue"
-                    },
-                    "metaattrs": {
-                        "intent": "setter"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "SH_this",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout",
-                                "struct": "Cstruct_ptr"
-                            },
-                            "specifier": [
-                                "Cstruct_ptr"
-                            ],
-                            "typemap_name": "Cstruct_ptr"
+                        "metaattrs": {
+                            "intent": "setter"
                         },
-                        {
-                            "attrs": {
-                                "intent": "in"
+                        "name": "Cstruct_ptr_set_const_dvalue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout",
+                                        "struct": "Cstruct_ptr"
+                                    },
+                                    "name": "SH_this",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct_ptr"
+                                },
+                                "specifier": [
+                                    "Cstruct_ptr"
+                                ],
+                                "typemap_name": "Cstruct_ptr"
                             },
-                            "const": true,
-                            "declarator": {
-                                "name": "val",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "setter"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "setter"
+                                    },
+                                    "name": "val",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5146,49 +5233,51 @@
                 "_generated": "getter/setter",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "left": {
+                                        "name": "nitems"
+                                    },
+                                    "op": "+",
+                                    "right": {
+                                        "name": "nitems"
+                                    }
+                                }
+                            ],
+                            "intent": "getter",
+                            "struct": "Cstruct_list"
+                        },
                         "name": "Cstruct_list_get_ivalue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in",
+                                        "struct": "Cstruct_list"
+                                    },
+                                    "name": "SH_this",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct_list"
+                                },
+                                "specifier": [
+                                    "Cstruct_list"
+                                ],
+                                "typemap_name": "Cstruct_list"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "left": {
-                                    "name": "nitems"
-                                },
-                                "op": "+",
-                                "right": {
-                                    "name": "nitems"
-                                }
-                            }
                         ],
-                        "intent": "getter",
-                        "struct": "Cstruct_list"
+                        "typemap_name": "int"
                     },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "SH_this",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in",
-                                "struct": "Cstruct_list"
-                            },
-                            "specifier": [
-                                "Cstruct_list"
-                            ],
-                            "typemap_name": "Cstruct_list"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -5248,50 +5337,52 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "left": {
+                                        "name": "nitems"
+                                    },
+                                    "op": "+",
+                                    "right": {
+                                        "name": "nitems"
+                                    }
+                                }
+                            ],
+                            "intent": "getter",
+                            "struct": "Cstruct_list"
+                        },
                         "name": "Cstruct_list_get_ivalue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in",
+                                        "struct": "Cstruct_list"
+                                    },
+                                    "name": "SH_this",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct_list"
+                                },
+                                "specifier": [
+                                    "Cstruct_list"
+                                ],
+                                "typemap_name": "Cstruct_list"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "left": {
-                                    "name": "nitems"
-                                },
-                                "op": "+",
-                                "right": {
-                                    "name": "nitems"
-                                }
-                            }
                         ],
-                        "intent": "getter",
-                        "struct": "Cstruct_list"
+                        "typemap_name": "int"
                     },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "SH_this",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in",
-                                "struct": "Cstruct_list"
-                            },
-                            "specifier": [
-                                "Cstruct_list"
-                            ],
-                            "typemap_name": "Cstruct_list"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -5404,63 +5495,66 @@
                 "_generated": "getter/setter",
                 "ast": {
                     "declarator": {
-                        "name": "Cstruct_list_set_ivalue"
-                    },
-                    "metaattrs": {
-                        "intent": "setter"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "SH_this",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout",
-                                "struct": "Cstruct_list"
-                            },
-                            "specifier": [
-                                "Cstruct_list"
-                            ],
-                            "typemap_name": "Cstruct_list"
+                        "metaattrs": {
+                            "intent": "setter"
                         },
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "val",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "left": {
-                                            "name": "nitems"
-                                        },
-                                        "op": "+",
-                                        "right": {
-                                            "name": "nitems"
+                        "name": "Cstruct_list_set_ivalue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout",
+                                        "struct": "Cstruct_list"
+                                    },
+                                    "name": "SH_this",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
                                         }
-                                    }
+                                    ],
+                                    "typemap_name": "Cstruct_list"
+                                },
+                                "specifier": [
+                                    "Cstruct_list"
                                 ],
-                                "intent": "setter"
+                                "typemap_name": "Cstruct_list"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "left": {
+                                                    "name": "nitems"
+                                                },
+                                                "op": "+",
+                                                "right": {
+                                                    "name": "nitems"
+                                                }
+                                            }
+                                        ],
+                                        "intent": "setter"
+                                    },
+                                    "name": "val",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5588,49 +5682,51 @@
                 "_generated": "getter/setter",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "left": {
+                                        "name": "nitems"
+                                    },
+                                    "op": "*",
+                                    "right": {
+                                        "name": "TWO"
+                                    }
+                                }
+                            ],
+                            "intent": "getter",
+                            "struct": "Cstruct_list"
+                        },
                         "name": "Cstruct_list_get_dvalue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in",
+                                        "struct": "Cstruct_list"
+                                    },
+                                    "name": "SH_this",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct_list"
+                                },
+                                "specifier": [
+                                    "Cstruct_list"
+                                ],
+                                "typemap_name": "Cstruct_list"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "left": {
-                                    "name": "nitems"
-                                },
-                                "op": "*",
-                                "right": {
-                                    "name": "TWO"
-                                }
-                            }
                         ],
-                        "intent": "getter",
-                        "struct": "Cstruct_list"
+                        "typemap_name": "double"
                     },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "SH_this",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in",
-                                "struct": "Cstruct_list"
-                            },
-                            "specifier": [
-                                "Cstruct_list"
-                            ],
-                            "typemap_name": "Cstruct_list"
-                        }
-                    ],
                     "specifier": [
                         "double"
                     ],
@@ -5690,50 +5786,52 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "left": {
+                                        "name": "nitems"
+                                    },
+                                    "op": "*",
+                                    "right": {
+                                        "name": "TWO"
+                                    }
+                                }
+                            ],
+                            "intent": "getter",
+                            "struct": "Cstruct_list"
+                        },
                         "name": "Cstruct_list_get_dvalue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in",
+                                        "struct": "Cstruct_list"
+                                    },
+                                    "name": "SH_this",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct_list"
+                                },
+                                "specifier": [
+                                    "Cstruct_list"
+                                ],
+                                "typemap_name": "Cstruct_list"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "left": {
-                                    "name": "nitems"
-                                },
-                                "op": "*",
-                                "right": {
-                                    "name": "TWO"
-                                }
-                            }
                         ],
-                        "intent": "getter",
-                        "struct": "Cstruct_list"
+                        "typemap_name": "double"
                     },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "SH_this",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in",
-                                "struct": "Cstruct_list"
-                            },
-                            "specifier": [
-                                "Cstruct_list"
-                            ],
-                            "typemap_name": "Cstruct_list"
-                        }
-                    ],
                     "specifier": [
                         "double"
                     ],
@@ -5846,63 +5944,66 @@
                 "_generated": "getter/setter",
                 "ast": {
                     "declarator": {
-                        "name": "Cstruct_list_set_dvalue"
-                    },
-                    "metaattrs": {
-                        "intent": "setter"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "SH_this",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout",
-                                "struct": "Cstruct_list"
-                            },
-                            "specifier": [
-                                "Cstruct_list"
-                            ],
-                            "typemap_name": "Cstruct_list"
+                        "metaattrs": {
+                            "intent": "setter"
                         },
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "val",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "left": {
-                                            "name": "nitems"
-                                        },
-                                        "op": "*",
-                                        "right": {
-                                            "name": "TWO"
+                        "name": "Cstruct_list_set_dvalue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout",
+                                        "struct": "Cstruct_list"
+                                    },
+                                    "name": "SH_this",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
                                         }
-                                    }
+                                    ],
+                                    "typemap_name": "Cstruct_list"
+                                },
+                                "specifier": [
+                                    "Cstruct_list"
                                 ],
-                                "intent": "setter"
+                                "typemap_name": "Cstruct_list"
                             },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "left": {
+                                                    "name": "nitems"
+                                                },
+                                                "op": "*",
+                                                "right": {
+                                                    "name": "TWO"
+                                                }
+                                            }
+                                        ],
+                                        "intent": "setter"
+                                    },
+                                    "name": "val",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],

--- a/regression/reference/struct-c/struct.json
+++ b/regression/reference/struct-c/struct.json
@@ -673,6 +673,7 @@
                         },
                         "decl": "int get_x1()",
                         "declgen": "int get_x1(void)",
+                        "name": "get_x1",
                         "options": {},
                         "user_fmt": {
                             "field_name": "x1",
@@ -782,6 +783,7 @@
                         },
                         "decl": "void set_x1(int val)",
                         "declgen": "void set_x1(int val +intent(in)+value)",
+                        "name": "set_x1",
                         "options": {},
                         "user_fmt": {
                             "field_name": "x1",
@@ -880,6 +882,7 @@
                         },
                         "decl": "int get_y1()",
                         "declgen": "int get_y1(void)",
+                        "name": "get_y1",
                         "options": {},
                         "user_fmt": {
                             "field_name": "y1",
@@ -989,6 +992,7 @@
                         },
                         "decl": "void set_y1(int val)",
                         "declgen": "void set_y1(int val +intent(in)+value)",
+                        "name": "set_y1",
                         "options": {},
                         "user_fmt": {
                             "field_name": "y1",
@@ -1184,6 +1188,7 @@
                         },
                         "decl": "int get_x1()",
                         "declgen": "int get_x1(void)",
+                        "name": "get_x1",
                         "options": {},
                         "user_fmt": {
                             "field_name": "x1",
@@ -1293,6 +1298,7 @@
                         },
                         "decl": "void set_x1(int val)",
                         "declgen": "void set_x1(int val +intent(in)+value)",
+                        "name": "set_x1",
                         "options": {},
                         "user_fmt": {
                             "field_name": "x1",
@@ -1391,6 +1397,7 @@
                         },
                         "decl": "int get_y1()",
                         "declgen": "int get_y1(void)",
+                        "name": "get_y1",
                         "options": {},
                         "user_fmt": {
                             "field_name": "y1",
@@ -1500,6 +1507,7 @@
                         },
                         "decl": "void set_y1(int val)",
                         "declgen": "void set_y1(int val +intent(in)+value)",
+                        "name": "set_y1",
                         "options": {},
                         "user_fmt": {
                             "field_name": "y1",
@@ -1598,6 +1606,7 @@
                         },
                         "decl": "int get_z1()",
                         "declgen": "int get_z1(void)",
+                        "name": "get_z1",
                         "options": {},
                         "user_fmt": {
                             "field_name": "z1",
@@ -1707,6 +1716,7 @@
                         },
                         "decl": "void set_z1(int val)",
                         "declgen": "void set_z1(int val +intent(in)+value)",
+                        "name": "set_z1",
                         "options": {},
                         "user_fmt": {
                             "field_name": "z1",
@@ -1953,6 +1963,7 @@
                 },
                 "decl": "int passStructByValue(Cstruct1 arg)",
                 "declgen": "int passStructByValue(Cstruct1 arg +value)",
+                "name": "passStructByValue",
                 "options": {
                     "literalinclude": true
                 },
@@ -2087,6 +2098,7 @@
                 },
                 "decl": "int passStruct1(const Cstruct1 *arg)",
                 "declgen": "int passStruct1(const Cstruct1 * arg)",
+                "name": "passStruct1",
                 "options": {
                     "literalinclude": true
                 },
@@ -2250,6 +2262,7 @@
                 "doxygen": {
                     "description": "Pass name argument which will build a bufferify function.\n"
                 },
+                "name": "passStruct2",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2434,6 +2447,7 @@
                 "doxygen": {
                     "description": "Pass name argument which will build a bufferify function.\n"
                 },
+                "name": "passStruct2",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -2591,6 +2605,7 @@
                 },
                 "decl": "int acceptStructInPtr(Cstruct1 *arg +intent(in))",
                 "declgen": "int acceptStructInPtr(Cstruct1 * arg +intent(in))",
+                "name": "acceptStructInPtr",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2760,6 +2775,7 @@
                 "doxygen": {
                     "description": "Pass name argument which will build a bufferify function.\n"
                 },
+                "name": "acceptStructOutPtr",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2929,6 +2945,7 @@
                 },
                 "decl": "void acceptStructInOutPtr(Cstruct1 *arg +intent(inout))",
                 "declgen": "void acceptStructInOutPtr(Cstruct1 * arg +intent(inout))",
+                "name": "acceptStructInOutPtr",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3043,6 +3060,7 @@
                 },
                 "decl": "Cstruct1 returnStructByValue(int i, double d);",
                 "declgen": "Cstruct1 returnStructByValue(int i +value, double d +value)",
+                "name": "returnStructByValue",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3235,6 +3253,7 @@
                     "brief": "Return a pointer to a struct",
                     "description": "Does not generate a bufferify C wrapper.\n"
                 },
+                "name": "returnStructPtr1",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3418,6 +3437,7 @@
                     "brief": "Return a pointer to a struct",
                     "description": "Does not generate a bufferify C wrapper.\n"
                 },
+                "name": "returnStructPtr1",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -3620,6 +3640,7 @@
                     "brief": "Return a pointer to a struct",
                     "description": "Generates a bufferify C wrapper function.\n"
                 },
+                "name": "returnStructPtr2",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3855,6 +3876,7 @@
                     "brief": "Return a pointer to a struct",
                     "description": "Generates a bufferify C wrapper function.\n"
                 },
+                "name": "returnStructPtr2",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -4033,6 +4055,7 @@
                 },
                 "decl": "Cstruct_list *get_global_struct_list();",
                 "declgen": "Cstruct_list * get_global_struct_list(void)",
+                "name": "get_global_struct_list",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -4117,6 +4140,7 @@
                 },
                 "decl": "Cstruct_list *get_global_struct_list();",
                 "declgen": "Cstruct_list * get_global_struct_list(void)",
+                "name": "get_global_struct_list",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -4187,6 +4211,7 @@
                 },
                 "decl": "Cstruct_as_class *Create_Cstruct_as_class(void)",
                 "declgen": "Cstruct_as_class * Create_Cstruct_as_class(void)",
+                "name": "Create_Cstruct_as_class",
                 "options": {
                     "class_ctor": "Cstruct_as_class",
                     "literalinclude": true,
@@ -4309,6 +4334,7 @@
                 },
                 "decl": "Cstruct_as_class *Create_Cstruct_as_class_args(int x, int y)",
                 "declgen": "Cstruct_as_class * Create_Cstruct_as_class_args(int x +value, int y +value)",
+                "name": "Create_Cstruct_as_class_args",
                 "options": {
                     "class_ctor": "Cstruct_as_class",
                     "wrap_python": false
@@ -4483,6 +4509,7 @@
                 },
                 "decl": "int Cstruct_as_class_sum(const Cstruct_as_class *point +pass)",
                 "declgen": "int Cstruct_as_class_sum(const Cstruct_as_class * point +pass)",
+                "name": "Cstruct_as_class_sum",
                 "options": {
                     "class_method": "Cstruct_as_class",
                     "wrap_python": false
@@ -4658,6 +4685,7 @@
                 },
                 "decl": "Cstruct_as_subclass *Create_Cstruct_as_subclass_args(int x, int y, int z)",
                 "declgen": "Cstruct_as_subclass * Create_Cstruct_as_subclass_args(int x +value, int y +value, int z +value)",
+                "name": "Create_Cstruct_as_subclass_args",
                 "options": {
                     "class_ctor": "Cstruct_as_subclass",
                     "wrap_python": false
@@ -4876,6 +4904,7 @@
                 },
                 "decl": "const double * Cstruct_ptr_get_const_dvalue(Cstruct_ptr *SH_this)",
                 "declgen": "const double * Cstruct_ptr_get_const_dvalue(Cstruct_ptr * SH_this)",
+                "name": "Cstruct_ptr_get_const_dvalue",
                 "options": {},
                 "user_fmt": {
                     "field_name": "const_dvalue",
@@ -4965,6 +4994,7 @@
                 },
                 "decl": "const double * Cstruct_ptr_get_const_dvalue(Cstruct_ptr *SH_this)",
                 "declgen": "const double * Cstruct_ptr_get_const_dvalue(Cstruct_ptr * SH_this)",
+                "name": "Cstruct_ptr_get_const_dvalue",
                 "options": {},
                 "splicer_group": "buf",
                 "user_fmt": {
@@ -5118,6 +5148,7 @@
                 },
                 "decl": "void Cstruct_ptr_set_const_dvalue(Cstruct_ptr *SH_this,const double * val)",
                 "declgen": "void Cstruct_ptr_set_const_dvalue(Cstruct_ptr * SH_this, const double * val +intent(in))",
+                "name": "Cstruct_ptr_set_const_dvalue",
                 "options": {},
                 "user_fmt": {
                     "field_name": "const_dvalue",
@@ -5285,6 +5316,7 @@
                 },
                 "decl": "int * Cstruct_list_get_ivalue(Cstruct_list *SH_this)",
                 "declgen": "int * Cstruct_list_get_ivalue(Cstruct_list * SH_this)",
+                "name": "Cstruct_list_get_ivalue",
                 "options": {},
                 "user_fmt": {
                     "field_name": "ivalue",
@@ -5390,6 +5422,7 @@
                 },
                 "decl": "int * Cstruct_list_get_ivalue(Cstruct_list *SH_this)",
                 "declgen": "int * Cstruct_list_get_ivalue(Cstruct_list * SH_this)",
+                "name": "Cstruct_list_get_ivalue",
                 "options": {},
                 "splicer_group": "buf",
                 "user_fmt": {
@@ -5562,6 +5595,7 @@
                 },
                 "decl": "void Cstruct_list_set_ivalue(Cstruct_list *SH_this,int * val)",
                 "declgen": "void Cstruct_list_set_ivalue(Cstruct_list * SH_this, int * val +intent(in)+rank(1))",
+                "name": "Cstruct_list_set_ivalue",
                 "options": {},
                 "user_fmt": {
                     "field_name": "ivalue",
@@ -5734,6 +5768,7 @@
                 },
                 "decl": "double * Cstruct_list_get_dvalue(Cstruct_list *SH_this)",
                 "declgen": "double * Cstruct_list_get_dvalue(Cstruct_list * SH_this)",
+                "name": "Cstruct_list_get_dvalue",
                 "options": {},
                 "user_fmt": {
                     "field_name": "dvalue",
@@ -5839,6 +5874,7 @@
                 },
                 "decl": "double * Cstruct_list_get_dvalue(Cstruct_list *SH_this)",
                 "declgen": "double * Cstruct_list_get_dvalue(Cstruct_list * SH_this)",
+                "name": "Cstruct_list_get_dvalue",
                 "options": {},
                 "splicer_group": "buf",
                 "user_fmt": {
@@ -6011,6 +6047,7 @@
                 },
                 "decl": "void Cstruct_list_set_dvalue(Cstruct_list *SH_this,double * val)",
                 "declgen": "void Cstruct_list_set_dvalue(Cstruct_list * SH_this, double * val +intent(in)+rank(1))",
+                "name": "Cstruct_list_set_dvalue",
                 "options": {},
                 "user_fmt": {
                     "field_name": "dvalue",

--- a/regression/reference/struct-class-c/struct.json
+++ b/regression/reference/struct-class-c/struct.json
@@ -23,6 +23,7 @@
                                 "_constructor": true,
                                 "name": "Cstruct1_ctor"
                             },
+                            "declarator": {},
                             "metaattrs": {
                                 "intent": "ctor"
                             },
@@ -258,6 +259,7 @@
                                 "_constructor": true,
                                 "name": "Cstruct_ptr_ctor"
                             },
+                            "declarator": {},
                             "metaattrs": {
                                 "intent": "ctor"
                             },
@@ -525,6 +527,7 @@
                                 "_constructor": true,
                                 "name": "Cstruct_list_ctor"
                             },
+                            "declarator": {},
                             "metaattrs": {
                                 "intent": "ctor"
                             },
@@ -1035,6 +1038,7 @@
                                 "_constructor": true,
                                 "name": "Cstruct_numpy_ctor"
                             },
+                            "declarator": {},
                             "metaattrs": {
                                 "intent": "ctor"
                             },
@@ -1413,6 +1417,7 @@
                                 "_constructor": true,
                                 "name": "Arrays1_ctor"
                             },
+                            "declarator": {},
                             "metaattrs": {
                                 "intent": "ctor"
                             },

--- a/regression/reference/struct-class-c/struct.json
+++ b/regression/reference/struct-class-c/struct.json
@@ -20,6 +20,13 @@
                         "_generated": "struct_as_class_ctor",
                         "ast": {
                             "declarator": {
+                                "attrs": {
+                                    "_constructor": true,
+                                    "name": "Cstruct1_ctor"
+                                },
+                                "metaattrs": {
+                                    "intent": "ctor"
+                                },
                                 "typemap_name": "Cstruct1"
                             },
                             "specifier": [
@@ -225,6 +232,13 @@
                         "_generated": "struct_as_class_ctor",
                         "ast": {
                             "declarator": {
+                                "attrs": {
+                                    "_constructor": true,
+                                    "name": "Cstruct_ptr_ctor"
+                                },
+                                "metaattrs": {
+                                    "intent": "ctor"
+                                },
                                 "typemap_name": "Cstruct_ptr"
                             },
                             "specifier": [
@@ -451,6 +465,13 @@
                         "_generated": "struct_as_class_ctor",
                         "ast": {
                             "declarator": {
+                                "attrs": {
+                                    "_constructor": true,
+                                    "name": "Cstruct_list_ctor"
+                                },
+                                "metaattrs": {
+                                    "intent": "ctor"
+                                },
                                 "typemap_name": "Cstruct_list"
                             },
                             "specifier": [
@@ -853,6 +874,13 @@
                         "_generated": "struct_as_class_ctor",
                         "ast": {
                             "declarator": {
+                                "attrs": {
+                                    "_constructor": true,
+                                    "name": "Cstruct_numpy_ctor"
+                                },
+                                "metaattrs": {
+                                    "intent": "ctor"
+                                },
                                 "typemap_name": "Cstruct_numpy"
                             },
                             "specifier": [
@@ -1163,6 +1191,13 @@
                         "_generated": "struct_as_class_ctor",
                         "ast": {
                             "declarator": {
+                                "attrs": {
+                                    "_constructor": true,
+                                    "name": "Arrays1_ctor"
+                                },
+                                "metaattrs": {
+                                    "intent": "ctor"
+                                },
                                 "typemap_name": "Arrays1"
                             },
                             "specifier": [

--- a/regression/reference/struct-class-c/struct.json
+++ b/regression/reference/struct-class-c/struct.json
@@ -19,42 +19,9 @@
                         "<FUNCTION>": "0 ****************************************",
                         "_generated": "struct_as_class_ctor",
                         "ast": {
-                            "attrs": {
-                                "_constructor": true,
-                                "name": "Cstruct1_ctor"
+                            "declarator": {
+                                "typemap_name": "Cstruct1"
                             },
-                            "declarator": {},
-                            "metaattrs": {
-                                "intent": "ctor"
-                            },
-                            "params": [
-                                {
-                                    "declarator": {
-                                        "name": "ifield"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in",
-                                        "struct_member": "ifield"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                },
-                                {
-                                    "declarator": {
-                                        "name": "dfield"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in",
-                                        "struct_member": "dfield"
-                                    },
-                                    "specifier": [
-                                        "double"
-                                    ],
-                                    "typemap_name": "double"
-                                }
-                            ],
                             "specifier": [
                                 "Cstruct1"
                             ],
@@ -164,7 +131,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "ifield"
+                                "name": "ifield",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -192,7 +160,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "dfield"
+                                "name": "dfield",
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -255,53 +224,9 @@
                         "<FUNCTION>": "1 ****************************************",
                         "_generated": "struct_as_class_ctor",
                         "ast": {
-                            "attrs": {
-                                "_constructor": true,
-                                "name": "Cstruct_ptr_ctor"
+                            "declarator": {
+                                "typemap_name": "Cstruct_ptr"
                             },
-                            "declarator": {},
-                            "metaattrs": {
-                                "intent": "ctor"
-                            },
-                            "params": [
-                                {
-                                    "declarator": {
-                                        "name": "cfield",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in",
-                                        "struct_member": "cfield"
-                                    },
-                                    "specifier": [
-                                        "char"
-                                    ],
-                                    "typemap_name": "char"
-                                },
-                                {
-                                    "const": true,
-                                    "declarator": {
-                                        "name": "const_dvalue",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in",
-                                        "struct_member": "const_dvalue"
-                                    },
-                                    "specifier": [
-                                        "double"
-                                    ],
-                                    "typemap_name": "double"
-                                }
-                            ],
                             "specifier": [
                                 "Cstruct_ptr"
                             ],
@@ -420,7 +345,8 @@
                                     {
                                         "ptr": "*"
                                     }
-                                ]
+                                ],
+                                "typemap_name": "char"
                             },
                             "specifier": [
                                 "char"
@@ -457,7 +383,8 @@
                                     {
                                         "ptr": "*"
                                     }
-                                ]
+                                ],
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -523,122 +450,9 @@
                         "<FUNCTION>": "2 ****************************************",
                         "_generated": "struct_as_class_ctor",
                         "ast": {
-                            "attrs": {
-                                "_constructor": true,
-                                "name": "Cstruct_list_ctor"
+                            "declarator": {
+                                "typemap_name": "Cstruct_list"
                             },
-                            "declarator": {},
-                            "metaattrs": {
-                                "intent": "ctor"
-                            },
-                            "params": [
-                                {
-                                    "declarator": {
-                                        "name": "nitems"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in",
-                                        "struct_member": "nitems"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                },
-                                {
-                                    "attrs": {
-                                        "dimension": "nitems+nitems"
-                                    },
-                                    "declarator": {
-                                        "name": "ivalue",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "dimension": [
-                                            {
-                                                "left": {
-                                                    "name": "nitems"
-                                                },
-                                                "op": "+",
-                                                "right": {
-                                                    "name": "nitems"
-                                                }
-                                            }
-                                        ],
-                                        "intent": "in",
-                                        "struct_member": "ivalue"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                },
-                                {
-                                    "attrs": {
-                                        "dimension": "nitems*TWO"
-                                    },
-                                    "declarator": {
-                                        "name": "dvalue",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "dimension": [
-                                            {
-                                                "left": {
-                                                    "name": "nitems"
-                                                },
-                                                "op": "*",
-                                                "right": {
-                                                    "name": "TWO"
-                                                }
-                                            }
-                                        ],
-                                        "intent": "in",
-                                        "struct_member": "dvalue"
-                                    },
-                                    "specifier": [
-                                        "double"
-                                    ],
-                                    "typemap_name": "double"
-                                },
-                                {
-                                    "attrs": {
-                                        "dimension": "nitems"
-                                    },
-                                    "declarator": {
-                                        "name": "svalue",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            },
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "dimension": [
-                                            {
-                                                "name": "nitems"
-                                            }
-                                        ],
-                                        "intent": "in",
-                                        "struct_member": "svalue"
-                                    },
-                                    "specifier": [
-                                        "char"
-                                    ],
-                                    "typemap_name": "char"
-                                }
-                            ],
                             "specifier": [
                                 "Cstruct_list"
                             ],
@@ -818,7 +632,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "nitems"
+                                "name": "nitems",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -845,29 +660,30 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems+nitems"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems+nitems"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "left": {
+                                                "name": "nitems"
+                                            },
+                                            "op": "+",
+                                            "right": {
+                                                "name": "nitems"
+                                            }
+                                        }
+                                    ]
+                                },
                                 "name": "ivalue",
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "left": {
-                                            "name": "nitems"
-                                        },
-                                        "op": "+",
-                                        "right": {
-                                            "name": "nitems"
-                                        }
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -897,29 +713,30 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems*TWO"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems*TWO"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "left": {
+                                                "name": "nitems"
+                                            },
+                                            "op": "*",
+                                            "right": {
+                                                "name": "TWO"
+                                            }
+                                        }
+                                    ]
+                                },
                                 "name": "dvalue",
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "left": {
-                                            "name": "nitems"
-                                        },
-                                        "op": "*",
-                                        "right": {
-                                            "name": "TWO"
-                                        }
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -949,10 +766,17 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "name": "nitems"
+                                        }
+                                    ]
+                                },
                                 "name": "svalue",
                                 "pointer": [
                                     {
@@ -961,14 +785,8 @@
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nitems"
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "char"
                             },
                             "specifier": [
                                 "char"
@@ -1034,81 +852,9 @@
                         "<FUNCTION>": "3 ****************************************",
                         "_generated": "struct_as_class_ctor",
                         "ast": {
-                            "attrs": {
-                                "_constructor": true,
-                                "name": "Cstruct_numpy_ctor"
+                            "declarator": {
+                                "typemap_name": "Cstruct_numpy"
                             },
-                            "declarator": {},
-                            "metaattrs": {
-                                "intent": "ctor"
-                            },
-                            "params": [
-                                {
-                                    "declarator": {
-                                        "name": "nitems"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in",
-                                        "struct_member": "nitems"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                },
-                                {
-                                    "attrs": {
-                                        "dimension": "nitems"
-                                    },
-                                    "declarator": {
-                                        "name": "ivalue",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "dimension": [
-                                            {
-                                                "name": "nitems"
-                                            }
-                                        ],
-                                        "intent": "in",
-                                        "struct_member": "ivalue"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                },
-                                {
-                                    "attrs": {
-                                        "dimension": "nitems"
-                                    },
-                                    "declarator": {
-                                        "name": "dvalue",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "dimension": [
-                                            {
-                                                "name": "nitems"
-                                            }
-                                        ],
-                                        "intent": "in",
-                                        "struct_member": "dvalue"
-                                    },
-                                    "specifier": [
-                                        "double"
-                                    ],
-                                    "typemap_name": "double"
-                                }
-                            ],
                             "specifier": [
                                 "Cstruct_numpy"
                             ],
@@ -1258,7 +1004,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "nitems"
+                                "name": "nitems",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -1285,23 +1032,24 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "name": "nitems"
+                                        }
+                                    ]
+                                },
                                 "name": "ivalue",
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nitems"
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -1331,23 +1079,24 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "name": "nitems"
+                                        }
+                                    ]
+                                },
                                 "name": "dvalue",
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nitems"
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -1413,52 +1162,9 @@
                         "<FUNCTION>": "4 ****************************************",
                         "_generated": "struct_as_class_ctor",
                         "ast": {
-                            "attrs": {
-                                "_constructor": true,
-                                "name": "Arrays1_ctor"
+                            "declarator": {
+                                "typemap_name": "Arrays1"
                             },
-                            "declarator": {},
-                            "metaattrs": {
-                                "intent": "ctor"
-                            },
-                            "params": [
-                                {
-                                    "array": [
-                                        {
-                                            "constant": "20"
-                                        }
-                                    ],
-                                    "declarator": {
-                                        "name": "name"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in",
-                                        "struct_member": "name"
-                                    },
-                                    "specifier": [
-                                        "char"
-                                    ],
-                                    "typemap_name": "char"
-                                },
-                                {
-                                    "array": [
-                                        {
-                                            "constant": "10"
-                                        }
-                                    ],
-                                    "declarator": {
-                                        "name": "count"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in",
-                                        "struct_member": "count"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
                             "specifier": [
                                 "Arrays1"
                             ],
@@ -1573,13 +1279,14 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "array": [
-                                {
-                                    "constant": "20"
-                                }
-                            ],
                             "declarator": {
-                                "name": "name"
+                                "array": [
+                                    {
+                                        "constant": "20"
+                                    }
+                                ],
+                                "name": "name",
+                                "typemap_name": "char"
                             },
                             "specifier": [
                                 "char"
@@ -1609,13 +1316,14 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "array": [
-                                {
-                                    "constant": "10"
-                                }
-                            ],
                             "declarator": {
-                                "name": "count"
+                                "array": [
+                                    {
+                                        "constant": "10"
+                                    }
+                                ],
+                                "name": "count",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -1690,7 +1398,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "x1"
+                                "name": "x1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -1713,7 +1422,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "y1"
+                                "name": "y1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -1772,7 +1482,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "x1"
+                                "name": "x1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -1795,7 +1506,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "y1"
+                                "name": "y1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -1818,7 +1530,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "z1"
+                                "name": "z1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -1876,28 +1589,30 @@
                 "<FUNCTION>": "5 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passStructByValue"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "passStructByValue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -1968,31 +1683,33 @@
                 "<FUNCTION>": "6 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passStruct1"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "passStruct1",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -2064,52 +1781,55 @@
                 "<FUNCTION>": "7 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passStruct2"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "s1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "charlen": "LENOUTBUF",
-                                "intent": "out"
+                        "name": "passStruct2",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "s1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
                             },
-                            "declarator": {
-                                "name": "outbuf",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "charlen": "LENOUTBUF",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "outbuf",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -2205,33 +1925,35 @@
                 "<FUNCTION>": "8 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStructInPtr"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "acceptStructInPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -2301,63 +2023,67 @@
                 "<FUNCTION>": "9 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStructOutPtr"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "acceptStructOutPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
                             },
-                            "declarator": {
-                                "name": "i"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2452,33 +2178,35 @@
                 "<FUNCTION>": "10 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStructInOutPtr"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptStructInOutPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -2529,43 +2257,46 @@
                 "<FUNCTION>": "11 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "returnStructByValue"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "returnStructByValue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "Cstruct1"
+                    },
                     "specifier": [
                         "Cstruct1"
                     ],
@@ -2657,49 +2388,52 @@
                 "<FUNCTION>": "12 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnStructPtr1",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct1"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct1"
                     ],
@@ -2793,70 +2527,74 @@
                 "<FUNCTION>": "13 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnStructPtr2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "charlen": "LENOUTBUF",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "outbuf",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct1"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        },
-                        {
-                            "attrs": {
-                                "charlen": "LENOUTBUF",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "outbuf",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct1"
                     ],
@@ -2973,18 +2711,19 @@
                 "<FUNCTION>": "14 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "get_global_struct_list",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct_list"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "Cstruct_list"
                     ],
@@ -3030,18 +2769,19 @@
                 "<FUNCTION>": "15 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
                         "name": "Create_Cstruct_as_class",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct_as_class"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "Cstruct_as_class"
                     ],
@@ -3064,49 +2804,52 @@
                 "<FUNCTION>": "16 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
                         "name": "Create_Cstruct_as_class_args",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "x",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "y",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct_as_class"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "x"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "y"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct_as_class"
                     ],
@@ -3128,34 +2871,36 @@
                 "<FUNCTION>": "17 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "Cstruct_as_class_sum"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "Cstruct_as_class_sum",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "pass": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "point",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct_as_class"
+                                },
+                                "specifier": [
+                                    "Cstruct_as_class"
+                                ],
+                                "typemap_name": "Cstruct_as_class"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "pass": true
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "point",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct_as_class"
-                            ],
-                            "typemap_name": "Cstruct_as_class"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -3181,64 +2926,68 @@
                 "<FUNCTION>": "18 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
                         "name": "Create_Cstruct_as_subclass_args",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "x",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "y",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "z",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct_as_subclass"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "x"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "y"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "z"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct_as_subclass"
                     ],

--- a/regression/reference/struct-class-c/struct.json
+++ b/regression/reference/struct-class-c/struct.json
@@ -27,6 +27,36 @@
                                 "metaattrs": {
                                     "intent": "ctor"
                                 },
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "metaattrs": {
+                                                "intent": "in",
+                                                "struct_member": "ifield"
+                                            },
+                                            "name": "ifield",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    },
+                                    {
+                                        "declarator": {
+                                            "metaattrs": {
+                                                "intent": "in",
+                                                "struct_member": "dfield"
+                                            },
+                                            "name": "dfield",
+                                            "typemap_name": "double"
+                                        },
+                                        "specifier": [
+                                            "double"
+                                        ],
+                                        "typemap_name": "double"
+                                    }
+                                ],
                                 "typemap_name": "Cstruct1"
                             },
                             "specifier": [
@@ -239,6 +269,47 @@
                                 "metaattrs": {
                                     "intent": "ctor"
                                 },
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "metaattrs": {
+                                                "intent": "in",
+                                                "struct_member": "cfield"
+                                            },
+                                            "name": "cfield",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "char"
+                                        },
+                                        "specifier": [
+                                            "char"
+                                        ],
+                                        "typemap_name": "char"
+                                    },
+                                    {
+                                        "const": true,
+                                        "declarator": {
+                                            "metaattrs": {
+                                                "intent": "in",
+                                                "struct_member": "const_dvalue"
+                                            },
+                                            "name": "const_dvalue",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "double"
+                                        },
+                                        "specifier": [
+                                            "double"
+                                        ],
+                                        "typemap_name": "double"
+                                    }
+                                ],
                                 "typemap_name": "Cstruct_ptr"
                             },
                             "specifier": [
@@ -472,6 +543,118 @@
                                 "metaattrs": {
                                     "intent": "ctor"
                                 },
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "metaattrs": {
+                                                "intent": "in",
+                                                "struct_member": "nitems"
+                                            },
+                                            "name": "nitems",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    },
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "dimension": "nitems+nitems"
+                                            },
+                                            "metaattrs": {
+                                                "dimension": [
+                                                    {
+                                                        "left": {
+                                                            "name": "nitems"
+                                                        },
+                                                        "op": "+",
+                                                        "right": {
+                                                            "name": "nitems"
+                                                        }
+                                                    }
+                                                ],
+                                                "intent": "in",
+                                                "struct_member": "ivalue"
+                                            },
+                                            "name": "ivalue",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    },
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "dimension": "nitems*TWO"
+                                            },
+                                            "metaattrs": {
+                                                "dimension": [
+                                                    {
+                                                        "left": {
+                                                            "name": "nitems"
+                                                        },
+                                                        "op": "*",
+                                                        "right": {
+                                                            "name": "TWO"
+                                                        }
+                                                    }
+                                                ],
+                                                "intent": "in",
+                                                "struct_member": "dvalue"
+                                            },
+                                            "name": "dvalue",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "double"
+                                        },
+                                        "specifier": [
+                                            "double"
+                                        ],
+                                        "typemap_name": "double"
+                                    },
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "dimension": "nitems"
+                                            },
+                                            "metaattrs": {
+                                                "dimension": [
+                                                    {
+                                                        "name": "nitems"
+                                                    }
+                                                ],
+                                                "intent": "in",
+                                                "struct_member": "svalue"
+                                            },
+                                            "name": "svalue",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                },
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "char"
+                                        },
+                                        "specifier": [
+                                            "char"
+                                        ],
+                                        "typemap_name": "char"
+                                    }
+                                ],
                                 "typemap_name": "Cstruct_list"
                             },
                             "specifier": [
@@ -881,6 +1064,76 @@
                                 "metaattrs": {
                                     "intent": "ctor"
                                 },
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "metaattrs": {
+                                                "intent": "in",
+                                                "struct_member": "nitems"
+                                            },
+                                            "name": "nitems",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    },
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "dimension": "nitems"
+                                            },
+                                            "metaattrs": {
+                                                "dimension": [
+                                                    {
+                                                        "name": "nitems"
+                                                    }
+                                                ],
+                                                "intent": "in",
+                                                "struct_member": "ivalue"
+                                            },
+                                            "name": "ivalue",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    },
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "dimension": "nitems"
+                                            },
+                                            "metaattrs": {
+                                                "dimension": [
+                                                    {
+                                                        "name": "nitems"
+                                                    }
+                                                ],
+                                                "intent": "in",
+                                                "struct_member": "dvalue"
+                                            },
+                                            "name": "dvalue",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "double"
+                                        },
+                                        "specifier": [
+                                            "double"
+                                        ],
+                                        "typemap_name": "double"
+                                    }
+                                ],
                                 "typemap_name": "Cstruct_numpy"
                             },
                             "specifier": [
@@ -1198,6 +1451,46 @@
                                 "metaattrs": {
                                     "intent": "ctor"
                                 },
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "array": [
+                                                {
+                                                    "constant": "20"
+                                                }
+                                            ],
+                                            "metaattrs": {
+                                                "intent": "in",
+                                                "struct_member": "name"
+                                            },
+                                            "name": "name",
+                                            "typemap_name": "char"
+                                        },
+                                        "specifier": [
+                                            "char"
+                                        ],
+                                        "typemap_name": "char"
+                                    },
+                                    {
+                                        "declarator": {
+                                            "array": [
+                                                {
+                                                    "constant": "10"
+                                                }
+                                            ],
+                                            "metaattrs": {
+                                                "intent": "in",
+                                                "struct_member": "count"
+                                            },
+                                            "name": "count",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
                                 "typemap_name": "Arrays1"
                             },
                             "specifier": [

--- a/regression/reference/struct-class-c/struct.json
+++ b/regression/reference/struct-class-c/struct.json
@@ -59,6 +59,7 @@
                                 ],
                                 "typemap_name": "Cstruct1"
                             },
+                            "is_ctor": true,
                             "specifier": [
                                 "Cstruct1"
                             ],
@@ -313,6 +314,7 @@
                                 ],
                                 "typemap_name": "Cstruct_ptr"
                             },
+                            "is_ctor": true,
                             "specifier": [
                                 "Cstruct_ptr"
                             ],
@@ -659,6 +661,7 @@
                                 ],
                                 "typemap_name": "Cstruct_list"
                             },
+                            "is_ctor": true,
                             "specifier": [
                                 "Cstruct_list"
                             ],
@@ -1139,6 +1142,7 @@
                                 ],
                                 "typemap_name": "Cstruct_numpy"
                             },
+                            "is_ctor": true,
                             "specifier": [
                                 "Cstruct_numpy"
                             ],
@@ -1497,6 +1501,7 @@
                                 ],
                                 "typemap_name": "Arrays1"
                             },
+                            "is_ctor": true,
                             "specifier": [
                                 "Arrays1"
                             ],

--- a/regression/reference/struct-class-c/struct.json
+++ b/regression/reference/struct-class-c/struct.json
@@ -66,6 +66,7 @@
                         },
                         "decl": "Cstruct1_ctor",
                         "declgen": "Cstruct1(int ifield, double dfield) +name(Cstruct1_ctor)",
+                        "name": "Cstruct1_ctor",
                         "options": {
                             "wrap_c": false,
                             "wrap_fortran": false,
@@ -319,6 +320,7 @@
                         },
                         "decl": "Cstruct_ptr_ctor",
                         "declgen": "Cstruct_ptr(char * cfield, const double * const_dvalue) +name(Cstruct_ptr_ctor)",
+                        "name": "Cstruct_ptr_ctor",
                         "options": {
                             "wrap_c": false,
                             "wrap_fortran": false,
@@ -664,6 +666,7 @@
                         },
                         "decl": "Cstruct_list_ctor",
                         "declgen": "Cstruct_list(int nitems, int * ivalue +dimension(nitems+nitems), double * dvalue +dimension(nitems*TWO), char * * svalue +dimension(nitems)) +name(Cstruct_list_ctor)",
+                        "name": "Cstruct_list_ctor",
                         "options": {
                             "wrap_c": false,
                             "wrap_fortran": false,
@@ -1143,6 +1146,7 @@
                         },
                         "decl": "Cstruct_numpy_ctor",
                         "declgen": "Cstruct_numpy(int nitems, int * ivalue +dimension(nitems), double * dvalue +dimension(nitems)) +name(Cstruct_numpy_ctor)",
+                        "name": "Cstruct_numpy_ctor",
                         "options": {
                             "wrap_c": false,
                             "wrap_fortran": false,
@@ -1500,6 +1504,7 @@
                         },
                         "decl": "Arrays1_ctor",
                         "declgen": "Arrays1(char name[20], int count[10]) +name(Arrays1_ctor)",
+                        "name": "Arrays1_ctor",
                         "options": {
                             "wrap_c": false,
                             "wrap_fortran": false,
@@ -1948,6 +1953,7 @@
                 },
                 "decl": "int passStructByValue(Cstruct1 arg)",
                 "declgen": "int passStructByValue(Cstruct1 arg +value)",
+                "name": "passStructByValue",
                 "options": {
                     "literalinclude": true
                 },
@@ -2045,6 +2051,7 @@
                 },
                 "decl": "int passStruct1(const Cstruct1 *arg)",
                 "declgen": "int passStruct1(const Cstruct1 * arg)",
+                "name": "passStruct1",
                 "options": {
                     "literalinclude": true
                 },
@@ -2168,6 +2175,7 @@
                 "doxygen": {
                     "description": "Pass name argument which will build a bufferify function.\n"
                 },
+                "name": "passStruct2",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2289,6 +2297,7 @@
                 },
                 "decl": "int acceptStructInPtr(Cstruct1 *arg +intent(in))",
                 "declgen": "int acceptStructInPtr(Cstruct1 * arg +intent(in))",
+                "name": "acceptStructInPtr",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2422,6 +2431,7 @@
                 "doxygen": {
                     "description": "Pass name argument which will build a bufferify function.\n"
                 },
+                "name": "acceptStructOutPtr",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2542,6 +2552,7 @@
                 },
                 "decl": "void acceptStructInOutPtr(Cstruct1 *arg +intent(inout))",
                 "declgen": "void acceptStructInOutPtr(Cstruct1 * arg +intent(inout))",
+                "name": "acceptStructInOutPtr",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2632,6 +2643,7 @@
                 },
                 "decl": "Cstruct1 returnStructByValue(int i, double d);",
                 "declgen": "Cstruct1 returnStructByValue(int i +value, double d +value)",
+                "name": "returnStructByValue",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2773,6 +2785,7 @@
                     "brief": "Return a pointer to a struct",
                     "description": "Does not generate a bufferify C wrapper.\n"
                 },
+                "name": "returnStructPtr1",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2934,6 +2947,7 @@
                     "brief": "Return a pointer to a struct",
                     "description": "Generates a bufferify C wrapper function.\n"
                 },
+                "name": "returnStructPtr2",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3059,6 +3073,7 @@
                 },
                 "decl": "Cstruct_list *get_global_struct_list();",
                 "declgen": "Cstruct_list * get_global_struct_list(void)",
+                "name": "get_global_struct_list",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3117,6 +3132,7 @@
                 },
                 "decl": "Cstruct_as_class *Create_Cstruct_as_class(void)",
                 "declgen": "Cstruct_as_class * Create_Cstruct_as_class(void)",
+                "name": "Create_Cstruct_as_class",
                 "options": {
                     "class_ctor": "Cstruct_as_class",
                     "literalinclude": true,
@@ -3185,6 +3201,7 @@
                 },
                 "decl": "Cstruct_as_class *Create_Cstruct_as_class_args(int x, int y)",
                 "declgen": "Cstruct_as_class * Create_Cstruct_as_class_args(int x +value, int y +value)",
+                "name": "Create_Cstruct_as_class_args",
                 "options": {
                     "class_ctor": "Cstruct_as_class",
                     "wrap_python": false
@@ -3236,6 +3253,7 @@
                 },
                 "decl": "int Cstruct_as_class_sum(const Cstruct_as_class *point +pass)",
                 "declgen": "int Cstruct_as_class_sum(const Cstruct_as_class * point +pass)",
+                "name": "Cstruct_as_class_sum",
                 "options": {
                     "class_method": "Cstruct_as_class",
                     "wrap_python": false
@@ -3323,6 +3341,7 @@
                 },
                 "decl": "Cstruct_as_subclass *Create_Cstruct_as_subclass_args(int x, int y, int z)",
                 "declgen": "Cstruct_as_subclass * Create_Cstruct_as_subclass_args(int x +value, int y +value, int z +value)",
+                "name": "Create_Cstruct_as_subclass_args",
                 "options": {
                     "class_ctor": "Cstruct_as_subclass",
                     "wrap_python": false

--- a/regression/reference/struct-class-cxx/struct.json
+++ b/regression/reference/struct-class-cxx/struct.json
@@ -23,6 +23,7 @@
                                 "_constructor": true,
                                 "name": "Cstruct1_ctor"
                             },
+                            "declarator": {},
                             "metaattrs": {
                                 "intent": "ctor"
                             },
@@ -258,6 +259,7 @@
                                 "_constructor": true,
                                 "name": "Cstruct_ptr_ctor"
                             },
+                            "declarator": {},
                             "metaattrs": {
                                 "intent": "ctor"
                             },
@@ -525,6 +527,7 @@
                                 "_constructor": true,
                                 "name": "Cstruct_list_ctor"
                             },
+                            "declarator": {},
                             "metaattrs": {
                                 "intent": "ctor"
                             },
@@ -1035,6 +1038,7 @@
                                 "_constructor": true,
                                 "name": "Cstruct_numpy_ctor"
                             },
+                            "declarator": {},
                             "metaattrs": {
                                 "intent": "ctor"
                             },
@@ -1413,6 +1417,7 @@
                                 "_constructor": true,
                                 "name": "Arrays1_ctor"
                             },
+                            "declarator": {},
                             "metaattrs": {
                                 "intent": "ctor"
                             },

--- a/regression/reference/struct-class-cxx/struct.json
+++ b/regression/reference/struct-class-cxx/struct.json
@@ -20,6 +20,13 @@
                         "_generated": "struct_as_class_ctor",
                         "ast": {
                             "declarator": {
+                                "attrs": {
+                                    "_constructor": true,
+                                    "name": "Cstruct1_ctor"
+                                },
+                                "metaattrs": {
+                                    "intent": "ctor"
+                                },
                                 "typemap_name": "Cstruct1"
                             },
                             "specifier": [
@@ -225,6 +232,13 @@
                         "_generated": "struct_as_class_ctor",
                         "ast": {
                             "declarator": {
+                                "attrs": {
+                                    "_constructor": true,
+                                    "name": "Cstruct_ptr_ctor"
+                                },
+                                "metaattrs": {
+                                    "intent": "ctor"
+                                },
                                 "typemap_name": "Cstruct_ptr"
                             },
                             "specifier": [
@@ -451,6 +465,13 @@
                         "_generated": "struct_as_class_ctor",
                         "ast": {
                             "declarator": {
+                                "attrs": {
+                                    "_constructor": true,
+                                    "name": "Cstruct_list_ctor"
+                                },
+                                "metaattrs": {
+                                    "intent": "ctor"
+                                },
                                 "typemap_name": "Cstruct_list"
                             },
                             "specifier": [
@@ -853,6 +874,13 @@
                         "_generated": "struct_as_class_ctor",
                         "ast": {
                             "declarator": {
+                                "attrs": {
+                                    "_constructor": true,
+                                    "name": "Cstruct_numpy_ctor"
+                                },
+                                "metaattrs": {
+                                    "intent": "ctor"
+                                },
                                 "typemap_name": "Cstruct_numpy"
                             },
                             "specifier": [
@@ -1163,6 +1191,13 @@
                         "_generated": "struct_as_class_ctor",
                         "ast": {
                             "declarator": {
+                                "attrs": {
+                                    "_constructor": true,
+                                    "name": "Arrays1_ctor"
+                                },
+                                "metaattrs": {
+                                    "intent": "ctor"
+                                },
                                 "typemap_name": "Arrays1"
                             },
                             "specifier": [

--- a/regression/reference/struct-class-cxx/struct.json
+++ b/regression/reference/struct-class-cxx/struct.json
@@ -19,42 +19,9 @@
                         "<FUNCTION>": "0 ****************************************",
                         "_generated": "struct_as_class_ctor",
                         "ast": {
-                            "attrs": {
-                                "_constructor": true,
-                                "name": "Cstruct1_ctor"
+                            "declarator": {
+                                "typemap_name": "Cstruct1"
                             },
-                            "declarator": {},
-                            "metaattrs": {
-                                "intent": "ctor"
-                            },
-                            "params": [
-                                {
-                                    "declarator": {
-                                        "name": "ifield"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in",
-                                        "struct_member": "ifield"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                },
-                                {
-                                    "declarator": {
-                                        "name": "dfield"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in",
-                                        "struct_member": "dfield"
-                                    },
-                                    "specifier": [
-                                        "double"
-                                    ],
-                                    "typemap_name": "double"
-                                }
-                            ],
                             "specifier": [
                                 "Cstruct1"
                             ],
@@ -164,7 +131,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "ifield"
+                                "name": "ifield",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -192,7 +160,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "dfield"
+                                "name": "dfield",
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -255,53 +224,9 @@
                         "<FUNCTION>": "1 ****************************************",
                         "_generated": "struct_as_class_ctor",
                         "ast": {
-                            "attrs": {
-                                "_constructor": true,
-                                "name": "Cstruct_ptr_ctor"
+                            "declarator": {
+                                "typemap_name": "Cstruct_ptr"
                             },
-                            "declarator": {},
-                            "metaattrs": {
-                                "intent": "ctor"
-                            },
-                            "params": [
-                                {
-                                    "declarator": {
-                                        "name": "cfield",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in",
-                                        "struct_member": "cfield"
-                                    },
-                                    "specifier": [
-                                        "char"
-                                    ],
-                                    "typemap_name": "char"
-                                },
-                                {
-                                    "const": true,
-                                    "declarator": {
-                                        "name": "const_dvalue",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in",
-                                        "struct_member": "const_dvalue"
-                                    },
-                                    "specifier": [
-                                        "double"
-                                    ],
-                                    "typemap_name": "double"
-                                }
-                            ],
                             "specifier": [
                                 "Cstruct_ptr"
                             ],
@@ -420,7 +345,8 @@
                                     {
                                         "ptr": "*"
                                     }
-                                ]
+                                ],
+                                "typemap_name": "char"
                             },
                             "specifier": [
                                 "char"
@@ -457,7 +383,8 @@
                                     {
                                         "ptr": "*"
                                     }
-                                ]
+                                ],
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -523,122 +450,9 @@
                         "<FUNCTION>": "2 ****************************************",
                         "_generated": "struct_as_class_ctor",
                         "ast": {
-                            "attrs": {
-                                "_constructor": true,
-                                "name": "Cstruct_list_ctor"
+                            "declarator": {
+                                "typemap_name": "Cstruct_list"
                             },
-                            "declarator": {},
-                            "metaattrs": {
-                                "intent": "ctor"
-                            },
-                            "params": [
-                                {
-                                    "declarator": {
-                                        "name": "nitems"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in",
-                                        "struct_member": "nitems"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                },
-                                {
-                                    "attrs": {
-                                        "dimension": "nitems+nitems"
-                                    },
-                                    "declarator": {
-                                        "name": "ivalue",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "dimension": [
-                                            {
-                                                "left": {
-                                                    "name": "nitems"
-                                                },
-                                                "op": "+",
-                                                "right": {
-                                                    "name": "nitems"
-                                                }
-                                            }
-                                        ],
-                                        "intent": "in",
-                                        "struct_member": "ivalue"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                },
-                                {
-                                    "attrs": {
-                                        "dimension": "nitems*TWO"
-                                    },
-                                    "declarator": {
-                                        "name": "dvalue",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "dimension": [
-                                            {
-                                                "left": {
-                                                    "name": "nitems"
-                                                },
-                                                "op": "*",
-                                                "right": {
-                                                    "name": "TWO"
-                                                }
-                                            }
-                                        ],
-                                        "intent": "in",
-                                        "struct_member": "dvalue"
-                                    },
-                                    "specifier": [
-                                        "double"
-                                    ],
-                                    "typemap_name": "double"
-                                },
-                                {
-                                    "attrs": {
-                                        "dimension": "nitems"
-                                    },
-                                    "declarator": {
-                                        "name": "svalue",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            },
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "dimension": [
-                                            {
-                                                "name": "nitems"
-                                            }
-                                        ],
-                                        "intent": "in",
-                                        "struct_member": "svalue"
-                                    },
-                                    "specifier": [
-                                        "char"
-                                    ],
-                                    "typemap_name": "char"
-                                }
-                            ],
                             "specifier": [
                                 "Cstruct_list"
                             ],
@@ -818,7 +632,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "nitems"
+                                "name": "nitems",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -845,29 +660,30 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems+nitems"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems+nitems"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "left": {
+                                                "name": "nitems"
+                                            },
+                                            "op": "+",
+                                            "right": {
+                                                "name": "nitems"
+                                            }
+                                        }
+                                    ]
+                                },
                                 "name": "ivalue",
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "left": {
-                                            "name": "nitems"
-                                        },
-                                        "op": "+",
-                                        "right": {
-                                            "name": "nitems"
-                                        }
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -897,29 +713,30 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems*TWO"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems*TWO"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "left": {
+                                                "name": "nitems"
+                                            },
+                                            "op": "*",
+                                            "right": {
+                                                "name": "TWO"
+                                            }
+                                        }
+                                    ]
+                                },
                                 "name": "dvalue",
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "left": {
-                                            "name": "nitems"
-                                        },
-                                        "op": "*",
-                                        "right": {
-                                            "name": "TWO"
-                                        }
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -949,10 +766,17 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "name": "nitems"
+                                        }
+                                    ]
+                                },
                                 "name": "svalue",
                                 "pointer": [
                                     {
@@ -961,14 +785,8 @@
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nitems"
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "char"
                             },
                             "specifier": [
                                 "char"
@@ -1034,81 +852,9 @@
                         "<FUNCTION>": "3 ****************************************",
                         "_generated": "struct_as_class_ctor",
                         "ast": {
-                            "attrs": {
-                                "_constructor": true,
-                                "name": "Cstruct_numpy_ctor"
+                            "declarator": {
+                                "typemap_name": "Cstruct_numpy"
                             },
-                            "declarator": {},
-                            "metaattrs": {
-                                "intent": "ctor"
-                            },
-                            "params": [
-                                {
-                                    "declarator": {
-                                        "name": "nitems"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in",
-                                        "struct_member": "nitems"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                },
-                                {
-                                    "attrs": {
-                                        "dimension": "nitems"
-                                    },
-                                    "declarator": {
-                                        "name": "ivalue",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "dimension": [
-                                            {
-                                                "name": "nitems"
-                                            }
-                                        ],
-                                        "intent": "in",
-                                        "struct_member": "ivalue"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                },
-                                {
-                                    "attrs": {
-                                        "dimension": "nitems"
-                                    },
-                                    "declarator": {
-                                        "name": "dvalue",
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "metaattrs": {
-                                        "dimension": [
-                                            {
-                                                "name": "nitems"
-                                            }
-                                        ],
-                                        "intent": "in",
-                                        "struct_member": "dvalue"
-                                    },
-                                    "specifier": [
-                                        "double"
-                                    ],
-                                    "typemap_name": "double"
-                                }
-                            ],
                             "specifier": [
                                 "Cstruct_numpy"
                             ],
@@ -1258,7 +1004,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "nitems"
+                                "name": "nitems",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -1285,23 +1032,24 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "name": "nitems"
+                                        }
+                                    ]
+                                },
                                 "name": "ivalue",
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nitems"
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -1331,23 +1079,24 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "name": "nitems"
+                                        }
+                                    ]
+                                },
                                 "name": "dvalue",
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nitems"
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -1413,52 +1162,9 @@
                         "<FUNCTION>": "4 ****************************************",
                         "_generated": "struct_as_class_ctor",
                         "ast": {
-                            "attrs": {
-                                "_constructor": true,
-                                "name": "Arrays1_ctor"
+                            "declarator": {
+                                "typemap_name": "Arrays1"
                             },
-                            "declarator": {},
-                            "metaattrs": {
-                                "intent": "ctor"
-                            },
-                            "params": [
-                                {
-                                    "array": [
-                                        {
-                                            "constant": "20"
-                                        }
-                                    ],
-                                    "declarator": {
-                                        "name": "name"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in",
-                                        "struct_member": "name"
-                                    },
-                                    "specifier": [
-                                        "char"
-                                    ],
-                                    "typemap_name": "char"
-                                },
-                                {
-                                    "array": [
-                                        {
-                                            "constant": "10"
-                                        }
-                                    ],
-                                    "declarator": {
-                                        "name": "count"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in",
-                                        "struct_member": "count"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
                             "specifier": [
                                 "Arrays1"
                             ],
@@ -1573,13 +1279,14 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "array": [
-                                {
-                                    "constant": "20"
-                                }
-                            ],
                             "declarator": {
-                                "name": "name"
+                                "array": [
+                                    {
+                                        "constant": "20"
+                                    }
+                                ],
+                                "name": "name",
+                                "typemap_name": "char"
                             },
                             "specifier": [
                                 "char"
@@ -1609,13 +1316,14 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "array": [
-                                {
-                                    "constant": "10"
-                                }
-                            ],
                             "declarator": {
-                                "name": "count"
+                                "array": [
+                                    {
+                                        "constant": "10"
+                                    }
+                                ],
+                                "name": "count",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -1690,7 +1398,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "x1"
+                                "name": "x1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -1713,7 +1422,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "y1"
+                                "name": "y1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -1772,7 +1482,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "x1"
+                                "name": "x1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -1795,7 +1506,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "y1"
+                                "name": "y1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -1818,7 +1530,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "z1"
+                                "name": "z1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -1876,28 +1589,30 @@
                 "<FUNCTION>": "5 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passStructByValue"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "passStructByValue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -1968,31 +1683,33 @@
                 "<FUNCTION>": "6 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passStruct1"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "passStruct1",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -2064,52 +1781,55 @@
                 "<FUNCTION>": "7 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passStruct2"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "s1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "charlen": "LENOUTBUF",
-                                "intent": "out"
+                        "name": "passStruct2",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "s1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
                             },
-                            "declarator": {
-                                "name": "outbuf",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "charlen": "LENOUTBUF",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "outbuf",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -2205,33 +1925,35 @@
                 "<FUNCTION>": "8 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStructInPtr"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "acceptStructInPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -2301,63 +2023,67 @@
                 "<FUNCTION>": "9 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStructOutPtr"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "acceptStructOutPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
                             },
-                            "declarator": {
-                                "name": "i"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2452,33 +2178,35 @@
                 "<FUNCTION>": "10 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStructInOutPtr"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptStructInOutPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -2529,43 +2257,46 @@
                 "<FUNCTION>": "11 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "returnStructByValue"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "returnStructByValue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "Cstruct1"
+                    },
                     "specifier": [
                         "Cstruct1"
                     ],
@@ -2657,49 +2388,52 @@
                 "<FUNCTION>": "12 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnStructPtr1",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct1"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct1"
                     ],
@@ -2793,70 +2527,74 @@
                 "<FUNCTION>": "13 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnStructPtr2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "charlen": "LENOUTBUF",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "outbuf",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct1"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        },
-                        {
-                            "attrs": {
-                                "charlen": "LENOUTBUF",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "outbuf",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct1"
                     ],
@@ -2973,18 +2711,19 @@
                 "<FUNCTION>": "14 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "get_global_struct_list",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct_list"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "Cstruct_list"
                     ],
@@ -3030,18 +2769,19 @@
                 "<FUNCTION>": "15 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
                         "name": "Create_Cstruct_as_class",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct_as_class"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "Cstruct_as_class"
                     ],
@@ -3064,49 +2804,52 @@
                 "<FUNCTION>": "16 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
                         "name": "Create_Cstruct_as_class_args",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "x",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "y",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct_as_class"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "x"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "y"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct_as_class"
                     ],
@@ -3128,34 +2871,36 @@
                 "<FUNCTION>": "17 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "Cstruct_as_class_sum"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "Cstruct_as_class_sum",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "pass": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "point",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct_as_class"
+                                },
+                                "specifier": [
+                                    "Cstruct_as_class"
+                                ],
+                                "typemap_name": "Cstruct_as_class"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "pass": true
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "point",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct_as_class"
-                            ],
-                            "typemap_name": "Cstruct_as_class"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -3181,64 +2926,68 @@
                 "<FUNCTION>": "18 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
                         "name": "Create_Cstruct_as_subclass_args",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "x",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "y",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "z",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct_as_subclass"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "x"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "y"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "z"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct_as_subclass"
                     ],

--- a/regression/reference/struct-class-cxx/struct.json
+++ b/regression/reference/struct-class-cxx/struct.json
@@ -27,6 +27,36 @@
                                 "metaattrs": {
                                     "intent": "ctor"
                                 },
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "metaattrs": {
+                                                "intent": "in",
+                                                "struct_member": "ifield"
+                                            },
+                                            "name": "ifield",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    },
+                                    {
+                                        "declarator": {
+                                            "metaattrs": {
+                                                "intent": "in",
+                                                "struct_member": "dfield"
+                                            },
+                                            "name": "dfield",
+                                            "typemap_name": "double"
+                                        },
+                                        "specifier": [
+                                            "double"
+                                        ],
+                                        "typemap_name": "double"
+                                    }
+                                ],
                                 "typemap_name": "Cstruct1"
                             },
                             "specifier": [
@@ -239,6 +269,47 @@
                                 "metaattrs": {
                                     "intent": "ctor"
                                 },
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "metaattrs": {
+                                                "intent": "in",
+                                                "struct_member": "cfield"
+                                            },
+                                            "name": "cfield",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "char"
+                                        },
+                                        "specifier": [
+                                            "char"
+                                        ],
+                                        "typemap_name": "char"
+                                    },
+                                    {
+                                        "const": true,
+                                        "declarator": {
+                                            "metaattrs": {
+                                                "intent": "in",
+                                                "struct_member": "const_dvalue"
+                                            },
+                                            "name": "const_dvalue",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "double"
+                                        },
+                                        "specifier": [
+                                            "double"
+                                        ],
+                                        "typemap_name": "double"
+                                    }
+                                ],
                                 "typemap_name": "Cstruct_ptr"
                             },
                             "specifier": [
@@ -472,6 +543,118 @@
                                 "metaattrs": {
                                     "intent": "ctor"
                                 },
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "metaattrs": {
+                                                "intent": "in",
+                                                "struct_member": "nitems"
+                                            },
+                                            "name": "nitems",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    },
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "dimension": "nitems+nitems"
+                                            },
+                                            "metaattrs": {
+                                                "dimension": [
+                                                    {
+                                                        "left": {
+                                                            "name": "nitems"
+                                                        },
+                                                        "op": "+",
+                                                        "right": {
+                                                            "name": "nitems"
+                                                        }
+                                                    }
+                                                ],
+                                                "intent": "in",
+                                                "struct_member": "ivalue"
+                                            },
+                                            "name": "ivalue",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    },
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "dimension": "nitems*TWO"
+                                            },
+                                            "metaattrs": {
+                                                "dimension": [
+                                                    {
+                                                        "left": {
+                                                            "name": "nitems"
+                                                        },
+                                                        "op": "*",
+                                                        "right": {
+                                                            "name": "TWO"
+                                                        }
+                                                    }
+                                                ],
+                                                "intent": "in",
+                                                "struct_member": "dvalue"
+                                            },
+                                            "name": "dvalue",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "double"
+                                        },
+                                        "specifier": [
+                                            "double"
+                                        ],
+                                        "typemap_name": "double"
+                                    },
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "dimension": "nitems"
+                                            },
+                                            "metaattrs": {
+                                                "dimension": [
+                                                    {
+                                                        "name": "nitems"
+                                                    }
+                                                ],
+                                                "intent": "in",
+                                                "struct_member": "svalue"
+                                            },
+                                            "name": "svalue",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                },
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "char"
+                                        },
+                                        "specifier": [
+                                            "char"
+                                        ],
+                                        "typemap_name": "char"
+                                    }
+                                ],
                                 "typemap_name": "Cstruct_list"
                             },
                             "specifier": [
@@ -881,6 +1064,76 @@
                                 "metaattrs": {
                                     "intent": "ctor"
                                 },
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "metaattrs": {
+                                                "intent": "in",
+                                                "struct_member": "nitems"
+                                            },
+                                            "name": "nitems",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    },
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "dimension": "nitems"
+                                            },
+                                            "metaattrs": {
+                                                "dimension": [
+                                                    {
+                                                        "name": "nitems"
+                                                    }
+                                                ],
+                                                "intent": "in",
+                                                "struct_member": "ivalue"
+                                            },
+                                            "name": "ivalue",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    },
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "dimension": "nitems"
+                                            },
+                                            "metaattrs": {
+                                                "dimension": [
+                                                    {
+                                                        "name": "nitems"
+                                                    }
+                                                ],
+                                                "intent": "in",
+                                                "struct_member": "dvalue"
+                                            },
+                                            "name": "dvalue",
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "double"
+                                        },
+                                        "specifier": [
+                                            "double"
+                                        ],
+                                        "typemap_name": "double"
+                                    }
+                                ],
                                 "typemap_name": "Cstruct_numpy"
                             },
                             "specifier": [
@@ -1198,6 +1451,46 @@
                                 "metaattrs": {
                                     "intent": "ctor"
                                 },
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "array": [
+                                                {
+                                                    "constant": "20"
+                                                }
+                                            ],
+                                            "metaattrs": {
+                                                "intent": "in",
+                                                "struct_member": "name"
+                                            },
+                                            "name": "name",
+                                            "typemap_name": "char"
+                                        },
+                                        "specifier": [
+                                            "char"
+                                        ],
+                                        "typemap_name": "char"
+                                    },
+                                    {
+                                        "declarator": {
+                                            "array": [
+                                                {
+                                                    "constant": "10"
+                                                }
+                                            ],
+                                            "metaattrs": {
+                                                "intent": "in",
+                                                "struct_member": "count"
+                                            },
+                                            "name": "count",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
                                 "typemap_name": "Arrays1"
                             },
                             "specifier": [

--- a/regression/reference/struct-class-cxx/struct.json
+++ b/regression/reference/struct-class-cxx/struct.json
@@ -59,6 +59,7 @@
                                 ],
                                 "typemap_name": "Cstruct1"
                             },
+                            "is_ctor": true,
                             "specifier": [
                                 "Cstruct1"
                             ],
@@ -313,6 +314,7 @@
                                 ],
                                 "typemap_name": "Cstruct_ptr"
                             },
+                            "is_ctor": true,
                             "specifier": [
                                 "Cstruct_ptr"
                             ],
@@ -659,6 +661,7 @@
                                 ],
                                 "typemap_name": "Cstruct_list"
                             },
+                            "is_ctor": true,
                             "specifier": [
                                 "Cstruct_list"
                             ],
@@ -1139,6 +1142,7 @@
                                 ],
                                 "typemap_name": "Cstruct_numpy"
                             },
+                            "is_ctor": true,
                             "specifier": [
                                 "Cstruct_numpy"
                             ],
@@ -1497,6 +1501,7 @@
                                 ],
                                 "typemap_name": "Arrays1"
                             },
+                            "is_ctor": true,
                             "specifier": [
                                 "Arrays1"
                             ],

--- a/regression/reference/struct-class-cxx/struct.json
+++ b/regression/reference/struct-class-cxx/struct.json
@@ -66,6 +66,7 @@
                         },
                         "decl": "Cstruct1_ctor",
                         "declgen": "Cstruct1(int ifield, double dfield) +name(Cstruct1_ctor)",
+                        "name": "Cstruct1_ctor",
                         "options": {
                             "wrap_c": false,
                             "wrap_fortran": false,
@@ -319,6 +320,7 @@
                         },
                         "decl": "Cstruct_ptr_ctor",
                         "declgen": "Cstruct_ptr(char * cfield, const double * const_dvalue) +name(Cstruct_ptr_ctor)",
+                        "name": "Cstruct_ptr_ctor",
                         "options": {
                             "wrap_c": false,
                             "wrap_fortran": false,
@@ -664,6 +666,7 @@
                         },
                         "decl": "Cstruct_list_ctor",
                         "declgen": "Cstruct_list(int nitems, int * ivalue +dimension(nitems+nitems), double * dvalue +dimension(nitems*TWO), char * * svalue +dimension(nitems)) +name(Cstruct_list_ctor)",
+                        "name": "Cstruct_list_ctor",
                         "options": {
                             "wrap_c": false,
                             "wrap_fortran": false,
@@ -1143,6 +1146,7 @@
                         },
                         "decl": "Cstruct_numpy_ctor",
                         "declgen": "Cstruct_numpy(int nitems, int * ivalue +dimension(nitems), double * dvalue +dimension(nitems)) +name(Cstruct_numpy_ctor)",
+                        "name": "Cstruct_numpy_ctor",
                         "options": {
                             "wrap_c": false,
                             "wrap_fortran": false,
@@ -1500,6 +1504,7 @@
                         },
                         "decl": "Arrays1_ctor",
                         "declgen": "Arrays1(char name[20], int count[10]) +name(Arrays1_ctor)",
+                        "name": "Arrays1_ctor",
                         "options": {
                             "wrap_c": false,
                             "wrap_fortran": false,
@@ -1948,6 +1953,7 @@
                 },
                 "decl": "int passStructByValue(Cstruct1 arg)",
                 "declgen": "int passStructByValue(Cstruct1 arg +value)",
+                "name": "passStructByValue",
                 "options": {
                     "literalinclude": true
                 },
@@ -2045,6 +2051,7 @@
                 },
                 "decl": "int passStruct1(const Cstruct1 *arg)",
                 "declgen": "int passStruct1(const Cstruct1 * arg)",
+                "name": "passStruct1",
                 "options": {
                     "literalinclude": true
                 },
@@ -2168,6 +2175,7 @@
                 "doxygen": {
                     "description": "Pass name argument which will build a bufferify function.\n"
                 },
+                "name": "passStruct2",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2289,6 +2297,7 @@
                 },
                 "decl": "int acceptStructInPtr(Cstruct1 *arg +intent(in))",
                 "declgen": "int acceptStructInPtr(Cstruct1 * arg +intent(in))",
+                "name": "acceptStructInPtr",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2422,6 +2431,7 @@
                 "doxygen": {
                     "description": "Pass name argument which will build a bufferify function.\n"
                 },
+                "name": "acceptStructOutPtr",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2542,6 +2552,7 @@
                 },
                 "decl": "void acceptStructInOutPtr(Cstruct1 *arg +intent(inout))",
                 "declgen": "void acceptStructInOutPtr(Cstruct1 * arg +intent(inout))",
+                "name": "acceptStructInOutPtr",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2632,6 +2643,7 @@
                 },
                 "decl": "Cstruct1 returnStructByValue(int i, double d);",
                 "declgen": "Cstruct1 returnStructByValue(int i +value, double d +value)",
+                "name": "returnStructByValue",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2773,6 +2785,7 @@
                     "brief": "Return a pointer to a struct",
                     "description": "Does not generate a bufferify C wrapper.\n"
                 },
+                "name": "returnStructPtr1",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2934,6 +2947,7 @@
                     "brief": "Return a pointer to a struct",
                     "description": "Generates a bufferify C wrapper function.\n"
                 },
+                "name": "returnStructPtr2",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3059,6 +3073,7 @@
                 },
                 "decl": "Cstruct_list *get_global_struct_list();",
                 "declgen": "Cstruct_list * get_global_struct_list(void)",
+                "name": "get_global_struct_list",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -3117,6 +3132,7 @@
                 },
                 "decl": "Cstruct_as_class *Create_Cstruct_as_class(void)",
                 "declgen": "Cstruct_as_class * Create_Cstruct_as_class(void)",
+                "name": "Create_Cstruct_as_class",
                 "options": {
                     "class_ctor": "Cstruct_as_class",
                     "literalinclude": true,
@@ -3185,6 +3201,7 @@
                 },
                 "decl": "Cstruct_as_class *Create_Cstruct_as_class_args(int x, int y)",
                 "declgen": "Cstruct_as_class * Create_Cstruct_as_class_args(int x +value, int y +value)",
+                "name": "Create_Cstruct_as_class_args",
                 "options": {
                     "class_ctor": "Cstruct_as_class",
                     "wrap_python": false
@@ -3236,6 +3253,7 @@
                 },
                 "decl": "int Cstruct_as_class_sum(const Cstruct_as_class *point +pass)",
                 "declgen": "int Cstruct_as_class_sum(const Cstruct_as_class * point +pass)",
+                "name": "Cstruct_as_class_sum",
                 "options": {
                     "class_method": "Cstruct_as_class",
                     "wrap_python": false
@@ -3323,6 +3341,7 @@
                 },
                 "decl": "Cstruct_as_subclass *Create_Cstruct_as_subclass_args(int x, int y, int z)",
                 "declgen": "Cstruct_as_subclass * Create_Cstruct_as_subclass_args(int x +value, int y +value, int z +value)",
+                "name": "Create_Cstruct_as_subclass_args",
                 "options": {
                     "class_ctor": "Cstruct_as_subclass",
                     "wrap_python": false

--- a/regression/reference/struct-cxx/struct.json
+++ b/regression/reference/struct-cxx/struct.json
@@ -26,7 +26,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "ifield"
+                                "name": "ifield",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -52,7 +53,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "dfield"
+                                "name": "dfield",
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -116,7 +118,8 @@
                                     {
                                         "ptr": "*"
                                     }
-                                ]
+                                ],
+                                "typemap_name": "char"
                             },
                             "specifier": [
                                 "char"
@@ -148,7 +151,8 @@
                                     {
                                         "ptr": "*"
                                     }
-                                ]
+                                ],
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -209,7 +213,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "nitems"
+                                "name": "nitems",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -234,29 +239,30 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems+nitems"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems+nitems"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "left": {
+                                                "name": "nitems"
+                                            },
+                                            "op": "+",
+                                            "right": {
+                                                "name": "nitems"
+                                            }
+                                        }
+                                    ]
+                                },
                                 "name": "ivalue",
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "left": {
-                                            "name": "nitems"
-                                        },
-                                        "op": "+",
-                                        "right": {
-                                            "name": "nitems"
-                                        }
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -281,29 +287,30 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems*TWO"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems*TWO"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "left": {
+                                                "name": "nitems"
+                                            },
+                                            "op": "*",
+                                            "right": {
+                                                "name": "TWO"
+                                            }
+                                        }
+                                    ]
+                                },
                                 "name": "dvalue",
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "left": {
-                                            "name": "nitems"
-                                        },
-                                        "op": "*",
-                                        "right": {
-                                            "name": "TWO"
-                                        }
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -328,10 +335,17 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "name": "nitems"
+                                        }
+                                    ]
+                                },
                                 "name": "svalue",
                                 "pointer": [
                                     {
@@ -340,14 +354,8 @@
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nitems"
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "char"
                             },
                             "specifier": [
                                 "char"
@@ -409,7 +417,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "nitems"
+                                "name": "nitems",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -434,23 +443,24 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "name": "nitems"
+                                        }
+                                    ]
+                                },
                                 "name": "ivalue",
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nitems"
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -475,23 +485,24 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "name": "nitems"
+                                        }
+                                    ]
+                                },
                                 "name": "dvalue",
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nitems"
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -551,13 +562,14 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "array": [
-                                {
-                                    "constant": "20"
-                                }
-                            ],
                             "declarator": {
-                                "name": "name"
+                                "array": [
+                                    {
+                                        "constant": "20"
+                                    }
+                                ],
+                                "name": "name",
+                                "typemap_name": "char"
                             },
                             "specifier": [
                                 "char"
@@ -582,13 +594,14 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "array": [
-                                {
-                                    "constant": "10"
-                                }
-                            ],
                             "declarator": {
-                                "name": "count"
+                                "array": [
+                                    {
+                                        "constant": "10"
+                                    }
+                                ],
+                                "name": "count",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -646,12 +659,13 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "get_x1"
+                                "metaattrs": {
+                                    "intent": "getter"
+                                },
+                                "name": "get_x1",
+                                "params": [],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "getter"
-                            },
-                            "params": [],
                             "specifier": [
                                 "int"
                             ],
@@ -736,29 +750,31 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "set_x1"
+                                "metaattrs": {
+                                    "intent": "setter"
+                                },
+                                "name": "set_x1",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "intent": "in",
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "setter"
+                                            },
+                                            "name": "val",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "setter"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "intent": "in",
-                                        "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "val"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "setter"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],
@@ -850,12 +866,13 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "get_y1"
+                                "metaattrs": {
+                                    "intent": "getter"
+                                },
+                                "name": "get_y1",
+                                "params": [],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "getter"
-                            },
-                            "params": [],
                             "specifier": [
                                 "int"
                             ],
@@ -940,29 +957,31 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "set_y1"
+                                "metaattrs": {
+                                    "intent": "setter"
+                                },
+                                "name": "set_y1",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "intent": "in",
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "setter"
+                                            },
+                                            "name": "val",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "setter"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "intent": "in",
-                                        "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "val"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "setter"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],
@@ -1061,7 +1080,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "x1"
+                                "name": "x1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -1087,7 +1107,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "y1"
+                                "name": "y1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -1149,12 +1170,13 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "get_x1"
+                                "metaattrs": {
+                                    "intent": "getter"
+                                },
+                                "name": "get_x1",
+                                "params": [],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "getter"
-                            },
-                            "params": [],
                             "specifier": [
                                 "int"
                             ],
@@ -1239,29 +1261,31 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "set_x1"
+                                "metaattrs": {
+                                    "intent": "setter"
+                                },
+                                "name": "set_x1",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "intent": "in",
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "setter"
+                                            },
+                                            "name": "val",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "setter"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "intent": "in",
-                                        "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "val"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "setter"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],
@@ -1353,12 +1377,13 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "get_y1"
+                                "metaattrs": {
+                                    "intent": "getter"
+                                },
+                                "name": "get_y1",
+                                "params": [],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "getter"
-                            },
-                            "params": [],
                             "specifier": [
                                 "int"
                             ],
@@ -1443,29 +1468,31 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "set_y1"
+                                "metaattrs": {
+                                    "intent": "setter"
+                                },
+                                "name": "set_y1",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "intent": "in",
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "setter"
+                                            },
+                                            "name": "val",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "setter"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "intent": "in",
-                                        "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "val"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "setter"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],
@@ -1557,12 +1584,13 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "get_z1"
+                                "metaattrs": {
+                                    "intent": "getter"
+                                },
+                                "name": "get_z1",
+                                "params": [],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "getter"
-                            },
-                            "params": [],
                             "specifier": [
                                 "int"
                             ],
@@ -1647,29 +1675,31 @@
                         "_generated": "getter/setter",
                         "ast": {
                             "declarator": {
-                                "name": "set_z1"
+                                "metaattrs": {
+                                    "intent": "setter"
+                                },
+                                "name": "set_z1",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "intent": "in",
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "setter"
+                                            },
+                                            "name": "val",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "setter"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "intent": "in",
-                                        "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "val"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "setter"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],
@@ -1769,7 +1799,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "x1"
+                                "name": "x1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -1795,7 +1826,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "y1"
+                                "name": "y1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -1821,7 +1853,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "z1"
+                                "name": "z1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -1889,28 +1922,30 @@
                 "<FUNCTION>": "10 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passStructByValue"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "passStructByValue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -2018,31 +2053,33 @@
                 "<FUNCTION>": "11 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passStruct1"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "passStruct1",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -2154,52 +2191,55 @@
                 "_PTR_F_C_index": "30",
                 "ast": {
                     "declarator": {
-                        "name": "passStruct2"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "s1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "charlen": "LENOUTBUF",
-                                "intent": "out"
+                        "name": "passStruct2",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "s1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
                             },
-                            "declarator": {
-                                "name": "outbuf",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "charlen": "LENOUTBUF",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "outbuf",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -2334,53 +2374,56 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "passStruct2"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "s1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "charlen": "LENOUTBUF",
-                                "intent": "out"
+                        "name": "passStruct2",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "s1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
                             },
-                            "declarator": {
-                                "name": "outbuf",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "charlen": "LENOUTBUF",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "out"
+                                    },
+                                    "name": "outbuf",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -2512,33 +2555,35 @@
                 "<FUNCTION>": "13 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStructInPtr"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "acceptStructInPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -2644,63 +2689,67 @@
                 "<FUNCTION>": "14 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStructOutPtr"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "acceptStructOutPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
                             },
-                            "declarator": {
-                                "name": "i"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2844,33 +2893,35 @@
                 "<FUNCTION>": "15 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStructInOutPtr"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptStructInOutPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -2945,43 +2996,46 @@
                 "<FUNCTION>": "16 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "returnStructByValue"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "returnStructByValue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "Cstruct1"
+                    },
                     "specifier": [
                         "Cstruct1"
                     ],
@@ -3124,49 +3178,52 @@
                 "_PTR_F_C_index": "31",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnStructPtr1",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct1"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct1"
                     ],
@@ -3303,50 +3360,53 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "buf",
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnStructPtr1",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct1"
                     },
-                    "metaattrs": {
-                        "api": "buf",
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct1"
                     ],
@@ -3481,70 +3541,74 @@
                 "_PTR_F_C_index": "32",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnStructPtr2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "charlen": "LENOUTBUF",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "outbuf",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct1"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        },
-                        {
-                            "attrs": {
-                                "charlen": "LENOUTBUF",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "outbuf",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct1"
                     ],
@@ -3710,72 +3774,76 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "buf",
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnStructPtr2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "charlen": "LENOUTBUF",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "out"
+                                    },
+                                    "name": "outbuf",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct1"
                     },
-                    "metaattrs": {
-                        "api": "buf",
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        },
-                        {
-                            "attrs": {
-                                "charlen": "LENOUTBUF",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "outbuf",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct1"
                     ],
@@ -3945,18 +4013,19 @@
                 "_PTR_F_C_index": "33",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "get_global_struct_list",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct_list"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "Cstruct_list"
                     ],
@@ -4027,19 +4096,20 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "buf",
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "get_global_struct_list",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct_list"
                     },
-                    "metaattrs": {
-                        "api": "buf",
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "Cstruct_list"
                     ],
@@ -4097,18 +4167,19 @@
                 "<FUNCTION>": "20 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
                         "name": "Create_Cstruct_as_class",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct_as_class"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "Cstruct_as_class"
                     ],
@@ -4185,49 +4256,52 @@
                 "<FUNCTION>": "21 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
                         "name": "Create_Cstruct_as_class_args",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "x",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "y",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct_as_class"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "x"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "y"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct_as_class"
                     ],
@@ -4372,34 +4446,36 @@
                 "<FUNCTION>": "22 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "Cstruct_as_class_sum"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "Cstruct_as_class_sum",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "pass": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "point",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct_as_class"
+                                },
+                                "specifier": [
+                                    "Cstruct_as_class"
+                                ],
+                                "typemap_name": "Cstruct_as_class"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "pass": true
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "point",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct_as_class"
-                            ],
-                            "typemap_name": "Cstruct_as_class"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -4513,64 +4589,68 @@
                 "<FUNCTION>": "23 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
                         "name": "Create_Cstruct_as_subclass_args",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "x",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "y",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "z",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct_as_subclass"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "x"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "y"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "z"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct_as_subclass"
                     ],
@@ -4755,38 +4835,40 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "getter",
+                            "struct": "Cstruct_ptr"
+                        },
                         "name": "Cstruct_ptr_get_const_dvalue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in",
+                                        "struct": "Cstruct_ptr"
+                                    },
+                                    "name": "SH_this",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct_ptr"
+                                },
+                                "specifier": [
+                                    "Cstruct_ptr"
+                                ],
+                                "typemap_name": "Cstruct_ptr"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "double"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "getter",
-                        "struct": "Cstruct_ptr"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "SH_this",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in",
-                                "struct": "Cstruct_ptr"
-                            },
-                            "specifier": [
-                                "Cstruct_ptr"
-                            ],
-                            "typemap_name": "Cstruct_ptr"
-                        }
-                    ],
                     "specifier": [
                         "double"
                     ],
@@ -4841,39 +4923,41 @@
                 "ast": {
                     "const": true,
                     "declarator": {
+                        "metaattrs": {
+                            "api": "buf",
+                            "deref": "pointer",
+                            "intent": "getter",
+                            "struct": "Cstruct_ptr"
+                        },
                         "name": "Cstruct_ptr_get_const_dvalue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in",
+                                        "struct": "Cstruct_ptr"
+                                    },
+                                    "name": "SH_this",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct_ptr"
+                                },
+                                "specifier": [
+                                    "Cstruct_ptr"
+                                ],
+                                "typemap_name": "Cstruct_ptr"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "double"
                     },
-                    "metaattrs": {
-                        "api": "buf",
-                        "deref": "pointer",
-                        "intent": "getter",
-                        "struct": "Cstruct_ptr"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "SH_this",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in",
-                                "struct": "Cstruct_ptr"
-                            },
-                            "specifier": [
-                                "Cstruct_ptr"
-                            ],
-                            "typemap_name": "Cstruct_ptr"
-                        }
-                    ],
                     "specifier": [
                         "double"
                     ],
@@ -4978,52 +5062,55 @@
                 "_generated": "getter/setter",
                 "ast": {
                     "declarator": {
-                        "name": "Cstruct_ptr_set_const_dvalue"
-                    },
-                    "metaattrs": {
-                        "intent": "setter"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "SH_this",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout",
-                                "struct": "Cstruct_ptr"
-                            },
-                            "specifier": [
-                                "Cstruct_ptr"
-                            ],
-                            "typemap_name": "Cstruct_ptr"
+                        "metaattrs": {
+                            "intent": "setter"
                         },
-                        {
-                            "attrs": {
-                                "intent": "in"
+                        "name": "Cstruct_ptr_set_const_dvalue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout",
+                                        "struct": "Cstruct_ptr"
+                                    },
+                                    "name": "SH_this",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct_ptr"
+                                },
+                                "specifier": [
+                                    "Cstruct_ptr"
+                                ],
+                                "typemap_name": "Cstruct_ptr"
                             },
-                            "const": true,
-                            "declarator": {
-                                "name": "val",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "setter"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "setter"
+                                    },
+                                    "name": "val",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5146,49 +5233,51 @@
                 "_generated": "getter/setter",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "left": {
+                                        "name": "nitems"
+                                    },
+                                    "op": "+",
+                                    "right": {
+                                        "name": "nitems"
+                                    }
+                                }
+                            ],
+                            "intent": "getter",
+                            "struct": "Cstruct_list"
+                        },
                         "name": "Cstruct_list_get_ivalue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in",
+                                        "struct": "Cstruct_list"
+                                    },
+                                    "name": "SH_this",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct_list"
+                                },
+                                "specifier": [
+                                    "Cstruct_list"
+                                ],
+                                "typemap_name": "Cstruct_list"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "left": {
-                                    "name": "nitems"
-                                },
-                                "op": "+",
-                                "right": {
-                                    "name": "nitems"
-                                }
-                            }
                         ],
-                        "intent": "getter",
-                        "struct": "Cstruct_list"
+                        "typemap_name": "int"
                     },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "SH_this",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in",
-                                "struct": "Cstruct_list"
-                            },
-                            "specifier": [
-                                "Cstruct_list"
-                            ],
-                            "typemap_name": "Cstruct_list"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -5248,50 +5337,52 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "left": {
+                                        "name": "nitems"
+                                    },
+                                    "op": "+",
+                                    "right": {
+                                        "name": "nitems"
+                                    }
+                                }
+                            ],
+                            "intent": "getter",
+                            "struct": "Cstruct_list"
+                        },
                         "name": "Cstruct_list_get_ivalue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in",
+                                        "struct": "Cstruct_list"
+                                    },
+                                    "name": "SH_this",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct_list"
+                                },
+                                "specifier": [
+                                    "Cstruct_list"
+                                ],
+                                "typemap_name": "Cstruct_list"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "left": {
-                                    "name": "nitems"
-                                },
-                                "op": "+",
-                                "right": {
-                                    "name": "nitems"
-                                }
-                            }
                         ],
-                        "intent": "getter",
-                        "struct": "Cstruct_list"
+                        "typemap_name": "int"
                     },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "SH_this",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in",
-                                "struct": "Cstruct_list"
-                            },
-                            "specifier": [
-                                "Cstruct_list"
-                            ],
-                            "typemap_name": "Cstruct_list"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -5404,63 +5495,66 @@
                 "_generated": "getter/setter",
                 "ast": {
                     "declarator": {
-                        "name": "Cstruct_list_set_ivalue"
-                    },
-                    "metaattrs": {
-                        "intent": "setter"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "SH_this",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout",
-                                "struct": "Cstruct_list"
-                            },
-                            "specifier": [
-                                "Cstruct_list"
-                            ],
-                            "typemap_name": "Cstruct_list"
+                        "metaattrs": {
+                            "intent": "setter"
                         },
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "val",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "left": {
-                                            "name": "nitems"
-                                        },
-                                        "op": "+",
-                                        "right": {
-                                            "name": "nitems"
+                        "name": "Cstruct_list_set_ivalue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout",
+                                        "struct": "Cstruct_list"
+                                    },
+                                    "name": "SH_this",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
                                         }
-                                    }
+                                    ],
+                                    "typemap_name": "Cstruct_list"
+                                },
+                                "specifier": [
+                                    "Cstruct_list"
                                 ],
-                                "intent": "setter"
+                                "typemap_name": "Cstruct_list"
                             },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "left": {
+                                                    "name": "nitems"
+                                                },
+                                                "op": "+",
+                                                "right": {
+                                                    "name": "nitems"
+                                                }
+                                            }
+                                        ],
+                                        "intent": "setter"
+                                    },
+                                    "name": "val",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5588,49 +5682,51 @@
                 "_generated": "getter/setter",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "left": {
+                                        "name": "nitems"
+                                    },
+                                    "op": "*",
+                                    "right": {
+                                        "name": "TWO"
+                                    }
+                                }
+                            ],
+                            "intent": "getter",
+                            "struct": "Cstruct_list"
+                        },
                         "name": "Cstruct_list_get_dvalue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in",
+                                        "struct": "Cstruct_list"
+                                    },
+                                    "name": "SH_this",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct_list"
+                                },
+                                "specifier": [
+                                    "Cstruct_list"
+                                ],
+                                "typemap_name": "Cstruct_list"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "left": {
-                                    "name": "nitems"
-                                },
-                                "op": "*",
-                                "right": {
-                                    "name": "TWO"
-                                }
-                            }
                         ],
-                        "intent": "getter",
-                        "struct": "Cstruct_list"
+                        "typemap_name": "double"
                     },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "SH_this",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in",
-                                "struct": "Cstruct_list"
-                            },
-                            "specifier": [
-                                "Cstruct_list"
-                            ],
-                            "typemap_name": "Cstruct_list"
-                        }
-                    ],
                     "specifier": [
                         "double"
                     ],
@@ -5690,50 +5786,52 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "deref": "pointer",
+                            "dimension": [
+                                {
+                                    "left": {
+                                        "name": "nitems"
+                                    },
+                                    "op": "*",
+                                    "right": {
+                                        "name": "TWO"
+                                    }
+                                }
+                            ],
+                            "intent": "getter",
+                            "struct": "Cstruct_list"
+                        },
                         "name": "Cstruct_list_get_dvalue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in",
+                                        "struct": "Cstruct_list"
+                                    },
+                                    "name": "SH_this",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct_list"
+                                },
+                                "specifier": [
+                                    "Cstruct_list"
+                                ],
+                                "typemap_name": "Cstruct_list"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
-                    },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "deref": "pointer",
-                        "dimension": [
-                            {
-                                "left": {
-                                    "name": "nitems"
-                                },
-                                "op": "*",
-                                "right": {
-                                    "name": "TWO"
-                                }
-                            }
                         ],
-                        "intent": "getter",
-                        "struct": "Cstruct_list"
+                        "typemap_name": "double"
                     },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "SH_this",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in",
-                                "struct": "Cstruct_list"
-                            },
-                            "specifier": [
-                                "Cstruct_list"
-                            ],
-                            "typemap_name": "Cstruct_list"
-                        }
-                    ],
                     "specifier": [
                         "double"
                     ],
@@ -5846,63 +5944,66 @@
                 "_generated": "getter/setter",
                 "ast": {
                     "declarator": {
-                        "name": "Cstruct_list_set_dvalue"
-                    },
-                    "metaattrs": {
-                        "intent": "setter"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "SH_this",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout",
-                                "struct": "Cstruct_list"
-                            },
-                            "specifier": [
-                                "Cstruct_list"
-                            ],
-                            "typemap_name": "Cstruct_list"
+                        "metaattrs": {
+                            "intent": "setter"
                         },
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "val",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "left": {
-                                            "name": "nitems"
-                                        },
-                                        "op": "*",
-                                        "right": {
-                                            "name": "TWO"
+                        "name": "Cstruct_list_set_dvalue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout",
+                                        "struct": "Cstruct_list"
+                                    },
+                                    "name": "SH_this",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
                                         }
-                                    }
+                                    ],
+                                    "typemap_name": "Cstruct_list"
+                                },
+                                "specifier": [
+                                    "Cstruct_list"
                                 ],
-                                "intent": "setter"
+                                "typemap_name": "Cstruct_list"
                             },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "dimension": [
+                                            {
+                                                "left": {
+                                                    "name": "nitems"
+                                                },
+                                                "op": "*",
+                                                "right": {
+                                                    "name": "TWO"
+                                                }
+                                            }
+                                        ],
+                                        "intent": "setter"
+                                    },
+                                    "name": "val",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],

--- a/regression/reference/struct-cxx/struct.json
+++ b/regression/reference/struct-cxx/struct.json
@@ -673,6 +673,7 @@
                         },
                         "decl": "int get_x1()",
                         "declgen": "int get_x1(void)",
+                        "name": "get_x1",
                         "options": {},
                         "user_fmt": {
                             "field_name": "x1",
@@ -782,6 +783,7 @@
                         },
                         "decl": "void set_x1(int val)",
                         "declgen": "void set_x1(int val +intent(in)+value)",
+                        "name": "set_x1",
                         "options": {},
                         "user_fmt": {
                             "field_name": "x1",
@@ -880,6 +882,7 @@
                         },
                         "decl": "int get_y1()",
                         "declgen": "int get_y1(void)",
+                        "name": "get_y1",
                         "options": {},
                         "user_fmt": {
                             "field_name": "y1",
@@ -989,6 +992,7 @@
                         },
                         "decl": "void set_y1(int val)",
                         "declgen": "void set_y1(int val +intent(in)+value)",
+                        "name": "set_y1",
                         "options": {},
                         "user_fmt": {
                             "field_name": "y1",
@@ -1184,6 +1188,7 @@
                         },
                         "decl": "int get_x1()",
                         "declgen": "int get_x1(void)",
+                        "name": "get_x1",
                         "options": {},
                         "user_fmt": {
                             "field_name": "x1",
@@ -1293,6 +1298,7 @@
                         },
                         "decl": "void set_x1(int val)",
                         "declgen": "void set_x1(int val +intent(in)+value)",
+                        "name": "set_x1",
                         "options": {},
                         "user_fmt": {
                             "field_name": "x1",
@@ -1391,6 +1397,7 @@
                         },
                         "decl": "int get_y1()",
                         "declgen": "int get_y1(void)",
+                        "name": "get_y1",
                         "options": {},
                         "user_fmt": {
                             "field_name": "y1",
@@ -1500,6 +1507,7 @@
                         },
                         "decl": "void set_y1(int val)",
                         "declgen": "void set_y1(int val +intent(in)+value)",
+                        "name": "set_y1",
                         "options": {},
                         "user_fmt": {
                             "field_name": "y1",
@@ -1598,6 +1606,7 @@
                         },
                         "decl": "int get_z1()",
                         "declgen": "int get_z1(void)",
+                        "name": "get_z1",
                         "options": {},
                         "user_fmt": {
                             "field_name": "z1",
@@ -1707,6 +1716,7 @@
                         },
                         "decl": "void set_z1(int val)",
                         "declgen": "void set_z1(int val +intent(in)+value)",
+                        "name": "set_z1",
                         "options": {},
                         "user_fmt": {
                             "field_name": "z1",
@@ -1953,6 +1963,7 @@
                 },
                 "decl": "int passStructByValue(Cstruct1 arg)",
                 "declgen": "int passStructByValue(Cstruct1 arg +value)",
+                "name": "passStructByValue",
                 "options": {
                     "literalinclude": true
                 },
@@ -2087,6 +2098,7 @@
                 },
                 "decl": "int passStruct1(const Cstruct1 *arg)",
                 "declgen": "int passStruct1(const Cstruct1 * arg)",
+                "name": "passStruct1",
                 "options": {
                     "literalinclude": true
                 },
@@ -2250,6 +2262,7 @@
                 "doxygen": {
                     "description": "Pass name argument which will build a bufferify function.\n"
                 },
+                "name": "passStruct2",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2434,6 +2447,7 @@
                 "doxygen": {
                     "description": "Pass name argument which will build a bufferify function.\n"
                 },
+                "name": "passStruct2",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -2591,6 +2605,7 @@
                 },
                 "decl": "int acceptStructInPtr(Cstruct1 *arg +intent(in))",
                 "declgen": "int acceptStructInPtr(Cstruct1 * arg +intent(in))",
+                "name": "acceptStructInPtr",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2760,6 +2775,7 @@
                 "doxygen": {
                     "description": "Pass name argument which will build a bufferify function.\n"
                 },
+                "name": "acceptStructOutPtr",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2929,6 +2945,7 @@
                 },
                 "decl": "void acceptStructInOutPtr(Cstruct1 *arg +intent(inout))",
                 "declgen": "void acceptStructInOutPtr(Cstruct1 * arg +intent(inout))",
+                "name": "acceptStructInOutPtr",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3043,6 +3060,7 @@
                 },
                 "decl": "Cstruct1 returnStructByValue(int i, double d);",
                 "declgen": "Cstruct1 returnStructByValue(int i +value, double d +value)",
+                "name": "returnStructByValue",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3235,6 +3253,7 @@
                     "brief": "Return a pointer to a struct",
                     "description": "Does not generate a bufferify C wrapper.\n"
                 },
+                "name": "returnStructPtr1",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3418,6 +3437,7 @@
                     "brief": "Return a pointer to a struct",
                     "description": "Does not generate a bufferify C wrapper.\n"
                 },
+                "name": "returnStructPtr1",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -3620,6 +3640,7 @@
                     "brief": "Return a pointer to a struct",
                     "description": "Generates a bufferify C wrapper function.\n"
                 },
+                "name": "returnStructPtr2",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3855,6 +3876,7 @@
                     "brief": "Return a pointer to a struct",
                     "description": "Generates a bufferify C wrapper function.\n"
                 },
+                "name": "returnStructPtr2",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -4033,6 +4055,7 @@
                 },
                 "decl": "Cstruct_list *get_global_struct_list();",
                 "declgen": "Cstruct_list * get_global_struct_list(void)",
+                "name": "get_global_struct_list",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -4117,6 +4140,7 @@
                 },
                 "decl": "Cstruct_list *get_global_struct_list();",
                 "declgen": "Cstruct_list * get_global_struct_list(void)",
+                "name": "get_global_struct_list",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -4187,6 +4211,7 @@
                 },
                 "decl": "Cstruct_as_class *Create_Cstruct_as_class(void)",
                 "declgen": "Cstruct_as_class * Create_Cstruct_as_class(void)",
+                "name": "Create_Cstruct_as_class",
                 "options": {
                     "class_ctor": "Cstruct_as_class",
                     "literalinclude": true,
@@ -4309,6 +4334,7 @@
                 },
                 "decl": "Cstruct_as_class *Create_Cstruct_as_class_args(int x, int y)",
                 "declgen": "Cstruct_as_class * Create_Cstruct_as_class_args(int x +value, int y +value)",
+                "name": "Create_Cstruct_as_class_args",
                 "options": {
                     "class_ctor": "Cstruct_as_class",
                     "wrap_python": false
@@ -4483,6 +4509,7 @@
                 },
                 "decl": "int Cstruct_as_class_sum(const Cstruct_as_class *point +pass)",
                 "declgen": "int Cstruct_as_class_sum(const Cstruct_as_class * point +pass)",
+                "name": "Cstruct_as_class_sum",
                 "options": {
                     "class_method": "Cstruct_as_class",
                     "wrap_python": false
@@ -4658,6 +4685,7 @@
                 },
                 "decl": "Cstruct_as_subclass *Create_Cstruct_as_subclass_args(int x, int y, int z)",
                 "declgen": "Cstruct_as_subclass * Create_Cstruct_as_subclass_args(int x +value, int y +value, int z +value)",
+                "name": "Create_Cstruct_as_subclass_args",
                 "options": {
                     "class_ctor": "Cstruct_as_subclass",
                     "wrap_python": false
@@ -4876,6 +4904,7 @@
                 },
                 "decl": "const double * Cstruct_ptr_get_const_dvalue(Cstruct_ptr *SH_this)",
                 "declgen": "const double * Cstruct_ptr_get_const_dvalue(Cstruct_ptr * SH_this)",
+                "name": "Cstruct_ptr_get_const_dvalue",
                 "options": {},
                 "user_fmt": {
                     "field_name": "const_dvalue",
@@ -4965,6 +4994,7 @@
                 },
                 "decl": "const double * Cstruct_ptr_get_const_dvalue(Cstruct_ptr *SH_this)",
                 "declgen": "const double * Cstruct_ptr_get_const_dvalue(Cstruct_ptr * SH_this)",
+                "name": "Cstruct_ptr_get_const_dvalue",
                 "options": {},
                 "splicer_group": "buf",
                 "user_fmt": {
@@ -5118,6 +5148,7 @@
                 },
                 "decl": "void Cstruct_ptr_set_const_dvalue(Cstruct_ptr *SH_this,const double * val)",
                 "declgen": "void Cstruct_ptr_set_const_dvalue(Cstruct_ptr * SH_this, const double * val +intent(in))",
+                "name": "Cstruct_ptr_set_const_dvalue",
                 "options": {},
                 "user_fmt": {
                     "field_name": "const_dvalue",
@@ -5285,6 +5316,7 @@
                 },
                 "decl": "int * Cstruct_list_get_ivalue(Cstruct_list *SH_this)",
                 "declgen": "int * Cstruct_list_get_ivalue(Cstruct_list * SH_this)",
+                "name": "Cstruct_list_get_ivalue",
                 "options": {},
                 "user_fmt": {
                     "field_name": "ivalue",
@@ -5390,6 +5422,7 @@
                 },
                 "decl": "int * Cstruct_list_get_ivalue(Cstruct_list *SH_this)",
                 "declgen": "int * Cstruct_list_get_ivalue(Cstruct_list * SH_this)",
+                "name": "Cstruct_list_get_ivalue",
                 "options": {},
                 "splicer_group": "buf",
                 "user_fmt": {
@@ -5562,6 +5595,7 @@
                 },
                 "decl": "void Cstruct_list_set_ivalue(Cstruct_list *SH_this,int * val)",
                 "declgen": "void Cstruct_list_set_ivalue(Cstruct_list * SH_this, int * val +intent(in)+rank(1))",
+                "name": "Cstruct_list_set_ivalue",
                 "options": {},
                 "user_fmt": {
                     "field_name": "ivalue",
@@ -5734,6 +5768,7 @@
                 },
                 "decl": "double * Cstruct_list_get_dvalue(Cstruct_list *SH_this)",
                 "declgen": "double * Cstruct_list_get_dvalue(Cstruct_list * SH_this)",
+                "name": "Cstruct_list_get_dvalue",
                 "options": {},
                 "user_fmt": {
                     "field_name": "dvalue",
@@ -5839,6 +5874,7 @@
                 },
                 "decl": "double * Cstruct_list_get_dvalue(Cstruct_list *SH_this)",
                 "declgen": "double * Cstruct_list_get_dvalue(Cstruct_list * SH_this)",
+                "name": "Cstruct_list_get_dvalue",
                 "options": {},
                 "splicer_group": "buf",
                 "user_fmt": {
@@ -6011,6 +6047,7 @@
                 },
                 "decl": "void Cstruct_list_set_dvalue(Cstruct_list *SH_this,double * val)",
                 "declgen": "void Cstruct_list_set_dvalue(Cstruct_list * SH_this, double * val +intent(in)+rank(1))",
+                "name": "Cstruct_list_set_dvalue",
                 "options": {},
                 "user_fmt": {
                     "field_name": "dvalue",

--- a/regression/reference/struct-list-cxx/struct.json
+++ b/regression/reference/struct-list-cxx/struct.json
@@ -893,6 +893,7 @@
                 },
                 "decl": "int passStructByValue(Cstruct1 arg)",
                 "declgen": "int passStructByValue(Cstruct1 arg +value)",
+                "name": "passStructByValue",
                 "options": {
                     "literalinclude": true
                 },
@@ -990,6 +991,7 @@
                 },
                 "decl": "int passStruct1(const Cstruct1 *arg)",
                 "declgen": "int passStruct1(const Cstruct1 * arg)",
+                "name": "passStruct1",
                 "options": {
                     "literalinclude": true
                 },
@@ -1113,6 +1115,7 @@
                 "doxygen": {
                     "description": "Pass name argument which will build a bufferify function.\n"
                 },
+                "name": "passStruct2",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1234,6 +1237,7 @@
                 },
                 "decl": "int acceptStructInPtr(Cstruct1 *arg +intent(in))",
                 "declgen": "int acceptStructInPtr(Cstruct1 * arg +intent(in))",
+                "name": "acceptStructInPtr",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1367,6 +1371,7 @@
                 "doxygen": {
                     "description": "Pass name argument which will build a bufferify function.\n"
                 },
+                "name": "acceptStructOutPtr",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1489,6 +1494,7 @@
                 },
                 "decl": "void acceptStructInOutPtr(Cstruct1 *arg +intent(inout))",
                 "declgen": "void acceptStructInOutPtr(Cstruct1 * arg +intent(inout))",
+                "name": "acceptStructInOutPtr",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1581,6 +1587,7 @@
                 },
                 "decl": "Cstruct1 returnStructByValue(int i, double d);",
                 "declgen": "Cstruct1 returnStructByValue(int i +value, double d +value)",
+                "name": "returnStructByValue",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1721,6 +1728,7 @@
                     "brief": "Return a pointer to a struct",
                     "description": "Does not generate a bufferify C wrapper.\n"
                 },
+                "name": "returnStructPtr1",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1884,6 +1892,7 @@
                     "brief": "Return a pointer to a struct",
                     "description": "Generates a bufferify C wrapper function.\n"
                 },
+                "name": "returnStructPtr2",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2011,6 +2020,7 @@
                 },
                 "decl": "Cstruct_list *get_global_struct_list();",
                 "declgen": "Cstruct_list * get_global_struct_list(void)",
+                "name": "get_global_struct_list",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2071,6 +2081,7 @@
                 },
                 "decl": "Cstruct_as_class *Create_Cstruct_as_class(void)",
                 "declgen": "Cstruct_as_class * Create_Cstruct_as_class(void)",
+                "name": "Create_Cstruct_as_class",
                 "options": {
                     "class_ctor": "Cstruct_as_class",
                     "literalinclude": true,
@@ -2139,6 +2150,7 @@
                 },
                 "decl": "Cstruct_as_class *Create_Cstruct_as_class_args(int x, int y)",
                 "declgen": "Cstruct_as_class * Create_Cstruct_as_class_args(int x +value, int y +value)",
+                "name": "Create_Cstruct_as_class_args",
                 "options": {
                     "class_ctor": "Cstruct_as_class",
                     "wrap_python": false
@@ -2190,6 +2202,7 @@
                 },
                 "decl": "int Cstruct_as_class_sum(const Cstruct_as_class *point +pass)",
                 "declgen": "int Cstruct_as_class_sum(const Cstruct_as_class * point +pass)",
+                "name": "Cstruct_as_class_sum",
                 "options": {
                     "class_method": "Cstruct_as_class",
                     "wrap_python": false
@@ -2277,6 +2290,7 @@
                 },
                 "decl": "Cstruct_as_subclass *Create_Cstruct_as_subclass_args(int x, int y, int z)",
                 "declgen": "Cstruct_as_subclass * Create_Cstruct_as_subclass_args(int x +value, int y +value, int z +value)",
+                "name": "Create_Cstruct_as_subclass_args",
                 "options": {
                     "class_ctor": "Cstruct_as_subclass",
                     "wrap_python": false

--- a/regression/reference/struct-list-cxx/struct.json
+++ b/regression/reference/struct-list-cxx/struct.json
@@ -26,7 +26,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "ifield"
+                                "name": "ifield",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -51,7 +52,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "dfield"
+                                "name": "dfield",
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -118,7 +120,8 @@
                                     {
                                         "ptr": "*"
                                     }
-                                ]
+                                ],
+                                "typemap_name": "char"
                             },
                             "specifier": [
                                 "char"
@@ -149,7 +152,8 @@
                                     {
                                         "ptr": "*"
                                     }
-                                ]
+                                ],
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -213,7 +217,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "nitems"
+                                "name": "nitems",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -237,29 +242,30 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems+nitems"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems+nitems"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "left": {
+                                                "name": "nitems"
+                                            },
+                                            "op": "+",
+                                            "right": {
+                                                "name": "nitems"
+                                            }
+                                        }
+                                    ]
+                                },
                                 "name": "ivalue",
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "left": {
-                                            "name": "nitems"
-                                        },
-                                        "op": "+",
-                                        "right": {
-                                            "name": "nitems"
-                                        }
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -283,29 +289,30 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems*TWO"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems*TWO"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "left": {
+                                                "name": "nitems"
+                                            },
+                                            "op": "*",
+                                            "right": {
+                                                "name": "TWO"
+                                            }
+                                        }
+                                    ]
+                                },
                                 "name": "dvalue",
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "left": {
-                                            "name": "nitems"
-                                        },
-                                        "op": "*",
-                                        "right": {
-                                            "name": "TWO"
-                                        }
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -329,10 +336,17 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "name": "nitems"
+                                        }
+                                    ]
+                                },
                                 "name": "svalue",
                                 "pointer": [
                                     {
@@ -341,14 +355,8 @@
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nitems"
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "char"
                             },
                             "specifier": [
                                 "char"
@@ -413,7 +421,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "nitems"
+                                "name": "nitems",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -437,23 +446,24 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "name": "nitems"
+                                        }
+                                    ]
+                                },
                                 "name": "ivalue",
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nitems"
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -477,23 +487,24 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "name": "nitems"
+                                        }
+                                    ]
+                                },
                                 "name": "dvalue",
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nitems"
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -556,13 +567,14 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "array": [
-                                {
-                                    "constant": "20"
-                                }
-                            ],
                             "declarator": {
-                                "name": "name"
+                                "array": [
+                                    {
+                                        "constant": "20"
+                                    }
+                                ],
+                                "name": "name",
+                                "typemap_name": "char"
                             },
                             "specifier": [
                                 "char"
@@ -586,13 +598,14 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "array": [
-                                {
-                                    "constant": "10"
-                                }
-                            ],
                             "declarator": {
-                                "name": "count"
+                                "array": [
+                                    {
+                                        "constant": "10"
+                                    }
+                                ],
+                                "name": "count",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -658,7 +671,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "x1"
+                                "name": "x1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -681,7 +695,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "y1"
+                                "name": "y1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -740,7 +755,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "x1"
+                                "name": "x1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -763,7 +779,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "y1"
+                                "name": "y1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -786,7 +803,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "z1"
+                                "name": "z1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -844,28 +862,30 @@
                 "<FUNCTION>": "0 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passStructByValue"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "passStructByValue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -936,31 +956,33 @@
                 "<FUNCTION>": "1 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passStruct1"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "passStruct1",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -1032,52 +1054,55 @@
                 "<FUNCTION>": "2 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passStruct2"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "s1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "charlen": "LENOUTBUF",
-                                "intent": "out"
+                        "name": "passStruct2",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "s1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
                             },
-                            "declarator": {
-                                "name": "outbuf",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "charlen": "LENOUTBUF",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "outbuf",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -1173,33 +1198,35 @@
                 "<FUNCTION>": "3 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStructInPtr"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "acceptStructInPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -1269,63 +1296,67 @@
                 "<FUNCTION>": "4 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStructOutPtr"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "acceptStructOutPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
                             },
-                            "declarator": {
-                                "name": "i"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1422,33 +1453,35 @@
                 "<FUNCTION>": "5 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStructInOutPtr"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptStructInOutPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -1501,43 +1534,46 @@
                 "<FUNCTION>": "6 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "returnStructByValue"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "returnStructByValue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "Cstruct1"
+                    },
                     "specifier": [
                         "Cstruct1"
                     ],
@@ -1628,49 +1664,52 @@
                 "<FUNCTION>": "7 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnStructPtr1",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct1"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct1"
                     ],
@@ -1766,70 +1805,74 @@
                 "<FUNCTION>": "8 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnStructPtr2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "charlen": "LENOUTBUF",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "outbuf",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct1"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        },
-                        {
-                            "attrs": {
-                                "charlen": "LENOUTBUF",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "outbuf",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct1"
                     ],
@@ -1948,18 +1991,19 @@
                 "<FUNCTION>": "9 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "get_global_struct_list",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct_list"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "Cstruct_list"
                     ],
@@ -2007,18 +2051,19 @@
                 "<FUNCTION>": "10 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
                         "name": "Create_Cstruct_as_class",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct_as_class"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "Cstruct_as_class"
                     ],
@@ -2041,49 +2086,52 @@
                 "<FUNCTION>": "11 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
                         "name": "Create_Cstruct_as_class_args",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "x",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "y",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct_as_class"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "x"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "y"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct_as_class"
                     ],
@@ -2105,34 +2153,36 @@
                 "<FUNCTION>": "12 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "Cstruct_as_class_sum"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "Cstruct_as_class_sum",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "pass": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "point",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct_as_class"
+                                },
+                                "specifier": [
+                                    "Cstruct_as_class"
+                                ],
+                                "typemap_name": "Cstruct_as_class"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "pass": true
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "point",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct_as_class"
-                            ],
-                            "typemap_name": "Cstruct_as_class"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -2158,64 +2208,68 @@
                 "<FUNCTION>": "13 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
                         "name": "Create_Cstruct_as_subclass_args",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "x",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "y",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "z",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct_as_subclass"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "x"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "y"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "z"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct_as_subclass"
                     ],

--- a/regression/reference/struct-numpy-c/struct.json
+++ b/regression/reference/struct-numpy-c/struct.json
@@ -893,6 +893,7 @@
                 },
                 "decl": "int passStructByValue(Cstruct1 arg)",
                 "declgen": "int passStructByValue(Cstruct1 arg +value)",
+                "name": "passStructByValue",
                 "options": {
                     "literalinclude": true
                 },
@@ -990,6 +991,7 @@
                 },
                 "decl": "int passStruct1(const Cstruct1 *arg)",
                 "declgen": "int passStruct1(const Cstruct1 * arg)",
+                "name": "passStruct1",
                 "options": {
                     "literalinclude": true
                 },
@@ -1113,6 +1115,7 @@
                 "doxygen": {
                     "description": "Pass name argument which will build a bufferify function.\n"
                 },
+                "name": "passStruct2",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1234,6 +1237,7 @@
                 },
                 "decl": "int acceptStructInPtr(Cstruct1 *arg +intent(in))",
                 "declgen": "int acceptStructInPtr(Cstruct1 * arg +intent(in))",
+                "name": "acceptStructInPtr",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1367,6 +1371,7 @@
                 "doxygen": {
                     "description": "Pass name argument which will build a bufferify function.\n"
                 },
+                "name": "acceptStructOutPtr",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1487,6 +1492,7 @@
                 },
                 "decl": "void acceptStructInOutPtr(Cstruct1 *arg +intent(inout))",
                 "declgen": "void acceptStructInOutPtr(Cstruct1 * arg +intent(inout))",
+                "name": "acceptStructInOutPtr",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1577,6 +1583,7 @@
                 },
                 "decl": "Cstruct1 returnStructByValue(int i, double d);",
                 "declgen": "Cstruct1 returnStructByValue(int i +value, double d +value)",
+                "name": "returnStructByValue",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1718,6 +1725,7 @@
                     "brief": "Return a pointer to a struct",
                     "description": "Does not generate a bufferify C wrapper.\n"
                 },
+                "name": "returnStructPtr1",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1879,6 +1887,7 @@
                     "brief": "Return a pointer to a struct",
                     "description": "Generates a bufferify C wrapper function.\n"
                 },
+                "name": "returnStructPtr2",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2004,6 +2013,7 @@
                 },
                 "decl": "Cstruct_list *get_global_struct_list();",
                 "declgen": "Cstruct_list * get_global_struct_list(void)",
+                "name": "get_global_struct_list",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2062,6 +2072,7 @@
                 },
                 "decl": "Cstruct_as_class *Create_Cstruct_as_class(void)",
                 "declgen": "Cstruct_as_class * Create_Cstruct_as_class(void)",
+                "name": "Create_Cstruct_as_class",
                 "options": {
                     "class_ctor": "Cstruct_as_class",
                     "literalinclude": true,
@@ -2130,6 +2141,7 @@
                 },
                 "decl": "Cstruct_as_class *Create_Cstruct_as_class_args(int x, int y)",
                 "declgen": "Cstruct_as_class * Create_Cstruct_as_class_args(int x +value, int y +value)",
+                "name": "Create_Cstruct_as_class_args",
                 "options": {
                     "class_ctor": "Cstruct_as_class",
                     "wrap_python": false
@@ -2181,6 +2193,7 @@
                 },
                 "decl": "int Cstruct_as_class_sum(const Cstruct_as_class *point +pass)",
                 "declgen": "int Cstruct_as_class_sum(const Cstruct_as_class * point +pass)",
+                "name": "Cstruct_as_class_sum",
                 "options": {
                     "class_method": "Cstruct_as_class",
                     "wrap_python": false
@@ -2268,6 +2281,7 @@
                 },
                 "decl": "Cstruct_as_subclass *Create_Cstruct_as_subclass_args(int x, int y, int z)",
                 "declgen": "Cstruct_as_subclass * Create_Cstruct_as_subclass_args(int x +value, int y +value, int z +value)",
+                "name": "Create_Cstruct_as_subclass_args",
                 "options": {
                     "class_ctor": "Cstruct_as_subclass",
                     "wrap_python": false

--- a/regression/reference/struct-numpy-c/struct.json
+++ b/regression/reference/struct-numpy-c/struct.json
@@ -26,7 +26,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "ifield"
+                                "name": "ifield",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -51,7 +52,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "dfield"
+                                "name": "dfield",
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -118,7 +120,8 @@
                                     {
                                         "ptr": "*"
                                     }
-                                ]
+                                ],
+                                "typemap_name": "char"
                             },
                             "specifier": [
                                 "char"
@@ -149,7 +152,8 @@
                                     {
                                         "ptr": "*"
                                     }
-                                ]
+                                ],
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -213,7 +217,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "nitems"
+                                "name": "nitems",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -237,29 +242,30 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems+nitems"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems+nitems"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "left": {
+                                                "name": "nitems"
+                                            },
+                                            "op": "+",
+                                            "right": {
+                                                "name": "nitems"
+                                            }
+                                        }
+                                    ]
+                                },
                                 "name": "ivalue",
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "left": {
-                                            "name": "nitems"
-                                        },
-                                        "op": "+",
-                                        "right": {
-                                            "name": "nitems"
-                                        }
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -283,29 +289,30 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems*TWO"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems*TWO"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "left": {
+                                                "name": "nitems"
+                                            },
+                                            "op": "*",
+                                            "right": {
+                                                "name": "TWO"
+                                            }
+                                        }
+                                    ]
+                                },
                                 "name": "dvalue",
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "left": {
-                                            "name": "nitems"
-                                        },
-                                        "op": "*",
-                                        "right": {
-                                            "name": "TWO"
-                                        }
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -329,10 +336,17 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "name": "nitems"
+                                        }
+                                    ]
+                                },
                                 "name": "svalue",
                                 "pointer": [
                                     {
@@ -341,14 +355,8 @@
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nitems"
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "char"
                             },
                             "specifier": [
                                 "char"
@@ -413,7 +421,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "nitems"
+                                "name": "nitems",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -437,23 +446,24 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "name": "nitems"
+                                        }
+                                    ]
+                                },
                                 "name": "ivalue",
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nitems"
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -477,23 +487,24 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "name": "nitems"
+                                        }
+                                    ]
+                                },
                                 "name": "dvalue",
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nitems"
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -556,13 +567,14 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "array": [
-                                {
-                                    "constant": "20"
-                                }
-                            ],
                             "declarator": {
-                                "name": "name"
+                                "array": [
+                                    {
+                                        "constant": "20"
+                                    }
+                                ],
+                                "name": "name",
+                                "typemap_name": "char"
                             },
                             "specifier": [
                                 "char"
@@ -586,13 +598,14 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "array": [
-                                {
-                                    "constant": "10"
-                                }
-                            ],
                             "declarator": {
-                                "name": "count"
+                                "array": [
+                                    {
+                                        "constant": "10"
+                                    }
+                                ],
+                                "name": "count",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -658,7 +671,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "x1"
+                                "name": "x1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -681,7 +695,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "y1"
+                                "name": "y1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -740,7 +755,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "x1"
+                                "name": "x1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -763,7 +779,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "y1"
+                                "name": "y1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -786,7 +803,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "z1"
+                                "name": "z1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -844,28 +862,30 @@
                 "<FUNCTION>": "0 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passStructByValue"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "passStructByValue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -936,31 +956,33 @@
                 "<FUNCTION>": "1 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passStruct1"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "passStruct1",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -1032,52 +1054,55 @@
                 "<FUNCTION>": "2 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passStruct2"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "s1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "charlen": "LENOUTBUF",
-                                "intent": "out"
+                        "name": "passStruct2",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "s1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
                             },
-                            "declarator": {
-                                "name": "outbuf",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "charlen": "LENOUTBUF",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "outbuf",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -1173,33 +1198,35 @@
                 "<FUNCTION>": "3 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStructInPtr"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "acceptStructInPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -1269,63 +1296,67 @@
                 "<FUNCTION>": "4 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStructOutPtr"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "acceptStructOutPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
                             },
-                            "declarator": {
-                                "name": "i"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1420,33 +1451,35 @@
                 "<FUNCTION>": "5 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStructInOutPtr"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptStructInOutPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -1497,43 +1530,46 @@
                 "<FUNCTION>": "6 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "returnStructByValue"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "returnStructByValue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "Cstruct1"
+                    },
                     "specifier": [
                         "Cstruct1"
                     ],
@@ -1625,49 +1661,52 @@
                 "<FUNCTION>": "7 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnStructPtr1",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct1"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct1"
                     ],
@@ -1761,70 +1800,74 @@
                 "<FUNCTION>": "8 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnStructPtr2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "charlen": "LENOUTBUF",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "outbuf",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct1"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        },
-                        {
-                            "attrs": {
-                                "charlen": "LENOUTBUF",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "outbuf",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct1"
                     ],
@@ -1941,18 +1984,19 @@
                 "<FUNCTION>": "9 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "get_global_struct_list",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct_list"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "Cstruct_list"
                     ],
@@ -1998,18 +2042,19 @@
                 "<FUNCTION>": "10 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
                         "name": "Create_Cstruct_as_class",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct_as_class"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "Cstruct_as_class"
                     ],
@@ -2032,49 +2077,52 @@
                 "<FUNCTION>": "11 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
                         "name": "Create_Cstruct_as_class_args",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "x",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "y",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct_as_class"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "x"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "y"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct_as_class"
                     ],
@@ -2096,34 +2144,36 @@
                 "<FUNCTION>": "12 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "Cstruct_as_class_sum"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "Cstruct_as_class_sum",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "pass": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "point",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct_as_class"
+                                },
+                                "specifier": [
+                                    "Cstruct_as_class"
+                                ],
+                                "typemap_name": "Cstruct_as_class"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "pass": true
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "point",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct_as_class"
-                            ],
-                            "typemap_name": "Cstruct_as_class"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -2149,64 +2199,68 @@
                 "<FUNCTION>": "13 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
                         "name": "Create_Cstruct_as_subclass_args",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "x",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "y",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "z",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct_as_subclass"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "x"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "y"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "z"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct_as_subclass"
                     ],

--- a/regression/reference/struct-numpy-cxx/struct.json
+++ b/regression/reference/struct-numpy-cxx/struct.json
@@ -893,6 +893,7 @@
                 },
                 "decl": "int passStructByValue(Cstruct1 arg)",
                 "declgen": "int passStructByValue(Cstruct1 arg +value)",
+                "name": "passStructByValue",
                 "options": {
                     "literalinclude": true
                 },
@@ -990,6 +991,7 @@
                 },
                 "decl": "int passStruct1(const Cstruct1 *arg)",
                 "declgen": "int passStruct1(const Cstruct1 * arg)",
+                "name": "passStruct1",
                 "options": {
                     "literalinclude": true
                 },
@@ -1113,6 +1115,7 @@
                 "doxygen": {
                     "description": "Pass name argument which will build a bufferify function.\n"
                 },
+                "name": "passStruct2",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1234,6 +1237,7 @@
                 },
                 "decl": "int acceptStructInPtr(Cstruct1 *arg +intent(in))",
                 "declgen": "int acceptStructInPtr(Cstruct1 * arg +intent(in))",
+                "name": "acceptStructInPtr",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1367,6 +1371,7 @@
                 "doxygen": {
                     "description": "Pass name argument which will build a bufferify function.\n"
                 },
+                "name": "acceptStructOutPtr",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1487,6 +1492,7 @@
                 },
                 "decl": "void acceptStructInOutPtr(Cstruct1 *arg +intent(inout))",
                 "declgen": "void acceptStructInOutPtr(Cstruct1 * arg +intent(inout))",
+                "name": "acceptStructInOutPtr",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1577,6 +1583,7 @@
                 },
                 "decl": "Cstruct1 returnStructByValue(int i, double d);",
                 "declgen": "Cstruct1 returnStructByValue(int i +value, double d +value)",
+                "name": "returnStructByValue",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1718,6 +1725,7 @@
                     "brief": "Return a pointer to a struct",
                     "description": "Does not generate a bufferify C wrapper.\n"
                 },
+                "name": "returnStructPtr1",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1879,6 +1887,7 @@
                     "brief": "Return a pointer to a struct",
                     "description": "Generates a bufferify C wrapper function.\n"
                 },
+                "name": "returnStructPtr2",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2004,6 +2013,7 @@
                 },
                 "decl": "Cstruct_list *get_global_struct_list();",
                 "declgen": "Cstruct_list * get_global_struct_list(void)",
+                "name": "get_global_struct_list",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -2062,6 +2072,7 @@
                 },
                 "decl": "Cstruct_as_class *Create_Cstruct_as_class(void)",
                 "declgen": "Cstruct_as_class * Create_Cstruct_as_class(void)",
+                "name": "Create_Cstruct_as_class",
                 "options": {
                     "class_ctor": "Cstruct_as_class",
                     "literalinclude": true,
@@ -2130,6 +2141,7 @@
                 },
                 "decl": "Cstruct_as_class *Create_Cstruct_as_class_args(int x, int y)",
                 "declgen": "Cstruct_as_class * Create_Cstruct_as_class_args(int x +value, int y +value)",
+                "name": "Create_Cstruct_as_class_args",
                 "options": {
                     "class_ctor": "Cstruct_as_class",
                     "wrap_python": false
@@ -2181,6 +2193,7 @@
                 },
                 "decl": "int Cstruct_as_class_sum(const Cstruct_as_class *point +pass)",
                 "declgen": "int Cstruct_as_class_sum(const Cstruct_as_class * point +pass)",
+                "name": "Cstruct_as_class_sum",
                 "options": {
                     "class_method": "Cstruct_as_class",
                     "wrap_python": false
@@ -2268,6 +2281,7 @@
                 },
                 "decl": "Cstruct_as_subclass *Create_Cstruct_as_subclass_args(int x, int y, int z)",
                 "declgen": "Cstruct_as_subclass * Create_Cstruct_as_subclass_args(int x +value, int y +value, int z +value)",
+                "name": "Create_Cstruct_as_subclass_args",
                 "options": {
                     "class_ctor": "Cstruct_as_subclass",
                     "wrap_python": false

--- a/regression/reference/struct-numpy-cxx/struct.json
+++ b/regression/reference/struct-numpy-cxx/struct.json
@@ -26,7 +26,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "ifield"
+                                "name": "ifield",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -51,7 +52,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "dfield"
+                                "name": "dfield",
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -118,7 +120,8 @@
                                     {
                                         "ptr": "*"
                                     }
-                                ]
+                                ],
+                                "typemap_name": "char"
                             },
                             "specifier": [
                                 "char"
@@ -149,7 +152,8 @@
                                     {
                                         "ptr": "*"
                                     }
-                                ]
+                                ],
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -213,7 +217,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "nitems"
+                                "name": "nitems",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -237,29 +242,30 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems+nitems"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems+nitems"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "left": {
+                                                "name": "nitems"
+                                            },
+                                            "op": "+",
+                                            "right": {
+                                                "name": "nitems"
+                                            }
+                                        }
+                                    ]
+                                },
                                 "name": "ivalue",
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "left": {
-                                            "name": "nitems"
-                                        },
-                                        "op": "+",
-                                        "right": {
-                                            "name": "nitems"
-                                        }
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -283,29 +289,30 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems*TWO"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems*TWO"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "left": {
+                                                "name": "nitems"
+                                            },
+                                            "op": "*",
+                                            "right": {
+                                                "name": "TWO"
+                                            }
+                                        }
+                                    ]
+                                },
                                 "name": "dvalue",
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "left": {
-                                            "name": "nitems"
-                                        },
-                                        "op": "*",
-                                        "right": {
-                                            "name": "TWO"
-                                        }
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -329,10 +336,17 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "name": "nitems"
+                                        }
+                                    ]
+                                },
                                 "name": "svalue",
                                 "pointer": [
                                     {
@@ -341,14 +355,8 @@
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nitems"
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "char"
                             },
                             "specifier": [
                                 "char"
@@ -413,7 +421,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "nitems"
+                                "name": "nitems",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -437,23 +446,24 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "name": "nitems"
+                                        }
+                                    ]
+                                },
                                 "name": "ivalue",
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nitems"
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -477,23 +487,24 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "attrs": {
-                                "dimension": "nitems"
-                            },
                             "declarator": {
+                                "attrs": {
+                                    "dimension": "nitems"
+                                },
+                                "metaattrs": {
+                                    "dimension": [
+                                        {
+                                            "name": "nitems"
+                                        }
+                                    ]
+                                },
                                 "name": "dvalue",
                                 "pointer": [
                                     {
                                         "ptr": "*"
                                     }
-                                ]
-                            },
-                            "metaattrs": {
-                                "dimension": [
-                                    {
-                                        "name": "nitems"
-                                    }
-                                ]
+                                ],
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -556,13 +567,14 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "array": [
-                                {
-                                    "constant": "20"
-                                }
-                            ],
                             "declarator": {
-                                "name": "name"
+                                "array": [
+                                    {
+                                        "constant": "20"
+                                    }
+                                ],
+                                "name": "name",
+                                "typemap_name": "char"
                             },
                             "specifier": [
                                 "char"
@@ -586,13 +598,14 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "array": [
-                                {
-                                    "constant": "10"
-                                }
-                            ],
                             "declarator": {
-                                "name": "count"
+                                "array": [
+                                    {
+                                        "constant": "10"
+                                    }
+                                ],
+                                "name": "count",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -658,7 +671,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "x1"
+                                "name": "x1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -681,7 +695,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "y1"
+                                "name": "y1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -740,7 +755,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "x1"
+                                "name": "x1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -763,7 +779,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "y1"
+                                "name": "y1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -786,7 +803,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "z1"
+                                "name": "z1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -844,28 +862,30 @@
                 "<FUNCTION>": "0 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passStructByValue"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "passStructByValue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -936,31 +956,33 @@
                 "<FUNCTION>": "1 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passStruct1"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "passStruct1",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -1032,52 +1054,55 @@
                 "<FUNCTION>": "2 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "passStruct2"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "s1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "charlen": "LENOUTBUF",
-                                "intent": "out"
+                        "name": "passStruct2",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "s1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
                             },
-                            "declarator": {
-                                "name": "outbuf",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "charlen": "LENOUTBUF",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "outbuf",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -1173,33 +1198,35 @@
                 "<FUNCTION>": "3 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStructInPtr"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "acceptStructInPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -1269,63 +1296,67 @@
                 "<FUNCTION>": "4 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStructOutPtr"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "acceptStructOutPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
                             },
-                            "declarator": {
-                                "name": "i"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1420,33 +1451,35 @@
                 "<FUNCTION>": "5 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptStructInOutPtr"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "acceptStructInOutPtr",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct1"
+                                },
+                                "specifier": [
+                                    "Cstruct1"
+                                ],
+                                "typemap_name": "Cstruct1"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout"
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "Cstruct1"
-                            ],
-                            "typemap_name": "Cstruct1"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -1497,43 +1530,46 @@
                 "<FUNCTION>": "6 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "returnStructByValue"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "returnStructByValue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "Cstruct1"
+                    },
                     "specifier": [
                         "Cstruct1"
                     ],
@@ -1625,49 +1661,52 @@
                 "<FUNCTION>": "7 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnStructPtr1",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct1"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct1"
                     ],
@@ -1761,70 +1800,74 @@
                 "<FUNCTION>": "8 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "returnStructPtr2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "d",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "charlen": "LENOUTBUF",
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "outbuf",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "char"
+                                },
+                                "specifier": [
+                                    "char"
+                                ],
+                                "typemap_name": "char"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct1"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "d"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        },
-                        {
-                            "attrs": {
-                                "charlen": "LENOUTBUF",
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "outbuf",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "char"
-                            ],
-                            "typemap_name": "char"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct1"
                     ],
@@ -1941,18 +1984,19 @@
                 "<FUNCTION>": "9 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "deref": "pointer",
+                            "intent": "function"
+                        },
                         "name": "get_global_struct_list",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct_list"
                     },
-                    "metaattrs": {
-                        "deref": "pointer",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "Cstruct_list"
                     ],
@@ -1998,18 +2042,19 @@
                 "<FUNCTION>": "10 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
                         "name": "Create_Cstruct_as_class",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct_as_class"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "Cstruct_as_class"
                     ],
@@ -2032,49 +2077,52 @@
                 "<FUNCTION>": "11 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
                         "name": "Create_Cstruct_as_class_args",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "x",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "y",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct_as_class"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "x"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "y"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct_as_class"
                     ],
@@ -2096,34 +2144,36 @@
                 "<FUNCTION>": "12 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "Cstruct_as_class_sum"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "Cstruct_as_class_sum",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "pass": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "point",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct_as_class"
+                                },
+                                "specifier": [
+                                    "Cstruct_as_class"
+                                ],
+                                "typemap_name": "Cstruct_as_class"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "pass": true
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "point",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct_as_class"
-                            ],
-                            "typemap_name": "Cstruct_as_class"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -2149,64 +2199,68 @@
                 "<FUNCTION>": "13 ****************************************",
                 "ast": {
                     "declarator": {
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
                         "name": "Create_Cstruct_as_subclass_args",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "x",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "y",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "z",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
                         "pointer": [
                             {
                                 "ptr": "*"
                             }
-                        ]
+                        ],
+                        "typemap_name": "Cstruct_as_subclass"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "x"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "y"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "z"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "Cstruct_as_subclass"
                     ],

--- a/regression/reference/struct-py-c/struct-py.json
+++ b/regression/reference/struct-py-c/struct-py.json
@@ -14,42 +14,9 @@
                         "<FUNCTION>": "0 ****************************************",
                         "_generated": "struct_as_class_ctor",
                         "ast": {
-                            "attrs": {
-                                "_constructor": true,
-                                "name": "Cstruct_as_class_ctor"
+                            "declarator": {
+                                "typemap_name": "Cstruct_as_class"
                             },
-                            "declarator": {},
-                            "metaattrs": {
-                                "intent": "ctor"
-                            },
-                            "params": [
-                                {
-                                    "declarator": {
-                                        "name": "x1"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in",
-                                        "struct_member": "x1"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                },
-                                {
-                                    "declarator": {
-                                        "name": "y1"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in",
-                                        "struct_member": "y1"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
                             "specifier": [
                                 "Cstruct_as_class"
                             ],
@@ -159,7 +126,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "x1"
+                                "name": "x1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -187,7 +155,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "y1"
+                                "name": "y1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -257,7 +226,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "x2"
+                                "name": "x2",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -282,7 +252,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "y2"
+                                "name": "y2",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -348,53 +319,56 @@
                 "<FUNCTION>": "1 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptBothStructs"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in"
-                            },
-                            "declarator": {
-                                "name": "s1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct_as_class"
-                            ],
-                            "typemap_name": "Cstruct_as_class"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "intent": "in"
+                        "name": "acceptBothStructs",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "s1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct_as_class"
+                                },
+                                "specifier": [
+                                    "Cstruct_as_class"
+                                ],
+                                "typemap_name": "Cstruct_as_class"
                             },
-                            "declarator": {
-                                "name": "s2",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct_as_numpy"
-                            ],
-                            "typemap_name": "Cstruct_as_numpy"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "s2",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct_as_numpy"
+                                },
+                                "specifier": [
+                                    "Cstruct_as_numpy"
+                                ],
+                                "typemap_name": "Cstruct_as_numpy"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],

--- a/regression/reference/struct-py-c/struct-py.json
+++ b/regression/reference/struct-py-c/struct-py.json
@@ -18,6 +18,7 @@
                                 "_constructor": true,
                                 "name": "Cstruct_as_class_ctor"
                             },
+                            "declarator": {},
                             "metaattrs": {
                                 "intent": "ctor"
                             },

--- a/regression/reference/struct-py-c/struct-py.json
+++ b/regression/reference/struct-py-c/struct-py.json
@@ -61,6 +61,7 @@
                         },
                         "decl": "Cstruct_as_class_ctor",
                         "declgen": "Cstruct_as_class(int x1, int y1) +name(Cstruct_as_class_ctor)",
+                        "name": "Cstruct_as_class_ctor",
                         "options": {
                             "wrap_c": false,
                             "wrap_fortran": false,
@@ -413,6 +414,7 @@
                 },
                 "decl": "int acceptBothStructs( Cstruct_as_class *s1 +intent(in), Cstruct_as_numpy *s2 +intent(in))",
                 "declgen": "int acceptBothStructs(Cstruct_as_class * s1 +intent(in), Cstruct_as_numpy * s2 +intent(in))",
+                "name": "acceptBothStructs",
                 "options": {},
                 "wrap": {
                     "python": true

--- a/regression/reference/struct-py-c/struct-py.json
+++ b/regression/reference/struct-py-c/struct-py.json
@@ -54,6 +54,7 @@
                                 ],
                                 "typemap_name": "Cstruct_as_class"
                             },
+                            "is_ctor": true,
                             "specifier": [
                                 "Cstruct_as_class"
                             ],

--- a/regression/reference/struct-py-c/struct-py.json
+++ b/regression/reference/struct-py-c/struct-py.json
@@ -22,6 +22,36 @@
                                 "metaattrs": {
                                     "intent": "ctor"
                                 },
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "metaattrs": {
+                                                "intent": "in",
+                                                "struct_member": "x1"
+                                            },
+                                            "name": "x1",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    },
+                                    {
+                                        "declarator": {
+                                            "metaattrs": {
+                                                "intent": "in",
+                                                "struct_member": "y1"
+                                            },
+                                            "name": "y1",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
                                 "typemap_name": "Cstruct_as_class"
                             },
                             "specifier": [

--- a/regression/reference/struct-py-c/struct-py.json
+++ b/regression/reference/struct-py-c/struct-py.json
@@ -15,6 +15,13 @@
                         "_generated": "struct_as_class_ctor",
                         "ast": {
                             "declarator": {
+                                "attrs": {
+                                    "_constructor": true,
+                                    "name": "Cstruct_as_class_ctor"
+                                },
+                                "metaattrs": {
+                                    "intent": "ctor"
+                                },
                                 "typemap_name": "Cstruct_as_class"
                             },
                             "specifier": [

--- a/regression/reference/struct-py-cxx/struct-py.json
+++ b/regression/reference/struct-py-cxx/struct-py.json
@@ -14,42 +14,9 @@
                         "<FUNCTION>": "0 ****************************************",
                         "_generated": "struct_as_class_ctor",
                         "ast": {
-                            "attrs": {
-                                "_constructor": true,
-                                "name": "Cstruct_as_class_ctor"
+                            "declarator": {
+                                "typemap_name": "Cstruct_as_class"
                             },
-                            "declarator": {},
-                            "metaattrs": {
-                                "intent": "ctor"
-                            },
-                            "params": [
-                                {
-                                    "declarator": {
-                                        "name": "x1"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in",
-                                        "struct_member": "x1"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                },
-                                {
-                                    "declarator": {
-                                        "name": "y1"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in",
-                                        "struct_member": "y1"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
                             "specifier": [
                                 "Cstruct_as_class"
                             ],
@@ -159,7 +126,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "x1"
+                                "name": "x1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -187,7 +155,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "y1"
+                                "name": "y1",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -257,7 +226,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "x2"
+                                "name": "x2",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -282,7 +252,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "y2"
+                                "name": "y2",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -348,53 +319,56 @@
                 "<FUNCTION>": "1 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "acceptBothStructs"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in"
-                            },
-                            "declarator": {
-                                "name": "s1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct_as_class"
-                            ],
-                            "typemap_name": "Cstruct_as_class"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "intent": "in"
+                        "name": "acceptBothStructs",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "s1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct_as_class"
+                                },
+                                "specifier": [
+                                    "Cstruct_as_class"
+                                ],
+                                "typemap_name": "Cstruct_as_class"
                             },
-                            "declarator": {
-                                "name": "s2",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Cstruct_as_numpy"
-                            ],
-                            "typemap_name": "Cstruct_as_numpy"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "s2",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Cstruct_as_numpy"
+                                },
+                                "specifier": [
+                                    "Cstruct_as_numpy"
+                                ],
+                                "typemap_name": "Cstruct_as_numpy"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],

--- a/regression/reference/struct-py-cxx/struct-py.json
+++ b/regression/reference/struct-py-cxx/struct-py.json
@@ -18,6 +18,7 @@
                                 "_constructor": true,
                                 "name": "Cstruct_as_class_ctor"
                             },
+                            "declarator": {},
                             "metaattrs": {
                                 "intent": "ctor"
                             },

--- a/regression/reference/struct-py-cxx/struct-py.json
+++ b/regression/reference/struct-py-cxx/struct-py.json
@@ -61,6 +61,7 @@
                         },
                         "decl": "Cstruct_as_class_ctor",
                         "declgen": "Cstruct_as_class(int x1, int y1) +name(Cstruct_as_class_ctor)",
+                        "name": "Cstruct_as_class_ctor",
                         "options": {
                             "wrap_c": false,
                             "wrap_fortran": false,
@@ -413,6 +414,7 @@
                 },
                 "decl": "int acceptBothStructs( Cstruct_as_class *s1 +intent(in), Cstruct_as_numpy *s2 +intent(in))",
                 "declgen": "int acceptBothStructs(Cstruct_as_class * s1 +intent(in), Cstruct_as_numpy * s2 +intent(in))",
+                "name": "acceptBothStructs",
                 "options": {},
                 "wrap": {
                     "python": true

--- a/regression/reference/struct-py-cxx/struct-py.json
+++ b/regression/reference/struct-py-cxx/struct-py.json
@@ -54,6 +54,7 @@
                                 ],
                                 "typemap_name": "Cstruct_as_class"
                             },
+                            "is_ctor": true,
                             "specifier": [
                                 "Cstruct_as_class"
                             ],

--- a/regression/reference/struct-py-cxx/struct-py.json
+++ b/regression/reference/struct-py-cxx/struct-py.json
@@ -22,6 +22,36 @@
                                 "metaattrs": {
                                     "intent": "ctor"
                                 },
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "metaattrs": {
+                                                "intent": "in",
+                                                "struct_member": "x1"
+                                            },
+                                            "name": "x1",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    },
+                                    {
+                                        "declarator": {
+                                            "metaattrs": {
+                                                "intent": "in",
+                                                "struct_member": "y1"
+                                            },
+                                            "name": "y1",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
                                 "typemap_name": "Cstruct_as_class"
                             },
                             "specifier": [

--- a/regression/reference/struct-py-cxx/struct-py.json
+++ b/regression/reference/struct-py-cxx/struct-py.json
@@ -15,6 +15,13 @@
                         "_generated": "struct_as_class_ctor",
                         "ast": {
                             "declarator": {
+                                "attrs": {
+                                    "_constructor": true,
+                                    "name": "Cstruct_as_class_ctor"
+                                },
+                                "metaattrs": {
+                                    "intent": "ctor"
+                                },
                                 "typemap_name": "Cstruct_as_class"
                             },
                             "specifier": [

--- a/regression/reference/structlist/structlist.json
+++ b/regression/reference/structlist/structlist.json
@@ -70,6 +70,7 @@
                         },
                         "decl": "Arrays1_ctor",
                         "declgen": "Arrays1(char name[20], int count[10]) +name(Arrays1_ctor)",
+                        "name": "Arrays1_ctor",
                         "options": {
                             "wrap_c": false,
                             "wrap_fortran": false,

--- a/regression/reference/structlist/structlist.json
+++ b/regression/reference/structlist/structlist.json
@@ -63,6 +63,7 @@
                                 ],
                                 "typemap_name": "Arrays1"
                             },
+                            "is_ctor": true,
                             "specifier": [
                                 "Arrays1"
                             ],

--- a/regression/reference/structlist/structlist.json
+++ b/regression/reference/structlist/structlist.json
@@ -14,6 +14,13 @@
                         "_generated": "struct_as_class_ctor",
                         "ast": {
                             "declarator": {
+                                "attrs": {
+                                    "_constructor": true,
+                                    "name": "Arrays1_ctor"
+                                },
+                                "metaattrs": {
+                                    "intent": "ctor"
+                                },
                                 "typemap_name": "Arrays1"
                             },
                             "specifier": [

--- a/regression/reference/structlist/structlist.json
+++ b/regression/reference/structlist/structlist.json
@@ -21,6 +21,46 @@
                                 "metaattrs": {
                                     "intent": "ctor"
                                 },
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "array": [
+                                                {
+                                                    "constant": "20"
+                                                }
+                                            ],
+                                            "metaattrs": {
+                                                "intent": "in",
+                                                "struct_member": "name"
+                                            },
+                                            "name": "name",
+                                            "typemap_name": "char"
+                                        },
+                                        "specifier": [
+                                            "char"
+                                        ],
+                                        "typemap_name": "char"
+                                    },
+                                    {
+                                        "declarator": {
+                                            "array": [
+                                                {
+                                                    "constant": "10"
+                                                }
+                                            ],
+                                            "metaattrs": {
+                                                "intent": "in",
+                                                "struct_member": "count"
+                                            },
+                                            "name": "count",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
                                 "typemap_name": "Arrays1"
                             },
                             "specifier": [

--- a/regression/reference/structlist/structlist.json
+++ b/regression/reference/structlist/structlist.json
@@ -13,52 +13,9 @@
                         "<FUNCTION>": "0 ****************************************",
                         "_generated": "struct_as_class_ctor",
                         "ast": {
-                            "attrs": {
-                                "_constructor": true,
-                                "name": "Arrays1_ctor"
+                            "declarator": {
+                                "typemap_name": "Arrays1"
                             },
-                            "declarator": {},
-                            "metaattrs": {
-                                "intent": "ctor"
-                            },
-                            "params": [
-                                {
-                                    "array": [
-                                        {
-                                            "constant": "20"
-                                        }
-                                    ],
-                                    "declarator": {
-                                        "name": "name"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in",
-                                        "struct_member": "name"
-                                    },
-                                    "specifier": [
-                                        "char"
-                                    ],
-                                    "typemap_name": "char"
-                                },
-                                {
-                                    "array": [
-                                        {
-                                            "constant": "10"
-                                        }
-                                    ],
-                                    "declarator": {
-                                        "name": "count"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in",
-                                        "struct_member": "count"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
                             "specifier": [
                                 "Arrays1"
                             ],
@@ -174,13 +131,14 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "array": [
-                                {
-                                    "constant": "20"
-                                }
-                            ],
                             "declarator": {
-                                "name": "name"
+                                "array": [
+                                    {
+                                        "constant": "20"
+                                    }
+                                ],
+                                "name": "name",
+                                "typemap_name": "char"
                             },
                             "specifier": [
                                 "char"
@@ -210,13 +168,14 @@
                     {
                         "<VARIABLE>": "****************************************",
                         "ast": {
-                            "array": [
-                                {
-                                    "constant": "10"
-                                }
-                            ],
                             "declarator": {
-                                "name": "count"
+                                "array": [
+                                    {
+                                        "constant": "10"
+                                    }
+                                ],
+                                "name": "count",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"

--- a/regression/reference/structlist/structlist.json
+++ b/regression/reference/structlist/structlist.json
@@ -17,6 +17,7 @@
                                 "_constructor": true,
                                 "name": "Arrays1_ctor"
                             },
+                            "declarator": {},
                             "metaattrs": {
                                 "intent": "ctor"
                             },

--- a/regression/reference/templates/templates.json
+++ b/regression/reference/templates/templates.json
@@ -160,9 +160,10 @@
                                             "name": "arg1"
                                         },
                                         "specifier": [
-                                            "T"
+                                            "int"
                                         ],
-                                        "template_argument": "T"
+                                        "template_argument": "T",
+                                        "typemap_name": "int"
                                     },
                                     {
                                         "declarator": {
@@ -175,9 +176,10 @@
                                             "name": "arg2"
                                         },
                                         "specifier": [
-                                            "U"
+                                            "double"
                                         ],
-                                        "template_argument": "U"
+                                        "template_argument": "U",
+                                        "typemap_name": "double"
                                     }
                                 ],
                                 "typemap_name": "void"
@@ -745,9 +747,10 @@
                                             "name": "v"
                                         },
                                         "specifier": [
-                                            "T"
+                                            "int"
                                         ],
-                                        "template_argument": "T"
+                                        "template_argument": "T",
+                                        "typemap_name": "int"
                                     }
                                 ],
                                 "typemap_name": "void"
@@ -1343,9 +1346,10 @@
                                             "name": "v"
                                         },
                                         "specifier": [
-                                            "T"
+                                            "double"
                                         ],
-                                        "template_argument": "T"
+                                        "template_argument": "T",
+                                        "typemap_name": "double"
                                     }
                                 ],
                                 "typemap_name": "void"
@@ -1841,9 +1845,10 @@
                                     "name": "arg1"
                                 },
                                 "specifier": [
-                                    "T"
+                                    "int"
                                 ],
-                                "template_argument": "T"
+                                "template_argument": "T",
+                                "typemap_name": "int"
                             },
                             {
                                 "declarator": {
@@ -1856,9 +1861,10 @@
                                     "name": "arg2"
                                 },
                                 "specifier": [
-                                    "U"
+                                    "long"
                                 ],
-                                "template_argument": "U"
+                                "template_argument": "U",
+                                "typemap_name": "long"
                             }
                         ],
                         "typemap_name": "void"
@@ -2078,9 +2084,10 @@
                                     "name": "arg1"
                                 },
                                 "specifier": [
-                                    "T"
+                                    "float"
                                 ],
-                                "template_argument": "T"
+                                "template_argument": "T",
+                                "typemap_name": "float"
                             },
                             {
                                 "declarator": {
@@ -2093,9 +2100,10 @@
                                     "name": "arg2"
                                 },
                                 "specifier": [
-                                    "U"
+                                    "double"
                                 ],
-                                "template_argument": "U"
+                                "template_argument": "U",
+                                "typemap_name": "double"
                             }
                         ],
                         "typemap_name": "void"
@@ -2891,9 +2899,10 @@
                                                     ]
                                                 },
                                                 "specifier": [
-                                                    "T"
+                                                    "int"
                                                 ],
-                                                "template_argument": "T"
+                                                "template_argument": "T",
+                                                "typemap_name": "int"
                                             }
                                         ],
                                         "typemap_name": "void"
@@ -3695,9 +3704,10 @@
                                                     ]
                                                 },
                                                 "specifier": [
-                                                    "T"
+                                                    "double"
                                                 ],
-                                                "template_argument": "T"
+                                                "template_argument": "T",
+                                                "typemap_name": "double"
                                             }
                                         ],
                                         "typemap_name": "void"

--- a/regression/reference/templates/templates.json
+++ b/regression/reference/templates/templates.json
@@ -61,43 +61,44 @@
                         "_overloaded": true,
                         "ast": {
                             "declarator": {
-                                "name": "nested"
-                            },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "arg1"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in"
-                                    },
-                                    "specifier": [
-                                        "T"
-                                    ],
-                                    "template_argument": "T"
+                                "metaattrs": {
+                                    "intent": "subroutine"
                                 },
-                                {
-                                    "attrs": {
-                                        "value": true
+                                "name": "nested",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "in"
+                                            },
+                                            "name": "arg1"
+                                        },
+                                        "specifier": [
+                                            "T"
+                                        ],
+                                        "template_argument": "T"
                                     },
-                                    "declarator": {
-                                        "name": "arg2"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in"
-                                    },
-                                    "specifier": [
-                                        "U"
-                                    ],
-                                    "template_argument": "U"
-                                }
-                            ],
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "in"
+                                            },
+                                            "name": "arg2"
+                                        },
+                                        "specifier": [
+                                            "U"
+                                        ],
+                                        "template_argument": "U"
+                                    }
+                                ],
+                                "typemap_name": "void"
+                            },
                             "specifier": [
                                 "void"
                             ],
@@ -143,45 +144,44 @@
                         "_overloaded": true,
                         "ast": {
                             "declarator": {
-                                "name": "nested"
-                            },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "arg1"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "template_argument": "T",
-                                    "typemap_name": "int"
+                                "metaattrs": {
+                                    "intent": "subroutine"
                                 },
-                                {
-                                    "attrs": {
-                                        "value": true
+                                "name": "nested",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "in"
+                                            },
+                                            "name": "arg1"
+                                        },
+                                        "specifier": [
+                                            "T"
+                                        ],
+                                        "template_argument": "T"
                                     },
-                                    "declarator": {
-                                        "name": "arg2"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in"
-                                    },
-                                    "specifier": [
-                                        "double"
-                                    ],
-                                    "template_argument": "U",
-                                    "typemap_name": "double"
-                                }
-                            ],
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "in"
+                                            },
+                                            "name": "arg2"
+                                        },
+                                        "specifier": [
+                                            "U"
+                                        ],
+                                        "template_argument": "U"
+                                    }
+                                ],
+                                "typemap_name": "void"
+                            },
                             "specifier": [
                                 "void"
                             ],
@@ -414,16 +414,18 @@
                         "<FUNCTION>": "2 ****************************************",
                         "_overloaded": true,
                         "ast": {
-                            "attrs": {
-                                "_constructor": true,
-                                "_name": "ctor"
+                            "declarator": {
+                                "attrs": {
+                                    "_constructor": true,
+                                    "_name": "ctor"
+                                },
+                                "metaattrs": {
+                                    "api": "capptr",
+                                    "intent": "ctor"
+                                },
+                                "params": [],
+                                "typemap_name": "structAsClass"
                             },
-                            "declarator": {},
-                            "metaattrs": {
-                                "api": "capptr",
-                                "intent": "ctor"
-                            },
-                            "params": [],
                             "specifier": [
                                 "structAsClass"
                             ],
@@ -497,28 +499,30 @@
                         "<FUNCTION>": "3 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "set_npts"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "set_npts",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "in"
+                                            },
+                                            "name": "n",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "n"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],
@@ -598,12 +602,13 @@
                         "<FUNCTION>": "4 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "get_npts"
+                                "metaattrs": {
+                                    "intent": "function"
+                                },
+                                "name": "get_npts",
+                                "params": [],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "function"
-                            },
-                            "params": [],
                             "specifier": [
                                 "int"
                             ],
@@ -678,28 +683,29 @@
                         "<FUNCTION>": "5 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "set_value"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "set_value",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "in"
+                                            },
+                                            "name": "v"
+                                        },
+                                        "specifier": [
+                                            "T"
+                                        ],
+                                        "template_argument": "T"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "v"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in"
-                                    },
-                                    "specifier": [
-                                        "T"
-                                    ],
-                                    "template_argument": "T"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],
@@ -723,29 +729,29 @@
                         "_generated": "cxx_template",
                         "ast": {
                             "declarator": {
-                                "name": "set_value"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "set_value",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "in"
+                                            },
+                                            "name": "v"
+                                        },
+                                        "specifier": [
+                                            "T"
+                                        ],
+                                        "template_argument": "T"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "v"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "template_argument": "T",
-                                    "typemap_name": "int"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],
@@ -826,12 +832,12 @@
                         "<FUNCTION>": "6 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "get_value"
+                                "metaattrs": {
+                                    "intent": "function"
+                                },
+                                "name": "get_value",
+                                "params": []
                             },
-                            "metaattrs": {
-                                "intent": "function"
-                            },
-                            "params": [],
                             "specifier": [
                                 "T"
                             ],
@@ -855,12 +861,12 @@
                         "_generated": "cxx_template",
                         "ast": {
                             "declarator": {
-                                "name": "get_value"
+                                "metaattrs": {
+                                    "intent": "function"
+                                },
+                                "name": "get_value",
+                                "params": []
                             },
-                            "metaattrs": {
-                                "intent": "function"
-                            },
-                            "params": [],
                             "specifier": [
                                 "int"
                             ],
@@ -1006,16 +1012,18 @@
                         "<FUNCTION>": "9 ****************************************",
                         "_overloaded": true,
                         "ast": {
-                            "attrs": {
-                                "_constructor": true,
-                                "_name": "ctor"
+                            "declarator": {
+                                "attrs": {
+                                    "_constructor": true,
+                                    "_name": "ctor"
+                                },
+                                "metaattrs": {
+                                    "api": "capptr",
+                                    "intent": "ctor"
+                                },
+                                "params": [],
+                                "typemap_name": "structAsClass"
                             },
-                            "declarator": {},
-                            "metaattrs": {
-                                "api": "capptr",
-                                "intent": "ctor"
-                            },
-                            "params": [],
                             "specifier": [
                                 "structAsClass"
                             ],
@@ -1089,28 +1097,30 @@
                         "<FUNCTION>": "10 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "set_npts"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "set_npts",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "in"
+                                            },
+                                            "name": "n",
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "n"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in"
-                                    },
-                                    "specifier": [
-                                        "int"
-                                    ],
-                                    "typemap_name": "int"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],
@@ -1190,12 +1200,13 @@
                         "<FUNCTION>": "11 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "get_npts"
+                                "metaattrs": {
+                                    "intent": "function"
+                                },
+                                "name": "get_npts",
+                                "params": [],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "function"
-                            },
-                            "params": [],
                             "specifier": [
                                 "int"
                             ],
@@ -1270,28 +1281,29 @@
                         "<FUNCTION>": "12 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "set_value"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "set_value",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "in"
+                                            },
+                                            "name": "v"
+                                        },
+                                        "specifier": [
+                                            "T"
+                                        ],
+                                        "template_argument": "T"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "v"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in"
-                                    },
-                                    "specifier": [
-                                        "T"
-                                    ],
-                                    "template_argument": "T"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],
@@ -1315,29 +1327,29 @@
                         "_generated": "cxx_template",
                         "ast": {
                             "declarator": {
-                                "name": "set_value"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "set_value",
+                                "params": [
+                                    {
+                                        "declarator": {
+                                            "attrs": {
+                                                "value": true
+                                            },
+                                            "metaattrs": {
+                                                "intent": "in"
+                                            },
+                                            "name": "v"
+                                        },
+                                        "specifier": [
+                                            "T"
+                                        ],
+                                        "template_argument": "T"
+                                    }
+                                ],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [
-                                {
-                                    "attrs": {
-                                        "value": true
-                                    },
-                                    "declarator": {
-                                        "name": "v"
-                                    },
-                                    "metaattrs": {
-                                        "intent": "in"
-                                    },
-                                    "specifier": [
-                                        "double"
-                                    ],
-                                    "template_argument": "T",
-                                    "typemap_name": "double"
-                                }
-                            ],
                             "specifier": [
                                 "void"
                             ],
@@ -1418,12 +1430,12 @@
                         "<FUNCTION>": "13 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "get_value"
+                                "metaattrs": {
+                                    "intent": "function"
+                                },
+                                "name": "get_value",
+                                "params": []
                             },
-                            "metaattrs": {
-                                "intent": "function"
-                            },
-                            "params": [],
                             "specifier": [
                                 "T"
                             ],
@@ -1447,12 +1459,12 @@
                         "_generated": "cxx_template",
                         "ast": {
                             "declarator": {
-                                "name": "get_value"
+                                "metaattrs": {
+                                    "intent": "function"
+                                },
+                                "name": "get_value",
+                                "params": []
                             },
-                            "metaattrs": {
-                                "intent": "function"
-                            },
-                            "params": [],
                             "specifier": [
                                 "double"
                             ],
@@ -1607,19 +1619,22 @@
                 "<FUNCTION>": "30 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "returnUserType"
+                        "metaattrs": {
+                            "api": "capptr",
+                            "intent": "function"
+                        },
+                        "name": "returnUserType",
+                        "params": [],
+                        "typemap_name": "user"
                     },
-                    "metaattrs": {
-                        "api": "capptr",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "user"
                     ],
                     "template_arguments": [
                         {
-                            "declarator": {},
+                            "declarator": {
+                                "typemap_name": "int"
+                            },
                             "specifier": [
                                 "int"
                             ],
@@ -1699,43 +1714,44 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "FunctionTU"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "T"
-                            ],
-                            "template_argument": "T"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "FunctionTU",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1"
+                                },
+                                "specifier": [
+                                    "T"
+                                ],
+                                "template_argument": "T"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "U"
-                            ],
-                            "template_argument": "U"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2"
+                                },
+                                "specifier": [
+                                    "U"
+                                ],
+                                "template_argument": "U"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1809,45 +1825,44 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "FunctionTU"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "template_argument": "T",
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "FunctionTU",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1"
+                                },
+                                "specifier": [
+                                    "T"
+                                ],
+                                "template_argument": "T"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "long"
-                            ],
-                            "template_argument": "U",
-                            "typemap_name": "long"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2"
+                                },
+                                "specifier": [
+                                    "U"
+                                ],
+                                "template_argument": "U"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2047,45 +2062,44 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "FunctionTU"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "float"
-                            ],
-                            "template_argument": "T",
-                            "typemap_name": "float"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "FunctionTU",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1"
+                                },
+                                "specifier": [
+                                    "T"
+                                ],
+                                "template_argument": "T"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "template_argument": "U",
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2"
+                                },
+                                "specifier": [
+                                    "U"
+                                ],
+                                "template_argument": "U"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2287,12 +2301,13 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UseImplWorker"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "UseImplWorker",
+                        "params": [],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -2355,12 +2370,13 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UseImplWorker"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "UseImplWorker",
+                        "params": [],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -2489,12 +2505,13 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UseImplWorker"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "UseImplWorker",
+                        "params": [],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -2634,16 +2651,18 @@
                                 "<FUNCTION>": "16 ****************************************",
                                 "_overloaded": true,
                                 "ast": {
-                                    "attrs": {
-                                        "_constructor": true,
-                                        "_name": "ctor"
+                                    "declarator": {
+                                        "attrs": {
+                                            "_constructor": true,
+                                            "_name": "ctor"
+                                        },
+                                        "metaattrs": {
+                                            "api": "capptr",
+                                            "intent": "ctor"
+                                        },
+                                        "params": [],
+                                        "typemap_name": "std::vector"
                                     },
-                                    "declarator": {},
-                                    "metaattrs": {
-                                        "api": "capptr",
-                                        "intent": "ctor"
-                                    },
-                                    "params": [],
                                     "specifier": [
                                         "vector"
                                     ],
@@ -2742,15 +2761,17 @@
                             {
                                 "<FUNCTION>": "17 ****************************************",
                                 "ast": {
-                                    "attrs": {
-                                        "_destructor": "vector",
-                                        "_name": "dtor"
+                                    "declarator": {
+                                        "attrs": {
+                                            "_destructor": "vector",
+                                            "_name": "dtor"
+                                        },
+                                        "metaattrs": {
+                                            "intent": "dtor"
+                                        },
+                                        "params": [],
+                                        "typemap_name": "void"
                                     },
-                                    "declarator": {},
-                                    "metaattrs": {
-                                        "intent": "dtor"
-                                    },
-                                    "params": [],
                                     "specifier": [
                                         "void"
                                     ],
@@ -2796,34 +2817,35 @@
                                 "<FUNCTION>": "18 ****************************************",
                                 "ast": {
                                     "declarator": {
-                                        "name": "push_back"
+                                        "metaattrs": {
+                                            "intent": "subroutine"
+                                        },
+                                        "name": "push_back",
+                                        "params": [
+                                            {
+                                                "const": true,
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "value",
+                                                    "pointer": [
+                                                        {
+                                                            "ptr": "&"
+                                                        }
+                                                    ]
+                                                },
+                                                "specifier": [
+                                                    "T"
+                                                ],
+                                                "template_argument": "T"
+                                            }
+                                        ],
+                                        "typemap_name": "void"
                                     },
-                                    "metaattrs": {
-                                        "intent": "subroutine"
-                                    },
-                                    "params": [
-                                        {
-                                            "attrs": {
-                                                "intent": "in"
-                                            },
-                                            "const": true,
-                                            "declarator": {
-                                                "name": "value",
-                                                "pointer": [
-                                                    {
-                                                        "ptr": "&"
-                                                    }
-                                                ]
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "T"
-                                            ],
-                                            "template_argument": "T"
-                                        }
-                                    ],
                                     "specifier": [
                                         "void"
                                     ],
@@ -2847,35 +2869,35 @@
                                 "_generated": "cxx_template",
                                 "ast": {
                                     "declarator": {
-                                        "name": "push_back"
+                                        "metaattrs": {
+                                            "intent": "subroutine"
+                                        },
+                                        "name": "push_back",
+                                        "params": [
+                                            {
+                                                "const": true,
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "value",
+                                                    "pointer": [
+                                                        {
+                                                            "ptr": "&"
+                                                        }
+                                                    ]
+                                                },
+                                                "specifier": [
+                                                    "T"
+                                                ],
+                                                "template_argument": "T"
+                                            }
+                                        ],
+                                        "typemap_name": "void"
                                     },
-                                    "metaattrs": {
-                                        "intent": "subroutine"
-                                    },
-                                    "params": [
-                                        {
-                                            "attrs": {
-                                                "intent": "in"
-                                            },
-                                            "const": true,
-                                            "declarator": {
-                                                "name": "value",
-                                                "pointer": [
-                                                    {
-                                                        "ptr": "&"
-                                                    }
-                                                ]
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "int"
-                                            ],
-                                            "template_argument": "T",
-                                            "typemap_name": "int"
-                                        }
-                                    ],
                                     "specifier": [
                                         "void"
                                     ],
@@ -2978,34 +3000,35 @@
                                 "<FUNCTION>": "19 ****************************************",
                                 "ast": {
                                     "declarator": {
+                                        "metaattrs": {
+                                            "deref": "pointer",
+                                            "intent": "function"
+                                        },
                                         "name": "at",
+                                        "params": [
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "value": true
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "n",
+                                                    "typemap_name": "std::vector::size_type"
+                                                },
+                                                "specifier": [
+                                                    "size_type"
+                                                ],
+                                                "typemap_name": "std::vector<int>::size_type"
+                                            }
+                                        ],
                                         "pointer": [
                                             {
                                                 "ptr": "&"
                                             }
                                         ]
                                     },
-                                    "metaattrs": {
-                                        "deref": "pointer",
-                                        "intent": "function"
-                                    },
-                                    "params": [
-                                        {
-                                            "attrs": {
-                                                "value": true
-                                            },
-                                            "declarator": {
-                                                "name": "n"
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "size_type"
-                                            ],
-                                            "typemap_name": "std::vector<int>::size_type"
-                                        }
-                                    ],
                                     "specifier": [
                                         "T"
                                     ],
@@ -3031,34 +3054,35 @@
                                 "_generated": "cxx_template",
                                 "ast": {
                                     "declarator": {
+                                        "metaattrs": {
+                                            "deref": "pointer",
+                                            "intent": "function"
+                                        },
                                         "name": "at",
+                                        "params": [
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "value": true
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "n",
+                                                    "typemap_name": "std::vector::size_type"
+                                                },
+                                                "specifier": [
+                                                    "size_type"
+                                                ],
+                                                "typemap_name": "std::vector<int>::size_type"
+                                            }
+                                        ],
                                         "pointer": [
                                             {
                                                 "ptr": "&"
                                             }
                                         ]
                                     },
-                                    "metaattrs": {
-                                        "deref": "pointer",
-                                        "intent": "function"
-                                    },
-                                    "params": [
-                                        {
-                                            "attrs": {
-                                                "value": true
-                                            },
-                                            "declarator": {
-                                                "name": "n"
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "size_type"
-                                            ],
-                                            "typemap_name": "std::vector<int>::size_type"
-                                        }
-                                    ],
                                     "specifier": [
                                         "int"
                                     ],
@@ -3211,35 +3235,36 @@
                                 "_generated": "arg_to_buffer",
                                 "ast": {
                                     "declarator": {
+                                        "metaattrs": {
+                                            "api": "buf",
+                                            "deref": "pointer",
+                                            "intent": "function"
+                                        },
                                         "name": "at",
+                                        "params": [
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "value": true
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "n",
+                                                    "typemap_name": "std::vector::size_type"
+                                                },
+                                                "specifier": [
+                                                    "size_type"
+                                                ],
+                                                "typemap_name": "std::vector<int>::size_type"
+                                            }
+                                        ],
                                         "pointer": [
                                             {
                                                 "ptr": "&"
                                             }
                                         ]
                                     },
-                                    "metaattrs": {
-                                        "api": "buf",
-                                        "deref": "pointer",
-                                        "intent": "function"
-                                    },
-                                    "params": [
-                                        {
-                                            "attrs": {
-                                                "value": true
-                                            },
-                                            "declarator": {
-                                                "name": "n"
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "size_type"
-                                            ],
-                                            "typemap_name": "std::vector<int>::size_type"
-                                        }
-                                    ],
                                     "specifier": [
                                         "int"
                                     ],
@@ -3430,16 +3455,18 @@
                                 "<FUNCTION>": "23 ****************************************",
                                 "_overloaded": true,
                                 "ast": {
-                                    "attrs": {
-                                        "_constructor": true,
-                                        "_name": "ctor"
+                                    "declarator": {
+                                        "attrs": {
+                                            "_constructor": true,
+                                            "_name": "ctor"
+                                        },
+                                        "metaattrs": {
+                                            "api": "capptr",
+                                            "intent": "ctor"
+                                        },
+                                        "params": [],
+                                        "typemap_name": "std::vector"
                                     },
-                                    "declarator": {},
-                                    "metaattrs": {
-                                        "api": "capptr",
-                                        "intent": "ctor"
-                                    },
-                                    "params": [],
                                     "specifier": [
                                         "vector"
                                     ],
@@ -3538,15 +3565,17 @@
                             {
                                 "<FUNCTION>": "24 ****************************************",
                                 "ast": {
-                                    "attrs": {
-                                        "_destructor": "vector",
-                                        "_name": "dtor"
+                                    "declarator": {
+                                        "attrs": {
+                                            "_destructor": "vector",
+                                            "_name": "dtor"
+                                        },
+                                        "metaattrs": {
+                                            "intent": "dtor"
+                                        },
+                                        "params": [],
+                                        "typemap_name": "void"
                                     },
-                                    "declarator": {},
-                                    "metaattrs": {
-                                        "intent": "dtor"
-                                    },
-                                    "params": [],
                                     "specifier": [
                                         "void"
                                     ],
@@ -3592,34 +3621,35 @@
                                 "<FUNCTION>": "25 ****************************************",
                                 "ast": {
                                     "declarator": {
-                                        "name": "push_back"
+                                        "metaattrs": {
+                                            "intent": "subroutine"
+                                        },
+                                        "name": "push_back",
+                                        "params": [
+                                            {
+                                                "const": true,
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "value",
+                                                    "pointer": [
+                                                        {
+                                                            "ptr": "&"
+                                                        }
+                                                    ]
+                                                },
+                                                "specifier": [
+                                                    "T"
+                                                ],
+                                                "template_argument": "T"
+                                            }
+                                        ],
+                                        "typemap_name": "void"
                                     },
-                                    "metaattrs": {
-                                        "intent": "subroutine"
-                                    },
-                                    "params": [
-                                        {
-                                            "attrs": {
-                                                "intent": "in"
-                                            },
-                                            "const": true,
-                                            "declarator": {
-                                                "name": "value",
-                                                "pointer": [
-                                                    {
-                                                        "ptr": "&"
-                                                    }
-                                                ]
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "T"
-                                            ],
-                                            "template_argument": "T"
-                                        }
-                                    ],
                                     "specifier": [
                                         "void"
                                     ],
@@ -3643,35 +3673,35 @@
                                 "_generated": "cxx_template",
                                 "ast": {
                                     "declarator": {
-                                        "name": "push_back"
+                                        "metaattrs": {
+                                            "intent": "subroutine"
+                                        },
+                                        "name": "push_back",
+                                        "params": [
+                                            {
+                                                "const": true,
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "value",
+                                                    "pointer": [
+                                                        {
+                                                            "ptr": "&"
+                                                        }
+                                                    ]
+                                                },
+                                                "specifier": [
+                                                    "T"
+                                                ],
+                                                "template_argument": "T"
+                                            }
+                                        ],
+                                        "typemap_name": "void"
                                     },
-                                    "metaattrs": {
-                                        "intent": "subroutine"
-                                    },
-                                    "params": [
-                                        {
-                                            "attrs": {
-                                                "intent": "in"
-                                            },
-                                            "const": true,
-                                            "declarator": {
-                                                "name": "value",
-                                                "pointer": [
-                                                    {
-                                                        "ptr": "&"
-                                                    }
-                                                ]
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "double"
-                                            ],
-                                            "template_argument": "T",
-                                            "typemap_name": "double"
-                                        }
-                                    ],
                                     "specifier": [
                                         "void"
                                     ],
@@ -3774,34 +3804,35 @@
                                 "<FUNCTION>": "26 ****************************************",
                                 "ast": {
                                     "declarator": {
+                                        "metaattrs": {
+                                            "deref": "pointer",
+                                            "intent": "function"
+                                        },
                                         "name": "at",
+                                        "params": [
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "value": true
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "n",
+                                                    "typemap_name": "std::vector::size_type"
+                                                },
+                                                "specifier": [
+                                                    "size_type"
+                                                ],
+                                                "typemap_name": "std::vector<double>::size_type"
+                                            }
+                                        ],
                                         "pointer": [
                                             {
                                                 "ptr": "&"
                                             }
                                         ]
                                     },
-                                    "metaattrs": {
-                                        "deref": "pointer",
-                                        "intent": "function"
-                                    },
-                                    "params": [
-                                        {
-                                            "attrs": {
-                                                "value": true
-                                            },
-                                            "declarator": {
-                                                "name": "n"
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "size_type"
-                                            ],
-                                            "typemap_name": "std::vector<double>::size_type"
-                                        }
-                                    ],
                                     "specifier": [
                                         "T"
                                     ],
@@ -3827,34 +3858,35 @@
                                 "_generated": "cxx_template",
                                 "ast": {
                                     "declarator": {
+                                        "metaattrs": {
+                                            "deref": "pointer",
+                                            "intent": "function"
+                                        },
                                         "name": "at",
+                                        "params": [
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "value": true
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "n",
+                                                    "typemap_name": "std::vector::size_type"
+                                                },
+                                                "specifier": [
+                                                    "size_type"
+                                                ],
+                                                "typemap_name": "std::vector<double>::size_type"
+                                            }
+                                        ],
                                         "pointer": [
                                             {
                                                 "ptr": "&"
                                             }
                                         ]
                                     },
-                                    "metaattrs": {
-                                        "deref": "pointer",
-                                        "intent": "function"
-                                    },
-                                    "params": [
-                                        {
-                                            "attrs": {
-                                                "value": true
-                                            },
-                                            "declarator": {
-                                                "name": "n"
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "size_type"
-                                            ],
-                                            "typemap_name": "std::vector<double>::size_type"
-                                        }
-                                    ],
                                     "specifier": [
                                         "double"
                                     ],
@@ -4007,35 +4039,36 @@
                                 "_generated": "arg_to_buffer",
                                 "ast": {
                                     "declarator": {
+                                        "metaattrs": {
+                                            "api": "buf",
+                                            "deref": "pointer",
+                                            "intent": "function"
+                                        },
                                         "name": "at",
+                                        "params": [
+                                            {
+                                                "declarator": {
+                                                    "attrs": {
+                                                        "value": true
+                                                    },
+                                                    "metaattrs": {
+                                                        "intent": "in"
+                                                    },
+                                                    "name": "n",
+                                                    "typemap_name": "std::vector::size_type"
+                                                },
+                                                "specifier": [
+                                                    "size_type"
+                                                ],
+                                                "typemap_name": "std::vector<double>::size_type"
+                                            }
+                                        ],
                                         "pointer": [
                                             {
                                                 "ptr": "&"
                                             }
                                         ]
                                     },
-                                    "metaattrs": {
-                                        "api": "buf",
-                                        "deref": "pointer",
-                                        "intent": "function"
-                                    },
-                                    "params": [
-                                        {
-                                            "attrs": {
-                                                "value": true
-                                            },
-                                            "declarator": {
-                                                "name": "n"
-                                            },
-                                            "metaattrs": {
-                                                "intent": "in"
-                                            },
-                                            "specifier": [
-                                                "size_type"
-                                            ],
-                                            "typemap_name": "std::vector<double>::size_type"
-                                        }
-                                    ],
                                     "specifier": [
                                         "double"
                                     ],

--- a/regression/reference/templates/templates.json
+++ b/regression/reference/templates/templates.json
@@ -430,6 +430,7 @@
                                 "params": [],
                                 "typemap_name": "structAsClass"
                             },
+                            "is_ctor": true,
                             "specifier": [
                                 "structAsClass"
                             ],
@@ -1036,6 +1037,7 @@
                                 "params": [],
                                 "typemap_name": "structAsClass"
                             },
+                            "is_ctor": true,
                             "specifier": [
                                 "structAsClass"
                             ],
@@ -2694,6 +2696,7 @@
                                         "params": [],
                                         "typemap_name": "std::vector"
                                     },
+                                    "is_ctor": true,
                                     "specifier": [
                                         "vector"
                                     ],
@@ -2804,6 +2807,7 @@
                                         "params": [],
                                         "typemap_name": "void"
                                     },
+                                    "is_dtor": "vector",
                                     "specifier": [
                                         "void"
                                     ],
@@ -3506,6 +3510,7 @@
                                         "params": [],
                                         "typemap_name": "std::vector"
                                     },
+                                    "is_ctor": true,
                                     "specifier": [
                                         "vector"
                                     ],
@@ -3616,6 +3621,7 @@
                                         "params": [],
                                         "typemap_name": "void"
                                     },
+                                    "is_dtor": "vector",
                                     "specifier": [
                                         "void"
                                     ],

--- a/regression/reference/templates/templates.json
+++ b/regression/reference/templates/templates.json
@@ -112,6 +112,7 @@
                         "decl": "template<U> void nested( T arg1, U arg2 );",
                         "declgen": "void nested(T arg1 +value, U arg2 +value)",
                         "have_template_args": true,
+                        "name": "nested",
                         "options": {},
                         "template_arguments": [
                             {
@@ -195,6 +196,7 @@
                             "double"
                         ],
                         "have_template_args": true,
+                        "name": "nested",
                         "options": {},
                         "template_arguments": [
                             {
@@ -435,6 +437,7 @@
                         },
                         "decl": "structAsClass()",
                         "declgen": "structAsClass(void)",
+                        "name": "ctor",
                         "options": {
                             "F_create_generic": true
                         },
@@ -532,6 +535,7 @@
                         },
                         "decl": "void set_npts(int n)",
                         "declgen": "void set_npts(int n +value)",
+                        "name": "set_npts",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -618,6 +622,7 @@
                         },
                         "decl": "int get_npts()",
                         "declgen": "int get_npts(void)",
+                        "name": "get_npts",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -716,6 +721,7 @@
                         "decl": "void set_value(T v)",
                         "declgen": "void set_value(T v +value)",
                         "have_template_args": true,
+                        "name": "set_value",
                         "options": {},
                         "wrap": {},
                         "zz_fmtdict": {
@@ -763,6 +769,7 @@
                         "decl": "void set_value(T v)",
                         "declgen": "void set_value(int v +value)",
                         "have_template_args": true,
+                        "name": "set_value",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -849,6 +856,7 @@
                         "decl": "T get_value()",
                         "declgen": "T get_value(void)",
                         "have_template_args": true,
+                        "name": "get_value",
                         "options": {},
                         "wrap": {},
                         "zz_fmtdict": {
@@ -879,6 +887,7 @@
                         "decl": "T get_value()",
                         "declgen": "int get_value(void)",
                         "have_template_args": true,
+                        "name": "get_value",
                         "options": {
                             "F_create_generic": false
                         },
@@ -1034,6 +1043,7 @@
                         },
                         "decl": "structAsClass()",
                         "declgen": "structAsClass(void)",
+                        "name": "ctor",
                         "options": {
                             "F_create_generic": true
                         },
@@ -1131,6 +1141,7 @@
                         },
                         "decl": "void set_npts(int n)",
                         "declgen": "void set_npts(int n +value)",
+                        "name": "set_npts",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -1217,6 +1228,7 @@
                         },
                         "decl": "int get_npts()",
                         "declgen": "int get_npts(void)",
+                        "name": "get_npts",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -1315,6 +1327,7 @@
                         "decl": "void set_value(T v)",
                         "declgen": "void set_value(T v +value)",
                         "have_template_args": true,
+                        "name": "set_value",
                         "options": {},
                         "wrap": {},
                         "zz_fmtdict": {
@@ -1362,6 +1375,7 @@
                         "decl": "void set_value(T v)",
                         "declgen": "void set_value(double v +value)",
                         "have_template_args": true,
+                        "name": "set_value",
                         "options": {},
                         "wrap": {
                             "c": true,
@@ -1448,6 +1462,7 @@
                         "decl": "T get_value()",
                         "declgen": "T get_value(void)",
                         "have_template_args": true,
+                        "name": "get_value",
                         "options": {},
                         "wrap": {},
                         "zz_fmtdict": {
@@ -1478,6 +1493,7 @@
                         "decl": "T get_value()",
                         "declgen": "double get_value(void)",
                         "have_template_args": true,
+                        "name": "get_value",
                         "options": {
                             "F_create_generic": false
                         },
@@ -1649,6 +1665,7 @@
                 },
                 "decl": "user<int> returnUserType(void);",
                 "declgen": "user<int> returnUserType(void)",
+                "name": "returnUserType",
                 "options": {
                     "wrap_python": false
                 },
@@ -1773,6 +1790,7 @@
                     "brief": "Function template with two template parameters."
                 },
                 "have_template_args": true,
+                "name": "FunctionTU",
                 "options": {},
                 "template_arguments": [
                     {
@@ -1880,6 +1898,7 @@
                     "brief": "Function template with two template parameters."
                 },
                 "have_template_args": true,
+                "name": "FunctionTU",
                 "options": {},
                 "template_arguments": [
                     {
@@ -2125,6 +2144,7 @@
                     "double"
                 ],
                 "have_template_args": true,
+                "name": "FunctionTU",
                 "options": {},
                 "template_arguments": [
                     {
@@ -2332,6 +2352,7 @@
                 "doxygen": {
                     "brief": "Function which uses a templated T in the implemetation."
                 },
+                "name": "UseImplWorker",
                 "options": {
                     "F_create_generic": false,
                     "PY_create_generic": false
@@ -2395,6 +2416,7 @@
                 "doxygen": {
                     "brief": "Function which uses a templated T in the implemetation."
                 },
+                "name": "UseImplWorker",
                 "options": {
                     "F_create_generic": false,
                     "PY_create_generic": false
@@ -2534,6 +2556,7 @@
                     "internal::ImplWorker1",
                     "internal::ImplWorker2"
                 ],
+                "name": "UseImplWorker",
                 "options": {
                     "F_create_generic": false,
                     "PY_create_generic": false
@@ -2678,6 +2701,7 @@
                                 },
                                 "decl": "vector()",
                                 "declgen": "vector(void)",
+                                "name": "ctor",
                                 "options": {
                                     "F_create_generic": true
                                 },
@@ -2787,6 +2811,7 @@
                                 },
                                 "decl": "~vector()",
                                 "declgen": "~vector(void)",
+                                "name": "dtor",
                                 "options": {},
                                 "wrap": {
                                     "c": true,
@@ -2862,6 +2887,7 @@
                                 "decl": "void push_back( const T& value+intent(in) )",
                                 "declgen": "void push_back(const T & value +intent(in))",
                                 "have_template_args": true,
+                                "name": "push_back",
                                 "options": {},
                                 "wrap": {},
                                 "zz_fmtdict": {
@@ -2915,6 +2941,7 @@
                                 "decl": "void push_back( const T& value+intent(in) )",
                                 "declgen": "void push_back(const int & value +intent(in))",
                                 "have_template_args": true,
+                                "name": "push_back",
                                 "options": {},
                                 "wrap": {
                                     "c": true,
@@ -3046,6 +3073,7 @@
                                 "decl": "T & at(size_type n)",
                                 "declgen": "T & at(size_type n +value)",
                                 "have_template_args": true,
+                                "name": "at",
                                 "options": {},
                                 "wrap": {},
                                 "zz_fmtdict": {
@@ -3101,6 +3129,7 @@
                                 "decl": "T & at(size_type n)",
                                 "declgen": "int & at(size_type n +value)",
                                 "have_template_args": true,
+                                "name": "at",
                                 "options": {
                                     "F_create_generic": false
                                 },
@@ -3283,6 +3312,7 @@
                                 "decl": "T & at(size_type n)",
                                 "declgen": "int & at(size_type n +value)",
                                 "have_template_args": true,
+                                "name": "at",
                                 "options": {
                                     "F_create_generic": false
                                 },
@@ -3483,6 +3513,7 @@
                                 },
                                 "decl": "vector()",
                                 "declgen": "vector(void)",
+                                "name": "ctor",
                                 "options": {
                                     "F_create_generic": true
                                 },
@@ -3592,6 +3623,7 @@
                                 },
                                 "decl": "~vector()",
                                 "declgen": "~vector(void)",
+                                "name": "dtor",
                                 "options": {},
                                 "wrap": {
                                     "c": true,
@@ -3667,6 +3699,7 @@
                                 "decl": "void push_back( const T& value+intent(in) )",
                                 "declgen": "void push_back(const T & value +intent(in))",
                                 "have_template_args": true,
+                                "name": "push_back",
                                 "options": {},
                                 "wrap": {},
                                 "zz_fmtdict": {
@@ -3720,6 +3753,7 @@
                                 "decl": "void push_back( const T& value+intent(in) )",
                                 "declgen": "void push_back(const double & value +intent(in))",
                                 "have_template_args": true,
+                                "name": "push_back",
                                 "options": {},
                                 "wrap": {
                                     "c": true,
@@ -3851,6 +3885,7 @@
                                 "decl": "T & at(size_type n)",
                                 "declgen": "T & at(size_type n +value)",
                                 "have_template_args": true,
+                                "name": "at",
                                 "options": {},
                                 "wrap": {},
                                 "zz_fmtdict": {
@@ -3906,6 +3941,7 @@
                                 "decl": "T & at(size_type n)",
                                 "declgen": "double & at(size_type n +value)",
                                 "have_template_args": true,
+                                "name": "at",
                                 "options": {
                                     "F_create_generic": false
                                 },
@@ -4088,6 +4124,7 @@
                                 "decl": "T & at(size_type n)",
                                 "declgen": "double & at(size_type n +value)",
                                 "have_template_args": true,
+                                "name": "at",
                                 "options": {
                                     "F_create_generic": false
                                 },

--- a/regression/reference/templates/templates.json
+++ b/regression/reference/templates/templates.json
@@ -418,6 +418,7 @@
                                 "_constructor": true,
                                 "_name": "ctor"
                             },
+                            "declarator": {},
                             "metaattrs": {
                                 "api": "capptr",
                                 "intent": "ctor"
@@ -1009,6 +1010,7 @@
                                 "_constructor": true,
                                 "_name": "ctor"
                             },
+                            "declarator": {},
                             "metaattrs": {
                                 "api": "capptr",
                                 "intent": "ctor"
@@ -2635,6 +2637,7 @@
                                         "_constructor": true,
                                         "_name": "ctor"
                                     },
+                                    "declarator": {},
                                     "metaattrs": {
                                         "api": "capptr",
                                         "intent": "ctor"
@@ -2742,6 +2745,7 @@
                                         "_destructor": "vector",
                                         "_name": "dtor"
                                     },
+                                    "declarator": {},
                                     "metaattrs": {
                                         "intent": "dtor"
                                     },
@@ -3429,6 +3433,7 @@
                                         "_constructor": true,
                                         "_name": "ctor"
                                     },
+                                    "declarator": {},
                                     "metaattrs": {
                                         "api": "capptr",
                                         "intent": "ctor"
@@ -3536,6 +3541,7 @@
                                         "_destructor": "vector",
                                         "_name": "dtor"
                                     },
+                                    "declarator": {},
                                     "metaattrs": {
                                         "intent": "dtor"
                                     },

--- a/regression/reference/templates/templates.json
+++ b/regression/reference/templates/templates.json
@@ -1619,6 +1619,7 @@
                     ],
                     "template_arguments": [
                         {
+                            "declarator": {},
                             "specifier": [
                                 "int"
                             ],

--- a/regression/reference/tutorial/tutorial.json
+++ b/regression/reference/tutorial/tutorial.json
@@ -83,12 +83,13 @@
                 "<FUNCTION>": "0 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "NoReturnNoArguments"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "NoReturnNoArguments",
+                        "params": [],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [],
                     "specifier": [
                         "void"
                     ],
@@ -140,43 +141,46 @@
                 "<FUNCTION>": "1 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "PassByValue"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "PassByValue",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "double"
+                    },
                     "specifier": [
                         "double"
                     ],
@@ -419,50 +423,53 @@
                 "ast": {
                     "const": true,
                     "declarator": {
-                        "name": "ConcatenateStrings"
-                    },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "intent": "function"
                         },
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg2",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
+                        "name": "ConcatenateStrings",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "std::string"
+                    },
                     "specifier": [
                         "std::string"
                     ],
@@ -621,53 +628,56 @@
                 "ast": {
                     "const": true,
                     "declarator": {
-                        "name": "ConcatenateStrings"
-                    },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "deref": "allocatable",
+                            "intent": "function"
                         },
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "arg2",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
+                        "name": "ConcatenateStrings",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "std::string"
+                    },
                     "specifier": [
                         "std::string"
                     ],
@@ -808,12 +818,13 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UseDefaultArguments"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "UseDefaultArguments",
+                        "params": [],
+                        "typemap_name": "double"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "double"
                     ],
@@ -896,29 +907,31 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UseDefaultArguments"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "UseDefaultArguments",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 3.1415,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "double"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "init": 3.1415,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
                     "specifier": [
                         "double"
                     ],
@@ -1043,45 +1056,48 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UseDefaultArguments"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "init": 3.1415,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "UseDefaultArguments",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 3.1415,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "init": "true",
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "bool"
-                            ],
-                            "typemap_name": "bool"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": "true",
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "bool"
+                                },
+                                "specifier": [
+                                    "bool"
+                                ],
+                                "typemap_name": "bool"
+                            }
+                        ],
+                        "typemap_name": "double"
+                    },
                     "specifier": [
                         "double"
                     ],
@@ -1335,31 +1351,33 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "OverloadedFunction"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "OverloadedFunction",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -1482,32 +1500,34 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "OverloadedFunction"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "OverloadedFunction",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -1581,28 +1601,30 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "OverloadedFunction"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "OverloadedFunction",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "indx",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "indx"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -1725,28 +1747,29 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "TemplateArgument"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "TemplateArgument",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg"
+                                },
+                                "specifier": [
+                                    "ArgType"
+                                ],
+                                "template_argument": "ArgType"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "ArgType"
-                            ],
-                            "template_argument": "ArgType"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -1804,29 +1827,29 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "TemplateArgument"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "TemplateArgument",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg"
+                                },
+                                "specifier": [
+                                    "ArgType"
+                                ],
+                                "template_argument": "ArgType"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "template_argument": "ArgType",
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -1981,29 +2004,29 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "TemplateArgument"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "TemplateArgument",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg"
+                                },
+                                "specifier": [
+                                    "ArgType"
+                                ],
+                                "template_argument": "ArgType"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "template_argument": "ArgType",
-                            "typemap_name": "double"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -2156,12 +2179,12 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "TemplateReturn"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "TemplateReturn",
+                        "params": []
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "RetType"
                     ],
@@ -2222,12 +2245,12 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "TemplateReturn"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "TemplateReturn",
+                        "params": []
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "int"
                     ],
@@ -2337,12 +2360,12 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "TemplateReturn"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "TemplateReturn",
+                        "params": []
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "double"
                     ],
@@ -2452,12 +2475,13 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "FortranGenericOverloaded"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "FortranGenericOverloaded",
+                        "params": [],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [],
                     "specifier": [
                         "void"
                     ],
@@ -2509,46 +2533,49 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "FortranGenericOverloaded"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "FortranGenericOverloaded",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2562,15 +2589,16 @@
                             {
                                 "const": true,
                                 "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
                                     "name": "name",
                                     "pointer": [
                                         {
                                             "ptr": "&"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    ],
+                                    "typemap_name": "std::string"
                                 },
                                 "specifier": [
                                     "std::string"
@@ -2578,14 +2606,15 @@
                                 "typemap_name": "std::string"
                             },
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "arg2"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
                                     "float"
@@ -2601,15 +2630,16 @@
                             {
                                 "const": true,
                                 "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
                                     "name": "name",
                                     "pointer": [
                                         {
                                             "ptr": "&"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    ],
+                                    "typemap_name": "std::string"
                                 },
                                 "specifier": [
                                     "std::string"
@@ -2617,14 +2647,15 @@
                                 "typemap_name": "std::string"
                             },
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "arg2"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "double"
                                 },
                                 "specifier": [
                                     "double"
@@ -2806,46 +2837,49 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "FortranGenericOverloaded"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "FortranGenericOverloaded",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "float"
-                            ],
-                            "typemap_name": "float"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2884,47 +2918,49 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "FortranGenericOverloaded"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "FortranGenericOverloaded",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "float"
-                            ],
-                            "typemap_name": "float"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3038,46 +3074,49 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "FortranGenericOverloaded"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "FortranGenericOverloaded",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3116,47 +3155,49 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "FortranGenericOverloaded"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "const": true,
-                            "declarator": {
-                                "name": "name",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::string"
-                            ],
-                            "typemap_name": "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "FortranGenericOverloaded",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "name",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::string"
+                                },
+                                "specifier": [
+                                    "std::string"
+                                ],
+                                "typemap_name": "std::string"
                             },
-                            "declarator": {
-                                "name": "arg2"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg2",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -3266,28 +3307,30 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UseDefaultOverload"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "UseDefaultOverload",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "num",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "num"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -3405,44 +3448,47 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UseDefaultOverload"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "num"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "UseDefaultOverload",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "num",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "offset"
-                            },
-                            "init": 0,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 0,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "offset",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -3598,60 +3644,64 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UseDefaultOverload"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "num"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "UseDefaultOverload",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "num",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "offset"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 0,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "offset",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "init": 0,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "stride"
-                            },
-                            "init": 1,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 1,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "stride",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -3967,43 +4017,46 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UseDefaultOverload"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "type"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "UseDefaultOverload",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "num"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "num",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -4149,59 +4202,63 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UseDefaultOverload"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "type"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "UseDefaultOverload",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
                             },
-                            "declarator": {
-                                "name": "num"
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "num",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "offset"
-                            },
-                            "init": 0,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 0,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "offset",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -4385,75 +4442,80 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "UseDefaultOverload"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "UseDefaultOverload",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "type",
+                                    "typemap_name": "double"
+                                },
+                                "specifier": [
+                                    "double"
+                                ],
+                                "typemap_name": "double"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "num",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 0,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "offset",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "init": 1,
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "stride",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "type"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "num"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "offset"
-                            },
-                            "init": 0,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "stride"
-                            },
-                            "init": 1,
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -4823,28 +4885,30 @@
                 "<FUNCTION>": "12 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "typefunc"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "typefunc",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "tutorial::TypeID"
+                                },
+                                "specifier": [
+                                    "TypeID"
+                                ],
+                                "typemap_name": "tutorial::TypeID"
+                            }
+                        ],
+                        "typemap_name": "tutorial::TypeID"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "TypeID"
-                            ],
-                            "typemap_name": "tutorial::TypeID"
-                        }
-                    ],
                     "specifier": [
                         "TypeID"
                     ],
@@ -5018,28 +5082,30 @@
                 "<FUNCTION>": "13 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "enumfunc"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "enumfunc",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "tutorial::EnumTypeID"
+                                },
+                                "specifier": [
+                                    "EnumTypeID"
+                                ],
+                                "typemap_name": "tutorial::EnumTypeID"
+                            }
+                        ],
+                        "typemap_name": "tutorial::EnumTypeID"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "EnumTypeID"
-                            ],
-                            "typemap_name": "tutorial::EnumTypeID"
-                        }
-                    ],
                     "specifier": [
                         "EnumTypeID"
                     ],
@@ -5219,28 +5285,30 @@
                 "<FUNCTION>": "14 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "colorfunc"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "colorfunc",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "tutorial::Color"
+                                },
+                                "specifier": [
+                                    "Color"
+                                ],
+                                "typemap_name": "tutorial::Color"
+                            }
+                        ],
+                        "typemap_name": "tutorial::Color"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "Color"
-                            ],
-                            "typemap_name": "tutorial::Color"
-                        }
-                    ],
                     "specifier": [
                         "Color"
                     ],
@@ -5418,53 +5486,56 @@
                 "<FUNCTION>": "15 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "getMinMax"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "min",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                        "name": "getMinMax",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "min",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "max",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "max",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -5621,62 +5692,68 @@
                 "<FUNCTION>": "16 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "callback1"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "in"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "func": {
-                                    "name": "incr",
-                                    "pointer": [
-                                        {
-                                            "ptr": "*"
-                                        }
-                                    ]
-                                }
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "params": [
-                                {
+                        "name": "callback1",
+                        "params": [
+                            {
+                                "declarator": {
                                     "attrs": {
                                         "value": true
                                     },
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "in",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            },
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "func": {
+                                        "name": "incr",
+                                        "pointer": [
+                                            {
+                                                "ptr": "*"
+                                            }
+                                        ],
+                                        "typemap_name": "int"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "params": [
+                                        {
+                                            "declarator": {
+                                                "attrs": {
+                                                    "value": true
+                                                },
+                                                "typemap_name": "int"
+                                            },
+                                            "specifier": [
+                                                "int"
+                                            ],
+                                            "typemap_name": "int"
+                                        }
                                     ],
                                     "typemap_name": "int"
-                                }
-                            ],
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -5822,23 +5899,24 @@
                 ],
                 "_PTR_F_C_index": "34",
                 "ast": {
-                    "attrs": {
-                        "len": "30"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "len": "30"
+                        },
+                        "metaattrs": {
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "LastFunctionCalled",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -5944,24 +6022,25 @@
                 "_PTR_C_CXX_index": "17",
                 "_generated": "arg_to_buffer",
                 "ast": {
-                    "attrs": {
-                        "len": "30"
-                    },
                     "const": true,
                     "declarator": {
+                        "attrs": {
+                            "len": "30"
+                        },
+                        "metaattrs": {
+                            "api": "buf",
+                            "deref": "copy",
+                            "intent": "function"
+                        },
                         "name": "LastFunctionCalled",
+                        "params": [],
                         "pointer": [
                             {
                                 "ptr": "&"
                             }
-                        ]
+                        ],
+                        "typemap_name": "std::string"
                     },
-                    "metaattrs": {
-                        "api": "buf",
-                        "deref": "copy",
-                        "intent": "function"
-                    },
-                    "params": [],
                     "specifier": [
                         "std::string"
                     ],
@@ -6027,7 +6106,8 @@
                 "<TYPEDEF>": "****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "TypeID"
+                        "name": "TypeID",
+                        "typemap_name": "int"
                     },
                     "specifier": [
                         "int"
@@ -6063,7 +6143,8 @@
                 "<TYPEDEF>": "****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "EnumTypeID"
+                        "name": "EnumTypeID",
+                        "typemap_name": "int"
                     },
                     "specifier": [
                         "int"
@@ -6105,7 +6186,8 @@
                 "<VARIABLE>": "****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "global_flag"
+                        "name": "global_flag",
+                        "typemap_name": "int"
                     },
                     "specifier": [
                         "int"
@@ -6136,7 +6218,8 @@
                 "<VARIABLE>": "****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "tutorial_flag"
+                        "name": "tutorial_flag",
+                        "typemap_name": "int"
                     },
                     "specifier": [
                         "int"

--- a/regression/reference/tutorial/tutorial.json
+++ b/regression/reference/tutorial/tutorial.json
@@ -1843,9 +1843,10 @@
                                     "name": "arg"
                                 },
                                 "specifier": [
-                                    "ArgType"
+                                    "int"
                                 ],
-                                "template_argument": "ArgType"
+                                "template_argument": "ArgType",
+                                "typemap_name": "int"
                             }
                         ],
                         "typemap_name": "void"
@@ -2020,9 +2021,10 @@
                                     "name": "arg"
                                 },
                                 "specifier": [
-                                    "ArgType"
+                                    "double"
                                 ],
-                                "template_argument": "ArgType"
+                                "template_argument": "ArgType",
+                                "typemap_name": "double"
                             }
                         ],
                         "typemap_name": "void"
@@ -2870,12 +2872,12 @@
                                         "intent": "in"
                                     },
                                     "name": "arg2",
-                                    "typemap_name": "double"
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
-                                    "double"
+                                    "float"
                                 ],
-                                "typemap_name": "double"
+                                "typemap_name": "float"
                             }
                         ],
                         "typemap_name": "void"
@@ -2927,6 +2929,7 @@
                                 "const": true,
                                 "declarator": {
                                     "metaattrs": {
+                                        "api": "buf",
                                         "intent": "in"
                                     },
                                     "name": "name",
@@ -2951,12 +2954,12 @@
                                         "intent": "in"
                                     },
                                     "name": "arg2",
-                                    "typemap_name": "double"
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
-                                    "double"
+                                    "float"
                                 ],
-                                "typemap_name": "double"
+                                "typemap_name": "float"
                             }
                         ],
                         "typemap_name": "void"
@@ -3164,6 +3167,7 @@
                                 "const": true,
                                 "declarator": {
                                     "metaattrs": {
+                                        "api": "buf",
                                         "intent": "in"
                                     },
                                     "name": "name",

--- a/regression/reference/tutorial/tutorial.json
+++ b/regression/reference/tutorial/tutorial.json
@@ -5664,6 +5664,7 @@
                                     "attrs": {
                                         "value": true
                                     },
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],

--- a/regression/reference/tutorial/tutorial.json
+++ b/regression/reference/tutorial/tutorial.json
@@ -97,6 +97,7 @@
                 },
                 "decl": "void NoReturnNoArguments()",
                 "declgen": "void NoReturnNoArguments(void)",
+                "name": "NoReturnNoArguments",
                 "options": {
                     "literalinclude": true
                 },
@@ -188,6 +189,7 @@
                 },
                 "decl": "double PassByValue(double arg1, int arg2)",
                 "declgen": "double PassByValue(double arg1 +value, int arg2 +value)",
+                "name": "PassByValue",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -480,6 +482,7 @@
                 "doxygen": {
                     "description": "Note that since a reference is returned, no intermediate string\nis allocated.  It is assumed +owner(library).\n"
                 },
+                "name": "ConcatenateStrings",
                 "options": {},
                 "wrap": {
                     "fortran": true,
@@ -688,6 +691,7 @@
                 "doxygen": {
                     "description": "Note that since a reference is returned, no intermediate string\nis allocated.  It is assumed +owner(library).\n"
                 },
+                "name": "ConcatenateStrings",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -837,6 +841,7 @@
                     "_arg1",
                     "_arg1_arg2"
                 ],
+                "name": "UseDefaultArguments",
                 "options": {
                     "literalinclude": true
                 },
@@ -944,6 +949,7 @@
                     "_arg1",
                     "_arg1_arg2"
                 ],
+                "name": "UseDefaultArguments",
                 "options": {
                     "literalinclude": true
                 },
@@ -1110,6 +1116,7 @@
                     "_arg1",
                     "_arg1_arg2"
                 ],
+                "name": "UseDefaultArguments",
                 "options": {
                     "literalinclude": true
                 },
@@ -1385,6 +1392,7 @@
                 },
                 "decl": "void OverloadedFunction(const std::string& name)",
                 "declgen": "void OverloadedFunction(const std::string & name)",
+                "name": "OverloadedFunction",
                 "options": {},
                 "user_fmt": {
                     "function_suffix": "_from_name"
@@ -1535,6 +1543,7 @@
                 },
                 "decl": "void OverloadedFunction(const std::string& name)",
                 "declgen": "void OverloadedFunction(const std::string & name)",
+                "name": "OverloadedFunction",
                 "options": {},
                 "splicer_group": "buf",
                 "user_fmt": {
@@ -1632,6 +1641,7 @@
                 },
                 "decl": "void OverloadedFunction(int indx)",
                 "declgen": "void OverloadedFunction(int indx +value)",
+                "name": "OverloadedFunction",
                 "options": {},
                 "user_fmt": {
                     "function_suffix": "_from_index"
@@ -1784,6 +1794,7 @@
                 "decl": "template<typename ArgType>\nvoid TemplateArgument(ArgType arg)\n",
                 "declgen": "void TemplateArgument(ArgType arg +value)",
                 "have_template_args": true,
+                "name": "TemplateArgument",
                 "options": {},
                 "template_arguments": [
                     {
@@ -1859,6 +1870,7 @@
                 "decl": "template<typename ArgType>\nvoid TemplateArgument(ArgType arg)\n",
                 "declgen": "void TemplateArgument(int arg +value)",
                 "have_template_args": true,
+                "name": "TemplateArgument",
                 "options": {},
                 "template_arguments": [
                     {
@@ -2041,6 +2053,7 @@
                     "double"
                 ],
                 "have_template_args": true,
+                "name": "TemplateArgument",
                 "options": {},
                 "template_arguments": [
                     {
@@ -2201,6 +2214,7 @@
                 "decl": "template<typename RetType> RetType TemplateReturn()",
                 "declgen": "RetType TemplateReturn(void)",
                 "have_template_args": true,
+                "name": "TemplateReturn",
                 "options": {
                     "wrap_lua": false,
                     "wrap_python": false
@@ -2262,6 +2276,7 @@
                 "decl": "template<typename RetType> RetType TemplateReturn()",
                 "declgen": "int TemplateReturn(void)",
                 "have_template_args": true,
+                "name": "TemplateReturn",
                 "options": {
                     "F_create_generic": false,
                     "wrap_lua": false,
@@ -2381,6 +2396,7 @@
                     "double"
                 ],
                 "have_template_args": true,
+                "name": "TemplateReturn",
                 "options": {
                     "F_create_generic": false,
                     "wrap_lua": false,
@@ -2491,6 +2507,7 @@
                 },
                 "decl": "void FortranGenericOverloaded()",
                 "declgen": "void FortranGenericOverloaded(void)",
+                "name": "FortranGenericOverloaded",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2669,6 +2686,7 @@
                         "generic": "(double arg2)"
                     }
                 ],
+                "name": "FortranGenericOverloaded",
                 "options": {
                     "F_string_len_trim": true
                 },
@@ -2889,6 +2907,7 @@
                 },
                 "decl": "void FortranGenericOverloaded(const std::string &name, double arg2)",
                 "declgen": "void FortranGenericOverloaded(const std::string & name, float arg2 +value)",
+                "name": "FortranGenericOverloaded",
                 "options": {
                     "F_string_len_trim": true
                 },
@@ -2971,6 +2990,7 @@
                 },
                 "decl": "void FortranGenericOverloaded(const std::string &name, double arg2)",
                 "declgen": "void FortranGenericOverloaded(const std::string & name, float arg2 +value)",
+                "name": "FortranGenericOverloaded",
                 "options": {
                     "F_string_len_trim": true
                 },
@@ -3127,6 +3147,7 @@
                 },
                 "decl": "void FortranGenericOverloaded(const std::string &name, double arg2)",
                 "declgen": "void FortranGenericOverloaded(const std::string & name, double arg2 +value)",
+                "name": "FortranGenericOverloaded",
                 "options": {
                     "F_string_len_trim": true
                 },
@@ -3209,6 +3230,7 @@
                 },
                 "decl": "void FortranGenericOverloaded(const std::string &name, double arg2)",
                 "declgen": "void FortranGenericOverloaded(const std::string & name, double arg2 +value)",
+                "name": "FortranGenericOverloaded",
                 "options": {
                     "F_string_len_trim": true
                 },
@@ -3347,6 +3369,7 @@
                     "_num_offset",
                     "_num_offset_stride"
                 ],
+                "name": "UseDefaultOverload",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3505,6 +3528,7 @@
                     "_num_offset",
                     "_num_offset_stride"
                 ],
+                "name": "UseDefaultOverload",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3718,6 +3742,7 @@
                     "_num_offset",
                     "_num_offset_stride"
                 ],
+                "name": "UseDefaultOverload",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -4068,6 +4093,7 @@
                 },
                 "decl": "int UseDefaultOverload(double type, int num, int offset = 0, int stride = 1)",
                 "declgen": "int UseDefaultOverload(double type +value, int num +value)",
+                "name": "UseDefaultOverload",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -4270,6 +4296,7 @@
                 },
                 "decl": "int UseDefaultOverload(double type, int num, int offset = 0, int stride = 1)",
                 "declgen": "int UseDefaultOverload(double type +value, int num +value, int offset=0 +value)",
+                "name": "UseDefaultOverload",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -4527,6 +4554,7 @@
                 },
                 "decl": "int UseDefaultOverload(double type, int num, int offset = 0, int stride = 1)",
                 "declgen": "int UseDefaultOverload(double type +value, int num +value, int offset=0 +value, int stride=1 +value)",
+                "name": "UseDefaultOverload",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -4920,6 +4948,7 @@
                 },
                 "decl": "TypeID typefunc(TypeID arg)",
                 "declgen": "TypeID typefunc(TypeID arg +value)",
+                "name": "typefunc",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -5117,6 +5146,7 @@
                 },
                 "decl": "EnumTypeID enumfunc(EnumTypeID arg)",
                 "declgen": "EnumTypeID enumfunc(EnumTypeID arg +value)",
+                "name": "enumfunc",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -5320,6 +5350,7 @@
                 },
                 "decl": "Color colorfunc(Color arg);",
                 "declgen": "Color colorfunc(Color arg +value)",
+                "name": "colorfunc",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -5550,6 +5581,7 @@
                 "doxygen": {
                     "brief": "Pass in reference to scalar"
                 },
+                "name": "getMinMax",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false
@@ -5769,6 +5801,7 @@
                 "doxygen": {
                     "brief": "Test function pointer"
                 },
+                "name": "callback1",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false,
@@ -5929,6 +5962,7 @@
                 },
                 "decl": "const std::string& LastFunctionCalled() +len(30)",
                 "declgen": "const std::string & LastFunctionCalled(void) +len(30)",
+                "name": "LastFunctionCalled",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -6053,6 +6087,7 @@
                 },
                 "decl": "const std::string& LastFunctionCalled() +len(30)",
                 "declgen": "const std::string & LastFunctionCalled(void) +len(30)",
+                "name": "LastFunctionCalled",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {

--- a/regression/reference/tutorial/tutorial.json
+++ b/regression/reference/tutorial/tutorial.json
@@ -5734,6 +5734,7 @@
                                     "metaattrs": {
                                         "intent": "in"
                                     },
+                                    "name": "incr",
                                     "params": [
                                         {
                                             "declarator": {

--- a/regression/reference/typedefs-c/typedefs.json
+++ b/regression/reference/typedefs-c/typedefs.json
@@ -18,7 +18,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "i"
+                                "name": "i",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -45,7 +46,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "d"
+                                "name": "d",
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -115,28 +117,30 @@
                 "<FUNCTION>": "0 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "typefunc"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "typefunc",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "TypeID"
+                                },
+                                "specifier": [
+                                    "TypeID"
+                                ],
+                                "typemap_name": "TypeID"
+                            }
+                        ],
+                        "typemap_name": "TypeID"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "TypeID"
-                            ],
-                            "typemap_name": "TypeID"
-                        }
-                    ],
                     "specifier": [
                         "TypeID"
                     ],
@@ -283,30 +287,32 @@
                 "<FUNCTION>": "1 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "typestruct"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "typestruct",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Struct1Rename"
+                                },
+                                "specifier": [
+                                    "Struct1Rename"
+                                ],
+                                "typemap_name": "Struct1Rename"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "Struct1Rename"
-                            ],
-                            "typemap_name": "Struct1Rename"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -414,7 +420,8 @@
                 "<TYPEDEF>": "****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "TypeID"
+                        "name": "TypeID",
+                        "typemap_name": "int"
                     },
                     "specifier": [
                         "int"
@@ -449,7 +456,8 @@
                 "<TYPEDEF>": "****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "Struct1Rename"
+                        "name": "Struct1Rename",
+                        "typemap_name": "s_Struct1"
                     },
                     "specifier": [
                         "struct s_Struct1"

--- a/regression/reference/typedefs-c/typedefs.json
+++ b/regression/reference/typedefs-c/typedefs.json
@@ -148,6 +148,7 @@
                 },
                 "decl": "TypeID typefunc(TypeID arg);",
                 "declgen": "TypeID typefunc(TypeID arg +value)",
+                "name": "typefunc",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -320,6 +321,7 @@
                 },
                 "decl": "void typestruct(Struct1Rename *arg1);",
                 "declgen": "void typestruct(Struct1Rename * arg1)",
+                "name": "typestruct",
                 "options": {},
                 "wrap": {
                     "c": true,

--- a/regression/reference/typedefs-c/typedefs.json
+++ b/regression/reference/typedefs-c/typedefs.json
@@ -448,30 +448,6 @@
             {
                 "<TYPEDEF>": "****************************************",
                 "ast": {
-                    "class_specifier": {
-                        "members": [
-                            {
-                                "declarator": {
-                                    "name": "i"
-                                },
-                                "specifier": [
-                                    "int"
-                                ],
-                                "typemap_name": "int"
-                            },
-                            {
-                                "declarator": {
-                                    "name": "d"
-                                },
-                                "specifier": [
-                                    "double"
-                                ],
-                                "typemap_name": "double"
-                            }
-                        ],
-                        "name": "s_Struct1",
-                        "typemap_name": "s_Struct1"
-                    },
                     "declarator": {
                         "name": "Struct1Rename"
                     },

--- a/regression/reference/typedefs-cxx/typedefs.json
+++ b/regression/reference/typedefs-cxx/typedefs.json
@@ -18,7 +18,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "i"
+                                "name": "i",
+                                "typemap_name": "int"
                             },
                             "specifier": [
                                 "int"
@@ -45,7 +46,8 @@
                         "<VARIABLE>": "****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "d"
+                                "name": "d",
+                                "typemap_name": "double"
                             },
                             "specifier": [
                                 "double"
@@ -115,28 +117,30 @@
                 "<FUNCTION>": "0 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "typefunc"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "typefunc",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "TypeID"
+                                },
+                                "specifier": [
+                                    "TypeID"
+                                ],
+                                "typemap_name": "TypeID"
+                            }
+                        ],
+                        "typemap_name": "TypeID"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "TypeID"
-                            ],
-                            "typemap_name": "TypeID"
-                        }
-                    ],
                     "specifier": [
                         "TypeID"
                     ],
@@ -283,30 +287,32 @@
                 "<FUNCTION>": "1 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "typestruct"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "typestruct",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "Struct1Rename"
+                                },
+                                "specifier": [
+                                    "Struct1Rename"
+                                ],
+                                "typemap_name": "Struct1Rename"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "Struct1Rename"
-                            ],
-                            "typemap_name": "Struct1Rename"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -414,7 +420,8 @@
                 "<TYPEDEF>": "****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "TypeID"
+                        "name": "TypeID",
+                        "typemap_name": "int"
                     },
                     "specifier": [
                         "int"
@@ -449,7 +456,8 @@
                 "<TYPEDEF>": "****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "Struct1Rename"
+                        "name": "Struct1Rename",
+                        "typemap_name": "s_Struct1"
                     },
                     "specifier": [
                         "struct s_Struct1"

--- a/regression/reference/typedefs-cxx/typedefs.json
+++ b/regression/reference/typedefs-cxx/typedefs.json
@@ -148,6 +148,7 @@
                 },
                 "decl": "TypeID typefunc(TypeID arg);",
                 "declgen": "TypeID typefunc(TypeID arg +value)",
+                "name": "typefunc",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -320,6 +321,7 @@
                 },
                 "decl": "void typestruct(Struct1Rename *arg1);",
                 "declgen": "void typestruct(Struct1Rename * arg1)",
+                "name": "typestruct",
                 "options": {},
                 "wrap": {
                     "c": true,

--- a/regression/reference/typedefs-cxx/typedefs.json
+++ b/regression/reference/typedefs-cxx/typedefs.json
@@ -448,30 +448,6 @@
             {
                 "<TYPEDEF>": "****************************************",
                 "ast": {
-                    "class_specifier": {
-                        "members": [
-                            {
-                                "declarator": {
-                                    "name": "i"
-                                },
-                                "specifier": [
-                                    "int"
-                                ],
-                                "typemap_name": "int"
-                            },
-                            {
-                                "declarator": {
-                                    "name": "d"
-                                },
-                                "specifier": [
-                                    "double"
-                                ],
-                                "typemap_name": "double"
-                            }
-                        ],
-                        "name": "s_Struct1",
-                        "typemap_name": "s_Struct1"
-                    },
                     "declarator": {
                         "name": "Struct1Rename"
                     },

--- a/regression/reference/typemap/typemap.json
+++ b/regression/reference/typemap/typemap.json
@@ -18,48 +18,51 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "passIndex"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "IndexType"
-                            ],
-                            "typemap_name": "IndexType"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                        "name": "passIndex",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i1",
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
                             },
-                            "declarator": {
-                                "name": "i2",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "IndexType"
-                            ],
-                            "typemap_name": "IndexType"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "i2",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
+                            }
+                        ],
+                        "typemap_name": "bool"
+                    },
                     "specifier": [
                         "bool"
                     ],
@@ -71,14 +74,15 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "i1"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i1",
+                                    "typemap_name": "int32_t"
                                 },
                                 "specifier": [
                                     "int32_t"
@@ -86,19 +90,20 @@
                                 "typemap_name": "int32_t"
                             },
                             {
-                                "attrs": {
-                                    "intent": "out"
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
                                     "name": "i2",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "out"
+                                    ],
+                                    "typemap_name": "IndexType"
                                 },
                                 "specifier": [
                                     "IndexType"
@@ -112,14 +117,15 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "i1"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i1",
+                                    "typemap_name": "int64_t"
                                 },
                                 "specifier": [
                                     "int64_t"
@@ -127,19 +133,20 @@
                                 "typemap_name": "int64_t"
                             },
                             {
-                                "attrs": {
-                                    "intent": "out"
-                                },
                                 "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
                                     "name": "i2",
                                     "pointer": [
                                         {
                                             "ptr": "*"
                                         }
-                                    ]
-                                },
-                                "metaattrs": {
-                                    "intent": "out"
+                                    ],
+                                    "typemap_name": "IndexType"
                                 },
                                 "specifier": [
                                     "IndexType"
@@ -268,48 +275,51 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "passIndex"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int32_t"
-                            ],
-                            "typemap_name": "int32_t"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                        "name": "passIndex",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i1",
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
                             },
-                            "declarator": {
-                                "name": "i2",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "IndexType"
-                            ],
-                            "typemap_name": "IndexType"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "i2",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
+                            }
+                        ],
+                        "typemap_name": "bool"
+                    },
                     "specifier": [
                         "bool"
                     ],
@@ -457,48 +467,51 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "passIndex"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int64_t"
-                            ],
-                            "typemap_name": "int64_t"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "intent": "out"
+                        "name": "passIndex",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i1",
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
                             },
-                            "declarator": {
-                                "name": "i2",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "IndexType"
-                            ],
-                            "typemap_name": "IndexType"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "i2",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
+                            }
+                        ],
+                        "typemap_name": "bool"
+                    },
                     "specifier": [
                         "bool"
                     ],
@@ -641,28 +654,30 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "passIndex2"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "passIndex2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i1",
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "IndexType"
-                            ],
-                            "typemap_name": "IndexType"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -674,14 +689,15 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "i1"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i1",
+                                    "typemap_name": "int32_t"
                                 },
                                 "specifier": [
                                     "int32_t"
@@ -695,14 +711,15 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "i1"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i1",
+                                    "typemap_name": "int64_t"
                                 },
                                 "specifier": [
                                     "int64_t"
@@ -779,28 +796,30 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "passIndex2"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "passIndex2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i1",
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int32_t"
-                            ],
-                            "typemap_name": "int32_t"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -839,28 +858,30 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "passIndex2"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "passIndex2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "i1",
+                                    "typemap_name": "IndexType"
+                                },
+                                "specifier": [
+                                    "IndexType"
+                                ],
+                                "typemap_name": "IndexType"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "i1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int64_t"
-                            ],
-                            "typemap_name": "int64_t"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -894,28 +915,30 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "passFloat"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "passFloat",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "f1",
+                                    "typemap_name": "FloatType"
+                                },
+                                "specifier": [
+                                    "FloatType"
+                                ],
+                                "typemap_name": "FloatType"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "f1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "FloatType"
-                            ],
-                            "typemap_name": "FloatType"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -927,14 +950,15 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "f1"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "f1",
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
                                     "float"
@@ -948,14 +972,15 @@
                     {
                         "decls": [
                             {
-                                "attrs": {
-                                    "value": true
-                                },
                                 "declarator": {
-                                    "name": "f1"
-                                },
-                                "metaattrs": {
-                                    "intent": "in"
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "f1",
+                                    "typemap_name": "double"
                                 },
                                 "specifier": [
                                     "double"
@@ -1032,28 +1057,30 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "passFloat"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "passFloat",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "f1",
+                                    "typemap_name": "FloatType"
+                                },
+                                "specifier": [
+                                    "FloatType"
+                                ],
+                                "typemap_name": "FloatType"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "f1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "float"
-                            ],
-                            "typemap_name": "float"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],
@@ -1092,28 +1119,30 @@
                 "_overloaded": true,
                 "ast": {
                     "declarator": {
-                        "name": "passFloat"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "passFloat",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "f1",
+                                    "typemap_name": "FloatType"
+                                },
+                                "specifier": [
+                                    "FloatType"
+                                ],
+                                "typemap_name": "FloatType"
+                            }
+                        ],
+                        "typemap_name": "void"
                     },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "f1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "double"
-                            ],
-                            "typemap_name": "double"
-                        }
-                    ],
                     "specifier": [
                         "void"
                     ],

--- a/regression/reference/typemap/typemap.json
+++ b/regression/reference/typemap/typemap.json
@@ -158,6 +158,7 @@
                         "generic": "(int64_t i1)"
                     }
                 ],
+                "name": "passIndex",
                 "options": {},
                 "wrap": {
                     "c": true
@@ -327,6 +328,7 @@
                 },
                 "decl": "bool passIndex(IndexType i1, IndexType *i2+intent(out))",
                 "declgen": "bool passIndex(int32_t i1 +value, IndexType * i2 +intent(out))",
+                "name": "passIndex",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -519,6 +521,7 @@
                 },
                 "decl": "bool passIndex(IndexType i1, IndexType *i2+intent(out))",
                 "declgen": "bool passIndex(int64_t i1 +value, IndexType * i2 +intent(out))",
+                "name": "passIndex",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -731,6 +734,7 @@
                         "generic": "(int64_t i1)"
                     }
                 ],
+                "name": "passIndex2",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -827,6 +831,7 @@
                 },
                 "decl": "void passIndex2(IndexType i1)",
                 "declgen": "void passIndex2(int32_t i1 +value)",
+                "name": "passIndex2",
                 "options": {},
                 "wrap": {
                     "fortran": true
@@ -889,6 +894,7 @@
                 },
                 "decl": "void passIndex2(IndexType i1)",
                 "declgen": "void passIndex2(int64_t i1 +value)",
+                "name": "passIndex2",
                 "options": {},
                 "wrap": {
                     "fortran": true
@@ -992,6 +998,7 @@
                         "generic": "(double f1)"
                     }
                 ],
+                "name": "passFloat",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -1088,6 +1095,7 @@
                 },
                 "decl": "void passFloat(FloatType f1);",
                 "declgen": "void passFloat(float f1 +value)",
+                "name": "passFloat",
                 "options": {},
                 "wrap": {
                     "fortran": true
@@ -1150,6 +1158,7 @@
                 },
                 "decl": "void passFloat(FloatType f1);",
                 "declgen": "void passFloat(double f1 +value)",
+                "name": "passFloat",
                 "options": {},
                 "wrap": {
                     "fortran": true

--- a/regression/reference/typemap/typemap.json
+++ b/regression/reference/typemap/typemap.json
@@ -289,12 +289,12 @@
                                         "intent": "in"
                                     },
                                     "name": "i1",
-                                    "typemap_name": "IndexType"
+                                    "typemap_name": "int32_t"
                                 },
                                 "specifier": [
-                                    "IndexType"
+                                    "int32_t"
                                 ],
-                                "typemap_name": "IndexType"
+                                "typemap_name": "int32_t"
                             },
                             {
                                 "declarator": {
@@ -481,12 +481,12 @@
                                         "intent": "in"
                                     },
                                     "name": "i1",
-                                    "typemap_name": "IndexType"
+                                    "typemap_name": "int64_t"
                                 },
                                 "specifier": [
-                                    "IndexType"
+                                    "int64_t"
                                 ],
-                                "typemap_name": "IndexType"
+                                "typemap_name": "int64_t"
                             },
                             {
                                 "declarator": {
@@ -810,12 +810,12 @@
                                         "intent": "in"
                                     },
                                     "name": "i1",
-                                    "typemap_name": "IndexType"
+                                    "typemap_name": "int32_t"
                                 },
                                 "specifier": [
-                                    "IndexType"
+                                    "int32_t"
                                 ],
-                                "typemap_name": "IndexType"
+                                "typemap_name": "int32_t"
                             }
                         ],
                         "typemap_name": "void"
@@ -872,12 +872,12 @@
                                         "intent": "in"
                                     },
                                     "name": "i1",
-                                    "typemap_name": "IndexType"
+                                    "typemap_name": "int64_t"
                                 },
                                 "specifier": [
-                                    "IndexType"
+                                    "int64_t"
                                 ],
-                                "typemap_name": "IndexType"
+                                "typemap_name": "int64_t"
                             }
                         ],
                         "typemap_name": "void"
@@ -1071,12 +1071,12 @@
                                         "intent": "in"
                                     },
                                     "name": "f1",
-                                    "typemap_name": "FloatType"
+                                    "typemap_name": "float"
                                 },
                                 "specifier": [
-                                    "FloatType"
+                                    "float"
                                 ],
-                                "typemap_name": "FloatType"
+                                "typemap_name": "float"
                             }
                         ],
                         "typemap_name": "void"
@@ -1133,12 +1133,12 @@
                                         "intent": "in"
                                     },
                                     "name": "f1",
-                                    "typemap_name": "FloatType"
+                                    "typemap_name": "double"
                                 },
                                 "specifier": [
-                                    "FloatType"
+                                    "double"
                                 ],
-                                "typemap_name": "FloatType"
+                                "typemap_name": "double"
                             }
                         ],
                         "typemap_name": "void"

--- a/regression/reference/types/types.json
+++ b/regression/reference/types/types.json
@@ -48,6 +48,7 @@
                 },
                 "decl": "short short_func(short arg1)",
                 "declgen": "short short_func(short arg1 +value)",
+                "name": "short_func",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -216,6 +217,7 @@
                 },
                 "decl": "int int_func(int arg1)",
                 "declgen": "int int_func(int arg1 +value)",
+                "name": "int_func",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -384,6 +386,7 @@
                 },
                 "decl": "long long_func(long arg1)",
                 "declgen": "long long_func(long arg1 +value)",
+                "name": "long_func",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -554,6 +557,7 @@
                 },
                 "decl": "long long long_long_func(long long arg1)",
                 "declgen": "long long long_long_func(long long arg1 +value)",
+                "name": "long_long_func",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -726,6 +730,7 @@
                 },
                 "decl": "short int short_int_func(short int arg1)",
                 "declgen": "short int short_int_func(short int arg1 +value)",
+                "name": "short_int_func",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -896,6 +901,7 @@
                 },
                 "decl": "long int long_int_func(long int arg1)",
                 "declgen": "long int long_int_func(long int arg1 +value)",
+                "name": "long_int_func",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -1068,6 +1074,7 @@
                 },
                 "decl": "long long int long_long_int_func(long long int arg1)",
                 "declgen": "long long int long_long_int_func(long long int arg1 +value)",
+                "name": "long_long_int_func",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -1238,6 +1245,7 @@
                 },
                 "decl": "unsigned unsigned_func(unsigned arg1)",
                 "declgen": "unsigned unsigned_func(unsigned arg1 +value)",
+                "name": "unsigned_func",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -1408,6 +1416,7 @@
                 },
                 "decl": "unsigned short ushort_func(unsigned short arg1)",
                 "declgen": "unsigned short ushort_func(unsigned short arg1 +value)",
+                "name": "ushort_func",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -1578,6 +1587,7 @@
                 },
                 "decl": "unsigned int uint_func(unsigned int arg1)",
                 "declgen": "unsigned int uint_func(unsigned int arg1 +value)",
+                "name": "uint_func",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -1748,6 +1758,7 @@
                 },
                 "decl": "unsigned long ulong_func(unsigned long arg1)",
                 "declgen": "unsigned long ulong_func(unsigned long arg1 +value)",
+                "name": "ulong_func",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -1920,6 +1931,7 @@
                 },
                 "decl": "unsigned long long ulong_long_func(unsigned long long arg1)",
                 "declgen": "unsigned long long ulong_long_func(unsigned long long arg1 +value)",
+                "name": "ulong_long_func",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2094,6 +2106,7 @@
                 },
                 "decl": "unsigned long int ulong_int_func(unsigned long int arg1)",
                 "declgen": "unsigned long int ulong_int_func(unsigned long int arg1 +value)",
+                "name": "ulong_int_func",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2262,6 +2275,7 @@
                 },
                 "decl": "int8_t  int8_func(int8_t arg1)",
                 "declgen": "int8_t int8_func(int8_t arg1 +value)",
+                "name": "int8_func",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2430,6 +2444,7 @@
                 },
                 "decl": "int16_t int16_func(int16_t arg1)",
                 "declgen": "int16_t int16_func(int16_t arg1 +value)",
+                "name": "int16_func",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2598,6 +2613,7 @@
                 },
                 "decl": "int32_t int32_func(int32_t arg1)",
                 "declgen": "int32_t int32_func(int32_t arg1 +value)",
+                "name": "int32_func",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2766,6 +2782,7 @@
                 },
                 "decl": "int64_t int64_func(int64_t arg1)",
                 "declgen": "int64_t int64_func(int64_t arg1 +value)",
+                "name": "int64_func",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -2934,6 +2951,7 @@
                 },
                 "decl": "uint8_t  uint8_func(uint8_t arg1)",
                 "declgen": "uint8_t uint8_func(uint8_t arg1 +value)",
+                "name": "uint8_func",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3102,6 +3120,7 @@
                 },
                 "decl": "uint16_t uint16_func(uint16_t arg1)",
                 "declgen": "uint16_t uint16_func(uint16_t arg1 +value)",
+                "name": "uint16_func",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3270,6 +3289,7 @@
                 },
                 "decl": "uint32_t uint32_func(uint32_t arg1)",
                 "declgen": "uint32_t uint32_func(uint32_t arg1 +value)",
+                "name": "uint32_func",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3438,6 +3458,7 @@
                 },
                 "decl": "uint64_t uint64_func(uint64_t arg1)",
                 "declgen": "uint64_t uint64_func(uint64_t arg1 +value)",
+                "name": "uint64_func",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3606,6 +3627,7 @@
                 },
                 "decl": "size_t size_func(size_t arg1)",
                 "declgen": "size_t size_func(size_t arg1 +value)",
+                "name": "size_func",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3774,6 +3796,7 @@
                 },
                 "decl": "bool bool_func(bool arg)",
                 "declgen": "bool bool_func(bool arg +value)",
+                "name": "bool_func",
                 "options": {},
                 "wrap": {
                     "c": true,
@@ -3954,6 +3977,7 @@
                     "brief": "Function which returns bool with other intent(out) arguments",
                     "description": "Python treats bool differently since Py_BuildValue does not support\nbool until Python 3.3.\nMust create a PyObject with PyBool_FromLong then include that object\nin call to Py_BuildValue as type 'O'.  But since two return values\nare being created, function return and argument flag, rename first\nlocal C variable to avoid duplicate names in wrapper.\n"
                 },
+                "name": "returnBoolAndOthers",
                 "options": {},
                 "wrap": {
                     "c": true,

--- a/regression/reference/types/types.json
+++ b/regression/reference/types/types.json
@@ -17,28 +17,30 @@
                 "<FUNCTION>": "0 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "short_func"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "short_func",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "short"
+                                },
+                                "specifier": [
+                                    "short"
+                                ],
+                                "typemap_name": "short"
+                            }
+                        ],
+                        "typemap_name": "short"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "short"
-                            ],
-                            "typemap_name": "short"
-                        }
-                    ],
                     "specifier": [
                         "short"
                     ],
@@ -183,28 +185,30 @@
                 "<FUNCTION>": "1 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "int_func"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "int_func",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "int"
                     ],
@@ -349,28 +353,30 @@
                 "<FUNCTION>": "2 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "long_func"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "long_func",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "long"
+                                },
+                                "specifier": [
+                                    "long"
+                                ],
+                                "typemap_name": "long"
+                            }
+                        ],
+                        "typemap_name": "long"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "long"
-                            ],
-                            "typemap_name": "long"
-                        }
-                    ],
                     "specifier": [
                         "long"
                     ],
@@ -515,29 +521,31 @@
                 "<FUNCTION>": "3 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "long_long_func"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "long_long_func",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "long_long"
+                                },
+                                "specifier": [
+                                    "long",
+                                    "long"
+                                ],
+                                "typemap_name": "long_long"
+                            }
+                        ],
+                        "typemap_name": "long_long"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "long",
-                                "long"
-                            ],
-                            "typemap_name": "long_long"
-                        }
-                    ],
                     "specifier": [
                         "long",
                         "long"
@@ -685,29 +693,31 @@
                 "<FUNCTION>": "4 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "short_int_func"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "short_int_func",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "short"
+                                },
+                                "specifier": [
+                                    "short",
+                                    "int"
+                                ],
+                                "typemap_name": "short"
+                            }
+                        ],
+                        "typemap_name": "short"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "short",
-                                "int"
-                            ],
-                            "typemap_name": "short"
-                        }
-                    ],
                     "specifier": [
                         "short",
                         "int"
@@ -853,29 +863,31 @@
                 "<FUNCTION>": "5 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "long_int_func"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "long_int_func",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "long"
+                                },
+                                "specifier": [
+                                    "long",
+                                    "int"
+                                ],
+                                "typemap_name": "long"
+                            }
+                        ],
+                        "typemap_name": "long"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "long",
-                                "int"
-                            ],
-                            "typemap_name": "long"
-                        }
-                    ],
                     "specifier": [
                         "long",
                         "int"
@@ -1021,30 +1033,32 @@
                 "<FUNCTION>": "6 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "long_long_int_func"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "long_long_int_func",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "long_long"
+                                },
+                                "specifier": [
+                                    "long",
+                                    "long",
+                                    "int"
+                                ],
+                                "typemap_name": "long_long"
+                            }
+                        ],
+                        "typemap_name": "long_long"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "long",
-                                "long",
-                                "int"
-                            ],
-                            "typemap_name": "long_long"
-                        }
-                    ],
                     "specifier": [
                         "long",
                         "long",
@@ -1193,28 +1207,30 @@
                 "<FUNCTION>": "7 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "unsigned_func"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "unsigned_func",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "unsigned_int"
+                                },
+                                "specifier": [
+                                    "unsigned"
+                                ],
+                                "typemap_name": "unsigned_int"
+                            }
+                        ],
+                        "typemap_name": "unsigned_int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "unsigned"
-                            ],
-                            "typemap_name": "unsigned_int"
-                        }
-                    ],
                     "specifier": [
                         "unsigned"
                     ],
@@ -1359,29 +1375,31 @@
                 "<FUNCTION>": "8 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "ushort_func"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "ushort_func",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "unsigned_short"
+                                },
+                                "specifier": [
+                                    "unsigned",
+                                    "short"
+                                ],
+                                "typemap_name": "unsigned_short"
+                            }
+                        ],
+                        "typemap_name": "unsigned_short"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "unsigned",
-                                "short"
-                            ],
-                            "typemap_name": "unsigned_short"
-                        }
-                    ],
                     "specifier": [
                         "unsigned",
                         "short"
@@ -1527,29 +1545,31 @@
                 "<FUNCTION>": "9 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "uint_func"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "uint_func",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "unsigned_int"
+                                },
+                                "specifier": [
+                                    "unsigned",
+                                    "int"
+                                ],
+                                "typemap_name": "unsigned_int"
+                            }
+                        ],
+                        "typemap_name": "unsigned_int"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "unsigned",
-                                "int"
-                            ],
-                            "typemap_name": "unsigned_int"
-                        }
-                    ],
                     "specifier": [
                         "unsigned",
                         "int"
@@ -1695,29 +1715,31 @@
                 "<FUNCTION>": "10 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "ulong_func"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "ulong_func",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "unsigned_long"
+                                },
+                                "specifier": [
+                                    "unsigned",
+                                    "long"
+                                ],
+                                "typemap_name": "unsigned_long"
+                            }
+                        ],
+                        "typemap_name": "unsigned_long"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "unsigned",
-                                "long"
-                            ],
-                            "typemap_name": "unsigned_long"
-                        }
-                    ],
                     "specifier": [
                         "unsigned",
                         "long"
@@ -1863,30 +1885,32 @@
                 "<FUNCTION>": "11 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "ulong_long_func"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "ulong_long_func",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "unsigned_long_long"
+                                },
+                                "specifier": [
+                                    "unsigned",
+                                    "long",
+                                    "long"
+                                ],
+                                "typemap_name": "unsigned_long_long"
+                            }
+                        ],
+                        "typemap_name": "unsigned_long_long"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "unsigned",
-                                "long",
-                                "long"
-                            ],
-                            "typemap_name": "unsigned_long_long"
-                        }
-                    ],
                     "specifier": [
                         "unsigned",
                         "long",
@@ -2035,30 +2059,32 @@
                 "<FUNCTION>": "12 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "ulong_int_func"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "ulong_int_func",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "unsigned_long"
+                                },
+                                "specifier": [
+                                    "unsigned",
+                                    "long",
+                                    "int"
+                                ],
+                                "typemap_name": "unsigned_long"
+                            }
+                        ],
+                        "typemap_name": "unsigned_long"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "unsigned",
-                                "long",
-                                "int"
-                            ],
-                            "typemap_name": "unsigned_long"
-                        }
-                    ],
                     "specifier": [
                         "unsigned",
                         "long",
@@ -2205,28 +2231,30 @@
                 "<FUNCTION>": "13 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "int8_func"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "int8_func",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "int8_t"
+                                },
+                                "specifier": [
+                                    "int8_t"
+                                ],
+                                "typemap_name": "int8_t"
+                            }
+                        ],
+                        "typemap_name": "int8_t"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int8_t"
-                            ],
-                            "typemap_name": "int8_t"
-                        }
-                    ],
                     "specifier": [
                         "int8_t"
                     ],
@@ -2371,28 +2399,30 @@
                 "<FUNCTION>": "14 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "int16_func"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "int16_func",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "int16_t"
+                                },
+                                "specifier": [
+                                    "int16_t"
+                                ],
+                                "typemap_name": "int16_t"
+                            }
+                        ],
+                        "typemap_name": "int16_t"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int16_t"
-                            ],
-                            "typemap_name": "int16_t"
-                        }
-                    ],
                     "specifier": [
                         "int16_t"
                     ],
@@ -2537,28 +2567,30 @@
                 "<FUNCTION>": "15 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "int32_func"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "int32_func",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "int32_t"
+                                },
+                                "specifier": [
+                                    "int32_t"
+                                ],
+                                "typemap_name": "int32_t"
+                            }
+                        ],
+                        "typemap_name": "int32_t"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int32_t"
-                            ],
-                            "typemap_name": "int32_t"
-                        }
-                    ],
                     "specifier": [
                         "int32_t"
                     ],
@@ -2703,28 +2735,30 @@
                 "<FUNCTION>": "16 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "int64_func"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "int64_func",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "int64_t"
+                                },
+                                "specifier": [
+                                    "int64_t"
+                                ],
+                                "typemap_name": "int64_t"
+                            }
+                        ],
+                        "typemap_name": "int64_t"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int64_t"
-                            ],
-                            "typemap_name": "int64_t"
-                        }
-                    ],
                     "specifier": [
                         "int64_t"
                     ],
@@ -2869,28 +2903,30 @@
                 "<FUNCTION>": "17 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "uint8_func"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "uint8_func",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "uint8_t"
+                                },
+                                "specifier": [
+                                    "uint8_t"
+                                ],
+                                "typemap_name": "uint8_t"
+                            }
+                        ],
+                        "typemap_name": "uint8_t"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "uint8_t"
-                            ],
-                            "typemap_name": "uint8_t"
-                        }
-                    ],
                     "specifier": [
                         "uint8_t"
                     ],
@@ -3035,28 +3071,30 @@
                 "<FUNCTION>": "18 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "uint16_func"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "uint16_func",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "uint16_t"
+                                },
+                                "specifier": [
+                                    "uint16_t"
+                                ],
+                                "typemap_name": "uint16_t"
+                            }
+                        ],
+                        "typemap_name": "uint16_t"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "uint16_t"
-                            ],
-                            "typemap_name": "uint16_t"
-                        }
-                    ],
                     "specifier": [
                         "uint16_t"
                     ],
@@ -3201,28 +3239,30 @@
                 "<FUNCTION>": "19 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "uint32_func"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "uint32_func",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "uint32_t"
+                                },
+                                "specifier": [
+                                    "uint32_t"
+                                ],
+                                "typemap_name": "uint32_t"
+                            }
+                        ],
+                        "typemap_name": "uint32_t"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "uint32_t"
-                            ],
-                            "typemap_name": "uint32_t"
-                        }
-                    ],
                     "specifier": [
                         "uint32_t"
                     ],
@@ -3367,28 +3407,30 @@
                 "<FUNCTION>": "20 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "uint64_func"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "uint64_func",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "uint64_t"
+                                },
+                                "specifier": [
+                                    "uint64_t"
+                                ],
+                                "typemap_name": "uint64_t"
+                            }
+                        ],
+                        "typemap_name": "uint64_t"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "uint64_t"
-                            ],
-                            "typemap_name": "uint64_t"
-                        }
-                    ],
                     "specifier": [
                         "uint64_t"
                     ],
@@ -3533,28 +3575,30 @@
                 "<FUNCTION>": "21 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "size_func"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "size_func",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "typemap_name": "size_t"
+                                },
+                                "specifier": [
+                                    "size_t"
+                                ],
+                                "typemap_name": "size_t"
+                            }
+                        ],
+                        "typemap_name": "size_t"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg1"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "size_t"
-                            ],
-                            "typemap_name": "size_t"
-                        }
-                    ],
                     "specifier": [
                         "size_t"
                     ],
@@ -3699,28 +3743,30 @@
                 "<FUNCTION>": "22 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "bool_func"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "bool_func",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "typemap_name": "bool"
+                                },
+                                "specifier": [
+                                    "bool"
+                                ],
+                                "typemap_name": "bool"
+                            }
+                        ],
+                        "typemap_name": "bool"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "arg"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "bool"
-                            ],
-                            "typemap_name": "bool"
-                        }
-                    ],
                     "specifier": [
                         "bool"
                     ],
@@ -3868,33 +3914,35 @@
                 "<FUNCTION>": "23 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "returnBoolAndOthers"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "returnBoolAndOthers",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out"
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "flag",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "bool"
                     },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out"
-                            },
-                            "declarator": {
-                                "name": "flag",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "bool"
                     ],

--- a/regression/reference/vectors-list/vectors.json
+++ b/regression/reference/vectors-list/vectors.json
@@ -44,6 +44,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],
@@ -154,6 +155,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],
@@ -247,6 +249,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],
@@ -337,6 +340,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],
@@ -417,6 +421,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],
@@ -480,6 +485,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],
@@ -540,6 +546,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],
@@ -597,6 +604,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "double"
                                     ],
@@ -772,6 +780,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "std::string"
                                     ],
@@ -832,6 +841,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "std::string"
                                     ],
@@ -895,6 +905,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "std::string"
                                     ],
@@ -961,6 +972,7 @@
                     ],
                     "template_arguments": [
                         {
+                            "declarator": {},
                             "specifier": [
                                 "int"
                             ],

--- a/regression/reference/vectors-list/vectors.json
+++ b/regression/reference/vectors-list/vectors.json
@@ -65,6 +65,7 @@
                 },
                 "decl": "int vector_sum(const std::vector<int> &arg)",
                 "declgen": "int vector_sum(const std::vector<int> & arg +rank(1))",
+                "name": "vector_sum",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false
@@ -183,6 +184,7 @@
                 "doxygen": {
                     "brief": "Copy vector into Fortran input array"
                 },
+                "name": "vector_iota_out",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false
@@ -310,6 +312,7 @@
                         "result": "num"
                     }
                 },
+                "name": "vector_iota_out_with_num",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false,
@@ -393,6 +396,7 @@
                         "result": "num"
                     }
                 },
+                "name": "vector_iota_out_with_num2",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false,
@@ -461,6 +465,7 @@
                 "doxygen": {
                     "brief": "Copy vector into Fortran allocatable array"
                 },
+                "name": "vector_iota_out_alloc",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false,
@@ -529,6 +534,7 @@
                 "doxygen": {
                     "brief": "Copy vector into Fortran allocatable array"
                 },
+                "name": "vector_iota_inout_alloc",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false,
@@ -591,6 +597,7 @@
                 },
                 "decl": "void vector_increment(std::vector<int> &arg)",
                 "declgen": "void vector_increment(std::vector<int> & arg +rank(1))",
+                "name": "vector_increment",
                 "options": {
                     "wrap_lua": false,
                     "wrap_python": false
@@ -656,6 +663,7 @@
                 "doxygen": {
                     "brief": "Copy vector into Fortran input array"
                 },
+                "name": "vector_iota_out_d",
                 "options": {
                     "wrap_lua": false
                 },
@@ -775,6 +783,7 @@
                 "doxygen": {
                     "brief": "Fortran 2-d array to vector<const double *>"
                 },
+                "name": "vector_of_pointers",
                 "options": {
                     "wrap_lua": false,
                     "wrap_python": false
@@ -841,6 +850,7 @@
                     "brief": "count number of underscore in vector of strings",
                     "decription": "The input will be copied in order to create the C++ argument\n"
                 },
+                "name": "vector_string_count",
                 "options": {
                     "wrap_python": false
                 },
@@ -906,6 +916,7 @@
                     "brief": "Fill in arg with some animal names",
                     "description": "The C++ function returns void. But the C and Fortran wrappers return\nan int with the number of items added to arg.\n"
                 },
+                "name": "vector_string_fill",
                 "options": {
                     "wrap_c": false,
                     "wrap_fortran": false,
@@ -973,6 +984,7 @@
                 "doxygen": {
                     "brief": "append '-like' to names."
                 },
+                "name": "vector_string_append",
                 "options": {
                     "wrap_c": false,
                     "wrap_fortran": false,
@@ -1038,6 +1050,7 @@
                 "doxygen": {
                     "description": "Implement iota function.\nReturn a vector as an ALLOCATABLE array.\nCopy results into the new array.\n"
                 },
+                "name": "ReturnVectorAlloc",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1154,6 +1167,7 @@
                 },
                 "decl": "int returnDim2(int *arg +rank(2)+intent(in), int len+implied(size(arg,2)))",
                 "declgen": "int returnDim2(int * arg +intent(in)+rank(2), int len +implied(size(arg,2))+value)",
+                "name": "returnDim2",
                 "options": {},
                 "wrap": {
                     "python": true

--- a/regression/reference/vectors-list/vectors.json
+++ b/regression/reference/vectors-list/vectors.json
@@ -17,43 +17,47 @@
                 "<FUNCTION>": "0 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "vector_sum"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "vector_sum",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -128,43 +132,47 @@
                 "<FUNCTION>": "1 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "vector_iota_out"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_iota_out",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -222,43 +230,47 @@
                 "<FUNCTION>": "2 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "vector_iota_out_with_num"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_iota_out_with_num",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -313,43 +325,47 @@
                 "<FUNCTION>": "3 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "vector_iota_out_with_num2"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_iota_out_with_num2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -392,45 +408,49 @@
                 "<FUNCTION>": "4 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "vector_iota_out_alloc"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "allocatable",
-                                "intent": "out",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "allocatable",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_iota_out_alloc",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "allocatable",
+                                        "intent": "out",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "deref": "allocatable",
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -456,45 +476,49 @@
                 "<FUNCTION>": "5 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "vector_iota_inout_alloc"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "allocatable",
-                                "intent": "inout",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "allocatable",
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_iota_inout_alloc",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "allocatable",
+                                        "intent": "inout",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "deref": "allocatable",
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -520,42 +544,46 @@
                 "<FUNCTION>": "6 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "vector_increment"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_increment",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -577,43 +605,47 @@
                 "<FUNCTION>": "7 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "vector_iota_out_d"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "double"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_iota_out_d",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "double"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "double"
+                                        },
+                                        "specifier": [
+                                            "double"
+                                        ],
+                                        "typemap_name": "double"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -670,65 +702,69 @@
                 "<FUNCTION>": "8 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "vector_of_pointers"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "const": true,
-                                    "declarator": {
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "specifier": [
-                                        "double"
-                                    ],
-                                    "typemap_name": "double"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "vector_of_pointers",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "const": true,
+                                        "declarator": {
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "double"
+                                        },
+                                        "specifier": [
+                                            "double"
+                                        ],
+                                        "typemap_name": "double"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
                             },
-                            "declarator": {
-                                "name": "num"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "num",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -753,43 +789,47 @@
                 "<FUNCTION>": "9 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "vector_string_count"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "std::string"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "vector_string_count",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "std::string"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "std::string"
+                                        },
+                                        "specifier": [
+                                            "std::string"
+                                        ],
+                                        "typemap_name": "std::string"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -814,43 +854,47 @@
                 "<FUNCTION>": "10 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "vector_string_fill"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_string_fill",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "std::string"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "std::string"
+                                        },
+                                        "specifier": [
+                                            "std::string"
+                                        ],
+                                        "typemap_name": "std::string"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -878,43 +922,47 @@
                 "<FUNCTION>": "11 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "vector_string_append"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_string_append",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "std::string"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "std::string"
+                                        },
+                                        "specifier": [
+                                            "std::string"
+                                        ],
+                                        "typemap_name": "std::string"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -940,39 +988,43 @@
             {
                 "<FUNCTION>": "12 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "rank": 1
-                    },
                     "declarator": {
-                        "name": "ReturnVectorAlloc"
+                        "attrs": {
+                            "rank": 1
+                        },
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
+                        "name": "ReturnVectorAlloc",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "n",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "std::vector"
                     },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "n"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "std::vector"
                     ],
                     "template_arguments": [
                         {
-                            "declarator": {},
+                            "declarator": {
+                                "typemap_name": "int"
+                            },
                             "specifier": [
                                 "int"
                             ],
@@ -1048,50 +1100,53 @@
                 "<FUNCTION>": "13 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "returnDim2"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 2
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "implied": "size(arg,2)",
-                                "value": true
+                        "name": "returnDim2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 2
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "len"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(arg,2)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "len",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],

--- a/regression/reference/vectors-numpy/vectors.json
+++ b/regression/reference/vectors-numpy/vectors.json
@@ -17,43 +17,47 @@
                 "<FUNCTION>": "0 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "vector_sum"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "vector_sum",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -127,43 +131,47 @@
                 "<FUNCTION>": "1 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "vector_iota_out"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_iota_out",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -223,43 +231,47 @@
                 "<FUNCTION>": "2 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "vector_iota_out_with_num"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_iota_out_with_num",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -314,43 +326,47 @@
                 "<FUNCTION>": "3 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "vector_iota_out_with_num2"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_iota_out_with_num2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -393,45 +409,49 @@
                 "<FUNCTION>": "4 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "vector_iota_out_alloc"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "allocatable",
-                                "intent": "out",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "allocatable",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_iota_out_alloc",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "allocatable",
+                                        "intent": "out",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "deref": "allocatable",
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -457,45 +477,49 @@
                 "<FUNCTION>": "5 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "vector_iota_inout_alloc"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "allocatable",
-                                "intent": "inout",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "allocatable",
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_iota_inout_alloc",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "allocatable",
+                                        "intent": "inout",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "deref": "allocatable",
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -521,42 +545,46 @@
                 "<FUNCTION>": "6 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "vector_increment"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_increment",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -578,43 +606,47 @@
                 "<FUNCTION>": "7 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "vector_iota_out_d"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "double"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_iota_out_d",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "double"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "double"
+                                        },
+                                        "specifier": [
+                                            "double"
+                                        ],
+                                        "typemap_name": "double"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -673,65 +705,69 @@
                 "<FUNCTION>": "8 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "vector_of_pointers"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "const": true,
-                                    "declarator": {
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "specifier": [
-                                        "double"
-                                    ],
-                                    "typemap_name": "double"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "vector_of_pointers",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "const": true,
+                                        "declarator": {
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "double"
+                                        },
+                                        "specifier": [
+                                            "double"
+                                        ],
+                                        "typemap_name": "double"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
                             },
-                            "declarator": {
-                                "name": "num"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "num",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -756,43 +792,47 @@
                 "<FUNCTION>": "9 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "vector_string_count"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "std::string"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "vector_string_count",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "std::string"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "std::string"
+                                        },
+                                        "specifier": [
+                                            "std::string"
+                                        ],
+                                        "typemap_name": "std::string"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -817,43 +857,47 @@
                 "<FUNCTION>": "10 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "vector_string_fill"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_string_fill",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "std::string"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "std::string"
+                                        },
+                                        "specifier": [
+                                            "std::string"
+                                        ],
+                                        "typemap_name": "std::string"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -881,43 +925,47 @@
                 "<FUNCTION>": "11 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "vector_string_append"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_string_append",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "std::string"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "std::string"
+                                        },
+                                        "specifier": [
+                                            "std::string"
+                                        ],
+                                        "typemap_name": "std::string"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -943,39 +991,43 @@
             {
                 "<FUNCTION>": "12 ****************************************",
                 "ast": {
-                    "attrs": {
-                        "rank": 1
-                    },
                     "declarator": {
-                        "name": "ReturnVectorAlloc"
+                        "attrs": {
+                            "rank": 1
+                        },
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
+                        "name": "ReturnVectorAlloc",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "n",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "std::vector"
                     },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "n"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "std::vector"
                     ],
                     "template_arguments": [
                         {
-                            "declarator": {},
+                            "declarator": {
+                                "typemap_name": "int"
+                            },
                             "specifier": [
                                 "int"
                             ],
@@ -1054,50 +1106,53 @@
                 "<FUNCTION>": "13 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "returnDim2"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 2
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "implied": "size(arg,2)",
-                                "value": true
+                        "name": "returnDim2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 2
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "len"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(arg,2)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "len",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],

--- a/regression/reference/vectors-numpy/vectors.json
+++ b/regression/reference/vectors-numpy/vectors.json
@@ -65,6 +65,7 @@
                 },
                 "decl": "int vector_sum(const std::vector<int> &arg)",
                 "declgen": "int vector_sum(const std::vector<int> & arg +rank(1))",
+                "name": "vector_sum",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false
@@ -182,6 +183,7 @@
                 "doxygen": {
                     "brief": "Copy vector into Fortran input array"
                 },
+                "name": "vector_iota_out",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false
@@ -311,6 +313,7 @@
                         "result": "num"
                     }
                 },
+                "name": "vector_iota_out_with_num",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false,
@@ -394,6 +397,7 @@
                         "result": "num"
                     }
                 },
+                "name": "vector_iota_out_with_num2",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false,
@@ -462,6 +466,7 @@
                 "doxygen": {
                     "brief": "Copy vector into Fortran allocatable array"
                 },
+                "name": "vector_iota_out_alloc",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false,
@@ -530,6 +535,7 @@
                 "doxygen": {
                     "brief": "Copy vector into Fortran allocatable array"
                 },
+                "name": "vector_iota_inout_alloc",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false,
@@ -592,6 +598,7 @@
                 },
                 "decl": "void vector_increment(std::vector<int> &arg)",
                 "declgen": "void vector_increment(std::vector<int> & arg +rank(1))",
+                "name": "vector_increment",
                 "options": {
                     "wrap_lua": false,
                     "wrap_python": false
@@ -657,6 +664,7 @@
                 "doxygen": {
                     "brief": "Copy vector into Fortran input array"
                 },
+                "name": "vector_iota_out_d",
                 "options": {
                     "wrap_lua": false
                 },
@@ -778,6 +786,7 @@
                 "doxygen": {
                     "brief": "Fortran 2-d array to vector<const double *>"
                 },
+                "name": "vector_of_pointers",
                 "options": {
                     "wrap_lua": false,
                     "wrap_python": false
@@ -844,6 +853,7 @@
                     "brief": "count number of underscore in vector of strings",
                     "decription": "The input will be copied in order to create the C++ argument\n"
                 },
+                "name": "vector_string_count",
                 "options": {
                     "wrap_python": false
                 },
@@ -909,6 +919,7 @@
                     "brief": "Fill in arg with some animal names",
                     "description": "The C++ function returns void. But the C and Fortran wrappers return\nan int with the number of items added to arg.\n"
                 },
+                "name": "vector_string_fill",
                 "options": {
                     "wrap_c": false,
                     "wrap_fortran": false,
@@ -976,6 +987,7 @@
                 "doxygen": {
                     "brief": "append '-like' to names."
                 },
+                "name": "vector_string_append",
                 "options": {
                     "wrap_c": false,
                     "wrap_fortran": false,
@@ -1041,6 +1053,7 @@
                 "doxygen": {
                     "description": "Implement iota function.\nReturn a vector as an ALLOCATABLE array.\nCopy results into the new array.\n"
                 },
+                "name": "ReturnVectorAlloc",
                 "options": {},
                 "wrap": {
                     "python": true
@@ -1160,6 +1173,7 @@
                 },
                 "decl": "int returnDim2(int *arg +rank(2)+intent(in), int len+implied(size(arg,2)))",
                 "declgen": "int returnDim2(int * arg +intent(in)+rank(2), int len +implied(size(arg,2))+value)",
+                "name": "returnDim2",
                 "options": {},
                 "wrap": {
                     "python": true

--- a/regression/reference/vectors-numpy/vectors.json
+++ b/regression/reference/vectors-numpy/vectors.json
@@ -44,6 +44,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],
@@ -153,6 +154,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],
@@ -248,6 +250,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],
@@ -338,6 +341,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],
@@ -418,6 +422,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],
@@ -481,6 +486,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],
@@ -541,6 +547,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],
@@ -598,6 +605,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "double"
                                     ],
@@ -775,6 +783,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "std::string"
                                     ],
@@ -835,6 +844,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "std::string"
                                     ],
@@ -898,6 +908,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "std::string"
                                     ],
@@ -964,6 +975,7 @@
                     ],
                     "template_arguments": [
                         {
+                            "declarator": {},
                             "specifier": [
                                 "int"
                             ],

--- a/regression/reference/vectors/vectors.json
+++ b/regression/reference/vectors/vectors.json
@@ -48,6 +48,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],
@@ -132,6 +133,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],
@@ -277,6 +279,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],
@@ -353,6 +356,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],
@@ -475,6 +479,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],
@@ -583,6 +588,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],
@@ -736,6 +742,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],
@@ -832,6 +839,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],
@@ -974,6 +982,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],
@@ -1053,6 +1062,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],
@@ -1178,6 +1188,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],
@@ -1257,6 +1268,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],
@@ -1381,6 +1393,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],
@@ -1453,6 +1466,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "int"
                                     ],
@@ -1574,6 +1588,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "double"
                                     ],
@@ -1649,6 +1664,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "double"
                                     ],
@@ -2087,6 +2103,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "std::string"
                                     ],
@@ -2175,6 +2192,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "std::string"
                                     ],
@@ -2327,6 +2345,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "std::string"
                                     ],
@@ -2390,6 +2409,7 @@
                             ],
                             "template_arguments": [
                                 {
+                                    "declarator": {},
                                     "specifier": [
                                         "std::string"
                                     ],
@@ -2460,6 +2480,7 @@
                     ],
                     "template_arguments": [
                         {
+                            "declarator": {},
                             "specifier": [
                                 "int"
                             ],
@@ -2550,6 +2571,7 @@
                     ],
                     "template_arguments": [
                         {
+                            "declarator": {},
                             "specifier": [
                                 "int"
                             ],

--- a/regression/reference/vectors/vectors.json
+++ b/regression/reference/vectors/vectors.json
@@ -21,43 +21,47 @@
                 "_PTR_F_C_index": "14",
                 "ast": {
                     "declarator": {
-                        "name": "vector_sum"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "vector_sum",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -105,44 +109,48 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "vector_sum"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "vector_sum",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -252,43 +260,47 @@
                 "_PTR_F_C_index": "15",
                 "ast": {
                     "declarator": {
-                        "name": "vector_iota_out"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_iota_out",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -328,44 +340,48 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "vector_iota_out"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_iota_out",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "api": "cdesc",
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -452,43 +468,47 @@
                 "_PTR_F_C_index": "16",
                 "ast": {
                     "declarator": {
-                        "name": "vector_iota_out_with_num"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_iota_out_with_num",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -560,44 +580,48 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "vector_iota_out_with_num"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_iota_out_with_num",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "api": "cdesc",
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -715,43 +739,47 @@
                 "_PTR_F_C_index": "17",
                 "ast": {
                     "declarator": {
-                        "name": "vector_iota_out_with_num2"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_iota_out_with_num2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -811,44 +839,48 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "vector_iota_out_with_num2"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_iota_out_with_num2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "api": "cdesc",
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -953,45 +985,49 @@
                 "_PTR_F_C_index": "18",
                 "ast": {
                     "declarator": {
-                        "name": "vector_iota_out_alloc"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "allocatable",
-                                "intent": "out",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "allocatable",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_iota_out_alloc",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "allocatable",
+                                        "intent": "out",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "deref": "allocatable",
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1032,46 +1068,50 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "vector_iota_out_alloc"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "allocatable",
-                                "intent": "out",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "deref": "allocatable",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_iota_out_alloc",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "allocatable",
+                                        "intent": "out",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "api": "cdesc",
+                                        "deref": "allocatable",
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1159,45 +1199,49 @@
                 "_PTR_F_C_index": "19",
                 "ast": {
                     "declarator": {
-                        "name": "vector_iota_inout_alloc"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "allocatable",
-                                "intent": "inout",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "deref": "allocatable",
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_iota_inout_alloc",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "allocatable",
+                                        "intent": "inout",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "deref": "allocatable",
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1238,46 +1282,50 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "vector_iota_inout_alloc"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "deref": "allocatable",
-                                "intent": "inout",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "deref": "allocatable",
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_iota_inout_alloc",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "deref": "allocatable",
+                                        "intent": "inout",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "api": "cdesc",
+                                        "deref": "allocatable",
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1367,42 +1415,46 @@
                 "_PTR_F_C_index": "20",
                 "ast": {
                     "declarator": {
-                        "name": "vector_increment"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_increment",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1439,43 +1491,47 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "vector_increment"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "int"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_increment",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "api": "cdesc",
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "int"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1561,43 +1617,47 @@
                 "_PTR_F_C_index": "21",
                 "ast": {
                     "declarator": {
-                        "name": "vector_iota_out_d"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "double"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_iota_out_d",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "double"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "double"
+                                        },
+                                        "specifier": [
+                                            "double"
+                                        ],
+                                        "typemap_name": "double"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1636,44 +1696,48 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "vector_iota_out_d"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "cdesc",
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "double"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_iota_out_d",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "api": "cdesc",
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "double"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "double"
+                                        },
+                                        "specifier": [
+                                            "double"
+                                        ],
+                                        "typemap_name": "double"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -1759,65 +1823,69 @@
                 "_PTR_F_C_index": "22",
                 "ast": {
                     "declarator": {
-                        "name": "vector_of_pointers"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "const": true,
-                                    "declarator": {
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "specifier": [
-                                        "double"
-                                    ],
-                                    "typemap_name": "double"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "vector_of_pointers",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "const": true,
+                                        "declarator": {
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "double"
+                                        },
+                                        "specifier": [
+                                            "double"
+                                        ],
+                                        "typemap_name": "double"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
                             },
-                            "declarator": {
-                                "name": "num"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "num",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -1869,66 +1937,70 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "vector_of_pointers"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg1",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "const": true,
-                                    "declarator": {
-                                        "pointer": [
-                                            {
-                                                "ptr": "*"
-                                            }
-                                        ]
-                                    },
-                                    "specifier": [
-                                        "double"
-                                    ],
-                                    "typemap_name": "double"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "value": true
+                        "name": "vector_of_pointers",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "in"
+                                    },
+                                    "name": "arg1",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
+                                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "const": true,
+                                        "declarator": {
+                                            "pointer": [
+                                                {
+                                                    "ptr": "*"
+                                                }
+                                            ],
+                                            "typemap_name": "double"
+                                        },
+                                        "specifier": [
+                                            "double"
+                                        ],
+                                        "typemap_name": "double"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
                             },
-                            "declarator": {
-                                "name": "num"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "num",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -2076,43 +2148,47 @@
                 "_PTR_F_C_index": "23",
                 "ast": {
                     "declarator": {
-                        "name": "vector_string_count"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "std::string"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "vector_string_count",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "std::string"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "std::string"
+                                        },
+                                        "specifier": [
+                                            "std::string"
+                                        ],
+                                        "typemap_name": "std::string"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -2164,44 +2240,48 @@
                 "_generated": "arg_to_buffer",
                 "ast": {
                     "declarator": {
-                        "name": "vector_string_count"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "rank": 1
-                            },
-                            "const": true,
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "api": "buf",
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "std::string"
+                        "metaattrs": {
+                            "intent": "function"
+                        },
+                        "name": "vector_string_count",
+                        "params": [
+                            {
+                                "const": true,
+                                "declarator": {
+                                    "attrs": {
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "api": "buf",
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "std::string"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "std::string"
+                                        },
+                                        "specifier": [
+                                            "std::string"
+                                        ],
+                                        "typemap_name": "std::string"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],
@@ -2318,43 +2398,47 @@
                 "<FUNCTION>": "10 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "vector_string_fill"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "out",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "out"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_string_fill",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "out",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "out"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "std::string"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "std::string"
+                                        },
+                                        "specifier": [
+                                            "std::string"
+                                        ],
+                                        "typemap_name": "std::string"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2382,43 +2466,47 @@
                 "<FUNCTION>": "11 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "vector_string_append"
-                    },
-                    "metaattrs": {
-                        "intent": "subroutine"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "inout",
-                                "rank": 1
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "&"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "inout"
-                            },
-                            "specifier": [
-                                "std::vector"
-                            ],
-                            "template_arguments": [
-                                {
-                                    "declarator": {},
-                                    "specifier": [
-                                        "std::string"
+                        "metaattrs": {
+                            "intent": "subroutine"
+                        },
+                        "name": "vector_string_append",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "inout",
+                                        "rank": 1
+                                    },
+                                    "metaattrs": {
+                                        "intent": "inout"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "&"
+                                        }
                                     ],
-                                    "typemap_name": "std::string"
-                                }
-                            ],
-                            "typemap_name": "std::vector"
-                        }
-                    ],
+                                    "typemap_name": "std::vector"
+                                },
+                                "specifier": [
+                                    "std::vector"
+                                ],
+                                "template_arguments": [
+                                    {
+                                        "declarator": {
+                                            "typemap_name": "std::string"
+                                        },
+                                        "specifier": [
+                                            "std::string"
+                                        ],
+                                        "typemap_name": "std::string"
+                                    }
+                                ],
+                                "typemap_name": "std::vector"
+                            }
+                        ],
+                        "typemap_name": "void"
+                    },
                     "specifier": [
                         "void"
                     ],
@@ -2448,39 +2536,43 @@
                 ],
                 "_PTR_F_C_index": "24",
                 "ast": {
-                    "attrs": {
-                        "rank": 1
-                    },
                     "declarator": {
-                        "name": "ReturnVectorAlloc"
+                        "attrs": {
+                            "rank": 1
+                        },
+                        "metaattrs": {
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
+                        "name": "ReturnVectorAlloc",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "n",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "std::vector"
                     },
-                    "metaattrs": {
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "n"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "std::vector"
                     ],
                     "template_arguments": [
                         {
-                            "declarator": {},
+                            "declarator": {
+                                "typemap_name": "int"
+                            },
                             "specifier": [
                                 "int"
                             ],
@@ -2538,40 +2630,44 @@
                 "_PTR_C_CXX_index": "12",
                 "_generated": "arg_to_buffer",
                 "ast": {
-                    "attrs": {
-                        "rank": 1
-                    },
                     "declarator": {
-                        "name": "ReturnVectorAlloc"
+                        "attrs": {
+                            "rank": 1
+                        },
+                        "metaattrs": {
+                            "api": "cdesc",
+                            "deref": "allocatable",
+                            "intent": "function"
+                        },
+                        "name": "ReturnVectorAlloc",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "n",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "std::vector"
                     },
-                    "metaattrs": {
-                        "api": "cdesc",
-                        "deref": "allocatable",
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "value": true
-                            },
-                            "declarator": {
-                                "name": "n"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
                     "specifier": [
                         "std::vector"
                     ],
                     "template_arguments": [
                         {
-                            "declarator": {},
+                            "declarator": {
+                                "typemap_name": "int"
+                            },
                             "specifier": [
                                 "int"
                             ],
@@ -2677,50 +2773,53 @@
                 "<FUNCTION>": "13 ****************************************",
                 "ast": {
                     "declarator": {
-                        "name": "returnDim2"
-                    },
-                    "metaattrs": {
-                        "intent": "function"
-                    },
-                    "params": [
-                        {
-                            "attrs": {
-                                "intent": "in",
-                                "rank": 2
-                            },
-                            "declarator": {
-                                "name": "arg",
-                                "pointer": [
-                                    {
-                                        "ptr": "*"
-                                    }
-                                ]
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
+                        "metaattrs": {
+                            "intent": "function"
                         },
-                        {
-                            "attrs": {
-                                "implied": "size(arg,2)",
-                                "value": true
+                        "name": "returnDim2",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "intent": "in",
+                                        "rank": 2
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "arg",
+                                    "pointer": [
+                                        {
+                                            "ptr": "*"
+                                        }
+                                    ],
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
                             },
-                            "declarator": {
-                                "name": "len"
-                            },
-                            "metaattrs": {
-                                "intent": "in"
-                            },
-                            "specifier": [
-                                "int"
-                            ],
-                            "typemap_name": "int"
-                        }
-                    ],
+                            {
+                                "declarator": {
+                                    "attrs": {
+                                        "implied": "size(arg,2)",
+                                        "value": true
+                                    },
+                                    "metaattrs": {
+                                        "intent": "in"
+                                    },
+                                    "name": "len",
+                                    "typemap_name": "int"
+                                },
+                                "specifier": [
+                                    "int"
+                                ],
+                                "typemap_name": "int"
+                            }
+                        ],
+                        "typemap_name": "int"
+                    },
                     "specifier": [
                         "int"
                     ],

--- a/regression/reference/vectors/vectors.json
+++ b/regression/reference/vectors/vectors.json
@@ -69,6 +69,7 @@
                 },
                 "decl": "int vector_sum(const std::vector<int> &arg)",
                 "declgen": "int vector_sum(const std::vector<int> & arg +rank(1))",
+                "name": "vector_sum",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false
@@ -158,6 +159,7 @@
                 },
                 "decl": "int vector_sum(const std::vector<int> &arg)",
                 "declgen": "int vector_sum(const std::vector<int> & arg +rank(1))",
+                "name": "vector_sum",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false
@@ -311,6 +313,7 @@
                 "doxygen": {
                     "brief": "Copy vector into Fortran input array"
                 },
+                "name": "vector_iota_out",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false
@@ -392,6 +395,7 @@
                 "doxygen": {
                     "brief": "Copy vector into Fortran input array"
                 },
+                "name": "vector_iota_out",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false
@@ -548,6 +552,7 @@
                         "result": "num"
                     }
                 },
+                "name": "vector_iota_out_with_num",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false,
@@ -661,6 +666,7 @@
                         "result": "num"
                     }
                 },
+                "name": "vector_iota_out_with_num",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false,
@@ -807,6 +813,7 @@
                         "result": "num"
                     }
                 },
+                "name": "vector_iota_out_with_num2",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false,
@@ -908,6 +915,7 @@
                         "result": "num"
                     }
                 },
+                "name": "vector_iota_out_with_num2",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false,
@@ -1038,6 +1046,7 @@
                 "doxygen": {
                     "brief": "Copy vector into Fortran allocatable array"
                 },
+                "name": "vector_iota_out_alloc",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false,
@@ -1122,6 +1131,7 @@
                 "doxygen": {
                     "brief": "Copy vector into Fortran allocatable array"
                 },
+                "name": "vector_iota_out_alloc",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false,
@@ -1252,6 +1262,7 @@
                 "doxygen": {
                     "brief": "Copy vector into Fortran allocatable array"
                 },
+                "name": "vector_iota_inout_alloc",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false,
@@ -1336,6 +1347,7 @@
                 "doxygen": {
                     "brief": "Copy vector into Fortran allocatable array"
                 },
+                "name": "vector_iota_inout_alloc",
                 "options": {
                     "literalinclude": true,
                     "wrap_lua": false,
@@ -1462,6 +1474,7 @@
                 },
                 "decl": "void vector_increment(std::vector<int> &arg)",
                 "declgen": "void vector_increment(std::vector<int> & arg +rank(1))",
+                "name": "vector_increment",
                 "options": {
                     "wrap_lua": false,
                     "wrap_python": false
@@ -1539,6 +1552,7 @@
                 },
                 "decl": "void vector_increment(std::vector<int> &arg)",
                 "declgen": "void vector_increment(std::vector<int> & arg +rank(1))",
+                "name": "vector_increment",
                 "options": {
                     "wrap_lua": false,
                     "wrap_python": false
@@ -1668,6 +1682,7 @@
                 "doxygen": {
                     "brief": "Copy vector into Fortran input array"
                 },
+                "name": "vector_iota_out_d",
                 "options": {
                     "wrap_lua": false
                 },
@@ -1748,6 +1763,7 @@
                 "doxygen": {
                     "brief": "Copy vector into Fortran input array"
                 },
+                "name": "vector_iota_out_d",
                 "options": {
                     "wrap_lua": false
                 },
@@ -1896,6 +1912,7 @@
                 "doxygen": {
                     "brief": "Fortran 2-d array to vector<const double *>"
                 },
+                "name": "vector_of_pointers",
                 "options": {
                     "wrap_lua": false,
                     "wrap_python": false
@@ -2011,6 +2028,7 @@
                 "doxygen": {
                     "brief": "Fortran 2-d array to vector<const double *>"
                 },
+                "name": "vector_of_pointers",
                 "options": {
                     "wrap_lua": false,
                     "wrap_python": false
@@ -2200,6 +2218,7 @@
                     "brief": "count number of underscore in vector of strings",
                     "decription": "The input will be copied in order to create the C++ argument\n"
                 },
+                "name": "vector_string_count",
                 "options": {
                     "wrap_python": false
                 },
@@ -2293,6 +2312,7 @@
                     "brief": "count number of underscore in vector of strings",
                     "decription": "The input will be copied in order to create the C++ argument\n"
                 },
+                "name": "vector_string_count",
                 "options": {
                     "wrap_python": false
                 },
@@ -2450,6 +2470,7 @@
                     "brief": "Fill in arg with some animal names",
                     "description": "The C++ function returns void. But the C and Fortran wrappers return\nan int with the number of items added to arg.\n"
                 },
+                "name": "vector_string_fill",
                 "options": {
                     "wrap_c": false,
                     "wrap_fortran": false,
@@ -2517,6 +2538,7 @@
                 "doxygen": {
                     "brief": "append '-like' to names."
                 },
+                "name": "vector_string_append",
                 "options": {
                     "wrap_c": false,
                     "wrap_fortran": false,
@@ -2586,6 +2608,7 @@
                 "doxygen": {
                     "description": "Implement iota function.\nReturn a vector as an ALLOCATABLE array.\nCopy results into the new array.\n"
                 },
+                "name": "ReturnVectorAlloc",
                 "options": {},
                 "wrap": {
                     "fortran": true
@@ -2681,6 +2704,7 @@
                 "doxygen": {
                     "description": "Implement iota function.\nReturn a vector as an ALLOCATABLE array.\nCopy results into the new array.\n"
                 },
+                "name": "ReturnVectorAlloc",
                 "options": {},
                 "splicer_group": "buf",
                 "wrap": {
@@ -2827,6 +2851,7 @@
                 },
                 "decl": "int returnDim2(int *arg +rank(2)+intent(in), int len+implied(size(arg,2)))",
                 "declgen": "int returnDim2(int * arg +intent(in)+rank(2), int len +implied(size(arg,2))+value)",
+                "name": "returnDim2",
                 "options": {},
                 "wrap": {
                     "c": true,

--- a/regression/reference/wrap/wrap.json
+++ b/regression/reference/wrap/wrap.json
@@ -13,12 +13,13 @@
                         "<FUNCTION>": "0 ****************************************",
                         "ast": {
                             "declarator": {
-                                "name": "FuncInClass"
+                                "metaattrs": {
+                                    "intent": "subroutine"
+                                },
+                                "name": "FuncInClass",
+                                "params": [],
+                                "typemap_name": "void"
                             },
-                            "metaattrs": {
-                                "intent": "subroutine"
-                            },
-                            "params": [],
                             "specifier": [
                                 "void"
                             ],

--- a/regression/reference/wrap/wrap.json
+++ b/regression/reference/wrap/wrap.json
@@ -27,6 +27,7 @@
                         },
                         "decl": "void FuncInClass(void)",
                         "declgen": "void FuncInClass(void)",
+                        "name": "FuncInClass",
                         "options": {
                             "wrap_fortran": true
                         },

--- a/regression/run/enum-c/enum.c
+++ b/regression/run/enum-c/enum.c
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2017-2023, Lawrence Livermore National Security, LLC and
+ * other Shroud Project Developers.
+ * See the top-level COPYRIGHT file for details.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
+
+#include "enum.h"
+
+enum Color global1;
+
+int convert_to_int(enum Color in)
+{
+    return in;
+}

--- a/shroud/ast.py
+++ b/shroud/ast.py
@@ -316,7 +316,7 @@ class NamespaceMixin(object):
         if ast is None:
             ast = declast.check_decl(decl, self.symtab)
 
-        name = ast.get_name()  # Local name.
+        name = ast.declarator.user_name  # Local name.
         node = TypedefNode(name, self, ast, fields)
         self.typedefs.append(node)
         return node
@@ -1288,7 +1288,7 @@ class ClassNode(AstNode, NamespaceMixin):
         for var in self.variables:
             self.map_name_to_node[var.name] = var
         for node in self.functions:
-            self.map_name_to_node[node.ast.name] = node
+            self.map_name_to_node[node.ast.declarator.user_name] = node
 
 ######################################################################
 
@@ -1462,7 +1462,7 @@ class FunctionNode(AstNode):
             generic.parse_generic(self.symtab)
             newparams = copy.deepcopy(ast.declarator.params)
             for garg in generic.decls:
-                i = declast.find_arg_index_by_name(newparams, garg.name)
+                i = declast.find_arg_index_by_name(newparams, garg.declarator.user_name)
                 if i < 0:
                     # XXX - For default argument, the generic argument may not exist.
                     print("Error in fortran_generic, '{}' not found in '{}' at line {}".format(
@@ -1478,7 +1478,7 @@ class FunctionNode(AstNode):
         if "attrs" in kwargs:
             attrs = kwargs["attrs"]
             for arg in ast.declarator.params:
-                name = arg.name
+                name = arg.declarator.user_name
                 if name in attrs:
                     arg.declarator.attrs.update(attrs[name])
         if "fattrs" in kwargs:
@@ -1498,7 +1498,7 @@ class FunctionNode(AstNode):
         # XXX - waring about unused fields in attrs
 
         fmt_func = self.fmtdict
-        fmt_func.function_name = ast.name
+        fmt_func.function_name = ast.declarator.user_name
         fmt_func.underscore_name = util.un_camel(fmt_func.function_name)
 
     def default_format(self, parent, fmtdict, kwargs):
@@ -1848,15 +1848,15 @@ class VariableNode(AstNode):
             # 'void foo()' instead of 'void foo'
             raise RuntimeError("Arguments given to variable:", ast.gen_decl())
         self.ast = ast
-        self.name = ast.name
+        self.name = ast.declarator.user_name
 
         # format for struct
         fmt_var = self.fmtdict
 
         # Treat similar to class
         #        fmt_struct.class_scope = self.name + '::'
-        fmt_var.field_name = ast.get_name(use_attr=False)
-        fmt_var.variable_name = ast.name
+        fmt_var.field_name = ast.declarator.name
+        fmt_var.variable_name = self.name
         fmt_var.variable_lower = fmt_var.variable_name.lower()
         fmt_var.variable_upper = fmt_var.variable_name.upper()
 

--- a/shroud/ast.py
+++ b/shroud/ast.py
@@ -1445,14 +1445,15 @@ class FunctionNode(AstNode):
             # 'void foo' instead of 'void foo()'
             raise RuntimeError("Missing arguments to function:", ast.gen_decl())
         self.ast = ast
-        self.name = ast.declarator.user_name
+        declarator = ast.declarator
+        self.name = declarator.user_name
 
         # Look for any template (include class template) arguments.
         self.have_template_args = False
         if ast.typemap.base == "template":
             self.have_template_args = True
         else:
-            for args in ast.declarator.params:
+            for args in declarator.params:
                 if args.typemap.base == "template":
                     self.have_template_args = True
                     break
@@ -1461,7 +1462,7 @@ class FunctionNode(AstNode):
         # by copying original params then substituting decls from fortran_generic.
         for generic in self.fortran_generic:
             generic.parse_generic(self.symtab)
-            newparams = copy.deepcopy(ast.declarator.params)
+            newparams = copy.deepcopy(declarator.params)
             for garg in generic.decls:
                 i = declast.find_arg_index_by_name(newparams, garg.declarator.user_name)
                 if i < 0:
@@ -1478,12 +1479,12 @@ class FunctionNode(AstNode):
         # add any attributes from YAML files to the ast
         if "attrs" in kwargs:
             attrs = kwargs["attrs"]
-            for arg in ast.declarator.params:
+            for arg in declarator.params:
                 name = arg.declarator.user_name
                 if name in attrs:
                     arg.declarator.attrs.update(attrs[name])
         if "fattrs" in kwargs:
-            ast.attrs.update(kwargs["fattrs"])
+            declarator.attrs.update(kwargs["fattrs"])
 
         if "splicer" in kwargs:
             self.splicer = kwargs["splicer"]

--- a/shroud/ast.py
+++ b/shroud/ast.py
@@ -1445,6 +1445,7 @@ class FunctionNode(AstNode):
             # 'void foo' instead of 'void foo()'
             raise RuntimeError("Missing arguments to function:", ast.gen_decl())
         self.ast = ast
+        self.name = ast.declarator.user_name
 
         # Look for any template (include class template) arguments.
         self.have_template_args = False
@@ -1498,7 +1499,7 @@ class FunctionNode(AstNode):
         # XXX - waring about unused fields in attrs
 
         fmt_func = self.fmtdict
-        fmt_func.function_name = ast.declarator.user_name
+        fmt_func.function_name = self.name
         fmt_func.underscore_name = util.un_camel(fmt_func.function_name)
 
     def default_format(self, parent, fmtdict, kwargs):

--- a/shroud/declast.py
+++ b/shroud/declast.py
@@ -2508,6 +2508,7 @@ def create_struct_ctor(cls):
     ast.specifier = [ cls.name ]
     ast.params = []
     ast.declarator = Declarator()  # SSS
+    ast.declarator.params = ast.params
     ast.declarator.typemap = cls.typemap
     ast.declarator.attrs = ast.attrs
     ast.declarator.metaattrs = ast.metaattrs

--- a/shroud/declast.py
+++ b/shroud/declast.py
@@ -1387,17 +1387,36 @@ class Declarator(Node):
             decl.append(self.ctor_dtor_name)
 
     def __str__(self):
-        out = ""
+        out = []
         for ptr in self.pointer:
-            out += str(ptr)
-            out += " "
+            out.append(str(ptr))
+            out.append(" ")
 
         if self.name:
-            out += self.name
+            out.append(self.name)
         elif self.func:
-            out += "(" + str(self.func) + ")"
+            out.append("(" + str(self.func) + ")")
 
-        return out
+        if self.params is not None:
+            out.append("(")
+            if self.params:
+                out.append(str(self.params[0]))
+                for param in self.params[1:]:
+                    out.append(",")
+                    out.append(str(param))
+            out.append(")")
+            if self.func_const:
+                out.append(" const")
+        if self.array:
+            for dim in self.array:
+                out.append("[")
+                out.append(todict.print_node(dim))
+                out.append("]")
+        if self.init:
+            out.append("=")
+            out.append(str(self.init))
+
+        return "".join(out)
 
 
 class Declaration(Node):
@@ -1561,33 +1580,10 @@ class Declaration(Node):
             else:
                 out.append("int")
 
-        out2 = []
-        if self.declarator:
-            var = str(self.declarator)
-            if var:
-                out2.append(var)
-        if self.params is not None:
-            out2.append("(")
-            if self.params:
-                out2.append(str(self.params[0]))
-                for param in self.params[1:]:
-                    out2.append(",")
-                    out2.append(str(param))
-            out2.append(")")
-            if self.func_const:
-                out2.append(" const")
-        if self.array:
-            for dim in self.array:
-                out2.append("[")
-                out2.append(todict.print_node(dim))
-                out2.append("]")
-        if self.init:
-            out2.append("=")
-            out2.append(str(self.init))
-
-        if out2:
+        var = str(self.declarator)
+        if var:
             out.append(" ")
-            out.extend(out2)
+            out.append(var)
         return "".join(out)
 
     def gen_decl(self, **kwargs):

--- a/shroud/declast.py
+++ b/shroud/declast.py
@@ -1233,7 +1233,6 @@ class Declarator(Node):
         
         self.ctor_dtor_name = False
 
-        # SSS
         self.params = None  # None=No parameters, []=empty parameters list
         self.array = []
         self.init = None  # initial value
@@ -1549,6 +1548,9 @@ class Declaration(Node):
         new.storage = self.storage[:]
         new.const = self.const
         new.volatile = self.volatile
+        new.typemap = self.typemap
+        new.template_arguments = self.template_arguments
+
         new.declarator = copy.deepcopy(self.declarator)
         new.declarator.name = name
         if not new.declarator.pointer:
@@ -1558,9 +1560,6 @@ class Declaration(Node):
         new.declarator.attrs = copy.deepcopy(self.declarator.attrs) # XXX no need for deepcopy in future
         new.declarator.metaattrs = copy.deepcopy(self.declarator.metaattrs)
         new.declarator.metaattrs["intent"] = "out"
-        new.typemap = self.typemap
-        new.template_arguments = self.template_arguments
-        # SSS
         new.declarator.params= None
         new.declarator.typemap = new.declarator.typemap
         return new

--- a/shroud/declast.py
+++ b/shroud/declast.py
@@ -698,6 +698,8 @@ class Parser(ExprParser):
         elif self.token.typ == "LPAREN":  # (*var)
             self.next()
             node.func = self.declarator()
+            # Promote name.
+            node.name = node.func.name
             self.mustbe("RPAREN")
 
         self.exit("declarator", str(node))
@@ -1448,10 +1450,10 @@ class Declarator(Node):
             out.append(str(ptr))
             out.append(" ")
 
-        if self.name:
-            out.append(self.name)
-        elif self.func:
+        if self.func:
             out.append("(" + str(self.func) + ")")
+        elif self.name:
+            out.append(self.name)
 
         if self.params is not None:
             out.append("(")
@@ -1525,20 +1527,8 @@ class Declaration(Node):
             name = self.attrs["name"] or self.attrs["_name"]
             if name is not None:
                 return name
-        name = self.declarator.name
-        if name is None:
-            if self.declarator.func:
-                name = self.declarator.func.name
-        return name
-
-    def set_name(self, name):
-        """Set name in declarator"""
-        if self.declarator.name:
-            self.declarator.name = name
-        else:
-            self.declarator.func.name = name
-
-    name = property(get_name, set_name, None, "Declaration name")
+        return self.declarator.name
+    name = property(get_name, None, None, "Declaration name")
 
     def set_type(self, ntypemap):
         """Set type specifier from a typemap."""

--- a/shroud/declast.py
+++ b/shroud/declast.py
@@ -803,7 +803,8 @@ class Parser(ExprParser):
         node.class_specifier = clsnode
         node.typemap = clsnode.typemap
         if self.have("EOF"):
-            pass
+            # Body added by other lines in YAML.
+            node.tag_body = True
         elif self.have("COLON"):
             if self.token.typ in ["PUBLIC", "PRIVATE", "PROTECTED"]:
                 access_specifier = self.token.value
@@ -822,6 +823,7 @@ class Parser(ExprParser):
                 self.mustbe("ID")
 
         if self.have("LCURLY"):
+            node.tag_body = True
             members = clsnode.members
             while self.token.typ != "RCURLY":
 #                members.append(self.declaration()) # GGG, accepts too much  - template
@@ -919,6 +921,7 @@ class Parser(ExprParser):
             node.specifier.append("enum " + ename)
         if self.have("LCURLY"):
             #        self.mustbe("LCURLY")
+            node.tag_body = True
             enumnode = Enum(ename, self.symtab, scope)
             members = enumnode.members
             while self.token.typ != "RCURLY":
@@ -973,10 +976,13 @@ class Parser(ExprParser):
             self.symtab.pop_scope()
             node.class_specifier = structnode
             node.typemap = structnode.typemap
+            node.tag_body = True
         elif self.have("EOF"):
             structnode = Struct(sname, self.symtab)
             node.class_specifier = structnode
             node.typemap = structnode.typemap
+            # Body added by other lines in YAML.
+            node.tag_body = True
             # GGG - Caller must call symtab.pop_scope when finished with members.
         else:
             structnode = self.symtab.current.lookup_tag("struct", sname)
@@ -1264,6 +1270,7 @@ class Declaration(Node):
         self.storage = []  # static, tyedef, ...
         self.enum_specifier = None   # Enum
         self.class_specifier = None  # CXXClass, Struct (union)
+        self.tag_body = False        # if True, members are defined.
         self.const = False
         self.volatile = False
         self.declarator = None

--- a/shroud/declast.py
+++ b/shroud/declast.py
@@ -806,6 +806,7 @@ class Parser(ExprParser):
             # Body added by other lines in YAML.
             node.tag_body = True
         elif self.have("COLON"):
+            node.tag_body = True
             if self.token.typ in ["PUBLIC", "PRIVATE", "PROTECTED"]:
                 access_specifier = self.token.value
                 self.next()

--- a/shroud/declast.py
+++ b/shroud/declast.py
@@ -1554,14 +1554,6 @@ class Declaration(Node):
     def get_full_type(self):
         return ' '.join(self.specifier)
 
-    def find_arg_by_name(self, name):
-        """Find argument in params with name."""
-        return find_arg_by_name(self.declarator.params, name)
-
-    def find_arg_index_by_name(self, name):
-        """Return index of argument in params with name."""
-        return find_arg_index_by_name(self.declarator.params, name)
-
     def _as_arg(self, name):
         """Create an argument to hold the function result.
         This is intended for pointer arguments, char, string or vector.

--- a/shroud/declast.py
+++ b/shroud/declast.py
@@ -1499,6 +1499,10 @@ class Declaration(Node):
         new.metaattrs["intent"] = "out"
         new.typemap = self.typemap
         new.template_arguments = self.template_arguments
+        # SSS
+        new.declarator.attrs = new.attrs
+        new.declarator.metaattrs = new.metaattrs
+        new.declarator.typemap = new.typemap
         return new
 
     def set_return_to_void(self):
@@ -1508,6 +1512,7 @@ class Declaration(Node):
         self.const = False
         self.volatile = False
         self.declarator.pointer = []
+        self.declarator.typemap = typemap.void_typemap
         self.template_arguments = []
 
     def result_as_arg(self, name):

--- a/shroud/declast.py
+++ b/shroud/declast.py
@@ -2504,6 +2504,8 @@ def create_struct_ctor(cls):
     ast.params = []
     ast.declarator = Declarator()  # SSS
     ast.declarator.typemap = cls.typemap
+    ast.declarator.attrs = ast.attrs
+    ast.declarator.metaattrs = ast.metaattrs
     return ast
 
 

--- a/shroud/generate.py
+++ b/shroud/generate.py
@@ -743,9 +743,9 @@ class GenFunctions(object):
         found_ctor = False
         found_dtor = False
         for node in cls.functions:
-            fattrs = node.ast.attrs
-            found_ctor = found_ctor or fattrs["_constructor"]
-            found_dtor = found_dtor or fattrs["_destructor"]
+            declarator = node.ast.declarator
+            found_ctor = found_ctor or declarator.is_ctor()
+            found_dtor = found_dtor or declarator.is_dtor()
 
         if found_ctor and found_dtor:
             return cls.functions

--- a/shroud/generate.py
+++ b/shroud/generate.py
@@ -563,7 +563,7 @@ class VerifyAttrs(object):
             arg.ftrim_char_in = options.F_trim_char_in
 
         if node:
-            if arg.init is not None:
+            if declarator.init is not None:
                 node._has_default_arg = True
             elif node._has_found_default is True:
                 raise RuntimeError("Expected default value for %s" % argname)
@@ -1513,7 +1513,7 @@ class GenFunctions(object):
 
         min_args = 0
         for i, arg in enumerate(node.ast.declarator.params):
-            if arg.init is None:
+            if arg.declarator.init is None:
                 min_args += 1
                 continue
             new = node.clone()

--- a/shroud/generate.py
+++ b/shroud/generate.py
@@ -1143,7 +1143,7 @@ class GenFunctions(object):
         cxx_overload = {}
         for function in functions:
             self.append_function_index(function)
-            cxx_overload.setdefault(function.ast.declarator.user_name, []).append(
+            cxx_overload.setdefault(function.name, []).append(
                 function._function_index
             )
 
@@ -1192,7 +1192,7 @@ class GenFunctions(object):
                 fmt.F_name_generic = name
                 function._overloaded = True
             else:
-                overloaded_functions.setdefault(function.ast.declarator.user_name, []).append(
+                overloaded_functions.setdefault(function.name, []).append(
                     function)
 
         # look for function overload and compute function_suffix

--- a/shroud/statements.py
+++ b/shroud/statements.py
@@ -32,7 +32,7 @@ def lookup_c_statements(arg):
         targ = arg.template_arguments[0]
         arg_typemap = targ.typemap
         specialize.append(arg_typemap.sgroup)
-        spointer = targ.get_indirect_stmt()
+        spointer = targ.declarator.get_indirect_stmt()
         specialize.append(spointer)
     return arg_typemap, specialize
 
@@ -51,7 +51,7 @@ def template_stmts(ast):
         targ = ast.template_arguments[0]
         arg_typemap = targ.typemap
         specialize.append(arg_typemap.sgroup)
-        spointer = targ.get_indirect_stmt()
+        spointer = targ.declarator.get_indirect_stmt()
         specialize.append(spointer)
     return specialize
 
@@ -114,13 +114,13 @@ def compute_return_prefix(arg, local_var):
         else:
             return ""
     elif local_var == "pointer":
-        if arg.is_pointer():
+        if arg.declarator.is_pointer():
             return ""
         else:
             return "*"
     elif local_var == "funcptr":
         return ""
-    elif arg.is_reference():
+    elif arg.declarator.is_reference():
         # Convert a return reference into a pointer.
         return "&"
     else:

--- a/shroud/todict.py
+++ b/shroud/todict.py
@@ -123,28 +123,11 @@ class ToDict(visitor.Visitor):
         if node.typemap.base != "template":
             # Only print name to avoid too much nesting.
             d["typemap_name"] = node.typemap.name
-# SSS
-#        attrs = {key: value
-#                 for (key, value) in node.attrs.items()
-#                 if value is not None}
-#        if attrs:
-#            d["attrs"] = attrs
-#
-#        metaattrs = {key: value
-#                 for (key, value) in node.metaattrs.items()
-#                 if value is not None}
-#        if metaattrs:
-#            if "struct_member" in metaattrs:
-#                # struct_member is a ast.VariableNode, add name instead
-#                # to avoid huge dump.
-#                metaattrs["struct_member"] = metaattrs["struct_member"].name
-#            if "dimension" in metaattrs:
-#                metaattrs["dimension"] = self.visit(metaattrs["dimension"])
-#            d["metaattrs"] = metaattrs
         
         add_true_fields(node, d, [
             "const", "volatile",
             "ftrim_char_in", "blanknull",
+            "is_ctor", "is_dtor",
         ])
         if node.declarator:
             # ctor and dtor have no declarator

--- a/shroud/todict.py
+++ b/shroud/todict.py
@@ -76,7 +76,7 @@ class ToDict(visitor.Visitor):
         self.add_visit_fields(node, d, ["pointer"])
         if node.name:
             d["name"] = node.name
-        elif node.func:
+        if node.func:
             d["func"] = self.visit(node.func)
         if node.params is not None:
             d["params"] = self.visit(node.params)

--- a/shroud/todict.py
+++ b/shroud/todict.py
@@ -359,7 +359,7 @@ class ToDict(visitor.Visitor):
         return d
 
     def visit_FunctionNode(self, node):
-        d = dict(ast=self.visit(node.ast), decl=node.decl)
+        d = dict(ast=self.visit(node.ast), decl=node.decl, name=node.name)
         add_comment(d, "function", node._function_index)
         self.add_visit_fields(
             node,

--- a/shroud/todict.py
+++ b/shroud/todict.py
@@ -87,7 +87,8 @@ class ToDict(visitor.Visitor):
         )
         if self.labelast:
             d["_ast"] = node.__class__.__name__
-        self.add_visit_fields(node, d, ["enum_specifier", "class_specifier"])
+        if node.tag_body:
+            self.add_visit_fields(node, d, ["enum_specifier", "class_specifier"])
         add_non_none_fields(node, d, ["template_argument"])
         if node.typemap.base != "template":
             # Only print name to avoid too much nesting.
@@ -630,7 +631,9 @@ class PrintNode(visitor.Visitor):
 
     def visit_Declaration(self, node):
         s = str(node)
-        if node.enum_specifier:
+        if not node.tag_body:
+            pass
+        elif node.enum_specifier:
             s += self.visit(node.enum_specifier)
         elif node.class_specifier:
             s += self.visit(node.class_specifier)

--- a/shroud/todict.py
+++ b/shroud/todict.py
@@ -134,12 +134,6 @@ class ToDict(visitor.Visitor):
             d["declarator"] = self.visit(node.declarator)
         if node.storage:
             d["storage"] = node.storage
-#        if node.params is not None:
-#            d["params"] = self.visit(node.params)
-#        if node.array:
-#            d["array"] = self.visit(node.array)
-#        if node.init is not None:
-#            d["init"] = node.init
         if node.template_arguments:
             lst = []
             for tp in node.template_arguments:

--- a/shroud/todict.py
+++ b/shroud/todict.py
@@ -78,21 +78,18 @@ class ToDict(visitor.Visitor):
             d["name"] = node.name
         elif node.func:
             d["func"] = self.visit(node.func)
-        return d
+        if node.params is not None:
+            d["params"] = self.visit(node.params)
+        if node.array:
+            d["array"] = self.visit(node.array)
+        if node.init is not None:
+            d["init"] = node.init
+        add_true_fields(node, d, ["func_const"])
 
-    def visit_Declaration(self, node):
-        d = dict(
-            specifier=node.specifier,
-            # #- node.array,
-        )
-        if self.labelast:
-            d["_ast"] = node.__class__.__name__
-        if node.tag_body:
-            self.add_visit_fields(node, d, ["enum_specifier", "class_specifier"])
-        add_non_none_fields(node, d, ["template_argument"])
         if node.typemap.base != "template":
             # Only print name to avoid too much nesting.
             d["typemap_name"] = node.typemap.name
+
         attrs = {key: value
                  for (key, value) in node.attrs.items()
                  if value is not None}
@@ -111,8 +108,42 @@ class ToDict(visitor.Visitor):
                 metaattrs["dimension"] = self.visit(metaattrs["dimension"])
             d["metaattrs"] = metaattrs
         
+        return d
+
+    def visit_Declaration(self, node):
+        d = dict(
+            specifier=node.specifier,
+            # #- node.array,
+        )
+        if self.labelast:
+            d["_ast"] = node.__class__.__name__
+        if node.tag_body:
+            self.add_visit_fields(node, d, ["enum_specifier", "class_specifier"])
+        add_non_none_fields(node, d, ["template_argument"])
+        if node.typemap.base != "template":
+            # Only print name to avoid too much nesting.
+            d["typemap_name"] = node.typemap.name
+# SSS
+#        attrs = {key: value
+#                 for (key, value) in node.attrs.items()
+#                 if value is not None}
+#        if attrs:
+#            d["attrs"] = attrs
+#
+#        metaattrs = {key: value
+#                 for (key, value) in node.metaattrs.items()
+#                 if value is not None}
+#        if metaattrs:
+#            if "struct_member" in metaattrs:
+#                # struct_member is a ast.VariableNode, add name instead
+#                # to avoid huge dump.
+#                metaattrs["struct_member"] = metaattrs["struct_member"].name
+#            if "dimension" in metaattrs:
+#                metaattrs["dimension"] = self.visit(metaattrs["dimension"])
+#            d["metaattrs"] = metaattrs
+        
         add_true_fields(node, d, [
-            "const", "func_const", "volatile",
+            "const", "volatile",
             "ftrim_char_in", "blanknull",
         ])
         if node.declarator:
@@ -120,12 +151,12 @@ class ToDict(visitor.Visitor):
             d["declarator"] = self.visit(node.declarator)
         if node.storage:
             d["storage"] = node.storage
-        if node.params is not None:
-            d["params"] = self.visit(node.params)
-        if node.array:
-            d["array"] = self.visit(node.array)
-        if node.init is not None:
-            d["init"] = node.init
+#        if node.params is not None:
+#            d["params"] = self.visit(node.params)
+#        if node.array:
+#            d["array"] = self.visit(node.array)
+#        if node.init is not None:
+#            d["init"] = node.init
         if node.template_arguments:
             lst = []
             for tp in node.template_arguments:

--- a/shroud/util.py
+++ b/shroud/util.py
@@ -472,7 +472,7 @@ class WrapperMixin(object):
 
     def get_metaattrs(self, ast):
         decl = []
-        ast.gen_attrs(ast.metaattrs, decl, dict(
+        ast.declarator.gen_attrs(ast.metaattrs, decl, dict(
             dimension=True,
             struct_member=True
         ))

--- a/shroud/util.py
+++ b/shroud/util.py
@@ -472,7 +472,7 @@ class WrapperMixin(object):
 
     def get_metaattrs(self, ast):
         decl = []
-        ast.declarator.gen_attrs(ast.metaattrs, decl, dict(
+        ast.declarator.gen_attrs(ast.declarator.metaattrs, decl, dict(
             dimension=True,
             struct_member=True
         ))

--- a/shroud/wrapc.py
+++ b/shroud/wrapc.py
@@ -744,10 +744,11 @@ class Wrapc(util.WrapperMixin):
             is_func  - True if function.
         """
 
+        declarator = ast.declarator
         if is_func:
             rootname = fmt.C_result
         else:
-            rootname = ast.name
+            rootname = declarator.user_name
             if ast.const:
                 fmt.c_const = "const "
             else:
@@ -1045,13 +1046,13 @@ class Wrapc(util.WrapperMixin):
 
         # --- Loop over function parameters
         for arg in ast.declarator.params:
-            arg_name = arg.name
+            declarator = arg.declarator
+            arg_name = declarator.user_name
             fmt_arg0 = fmtargs.setdefault(arg_name, {})
             fmt_arg = fmt_arg0.setdefault("fmtc", util.Scope(fmt_func))
             c_attrs = arg.attrs
             c_meta = arg.metaattrs
 
-            declarator = arg.declarator
             arg_typemap = arg.typemap  # XXX - look up vector
             sgroup = arg_typemap.sgroup
 
@@ -1075,7 +1076,7 @@ class Wrapc(util.WrapperMixin):
                     sapi, return_deref_attr,
                 ]
                 intent_blk = statements.lookup_fc_stmts(stmts)
-                fmt_arg.c_var = arg.name
+                fmt_arg.c_var = arg_name
                 self.name_temp_vars(arg_name, intent_blk, fmt_arg)
                 self.set_fmt_fields(cls, node, arg, arg_typemap, fmt_arg, False)
                 need_wrapper = True
@@ -1108,7 +1109,7 @@ class Wrapc(util.WrapperMixin):
                 stmts = ["c", c_meta["intent"], sgroup, spointer,
                          sapi, c_meta["deref"]] + specialize
                 intent_blk = statements.lookup_fc_stmts(stmts)
-                fmt_arg.c_var = arg.name
+                fmt_arg.c_var = arg_name
                 # XXX - order issue - c_var must be set before name_temp_vars,
                 #       but set by set_fmt_fields
                 self.name_temp_vars(arg_name, intent_blk, fmt_arg)
@@ -1389,7 +1390,7 @@ class Wrapc(util.WrapperMixin):
                 impl.append("#endif  // " + node.cpp_if)
         else:
             # There is no C wrapper, have Fortran call the function directly.
-            fmt_func.C_name = node.ast.name
+            fmt_func.C_name = node.ast.declarator.user_name
 
     def set_capsule_headers(self, headers):
         """Headers used by C_memory_dtor_function.

--- a/shroud/wrapc.py
+++ b/shroud/wrapc.py
@@ -1390,7 +1390,7 @@ class Wrapc(util.WrapperMixin):
                 impl.append("#endif  // " + node.cpp_if)
         else:
             # There is no C wrapper, have Fortran call the function directly.
-            fmt_func.C_name = node.ast.declarator.user_name
+            fmt_func.C_name = node.ast.declarator.name
 
     def set_capsule_headers(self, headers):
         """Headers used by C_memory_dtor_function.

--- a/shroud/wrapc.py
+++ b/shroud/wrapc.py
@@ -1044,7 +1044,7 @@ class Wrapc(util.WrapperMixin):
         #                 or the function result variable.
 
         # --- Loop over function parameters
-        for arg in ast.params:
+        for arg in ast.declarator.params:
             arg_name = arg.name
             fmt_arg0 = fmtargs.setdefault(arg_name, {})
             fmt_arg = fmt_arg0.setdefault("fmtc", util.Scope(fmt_func))

--- a/shroud/wrapc.py
+++ b/shroud/wrapc.py
@@ -767,9 +767,10 @@ class Wrapc(util.WrapperMixin):
                 fmt.c_blanknull = "1"
         
         attrs = ast.attrs
-        statements.assign_buf_variable_names(attrs, ast.metaattrs, fcn.options, fmt, rootname)
+        meta = ast.metaattrs
+        statements.assign_buf_variable_names(attrs, meta, fcn.options, fmt, rootname)
         
-        if ast.metaattrs["dimension"]:
+        if meta["dimension"]:
             if cls is not None:
                 parent = cls
                 cls.create_node_map()
@@ -783,7 +784,7 @@ class Wrapc(util.WrapperMixin):
                 parent = None
                 class_context = ""
             visitor = ToDimension(parent, fcn, fmt, class_context)
-            visitor.visit(ast.metaattrs["dimension"])
+            visitor.visit(meta["dimension"])
             fmt.rank = str(visitor.rank)
             if fmt.rank != "assumed":
                 if hasattr(fmt, "c_var_cdesc"):
@@ -900,7 +901,8 @@ class Wrapc(util.WrapperMixin):
         self.impl_typedef_nodes.update(node.gen_headers_typedef.items())
         header_typedef_nodes = OrderedDict()
 
-        sintent = ast.metaattrs["intent"]
+        meta = ast.metaattrs
+        sintent = meta["intent"]
         if CXX_subprogram == "subroutine":
             fmt_result = fmt_func
             fmt_pattern = fmt_func
@@ -916,7 +918,7 @@ class Wrapc(util.WrapperMixin):
             # intent will be "function", "ctor", "getter"
             junk, specialize = statements.lookup_c_statements(ast)
             stmts = ["c", sintent, result_typemap.sgroup, spointer,
-                     result_api, ast.metaattrs["deref"]] + specialize
+                     result_api, meta["deref"]] + specialize
             result_blk = statements.lookup_fc_stmts(stmts)
 
             fmt_result.idtor = "0"  # no destructor

--- a/shroud/wrapc.py
+++ b/shroud/wrapc.py
@@ -896,7 +896,7 @@ class Wrapc(util.WrapperMixin):
         is_dtor = CXX_ast.declarator.is_dtor()
         is_static = False
         is_pointer = CXX_ast.declarator.is_pointer()
-        is_const = ast.func_const
+        is_const = declarator.func_const
 
         # self.impl_typedef_nodes.update(node.gen_headers_typedef) Python 3.6
         self.impl_typedef_nodes.update(node.gen_headers_typedef.items())

--- a/shroud/wrapc.py
+++ b/shroud/wrapc.py
@@ -1660,7 +1660,7 @@ class ToDimension(todict.PrintNode):
                     return "{}{}".format(self.context, argname)
         else:
             deref = ''
-            arg = self.fcn.ast.find_arg_by_name(argname)
+            arg = self.fcn.ast.declarator.find_arg_by_name(argname)
             if arg:
                 declarator = arg.declarator
                 if arg.attrs["hidden"]:

--- a/shroud/wrapf.py
+++ b/shroud/wrapf.py
@@ -987,7 +987,7 @@ rv = .false.
                 arg_c_decl = []
                 modules = {}  # indexed as [module][variable]
                 imports = {}
-                for i, param in enumerate(arg.params):
+                for i, param in enumerate(arg.declarator.params):
                     name = param.name
                     if name is None:
                         fmt.index = str(i)
@@ -1055,7 +1055,7 @@ rv = .false.
             fmt -
             ast - Abstract Syntax Tree from parser
                node.ast for subprograms
-               node.params[n] for parameters
+               node.declarator.params[n] for parameters
             stmts_blk - typemap.CStmts or util.Scope
             modules - Build up USE statement.
             imports - Build up IMPORT statement.
@@ -1224,7 +1224,7 @@ rv = .false.
             fmt_func.F_C_result_clause = "\fresult(%s)" % fmt_func.F_result
 
         args_all_in = True  # assume all arguments are intent(in)
-        for arg in ast.params:
+        for arg in ast.declarator.params:
             # default argument's intent
             # XXX look at const, ptr
             declarator = arg.declarator
@@ -1744,10 +1744,10 @@ rv = .false.
         # May be one more argument to C function than Fortran function
         # (the result)
         #
-        f_args = ast.params
+        f_args = ast.declarator.params
         f_index = -1  # index into f_args
         have_f_arg = False
-        for c_arg in C_node.ast.params:
+        for c_arg in C_node.ast.declarator.params:
             arg_name = c_arg.name
             fmt_arg0 = fmtargs.setdefault(arg_name, {})
             fmt_arg = fmt_arg0.setdefault("fmtf", util.Scope(fmt_func))

--- a/shroud/wrapf.py
+++ b/shroud/wrapf.py
@@ -1075,7 +1075,7 @@ rv = .false.
         else:
             declarator = ast.declarator
             name = declarator.user_name
-            attrs = ast.attrs
+            attrs = declarator.attrs
             arg_c_names.append(name)
             # argument declarations
             if attrs["assumedtype"]:
@@ -1102,7 +1102,7 @@ rv = .false.
                 # Treat too many pointers as a type(C_PTR)
                 # and let the wrapper sort it out.
                 # 'char **' uses c_char_**_in as a special case.
-                intent = ast.metaattrs["intent"].upper()
+                intent = ast.declarator.metaattrs["intent"].upper()
                 arg_c_decl.append(
                     "type(C_PTR), intent({}) :: {}".format(
                         intent, fmt.F_C_var))
@@ -1140,7 +1140,7 @@ rv = .false.
         subprogram = declarator.get_subprogram()
         result_typemap = ast.typemap
         is_ctor = declarator.is_ctor()
-        is_pure = ast.attrs["pure"]
+        is_pure = declarator.attrs["pure"]
         is_static = False
         func_is_const = declarator.func_const
 
@@ -1170,7 +1170,7 @@ rv = .false.
                                       "function")
             self.set_fmt_fields_dimension(cls, node, ast, fmt_result)
 
-        r_meta = ast.metaattrs
+        r_meta = ast.declarator.metaattrs
         result_api = r_meta["api"]
         sintent = r_meta["intent"]
 
@@ -1241,8 +1241,8 @@ rv = .false.
             self.set_fmt_fields_iface(node, arg, fmt_arg, arg_name, arg_typemap)
             self.set_fmt_fields_dimension(cls, node, arg, fmt_arg)
             
-            attrs = arg.attrs
-            meta = arg.metaattrs
+            attrs = declarator.attrs
+            meta = declarator.metaattrs
             if attrs["hidden"] and node._generated:
                 continue
             intent = meta["intent"]
@@ -1498,7 +1498,8 @@ rv = .false.
         subprogram : str
             "function" or "subroutine" or None
         """
-        meta = ast.metaattrs
+        attrs = ast.declarator.attrs
+        meta = ast.declarator.metaattrs
 
         if subprogram == "subroutine":
             pass
@@ -1519,7 +1520,7 @@ rv = .false.
         f_c_module_line = ntypemap.f_c_module_line or ntypemap.f_module_line
         if f_c_module_line:
             fmt.f_c_module_line = f_c_module_line
-        statements.assign_buf_variable_names(ast.attrs, ast.metaattrs, fcn.options, fmt, rootname)
+        statements.assign_buf_variable_names(attrs, meta, fcn.options, fmt, rootname)
     
     def set_fmt_fields(self, cls, fcn, f_ast, c_ast, fmt,
                        subprogram=None,
@@ -1539,8 +1540,8 @@ rv = .false.
         subprogram : str
         ntypemap : typemap.Typemap
         """
-        c_attrs = c_ast.attrs
-        c_meta = c_ast.metaattrs
+        c_attrs = c_ast.declarator.attrs
+        c_meta = c_ast.declarator.metaattrs
 
         if subprogram == "subroutine":
             # XXX - no need to set f_type and sh_type
@@ -1577,10 +1578,11 @@ rv = .false.
         f_ast : declast.Declaration
         fmt: util.Scope
         """
-        f_attrs = f_ast.attrs
-        dim = f_ast.metaattrs["dimension"]
+        f_attrs = f_ast.declarator.attrs
+        f_meta = f_ast.declarator.metaattrs
+        dim = f_meta["dimension"]
         rank = f_attrs["rank"]
-        if f_ast.metaattrs["assumed-rank"]:
+        if f_meta["assumed-rank"]:
             fmt.f_c_dimension = "(..)"
             fmt.f_assumed_shape = "(..)"
         elif rank is not None:
@@ -1655,8 +1657,8 @@ rv = .false.
         imports = {}
         stmts_comments = []
 
-        r_attrs = ast.attrs
-        r_meta = ast.metaattrs
+        r_attrs = declarator.attrs
+        r_meta = declarator.metaattrs
         sintent = r_meta["intent"]
         if subprogram == "subroutine":
             fmt_result = fmt_func
@@ -1756,8 +1758,8 @@ rv = .false.
             fmt_arg.c_var = arg_name
 
             c_declarator = c_arg.declarator
-            c_attrs = c_arg.attrs
-            c_meta = c_arg.metaattrs
+            c_attrs = c_declarator.attrs
+            c_meta = c_declarator.metaattrs
             hidden = c_attrs["hidden"]
             intent = c_meta["intent"]
             optattr = False
@@ -1786,8 +1788,8 @@ rv = .false.
                 f_arg = f_args[f_index]
             f_declarator = f_arg.declarator
             f_name = f_declarator.user_name
-            f_attrs = f_arg.attrs
-            f_meta = f_arg.metaattrs
+            f_attrs = f_declarator.attrs
+            f_meta = f_declarator.metaattrs
 
             c_sgroup = c_arg.typemap.sgroup
             c_spointer = c_declarator.get_indirect_stmt()

--- a/shroud/wrapf.py
+++ b/shroud/wrapf.py
@@ -2345,7 +2345,7 @@ class ToDimension(todict.PrintNode):
                 else:
                     return "obj->{}".format(argname)
         else:
-            if self.fcn.ast.find_arg_by_name(argname) is None:
+            if self.fcn.ast.declarator.find_arg_by_name(argname) is None:
                 self.need_helper = True
             if node.args is None:
                 return argname  # variable
@@ -2411,7 +2411,7 @@ class ToImplied(todict.PrintNode):
             self.intermediate = True
             self.helper = "ShroudTypeDefines"
             argname = node.args[0].name
-            typearg = self.func.ast.find_arg_by_name(argname)
+            typearg = self.func.ast.declarator.find_arg_by_name(argname)
             arg_typemap = typearg.typemap
             return arg_typemap.sh_type
         elif argname == "len":

--- a/shroud/wrapf.py
+++ b/shroud/wrapf.py
@@ -1166,8 +1166,9 @@ rv = .false.
                                       "function")
             self.set_fmt_fields_dimension(cls, node, ast, fmt_result)
 
-        result_api = ast.metaattrs["api"]
-        sintent = ast.metaattrs["intent"]
+        r_meta = ast.metaattrs
+        result_api = r_meta["api"]
+        sintent = r_meta["intent"]
 
         if cls:
             is_static = "static" in ast.storage
@@ -1188,7 +1189,7 @@ rv = .false.
         sgroup = result_typemap.sgroup
         spointer = ast.get_indirect_stmt()
         c_stmts = ["c", sintent, sgroup, spointer, result_api,
-                   ast.metaattrs["deref"]] + specialize
+                   r_meta["deref"]] + specialize
         c_result_blk = statements.lookup_fc_stmts(c_stmts)
         c_result_blk = statements.lookup_local_stmts(
             ["c", result_api], c_result_blk, node)
@@ -1648,7 +1649,9 @@ rv = .false.
         imports = {}
         stmts_comments = []
 
-        sintent = ast.metaattrs["intent"]
+        r_attrs = ast.attrs
+        r_meta = ast.metaattrs
+        sintent = r_meta["intent"]
         if subprogram == "subroutine":
             fmt_result = fmt_func
             # intent will be "subroutine" or "dtor".
@@ -1663,10 +1666,10 @@ rv = .false.
             fmt_func.F_result_clause = "\fresult(%s)" % fmt_func.F_result
             sgroup = result_typemap.sgroup
             spointer = C_node.ast.get_indirect_stmt()
-            return_deref_attr = ast.metaattrs["deref"]
+            return_deref_attr = r_meta["deref"]
             junk, specialize = statements.lookup_c_statements(ast)
             f_stmts = ["f", sintent, sgroup, spointer, c_result_api,
-                       return_deref_attr, ast.attrs["owner"]] + specialize
+                       return_deref_attr, r_attrs["owner"]] + specialize
             c_stmts = ["c", sintent, sgroup, spointer, c_result_api,
                        return_deref_attr] + specialize
         fmt_func.F_subprogram = subprogram

--- a/shroud/wrapf.py
+++ b/shroud/wrapf.py
@@ -1141,7 +1141,7 @@ rv = .false.
         is_ctor = declarator.is_ctor()
         is_pure = ast.attrs["pure"]
         is_static = False
-        func_is_const = ast.func_const
+        func_is_const = declarator.func_const
 
         arg_c_names = []  # argument names for functions
         arg_c_decl = []  # declaraion of argument names
@@ -1880,8 +1880,8 @@ rv = .false.
                     self.add_module_from_stmts(f_result_blk, modules, imports, fmt_arg)
                 else:
                     # Generate declaration from argument.
-                    if options.F_default_args == "optional" and c_arg.init is not None:
-                        fmt_arg.default_value = c_arg.init
+                    if options.F_default_args == "optional" and c_arg.declarator.init is not None:
+                        fmt_arg.default_value = c_arg.declarator.init
                         optattr = True
                     arg_f_decl.append(f_arg.gen_arg_as_fortran(pass_obj=pass_obj, optional=optattr))
                     arg_f_names.append(fmt_arg.f_var)

--- a/shroud/wrapl.py
+++ b/shroud/wrapl.py
@@ -188,7 +188,7 @@ luaL_setfuncs({LUA_state_var}, {LUA_class_reg}, 0);
         for function in functions:
             if not function.wrap.lua:
                 continue
-            name = function.ast.name
+            name = function.ast.declarator.user_name
             if name in overloaded_methods:
                 overloaded_methods[name].append(function)
             else:
@@ -515,7 +515,7 @@ luaL_setfuncs({LUA_state_var}, {LUA_class_reg}, 0);
         for iarg in range(luafcn.nargs):
             arg = ast.declarator.params[iarg]
             a_declarator = arg.declarator
-            arg_name = arg.name
+            arg_name = a_declarator.user_name
             fmt_arg0 = fmtargs.setdefault(arg_name, {})
             fmt_arg = fmt_arg0.setdefault("fmtl", util.Scope(fmt_func))
             fmt_arg.LUA_index = LUA_index

--- a/shroud/wrapl.py
+++ b/shroud/wrapl.py
@@ -531,8 +531,8 @@ luaL_setfuncs({LUA_state_var}, {LUA_class_reg}, 0);
                 fmt_arg.c_deref = ""
                 fmt_arg.c_member = "."
                 fmt_arg.cxx_member = "."
-            attrs = arg.attrs
-            meta = arg.metaattrs
+            attrs = a_declarator.attrs
+            meta = a_declarator.metaattrs
 
             arg_typemap = arg.typemap
             fmt_arg.cxx_type = arg_typemap.cxx_type
@@ -592,7 +592,7 @@ luaL_setfuncs({LUA_state_var}, {LUA_class_reg}, 0);
         sgroup = None
         spointer = ast.declarator.get_indirect_stmt()
 #        print("DDDDDDDDDDDDDD", ast.name)
-        sintent = ast.metaattrs["intent"]
+        sintent = declarator.metaattrs["intent"]
         if is_ctor:
             fmt_func.LUA_used_param_state = True
 #            self.helpers.add_helper("maker", fmt_func)

--- a/shroud/wrapl.py
+++ b/shroud/wrapl.py
@@ -188,7 +188,7 @@ luaL_setfuncs({LUA_state_var}, {LUA_class_reg}, 0);
         for function in functions:
             if not function.wrap.lua:
                 continue
-            name = function.ast.declarator.user_name
+            name = function.name
             if name in overloaded_methods:
                 overloaded_methods[name].append(function)
             else:

--- a/shroud/wrapl.py
+++ b/shroud/wrapl.py
@@ -217,20 +217,21 @@ luaL_setfuncs({LUA_state_var}, {LUA_class_reg}, 0);
         node = overloads[0]
 
         ast = node.ast
+        declarator = ast.declarator
         fmt_func = node.fmtdict
         fmt = util.Scope(fmt_func)
         node.eval_template("LUA_name")
         node.eval_template("LUA_name_impl")
 
-        CXX_subprogram = ast.get_subprogram()
+        CXX_subprogram = declarator.get_subprogram()
 
         # XXX       ast = node.ast
         # XXX       result_type = ast.typename
         # XXX       result_is_ptr = ast.is_pointer()
         # XXX       result_is_ref = ast.is_reference()
 
-        is_ctor = ast.is_ctor()
-        is_dtor = ast.is_dtor()
+        is_ctor = declarator.is_ctor()
+        is_dtor = declarator.is_dtor()
         if is_dtor:
             CXX_subprogram = "subroutine"
             fmt.LUA_name = "__gc"
@@ -432,10 +433,11 @@ luaL_setfuncs({LUA_state_var}, {LUA_class_reg}, 0);
         #        node.eval_template('LUA_name_impl')
 
         ast = node.ast
-        CXX_subprogram = ast.get_subprogram()
+        declarator = ast.declarator
+        CXX_subprogram = declarator.get_subprogram()
         result_typemap = ast.typemap
-        is_ctor = ast.is_ctor()
-        is_dtor = ast.is_dtor()
+        is_ctor = declarator.is_ctor()
+        is_dtor = declarator.is_dtor()
         stmts_comments = self.stmts_comments
         stmts_comments_args = []  # Used to reorder comments
 
@@ -459,7 +461,7 @@ luaL_setfuncs({LUA_state_var}, {LUA_class_reg}, 0);
         fmt_result = node._fmtresult.setdefault("fmtl", util.Scope(fmt_func))
         if CXX_subprogram == "function":
             fmt_result.cxx_var = wformat("{CXX_local}{LUA_result}", fmt_result)
-            if is_ctor or ast.is_pointer():
+            if is_ctor or declarator.is_pointer():
                 #                fmt_result.c_member = '->'
                 fmt_result.cxx_member = "->"
                 fmt_result.cxx_addr = ""
@@ -512,6 +514,7 @@ luaL_setfuncs({LUA_state_var}, {LUA_class_reg}, 0);
         LUA_index = 1
         for iarg in range(luafcn.nargs):
             arg = ast.params[iarg]
+            a_declarator = arg.declarator
             arg_name = arg.name
             fmt_arg0 = fmtargs.setdefault(arg_name, {})
             fmt_arg = fmt_arg0.setdefault("fmtl", util.Scope(fmt_func))
@@ -520,7 +523,7 @@ luaL_setfuncs({LUA_state_var}, {LUA_class_reg}, 0);
             fmt_arg.cxx_var = arg_name
             fmt_arg.lua_var = "SH_Lua_" + arg_name
             fmt_arg.c_var_len = "L" + arg_name
-            if arg.is_pointer():
+            if a_declarator.is_pointer():
                 fmt_arg.c_deref = " *"
                 fmt_arg.c_member = "->"
                 fmt_arg.cxx_member = "->"
@@ -537,7 +540,7 @@ luaL_setfuncs({LUA_state_var}, {LUA_class_reg}, 0);
             intent_blk = None
             intent = meta["intent"]
             sgroup = arg_typemap.sgroup
-            spointer = arg.get_indirect_stmt()
+            spointer = a_declarator.get_indirect_stmt()
             stmts = None
             stmts = ["lua", intent, sgroup, spointer]
             if intent_blk is None:
@@ -587,7 +590,7 @@ luaL_setfuncs({LUA_state_var}, {LUA_class_reg}, 0);
         #        call_code.extend(post_parse)
 
         sgroup = None
-        spointer = ast.get_indirect_stmt()
+        spointer = ast.declarator.get_indirect_stmt()
 #        print("DDDDDDDDDDDDDD", ast.name)
         sintent = ast.metaattrs["intent"]
         if is_ctor:

--- a/shroud/wrapl.py
+++ b/shroud/wrapl.py
@@ -246,7 +246,7 @@ luaL_setfuncs({LUA_state_var}, {LUA_class_reg}, 0);
             nargs = 0
             in_args = []
             out_args = []
-            for arg in function.ast.params:
+            for arg in function.ast.declarator.params:
                 arg_typemap = arg.typemap
                 if arg.init is not None:
                     all_calls.append(
@@ -513,7 +513,7 @@ luaL_setfuncs({LUA_state_var}, {LUA_class_reg}, 0);
         # Each variation of default-arguments produces a new call.
         LUA_index = 1
         for iarg in range(luafcn.nargs):
-            arg = ast.params[iarg]
+            arg = ast.declarator.params[iarg]
             a_declarator = arg.declarator
             arg_name = arg.name
             fmt_arg0 = fmtargs.setdefault(arg_name, {})

--- a/shroud/wrapl.py
+++ b/shroud/wrapl.py
@@ -248,7 +248,7 @@ luaL_setfuncs({LUA_state_var}, {LUA_class_reg}, 0);
             out_args = []
             for arg in function.ast.declarator.params:
                 arg_typemap = arg.typemap
-                if arg.init is not None:
+                if arg.declarator.init is not None:
                     all_calls.append(
                         LuaFunction(
                             function, CXX_subprogram, in_args[:], out_args

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -3495,7 +3495,7 @@ class ToImplied(todict.PrintNode):
             fmt = self.func._fmtargs[argname]["fmtpy"]
 
             # find argname in function parameters
-            arg = self.func.ast.find_arg_by_name(argname)
+            arg = self.func.ast.declarator.find_arg_by_name(argname)
             if arg.metaattrs["intent"] == "out":
                 #   char *text+intent(out)+charlen(XXX), 
                 #   int ltext+implied(len(text)))

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -1432,7 +1432,7 @@ return 1;""",
                 offset += len(arg_name) + 1
 
                 # XXX default should be handled differently
-                if arg.init is not None:
+                if declarator.init is not None:
                     # Default value argument.
                     if not found_optional:
                         parse_format.append("|")  # add once
@@ -3340,8 +3340,9 @@ def py_struct_dimension(parent, var, fmt):
     # fmt.npy_intp_asgn     # assign to
     #    fmt.npy_intp_values     # comma separated list of values
     ast = var.ast
-    if ast.array: # Fixed size array.
-        metadim = ast.array
+    declarator = ast.declarator
+    if declarator.array: # Fixed size array.
+        metadim = declarator.array
     elif ast.attrs["dimension"] is not None:
         metadim = ast.metaattrs["dimension"]
     else:

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -1255,7 +1255,7 @@ return 1;""",
             )
 
         goto_fail = False
-        args = ast.params
+        args = ast.declarator.params
         arg_names = []    # Arguments to function, intent in or inout.
         arg_offsets = []
         arg_implied = []  # Collect implied arguments
@@ -2515,7 +2515,7 @@ return 1;""",
                     )
                 else:
                     body.append(
-                        "if (SHT_nargs == %d) {+" % len(overload.ast.params)
+                        "if (SHT_nargs == %d) {+" % len(overload.ast.declarator.params)
                     )
                 append_format(
                     body,

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -831,7 +831,7 @@ return 1;""",
 
         ########################################
         # setter
-        if not ast.attrs["readonly"]:
+        if not declarator.attrs["readonly"]:
             fmt_var.PY_setter = wformat(
                 options.PY_member_setter_template, fmt_var
             )
@@ -928,8 +928,8 @@ return 1;""",
             # XXX - cxx_var may not have prefix yet.
             fmt.npy_intp_asgn = wformat("{npy_dims_var}[0] = {cxx_var}->size();\n", fmt)
 
-        dimension = ast.metaattrs["dimension"]
-        rank = ast.attrs["rank"]
+        dimension = declarator.metaattrs["dimension"]
+        rank = declarator.attrs["rank"]
         if rank is not None:
             fmt.rank = str(rank)
         elif dimension:
@@ -1008,7 +1008,7 @@ return 1;""",
             arg -
             pre_call -
         """
-        implied = arg.attrs["implied"]
+        implied = arg.declarator.attrs["implied"]
         if implied:
             fmt = node._fmtargs[arg.declarator.user_name]["fmtpy"]
             fmt.pre_call_intent = py_implied(implied, node)
@@ -1294,15 +1294,15 @@ return 1;""",
                 fmt_arg.cxx_member = "."
                 fmt_arg.ctor_expr = fmt_arg.c_var
             update_fmt_from_typemap(fmt_arg, arg_typemap)
-            attrs = arg.attrs
-            meta = arg.metaattrs
+            attrs = declarator.attrs
+            meta = declarator.metaattrs
 
             self.set_fmt_fields(cls, node, arg, fmt_arg)
             self.set_cxx_nonconst_ptr(arg, fmt_arg)
             pass_var = fmt_arg.c_var  # The variable to pass to the function
             as_object = False
-            rank = arg.attrs["rank"]
-            dimension = arg.attrs["dimension"]
+            rank = attrs["rank"]
+            dimension = attrs["dimension"]
             hidden = attrs["hidden"]
             implied = attrs["implied"]
             intent = meta["intent"]
@@ -1316,7 +1316,7 @@ return 1;""",
                 intent_blk = lookup_stmts(stmts)
                 if intent_blk.name == "py_default":
                     intent_blk = None
-                struct_member = arg.metaattrs["struct_member"]
+                struct_member = meta["struct_member"]
                 struct_fmt = struct_member.fmtdict
                 fmt_arg.field_name = struct_fmt.field_name
                 fmt_arg.PY_member_object = struct_fmt.PY_member_object
@@ -1336,7 +1336,7 @@ return 1;""",
                 intent_blk = default_scope
             elif sgroup == "char":
                 stmts = ["py", intent, sgroup, spointer]
-                charlen = arg.attrs["charlen"]
+                charlen = attrs["charlen"]
                 if charlen:
                     fmt_arg.charlen = charlen
                     stmts.append("charlen")
@@ -1974,8 +1974,8 @@ return 1;""",
         options = node.options
         ast = node.ast
         declarator = ast.declarator
-        attrs = ast.attrs
-        meta = ast.metaattrs
+        attrs = declarator.attrs
+        meta = declarator.metaattrs
         is_ctor = declarator.is_ctor()
         result_typemap = ast.typemap
 
@@ -3345,8 +3345,8 @@ def py_struct_dimension(parent, var, fmt):
     declarator = ast.declarator
     if declarator.array: # Fixed size array.
         metadim = declarator.array
-    elif ast.attrs["dimension"] is not None:
-        metadim = ast.metaattrs["dimension"]
+    elif declarator.attrs["dimension"] is not None:
+        metadim = declarator.metaattrs["dimension"]
     else:
         metadim = None
     if metadim:
@@ -3499,12 +3499,12 @@ class ToImplied(todict.PrintNode):
 
             # find argname in function parameters
             arg = self.func.ast.declarator.find_arg_by_name(argname)
-            if arg.metaattrs["intent"] == "out":
+            if arg.declarator.metaattrs["intent"] == "out":
                 #   char *text+intent(out)+charlen(XXX), 
                 #   int ltext+implied(len(text)))
                 # len(text) in this case is the value of "charlen"
                 # since no variable is actually passed in as an argument.
-                return arg.attrs["charlen"]
+                return arg.declarator.attrs["charlen"]
             # XXX - need code for len_trim?
             return wformat("strlen({cxx_var})", fmt)
         elif argname == "len_trim":

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -1092,7 +1092,7 @@ return 1;""",
         """
         overloaded_methods = {}
         for function in functions:
-            flist = overloaded_methods.setdefault(function.ast.declarator.user_name, [])
+            flist = overloaded_methods.setdefault(function.name, [])
             if not function.wrap.python:
                 continue
             if not function.options.PY_create_generic:
@@ -2454,7 +2454,7 @@ return 1;""",
         mdone = {}
         for function in functions:
             # preserve order of multi-dispatch functions
-            mname = function.ast.declarator.user_name
+            mname = function.name
             if mname in mdone:
                 continue
             mdone[mname] = True

--- a/tests/check_decl.output
+++ b/tests/check_decl.output
@@ -728,6 +728,7 @@ stmts:
       pointer:
       - ptr: '*'
       typemap_name: int
+    name: fcn
     params:
     - _ast: Declaration
       declarator:

--- a/tests/check_decl.output
+++ b/tests/check_decl.output
@@ -196,6 +196,7 @@ stmts:
           _name: ctor
         params: []
         typemap_name: Class2
+      is_ctor: true
       specifier:
       - Class2
       typemap_name: Class2
@@ -206,6 +207,7 @@ stmts:
           _name: dtor
         params: []
         typemap_name: void
+      is_dtor: Class2
       specifier:
       - void
       typemap_name: void

--- a/tests/check_decl.output
+++ b/tests/check_decl.output
@@ -151,6 +151,7 @@ class Class1;
 XXXX AST
 stmts:
 - _ast: Declaration
+  declarator: {}
   specifier:
   - class Class1
   typemap_name: Class1
@@ -200,6 +201,7 @@ stmts:
       - void
       typemap_name: void
     name: Class2
+  declarator: {}
   specifier:
   - class Class2
   typemap_name: Class2
@@ -247,6 +249,7 @@ stmts:
       typemap_name: int
     name: Point
     typemap_name: Point
+  declarator: {}
   specifier:
   - struct Point
   typemap_name: Point
@@ -324,6 +327,7 @@ stmts:
       typemap_name: int
     name: list_s
     typemap_name: list_s
+  declarator: {}
   specifier:
   - struct list_s
   typemap_name: list_s
@@ -389,6 +393,7 @@ stmts:
       typemap_name: list_s
     name: list_s
     typemap_name: list_s
+  declarator: {}
   specifier:
   - struct list_s
   typemap_name: list_s
@@ -458,6 +463,7 @@ stmts:
       typemap_name: list_s
     name: list_s
     typemap_name: list_s
+  declarator: {}
   specifier:
   - struct list_s
   typemap_name: list_s
@@ -488,6 +494,7 @@ Color_typ local;
 XXXX AST
 stmts:
 - _ast: Declaration
+  declarator: {}
   enum_specifier:
     _ast: Enum
     members:
@@ -556,6 +563,7 @@ void func1(enum Color arg1,Color arg2);
 XXXX AST
 stmts:
 - _ast: Declaration
+  declarator: {}
   enum_specifier:
     _ast: Enum
     members:
@@ -678,6 +686,7 @@ stmts:
       - ptr: '*'
   params:
   - _ast: Declaration
+    declarator: {}
     specifier:
     - int
     typemap_name: int
@@ -752,6 +761,7 @@ stmts:
         parameters:
         - name: U
       name: user
+    declarator: {}
     specifier:
     - class user
     typemap_name: user
@@ -765,6 +775,7 @@ stmts:
   - user
   template_arguments:
   - _ast: Declaration
+    declarator: {}
     specifier:
     - int
     typemap_name: int
@@ -845,6 +856,7 @@ stmts:
         - int
         typemap_name: int
       name: name
+    declarator: {}
     specifier:
     - class name
     typemap_name: ns::name

--- a/tests/check_decl.output
+++ b/tests/check_decl.output
@@ -151,9 +151,6 @@ class Class1;
 XXXX AST
 stmts:
 - _ast: Declaration
-  class_specifier:
-    _ast: CXXClass
-    name: Class1
   specifier:
   - class Class1
   typemap_name: Class1

--- a/tests/check_decl.output
+++ b/tests/check_decl.output
@@ -162,6 +162,55 @@ symbols:
     typemap: Class1
 
 XXXXXXXXXXXXXXXXXXXX
+# Class constructor
+XXXX CODE
+class Class2 {
+  Class2();
+  ~Class2();
+};
+XXXX PRINT_NODE
+class Class2{
+Class2 ();
+~Class2 ();
+}
+;
+
+XXXX AST
+stmts:
+- _ast: Declaration
+  class_specifier:
+    _ast: CXXClass
+    members:
+    - _ast: Declaration
+      attrs:
+        _constructor: true
+        _name: ctor
+      declarator: {}
+      params: []
+      specifier:
+      - Class2
+      typemap_name: Class2
+    - _ast: Declaration
+      attrs:
+        _destructor: Class2
+        _name: dtor
+      declarator: {}
+      params: []
+      specifier:
+      - void
+      typemap_name: void
+    name: Class2
+  specifier:
+  - class Class2
+  typemap_name: Class2
+XXXX SymbolTable
+cls: Global
+symbols:
+  Class2:
+    cls: CXXClass
+    typemap: Class2
+
+XXXXXXXXXXXXXXXXXXXX
 # Structure for C++
 XXXX CODE
 struct Point { int x; int y;};

--- a/tests/check_decl.output
+++ b/tests/check_decl.output
@@ -64,6 +64,7 @@ stmts:
 - _ast: Declaration
   declarator:
     name: i
+    typemap_name: int
   specifier:
   - int
   typemap_name: int
@@ -71,6 +72,7 @@ stmts:
   const: true
   declarator:
     name: d
+    typemap_name: double
   specifier:
   - double
   typemap_name: double
@@ -95,6 +97,7 @@ stmts:
     name: i1
     pointer:
     - ptr: '*'
+    typemap_name: int
   specifier:
   - int
   typemap_name: int
@@ -104,6 +107,7 @@ stmts:
     pointer:
     - ptr: '*'
     - ptr: '*'
+    typemap_name: int
   specifier:
   - int
   typemap_name: int
@@ -112,6 +116,7 @@ stmts:
     name: i3
     pointer:
     - ptr: '&'
+    typemap_name: int
   specifier:
   - int
   typemap_name: int
@@ -129,6 +134,7 @@ stmts:
 - _ast: Declaration
   declarator:
     name: footype
+    typemap_name: int
   specifier:
   - int
   storage:
@@ -151,7 +157,8 @@ class Class1;
 XXXX AST
 stmts:
 - _ast: Declaration
-  declarator: {}
+  declarator:
+    typemap_name: Class1
   specifier:
   - class Class1
   typemap_name: Class1
@@ -183,25 +190,28 @@ stmts:
     _ast: CXXClass
     members:
     - _ast: Declaration
-      attrs:
-        _constructor: true
-        _name: ctor
-      declarator: {}
-      params: []
+      declarator:
+        attrs:
+          _constructor: true
+          _name: ctor
+        params: []
+        typemap_name: Class2
       specifier:
       - Class2
       typemap_name: Class2
     - _ast: Declaration
-      attrs:
-        _destructor: Class2
-        _name: dtor
-      declarator: {}
-      params: []
+      declarator:
+        attrs:
+          _destructor: Class2
+          _name: dtor
+        params: []
+        typemap_name: void
       specifier:
       - void
       typemap_name: void
     name: Class2
-  declarator: {}
+  declarator:
+    typemap_name: Class2
   specifier:
   - class Class2
   typemap_name: Class2
@@ -238,49 +248,57 @@ stmts:
     - _ast: Declaration
       declarator:
         name: x
+        typemap_name: int
       specifier:
       - int
       typemap_name: int
     - _ast: Declaration
       declarator:
         name: y
+        typemap_name: int
       specifier:
       - int
       typemap_name: int
     name: Point
     typemap_name: Point
-  declarator: {}
+  declarator:
+    typemap_name: Point
   specifier:
   - struct Point
   typemap_name: Point
 - _ast: Declaration
   declarator:
     name: end
+    typemap_name: Point
   specifier:
   - struct Point
   typemap_name: Point
 - _ast: Declaration
   declarator:
     name: start
+    typemap_name: Point
   specifier:
   - Point
   typemap_name: Point
 - _ast: Declaration
   declarator:
     name: func1
-  params:
-  - _ast: Declaration
-    declarator:
-      name: arg1
-    specifier:
-    - struct Point
-    typemap_name: Point
-  - _ast: Declaration
-    declarator:
-      name: arg2
-    specifier:
-    - Point
-    typemap_name: Point
+    params:
+    - _ast: Declaration
+      declarator:
+        name: arg1
+        typemap_name: Point
+      specifier:
+      - struct Point
+      typemap_name: Point
+    - _ast: Declaration
+      declarator:
+        name: arg2
+        typemap_name: Point
+      specifier:
+      - Point
+      typemap_name: Point
+    typemap_name: void
   specifier:
   - void
   typemap_name: void
@@ -322,24 +340,28 @@ stmts:
     - _ast: Declaration
       declarator:
         name: i
+        typemap_name: int
       specifier:
       - int
       typemap_name: int
     name: list_s
     typemap_name: list_s
-  declarator: {}
+  declarator:
+    typemap_name: list_s
   specifier:
   - struct list_s
   typemap_name: list_s
 - _ast: Declaration
   declarator:
     name: var1
+    typemap_name: list_s
   specifier:
   - struct list_s
   typemap_name: list_s
 - _ast: Declaration
   declarator:
     name: list_typ
+    typemap_name: list_s
   specifier:
   - struct list_s
   storage:
@@ -348,6 +370,7 @@ stmts:
 - _ast: Declaration
   declarator:
     name: var2
+    typemap_name: list_typ
   specifier:
   - list_typ
   typemap_name: list_typ
@@ -388,18 +411,21 @@ stmts:
         name: next
         pointer:
         - ptr: '*'
+        typemap_name: list_s
       specifier:
       - struct list_s
       typemap_name: list_s
     name: list_s
     typemap_name: list_s
-  declarator: {}
+  declarator:
+    typemap_name: list_s
   specifier:
   - struct list_s
   typemap_name: list_s
 - _ast: Declaration
   declarator:
     name: var1
+    typemap_name: list_s
   specifier:
   - struct list_s
   typemap_name: list_s
@@ -450,6 +476,7 @@ stmts:
         name: next
         pointer:
         - ptr: '*'
+        typemap_name: list_s
       specifier:
       - struct list_s
       typemap_name: list_s
@@ -458,12 +485,14 @@ stmts:
         name: prev
         pointer:
         - ptr: '*'
+        typemap_name: list_s
       specifier:
       - list_s
       typemap_name: list_s
     name: list_s
     typemap_name: list_s
-  declarator: {}
+  declarator:
+    typemap_name: list_s
   specifier:
   - struct list_s
   typemap_name: list_s
@@ -494,7 +523,8 @@ Color_typ local;
 XXXX AST
 stmts:
 - _ast: Declaration
-  declarator: {}
+  declarator:
+    typemap_name: Color
   enum_specifier:
     _ast: Enum
     members:
@@ -508,12 +538,14 @@ stmts:
 - _ast: Declaration
   declarator:
     name: global
+    typemap_name: Color
   specifier:
   - enum Color
   typemap_name: Color
 - _ast: Declaration
   declarator:
     name: Color_typ
+    typemap_name: Color
   specifier:
   - enum Color
   storage:
@@ -522,6 +554,7 @@ stmts:
 - _ast: Declaration
   declarator:
     name: local
+    typemap_name: Color_typ
   specifier:
   - Color_typ
   typemap_name: Color_typ
@@ -563,7 +596,8 @@ void func1(enum Color arg1,Color arg2);
 XXXX AST
 stmts:
 - _ast: Declaration
-  declarator: {}
+  declarator:
+    typemap_name: Color
   enum_specifier:
     _ast: Enum
     members:
@@ -577,32 +611,37 @@ stmts:
 - _ast: Declaration
   declarator:
     name: global
+    typemap_name: Color
   specifier:
   - enum Color
   typemap_name: Color
 - _ast: Declaration
   declarator:
+    init: RED
     name: flag
-  init: RED
+    typemap_name: Color
   specifier:
   - Color
   typemap_name: Color
 - _ast: Declaration
   declarator:
     name: func1
-  params:
-  - _ast: Declaration
-    declarator:
-      name: arg1
-    specifier:
-    - enum Color
-    typemap_name: Color
-  - _ast: Declaration
-    declarator:
-      name: arg2
-    specifier:
-    - Color
-    typemap_name: Color
+    params:
+    - _ast: Declaration
+      declarator:
+        name: arg1
+        typemap_name: Color
+      specifier:
+      - enum Color
+      typemap_name: Color
+    - _ast: Declaration
+      declarator:
+        name: arg2
+        typemap_name: Color
+      specifier:
+      - Color
+      typemap_name: Color
+    typemap_name: void
   specifier:
   - void
   typemap_name: void
@@ -635,6 +674,7 @@ stmts:
     name: address
     pointer:
     - ptr: '*'
+    typemap_name: void
   specifier:
   - void
   storage:
@@ -643,19 +683,22 @@ stmts:
 - _ast: Declaration
   declarator:
     name: var
+    typemap_name: address
   specifier:
   - address
   typemap_name: address
 - _ast: Declaration
   declarator:
     name: caller
-  params:
-  - _ast: Declaration
-    declarator:
-      name: arg1
-    specifier:
-    - address
-    typemap_name: address
+    params:
+    - _ast: Declaration
+      declarator:
+        name: arg1
+        typemap_name: address
+      specifier:
+      - address
+      typemap_name: address
+    typemap_name: void
   specifier:
   - void
   typemap_name: void
@@ -684,11 +727,14 @@ stmts:
       name: fcn
       pointer:
       - ptr: '*'
-  params:
-  - _ast: Declaration
-    declarator: {}
-    specifier:
-    - int
+      typemap_name: int
+    params:
+    - _ast: Declaration
+      declarator:
+        typemap_name: int
+      specifier:
+      - int
+      typemap_name: int
     typemap_name: int
   specifier:
   - int
@@ -698,13 +744,15 @@ stmts:
 - _ast: Declaration
   declarator:
     name: caller
-  params:
-  - _ast: Declaration
-    declarator:
-      name: callback
-    specifier:
-    - fcn
-    typemap_name: fcn
+    params:
+    - _ast: Declaration
+      declarator:
+        name: callback
+        typemap_name: fcn
+      specifier:
+      - fcn
+      typemap_name: fcn
+    typemap_name: void
   specifier:
   - void
   typemap_name: void
@@ -742,26 +790,28 @@ stmts:
           _ast: Declaration
           declarator:
             name: nested
-          params:
-          - _ast: Declaration
-            declarator:
-              name: arg1
-            specifier:
-            - T
-            template_argument: T
-          - _ast: Declaration
-            declarator:
-              name: arg2
-            specifier:
-            - U
-            template_argument: U
+            params:
+            - _ast: Declaration
+              declarator:
+                name: arg1
+              specifier:
+              - T
+              template_argument: T
+            - _ast: Declaration
+              declarator:
+                name: arg2
+              specifier:
+              - U
+              template_argument: U
+            typemap_name: void
           specifier:
           - void
           typemap_name: void
         parameters:
         - name: U
       name: user
-    declarator: {}
+    declarator:
+      typemap_name: user
     specifier:
     - class user
     typemap_name: user
@@ -770,12 +820,14 @@ stmts:
 - _ast: Declaration
   declarator:
     name: returnUserType
-  params: []
+    params: []
+    typemap_name: user
   specifier:
   - user
   template_arguments:
   - _ast: Declaration
-    declarator: {}
+    declarator:
+      typemap_name: int
     specifier:
     - int
     typemap_name: int
@@ -808,6 +860,7 @@ stmts:
   - _ast: Declaration
     declarator:
       name: i
+      typemap_name: int
     specifier:
     - int
     typemap_name: int
@@ -817,6 +870,7 @@ stmts:
     - _ast: Declaration
       declarator:
         name: j
+        typemap_name: int
       specifier:
       - int
       typemap_name: int
@@ -852,11 +906,13 @@ stmts:
       - _ast: Declaration
         declarator:
           name: imem
+          typemap_name: int
         specifier:
         - int
         typemap_name: int
       name: name
-    declarator: {}
+    declarator:
+      typemap_name: ns::name
     specifier:
     - class name
     typemap_name: ns::name

--- a/tests/check_decl.py
+++ b/tests/check_decl.py
@@ -41,6 +41,12 @@ typedef int footype;
 # Class statement
 class Class1;
 --------------------
+# Class constructor
+class Class2 {
+  Class2();
+  ~Class2();
+};
+--------------------
 # Structure for C++
 struct Point { int x; int y;};
 struct Point end;

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -258,10 +258,10 @@ class CheckAst(unittest.TestCase):
 
         self.assertEqual(len(library.classes), 2)
         self.assertEqual(len(library.classes[0].functions), 2)
-        self.assertEqual(library.classes[0].functions[0].ast.name, "c1func1")
-        self.assertEqual(library.classes[0].functions[1].ast.name, "c1func2")
+        self.assertEqual(library.classes[0].functions[0].ast.declarator.name, "c1func1")
+        self.assertEqual(library.classes[0].functions[1].ast.declarator.name, "c1func2")
         self.assertEqual(len(library.classes[1].functions), 1)
-        self.assertEqual(library.classes[1].functions[0].ast.name, "c2func1")
+        self.assertEqual(library.classes[1].functions[0].ast.declarator.name, "c2func1")
 
     def test_c_class3(self):
         """Test class options"""

--- a/tests/test_declast.py
+++ b/tests/test_declast.py
@@ -66,9 +66,13 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(
             todict.to_dict(r), {
                 'const': True,
-                'declarator': {'name': 'var1'},
+                'declarator': {
+                    'name': 'var1',
+                    'typemap_name': 'int',
+                },
                 'specifier': ['int'],
-                'typemap_name': 'int'})
+                'typemap_name': 'int',
+            })
         self.assertEqual("scalar", r.get_indirect_stmt())
 
         r = declast.check_decl("int const var1", symtab)
@@ -77,7 +81,10 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(
             todict.to_dict(r), {
                 'const': True,
-                'declarator': {'name': 'var1'},
+                'declarator': {
+                    'name': 'var1',
+                    'typemap_name': 'int',
+                },
                 'specifier': ['int'],
                 'typemap_name': 'int'})
         self.assertEqual("scalar", r.get_indirect_stmt())
@@ -111,8 +118,10 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(
             todict.to_dict(r), {
                 'declarator': {
-                    'name': 'var1', 'pointer': [
-                        {'const': True, 'ptr': '*'}]},
+                    'name': 'var1',
+                    'pointer': [{'const': True, 'ptr': '*'}],
+                    'typemap_name': 'int',
+                },
                 'specifier': ['int'],
                 'typemap_name': 'int'})
         self.assertEqual("*", r.get_indirect_stmt())
@@ -124,8 +133,10 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(
             todict.to_dict(r), {
                 'declarator': {
-                    'name': 'var1', 'pointer': [
-                        {'ptr': '*'}, {'ptr': '*'}]},
+                    'name': 'var1',
+                    'pointer': [{'ptr': '*'}, {'ptr': '*'}],
+                    'typemap_name': 'int'
+                },
                 'specifier': ['int'],
                 'typemap_name': 'int'
             })
@@ -139,10 +150,11 @@ class CheckParse(unittest.TestCase):
             todict.to_dict(r), {
                 'declarator': {
                     'name': 'var1',
-                    'pointer': [{   'ptr': '&'}, {   'ptr': '*'}]
+                    'pointer': [{   'ptr': '&'}, {   'ptr': '*'}],
+                    'typemap_name': 'int',
                 },
                 'specifier': ['int'],
-                'typemap_name': 'int'
+                'typemap_name': 'int',
             })
         self.assertEqual("&*", r.get_indirect_stmt())
         self.assertEqual("int **", r.as_cast())
@@ -155,11 +167,14 @@ class CheckParse(unittest.TestCase):
                 'const': True,
                 'declarator': {
                     'name': 'var1',
-                      'pointer': [
-                          {   'const': True, 'ptr': '*'},
-                          {   'const': True, 'ptr': '*'}]},
+                    'pointer': [
+                        {'const': True, 'ptr': '*'},
+                        {'const': True, 'ptr': '*'}
+                    ],
+                    'typemap_name': 'int',
+                },
                 'specifier': ['int'],
-                'typemap_name': 'int'
+                'typemap_name': 'int',
             })
         self.assertEqual("**", r.get_indirect_stmt())
         self.assertEqual("int **", r.as_cast())
@@ -173,8 +188,11 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(
             todict.to_dict(r),
             {
-                "attrs": {"name": "ivar", "readonly": True},
-                "declarator": {"name": "m_ivar"},
+                "declarator": {
+                    "name": "m_ivar",
+                    "attrs": {"name": "ivar", "readonly": True},
+                    "typemap_name": "int",
+                },
                 "specifier": ["int"],
                 "typemap_name": "int",
             },
@@ -188,10 +206,15 @@ class CheckParse(unittest.TestCase):
         s = r.gen_decl()
         self.assertEqual("int var1[20]", s)
         self.assertEqual(
-            {'declarator': {'name': 'var1'},
-             'array': [{ 'constant': '20'}],
-             'specifier': ['int'],
-             'typemap_name': 'int'},
+            {
+                'declarator': {
+                    'name': 'var1',
+                    'array': [{ 'constant': '20'}],
+                    'typemap_name': 'int',
+                },
+                'specifier': ['int'],
+                'typemap_name': 'int',
+            },
             todict.to_dict(r)
         )
         self.assertEqual("int *", r.as_cast())
@@ -207,11 +230,14 @@ class CheckParse(unittest.TestCase):
         s = r.gen_decl()
         self.assertEqual("int var2[20][10]", s)
         self.assertEqual(
-            {'declarator': {'name': 'var2'},
-             'array': [
-                 { 'constant': '20'},
-                 { 'constant': '10'},
-             ],
+            {'declarator': {
+                'name': 'var2',
+                'array': [
+                    { 'constant': '20'},
+                    { 'constant': '10'},
+                ],
+                'typemap_name': 'int',
+            },
              'specifier': ['int'],
              'typemap_name': 'int'},
             todict.to_dict(r)
@@ -229,11 +255,15 @@ class CheckParse(unittest.TestCase):
         s = r.gen_decl()
         self.assertEqual("int var3[DEFINE+3]", s)
         self.assertEqual(
-            {'array': [
-                {'left': {'name': 'DEFINE'},
-                 'op': '+',
-                 'right': {'constant': '3'}}],
-             'declarator': {'name': 'var3'},
+            {
+             'declarator': {
+                 'name': 'var3',
+                'array': [
+                    {'left': {'name': 'DEFINE'},
+                     'op': '+',
+                     'right': {'constant': '3'}}],
+                 'typemap_name': 'int',
+             },
              'specifier': ['int'],
              'typemap_name': 'int'},
             todict.to_dict(r)
@@ -328,8 +358,11 @@ class CheckParse(unittest.TestCase):
         s = r.gen_decl()
         self.assertEqual("char var1[20]", s)
         self.assertEqual(
-            {'declarator': {'name': 'var1'},
-             'array': [{ 'constant': '20'}],
+            {'declarator': {
+                'name': 'var1',
+                'array': [{ 'constant': '20'}],
+                'typemap_name': 'char',
+            },
              'specifier': ['char'],
              'typemap_name': 'char'},
             todict.to_dict(r)
@@ -351,12 +384,15 @@ class CheckParse(unittest.TestCase):
         s = r.gen_decl()
         self.assertEqual("char var2[20][10][5]", s)
         self.assertEqual(
-            {'declarator': {'name': 'var2'},
-             'array': [
-                 { 'constant': '20'},
-                 { 'constant': '10'},
-                 { 'constant': '5'},
-             ],
+            {'declarator': {
+                'name': 'var2',
+                'array': [
+                    { 'constant': '20'},
+                    { 'constant': '10'},
+                    { 'constant': '5'},
+                ],
+                'typemap_name': 'char',
+            },
              'specifier': ['char'],
              'typemap_name': 'char'},
             todict.to_dict(r)
@@ -378,12 +414,16 @@ class CheckParse(unittest.TestCase):
         s = r.gen_decl()
         self.assertEqual("char var3[DEFINE+3]", s)
         self.assertEqual(
-            {'array': [
-                {'left': {'name': 'DEFINE'},
-                 'op': '+',
-                 'right': {'constant': '3'}}],
-             'declarator': {'name': 'var3'},
-             'specifier': ['char'],
+            {
+             'declarator': {
+                 'name': 'var3',
+                 'array': [
+                     {'left': {'name': 'DEFINE'},
+                      'op': '+',
+                      'right': {'constant': '3'}}],
+                 'typemap_name': 'char',
+             },
+            'specifier': ['char'],
              'typemap_name': 'char'},
             todict.to_dict(r)
         )
@@ -404,9 +444,13 @@ class CheckParse(unittest.TestCase):
         s = r.gen_decl()
         self.assertEqual("char * var4[44]", s)
         self.assertEqual(
-            {'array': [{'constant': '44'}],
-             'declarator': {   'name': 'var4',
-                               'pointer': [{'ptr': '*'}]},
+            {
+             'declarator': {
+                 'name': 'var4',
+                 'array': [{'constant': '44'}],
+                 'pointer': [{'ptr': '*'}],
+                 'typemap_name': 'char',
+             },
              'specifier': ['char'],
              'typemap_name': 'char'},
             todict.to_dict(r)
@@ -431,12 +475,17 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(
             todict.to_dict(r),
             {
-                "declarator": {"name": "var1"},
+                "declarator": {
+                    "name": "var1",
+                    "typemap_name": "std::vector",
+                },
                 "specifier": ["std::vector"],
                 "template_arguments": [
                     {"specifier": ["int"],
                      "typemap_name": "int",
-                     "declarator": {},
+                     "declarator": {
+                         "typemap_name": "int",
+                     },
                     }
                 ],
                 "typemap_name": "std::vector",
@@ -462,13 +511,18 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(
             todict.to_dict(r),
             {
-                "declarator": {"name": "var1"},
+                "declarator": {
+                    "name": "var1",
+                    "typemap_name": "std::vector",
+                },
                 "specifier": ["std::vector"],
                 "template_arguments": [
                     {
                         "specifier": ["long", "long"],
                         "typemap_name": "long_long",
-                        "declarator": {},
+                        "declarator": {
+                            "typemap_name": "long_long",
+                        },
                     }
                 ],
                 "typemap_name": "std::vector",
@@ -481,13 +535,18 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(
             todict.to_dict(r),
             {
-                "declarator": {"name": "var1"},
+                "declarator": {
+                    "name": "var1",
+                    "typemap_name": "std::vector",
+                },
                 "specifier": ["std::vector"],
                 "template_arguments": [
                     {
                         "specifier": ["std::string"],
                         "typemap_name": "std::string",
-                        "declarator": {},
+                        "declarator": {
+                            "typemap_name": "std::string",
+                        },
                     }
                 ],
                 "typemap_name": "std::vector",
@@ -507,12 +566,21 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(
             todict.to_dict(r),
             {
-                'declarator': {'name': 'var1'},
+                'declarator': {
+                    'name': 'var1',
+                    'typemap_name': 'std::vector'
+                },
                 'specifier': ['std::vector'],
                 'template_arguments': [
-                    { 'declarator': {'pointer': [{'ptr': '*'}]},
-                      'specifier': ['int'],
-                      'typemap_name': 'int'}],
+                    {
+                        'declarator': {
+                            'pointer': [{'ptr': '*'}],
+                            'typemap_name': 'int',
+                        },
+                        'specifier': ['int'],
+                        'typemap_name': 'int',
+                    }
+                ],
                 'typemap_name': 'std::vector'
             }
         )
@@ -652,14 +720,22 @@ class CheckParse(unittest.TestCase):
             todict.to_dict(r),
             {
                 "declarator": {
-                    "func": {"name": "func", "pointer": [{"ptr": "*"}]},
-                },
-                "params": [
-                    {
-                        "specifier": ["int"],
+                    "func": {
+                        "name": "func",
+                        "pointer": [{"ptr": "*"}],
                         "typemap_name": "int",
-                        "declarator": {},
-                    }],
+                    },
+                    "params": [
+                        {
+                            "specifier": ["int"],
+                            "typemap_name": "int",
+                            "declarator": {
+                                "typemap_name": "int",
+                            },
+                        }
+                    ],
+                    "typemap_name": "int",
+                },
                 "specifier": ["int"],
                 "typemap_name": "int",
             },
@@ -706,7 +782,10 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(
             todict.to_dict(r),
             {
-                "declarator": {"name": "foo"},
+                "declarator": {
+                    "name": "foo",
+                    "typemap_name": "void",
+                },
                 "specifier": ["void"],
                 "typemap_name": "void",
             },
@@ -725,8 +804,11 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(
             todict.to_dict(r),
             {
-                "attrs": {"alias": "junk"},
-                "declarator": {"name": "foo"},
+                "declarator": {
+                    "name": "foo",
+                    "attrs": {"alias": "junk"},
+                    "typemap_name": "void",
+                },
                 "specifier": ["void"],
                 "typemap_name": "void",
             },
@@ -745,8 +827,11 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(
             todict.to_dict(r),
             {
-                "declarator": {"name": "foo"},
-                "params": [],
+                "declarator": {
+                    "name": "foo",
+                    "params": [],
+                    "typemap_name": "void",
+                },
                 "specifier": ["void"],
                 "typemap_name": "void",
             },
@@ -769,9 +854,13 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(
             todict.to_dict(r),
             {
-                "declarator": {"name": "foo", "pointer": [{"ptr": "*"}]},
-                "func_const": True,
-                "params": [],
+                "declarator": {
+                    "name": "foo",
+                    "pointer": [{"ptr": "*"}],
+                    "params": [],
+                    "func_const": True,
+                    "typemap_name": "void",
+                },
                 "specifier": ["void"],
                 "typemap_name": "void",
             },
@@ -793,14 +882,20 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(
             todict.to_dict(r),
             {
-                "declarator": {"name": "foo"},
-                "params": [
-                    {
-                        "declarator": {"name": "arg1"},
-                        "specifier": ["int"],
-                        "typemap_name": "int",
-                    }
-                ],
+                "declarator": {
+                    "name": "foo",
+                    "params": [
+                        {
+                            "declarator": {
+                                "name": "arg1",
+                                "typemap_name": "int",
+                            },
+                            "specifier": ["int"],
+                            "typemap_name": "int",
+                        }
+                    ],
+                    "typemap_name": "void",
+                },
                 "specifier": ["void"],
                 "typemap_name": "void",
             },
@@ -819,19 +914,28 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(
             todict.to_dict(r),
             {
-                "declarator": {"name": "foo"},
-                "params": [
-                    {
-                        "declarator": {"name": "arg1"},
-                        "specifier": ["int"],
-                        "typemap_name": "int",
-                    },
-                    {
-                        "declarator": {"name": "arg2"},
-                        "specifier": ["double"],
-                        "typemap_name": "double",
-                    },
-                ],
+                "declarator": {
+                    "name": "foo",
+                    "params": [
+                        {
+                            "declarator": {
+                                "name": "arg1",
+                                "typemap_name": "int",
+                            },
+                            "specifier": ["int"],
+                            "typemap_name": "int",
+                        },
+                        {
+                            "declarator": {
+                                "name": "arg2",
+                                "typemap_name": "double",
+                            },
+                            "specifier": ["double"],
+                            "typemap_name": "double",
+                        },
+                    ],
+                    "typemap_name": "void",
+                },
                 "specifier": ["void"],
                 "typemap_name": "void",
             },
@@ -859,9 +963,13 @@ class CheckParse(unittest.TestCase):
             todict.to_dict(r),
             {
                 "const": True,
-                "declarator": {"name": "getName", "pointer": [{"ptr": "&"}]},
-                "func_const": True,
-                "params": [],
+                "declarator": {
+                    "name": "getName",
+                    "func_const": True,
+                    "pointer": [{"ptr": "&"}],
+                    "params": [],
+                    "typemap_name": "std::string",
+                },
                 "specifier": ["std::string"],
                 "typemap_name": "std::string",
             },
@@ -890,23 +998,32 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(
             todict.to_dict(r),
             {
-                "attrs": {"attr2": "True", "len": 30},
                 "const": True,
-                "declarator": {"name": "foo"},
-                "params": [
-                    {
-                        "attrs": {"in": True},
-                        "declarator": {"name": "arg1"},
-                        "specifier": ["int"],
-                        "typemap_name": "int",
-                    },
-                    {
-                        "attrs": {"out": True},
-                        "declarator": {"name": "arg2"},
-                        "specifier": ["double"],
-                        "typemap_name": "double",
-                    },
-                ],
+                "declarator": {
+                    "name": "foo",
+                    "attrs": {"attr2": "True", "len": 30},
+                    "params": [
+                        {
+                            "declarator": {
+                                "name": "arg1",
+                                "attrs": {"in": True},
+                                "typemap_name": "int",
+                            },
+                            "specifier": ["int"],
+                            "typemap_name": "int",
+                        },
+                        {
+                            "declarator": {
+                                "name": "arg2",
+                                "attrs": {"out": True},
+                                "typemap_name": "double",
+                            },
+                            "specifier": ["double"],
+                            "typemap_name": "double",
+                        },
+                    ],
+                    "typemap_name": "void",
+                },
                 "specifier": ["void"],
                 "typemap_name": "void",
             },
@@ -927,11 +1044,13 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(
             todict.to_dict(r),
             {
-                "attrs": {"_constructor": True, "_name": "ctor"},
-                "params": [],
                 "specifier": ["Class1"],
                 "typemap_name": "Class1",
-                'declarator': {},
+                'declarator': {
+                    "attrs": {"_constructor": True, "_name": "ctor"},
+                    "params": [],
+                    "typemap_name": "Class1",
+                },
             },
         )
         self.assertEqual("ctor", r.get_name())
@@ -956,11 +1075,13 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(
             todict.to_dict(r),
             {
-                "attrs": {"_constructor": True, "_name": "ctor", "name": "new"},
-                "params": [],
                 "specifier": ["Class1"],
                 "typemap_name": "Class1",
-                'declarator': {},
+                'declarator': {
+                    "attrs": {"_constructor": True, "_name": "ctor", "name": "new"},
+                    "params": [],
+                    "typemap_name": "Class1",
+                },
             },
         )
         self.assertEqual("new", r.get_name())
@@ -984,11 +1105,13 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(
             todict.to_dict(r),
             {
-                "attrs": {"_destructor": "Class1", "_name": "dtor"},
-                "params": [],
                 "specifier": ["void"],
                 "typemap_name": "void",
-                'declarator': {},
+                'declarator': {
+                    "attrs": {"_destructor": "Class1", "_name": "dtor"},
+                    "params": [],
+                    "typemap_name": "void",
+                },
             },
         )
         self.assertEqual("dtor", r.get_name())
@@ -1017,7 +1140,9 @@ class CheckParse(unittest.TestCase):
                 },
                 'specifier': ['class Class2'],
                 'typemap_name': 'Class2',
-                "declarator": {},
+                "declarator": {
+                    'typemap_name': 'Class2',
+                },
             }
         )
 
@@ -1056,8 +1181,12 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(
             todict.to_dict(r),
             {
-                "declarator": {"name": "make", "pointer": [{"ptr": "*"}]},
-                "params": [],
+                "declarator": {
+                    "name": "make",
+                    "pointer": [{"ptr": "*"}],
+                    "params": [],
+                    "typemap_name": "Class1",
+                },
                 "specifier": ["Class1"],
                 "typemap_name": "Class1",
             },
@@ -1090,33 +1219,48 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(
             todict.to_dict(r),
             {
-                "declarator": {"name": "name"},
-                "params": [
-                    {
-                        "declarator": {"name": "arg1"},
-                        "init": 0,
-                        "specifier": ["int"],
-                        "typemap_name": "int",
-                    },
-                    {
-                        "declarator": {"name": "arg2"},
-                        "init": 0.0,
-                        "specifier": ["double"],
-                        "typemap_name": "double",
-                    },
-                    {
-                        "declarator": {"name": "arg3"},
-                        "init": '"name"',
-                        "specifier": ["std::string"],
-                        "typemap_name": "std::string",
-                    },
-                    {
-                        "declarator": {"name": "arg4"},
-                        "init": "true",
-                        "specifier": ["bool"],
-                        "typemap_name": "bool",
-                    },
-                ],
+                "declarator": {
+                    "name": "name",
+                    "params": [
+                        {
+                            "declarator": {
+                                "name": "arg1",
+                                "init": 0,
+                                "typemap_name": "int",
+                            },
+                            "specifier": ["int"],
+                            "typemap_name": "int",
+                        },
+                        {
+                            "declarator": {
+                                "name": "arg2",
+                                "init": 0.0,
+                                "typemap_name": "double",
+                            },
+                            "specifier": ["double"],
+                            "typemap_name": "double",
+                        },
+                        {
+                            "declarator": {
+                                "name": "arg3",
+                                "init": '"name"',
+                                "typemap_name": "std::string",
+                            },
+                            "specifier": ["std::string"],
+                            "typemap_name": "std::string",
+                        },
+                        {
+                            "declarator": {
+                                "name": "arg4",
+                                "init": "true",
+                                "typemap_name": "bool",
+                            },
+                            "specifier": ["bool"],
+                            "typemap_name": "bool",
+                        },
+                    ],
+                    "typemap_name": "void",
+                },
                 "specifier": ["void"],
                 "typemap_name": "void",
             },
@@ -1138,14 +1282,19 @@ class CheckParse(unittest.TestCase):
             todict.to_dict(r),
             {
                 "decl": {
-                    "declarator": {"name": "decl11"},
-                    "params": [
-                        {
-                            "declarator": {"name": "arg"},
-                            "specifier": ["ArgType"],
-                            "template_argument": "ArgType",
-                        }
-                    ],
+                    "declarator": {
+                        "name": "decl11",
+                        "params": [
+                            {
+                                "declarator": {
+                                    "name": "arg",
+                                },
+                                "specifier": ["ArgType"],
+                                "template_argument": "ArgType",
+                            }
+                        ],
+                        "typemap_name": "void",
+                    },
                     "specifier": ["void"],
                     "typemap_name": "void",
                 },
@@ -1175,26 +1324,37 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(
             todict.to_dict(r),
             {
-                "declarator": {"name": "decl12"},
-                "params": [
-                    {
-                        "declarator": {"name": "arg1"},
-                        "specifier": ["std::vector"],
-                        "template_arguments": [
-                            {
-                                "specifier": ["std::string"],
+                "declarator": {
+                    "name": "decl12",
+                    "typemap_name": "void",
+                    "params": [
+                        {
+                            "declarator": {
+                                "name": "arg1",
+                                "typemap_name": "std::vector",
+                            },
+                            "specifier": ["std::vector"],
+                            "template_arguments": [
+                                {
+                                    "specifier": ["std::string"],
+                                    "typemap_name": "std::string",
+                                    "declarator": {
+                                        "typemap_name": "std::string",
+                                    },
+                                }
+                            ],
+                            "typemap_name": "std::vector",
+                        },
+                        {
+                            "declarator": {
+                                "name": "arg2",
                                 "typemap_name": "std::string",
-                                "declarator": {},
-                            }
-                        ],
-                        "typemap_name": "std::vector",
-                    },
-                    {
-                        "declarator": {"name": "arg2"},
-                        "specifier": ["string"],
-                        "typemap_name": "std::string",
-                    },
-                ],
+                            },
+                            "specifier": ["string"],
+                            "typemap_name": "std::string",
+                        },
+                    ],
+                },
                 "specifier": ["void"],
                 "typemap_name": "void",
             },
@@ -1237,7 +1397,9 @@ class CheckParse(unittest.TestCase):
                     'class_specifier': {'name': 'vector'},
                     'specifier': ['class vector'],
                     'typemap_name': 'vector',
-                    'declarator': {},
+                    'declarator': {
+                        'typemap_name': 'vector',
+                    },
                 },
                 'parameters': [{'name': 'T'}]
             }
@@ -1255,7 +1417,9 @@ class CheckParse(unittest.TestCase):
                     'class_specifier': {'name': 'map'},
                     'specifier': ['class map'],
                     'typemap_name': 'vector::map',
-                    'declarator': {},
+                    'declarator': {
+                        'typemap_name': 'vector::map',
+                    },
                 },
                 'parameters': [{'name': 'Key'}, {'name': 'T'}]
             }
@@ -1310,7 +1474,10 @@ struct Cstruct_list {
         ast = members[0]
         self.assertEqual(
             todict.to_dict(ast), {
-                'declarator': {'name': 'nitems'},
+                'declarator': {
+                    'name': 'nitems',
+                    'typemap_name': 'int'
+                },
                 'specifier': ['int'],
                 'typemap_name': 'int'
             })
@@ -1319,10 +1486,11 @@ struct Cstruct_list {
             todict.to_dict(ast), {
                 'declarator': {
                     'name': 'ivalue',
-                    'pointer': [{   'ptr': '*'}]
+                    'pointer': [{   'ptr': '*'}],
+                    'typemap_name': 'int',
                 },
                 'specifier': ['int'],
-                'typemap_name': 'int'
+                'typemap_name': 'int',
             })
 
 
@@ -1437,7 +1605,10 @@ class CheckTypedef(unittest.TestCase):
         self.assertDictEqual(
             todict.to_dict(r),
             {
-                "declarator": {"name": "TypeID"},
+                "declarator": {
+                    "name": "TypeID",
+                    "typemap_name": "int",
+                },
                 "specifier": ["int"],
                 "storage": ["typedef"],
                 "typemap_name": "TypeID",
@@ -1494,8 +1665,10 @@ class CheckEnum(unittest.TestCase):
                     ],
                 },
                 'specifier': ['enum Color'],
+                "declarator": {
+                    'typemap_name': 'Color',
+                },
                 'typemap_name': 'Color',
-                "declarator": {},
             }
         )
 
@@ -1542,20 +1715,29 @@ class CheckStruct(unittest.TestCase):
                 'class_specifier': {
                     'members': [
                         {
-                            'declarator': {'name': 'i'},
+                            'declarator': {
+                                'name': 'i',
+                                'typemap_name': 'int'
+                            },
                             'specifier': ['int'],
                             'typemap_name': 'int'
                         },{
-                            'declarator': {'name': 'd'},
+                            'declarator': {
+                                'name': 'd',
+                                'typemap_name': 'double',
+                            },
                             'specifier': ['double'],
-                            'typemap_name': 'double'}
+                            'typemap_name': 'double',
+                        },
                     ],
                     'name': 'struct1',
                     'typemap_name': 'struct1'
                 },
                 'specifier': ['struct struct1'],
+                "declarator": {
+                    'typemap_name': 'struct1',
+                },
                 'typemap_name': 'struct1',
-                "declarator": {},
             }
         )
 
@@ -1572,8 +1754,10 @@ class CheckClass(unittest.TestCase):
             {
                 'class_specifier': {'name': 'Class1'},
                 'specifier': ['class Class1'],
+                'declarator': {
+                    'typemap_name': 'Class1',
+                },
                 'typemap_name': 'Class1',
-                'declarator': {},
             }
         )
 

--- a/tests/test_declast.py
+++ b/tests/test_declast.py
@@ -712,10 +712,10 @@ class CheckParse(unittest.TestCase):
         self.assertFalse(declarator.is_reference())
         self.assertTrue(declarator.is_function_pointer())
 
-        self.assertNotEqual(None, r.params)
-        self.assertEqual(1, len(r.params))
+        self.assertNotEqual(None, declarator.params)
+        self.assertEqual(1, len(declarator.params))
 
-        param0 = r.params[0]
+        param0 = declarator.params[0]
         s = param0.gen_decl()
         self.assertEqual("int", s)
         self.assertEqual("int", param0.typemap.name)
@@ -773,10 +773,10 @@ class CheckParse(unittest.TestCase):
         self.assertFalse(declarator.is_reference())
         self.assertTrue(declarator.is_function_pointer())
 
-        self.assertNotEqual(None, r.params)
-        self.assertEqual(1, len(r.params))
+        self.assertNotEqual(None, declarator.params)
+        self.assertEqual(1, len(declarator.params))
 
-        param0 = r.params[0]
+        param0 = declarator.params[0]
         s = param0.gen_decl()
         self.assertEqual("int * arg", s)
         self.assertEqual("int", param0.typemap.name)
@@ -1394,14 +1394,15 @@ class CheckParse(unittest.TestCase):
             symtab
         )
 
-        self.assertEqual(["long", "int"], r.params[0].specifier)
-        self.assertEqual("long", r.params[0].typemap.name)
+        params = r.declarator.params
+        self.assertEqual(["long", "int"], params[0].specifier)
+        self.assertEqual("long", params[0].typemap.name)
 
-        self.assertEqual(["long", "long"], r.params[1].specifier)
-        self.assertEqual("long_long", r.params[1].typemap.name)
+        self.assertEqual(["long", "long"], params[1].specifier)
+        self.assertEqual("long_long", params[1].typemap.name)
 
-        self.assertEqual(["unsigned", "int"], r.params[2].specifier)
-        self.assertEqual("unsigned_int", r.params[2].typemap.name)
+        self.assertEqual(["unsigned", "int"], params[2].specifier)
+        self.assertEqual("unsigned_int", params[2].typemap.name)
 
     def test_class_template(self):
         """Class templates"""

--- a/tests/test_declast.py
+++ b/tests/test_declast.py
@@ -31,16 +31,18 @@ class CheckParse(unittest.TestCase):
         symtab = declast.SymbolTable()
 
         r = declast.check_decl("int", symtab)
-        self.assertIsNone(r.get_subprogram())
-        self.assertEqual(0, r.is_pointer())
+        declarator = r.declarator
+        self.assertIsNone(declarator.get_subprogram())
+        self.assertEqual(0, declarator.is_pointer())
         s = r.gen_decl()
         self.assertEqual("int", s)
-        self.assertEqual("scalar", r.get_indirect_stmt())
-        self.assertEqual(None, r.get_array_size())
+        self.assertEqual("scalar", declarator.get_indirect_stmt())
+        self.assertEqual(None, declarator.get_array_size())
 
         r = declast.check_decl("int var1", symtab)
-        self.assertIsNone(r.get_subprogram())
-        self.assertEqual(0, r.is_pointer())
+        declarator = r.declarator
+        self.assertIsNone(declarator.get_subprogram())
+        self.assertEqual(0, declarator.is_pointer())
         s = r.gen_decl()
         self.assertEqual("int var1", s)
         s = r.bind_c()
@@ -51,8 +53,9 @@ class CheckParse(unittest.TestCase):
         self.assertEqual("integer(C_INT) :: var1", s)
 
         r = declast.check_decl("const int var1", symtab)
-        self.assertIsNone(r.get_subprogram())
-        self.assertEqual(0, r.is_pointer())
+        declarator = r.declarator
+        self.assertIsNone(declarator.get_subprogram())
+        self.assertEqual(0, declarator.is_pointer())
         s = r.gen_decl()
         self.assertEqual("const int var1", s)
         self.assertEqual("const int var1", r.gen_arg_as_c())
@@ -73,7 +76,7 @@ class CheckParse(unittest.TestCase):
                 'specifier': ['int'],
                 'typemap_name': 'int',
             })
-        self.assertEqual("scalar", r.get_indirect_stmt())
+        self.assertEqual("scalar", declarator.get_indirect_stmt())
 
         r = declast.check_decl("int const var1", symtab)
         s = r.gen_decl()
@@ -87,10 +90,11 @@ class CheckParse(unittest.TestCase):
                 },
                 'specifier': ['int'],
                 'typemap_name': 'int'})
-        self.assertEqual("scalar", r.get_indirect_stmt())
+        self.assertEqual("scalar", declarator.get_indirect_stmt())
         r = declast.check_decl("int *var1 +dimension(:)", symtab)
-        self.assertIsNone(r.get_subprogram())
-        self.assertEqual(1, r.is_pointer())
+        declarator = r.declarator
+        self.assertIsNone(declarator.get_subprogram())
+        self.assertEqual(1, declarator.is_pointer())
         s = r.gen_decl()
         self.assertEqual("int * var1 +dimension(:)", s)
         self.assertEqual("int * var1", r.gen_arg_as_c())
@@ -113,6 +117,7 @@ class CheckParse(unittest.TestCase):
         self.assertEqual("int *", r.as_cast())
 
         r = declast.check_decl("int * const var1", symtab)
+        declarator = r.declarator
         s = r.gen_decl()
         self.assertEqual("int * const var1", s)
         self.assertEqual(
@@ -124,10 +129,11 @@ class CheckParse(unittest.TestCase):
                 },
                 'specifier': ['int'],
                 'typemap_name': 'int'})
-        self.assertEqual("*", r.get_indirect_stmt())
-        self.assertEqual(None, r.get_array_size())
+        self.assertEqual("*", declarator.get_indirect_stmt())
+        self.assertEqual(None, declarator.get_array_size())
 
         r = declast.check_decl("int **var1", symtab)
+        declarator = r.declarator
         s = r.gen_decl()
         self.assertEqual("int * * var1", s)
         self.assertEqual(
@@ -140,10 +146,11 @@ class CheckParse(unittest.TestCase):
                 'specifier': ['int'],
                 'typemap_name': 'int'
             })
-        self.assertEqual("**", r.get_indirect_stmt())
-        self.assertEqual(None, r.get_array_size())
+        self.assertEqual("**", declarator.get_indirect_stmt())
+        self.assertEqual(None, declarator.get_array_size())
 
         r = declast.check_decl("int &*var1", symtab)
+        declarator = r.declarator
         s = r.gen_decl()
         self.assertEqual("int & * var1", s)
         self.assertEqual(
@@ -156,10 +163,11 @@ class CheckParse(unittest.TestCase):
                 'specifier': ['int'],
                 'typemap_name': 'int',
             })
-        self.assertEqual("&*", r.get_indirect_stmt())
+        self.assertEqual("&*", declarator.get_indirect_stmt())
         self.assertEqual("int **", r.as_cast())
 
         r = declast.check_decl("const int * const * const var1", symtab)
+        declarator = r.declarator
         s = r.gen_decl()
         self.assertEqual("const int * const * const var1", s)
         self.assertEqual(
@@ -176,7 +184,7 @@ class CheckParse(unittest.TestCase):
                 'specifier': ['int'],
                 'typemap_name': 'int',
             })
-        self.assertEqual("**", r.get_indirect_stmt())
+        self.assertEqual("**", declarator.get_indirect_stmt())
         self.assertEqual("int **", r.as_cast())
 
         r = declast.check_decl("long long var2", symtab)
@@ -314,9 +322,10 @@ class CheckParse(unittest.TestCase):
         self.assertEqual("character(len=:), allocatable :: var1", s)
 
         r = declast.check_decl("char **var1", symtab)
-        self.assertEqual(2, r.is_indirect())
-        self.assertEqual(2, r.is_array())
-        self.assertEqual('**', r.get_indirect_stmt())
+        declarator = r.declarator
+        self.assertEqual(2, declarator.is_indirect())
+        self.assertEqual(2, declarator.is_array())
+        self.assertEqual('**', declarator.get_indirect_stmt())
         self.assertEqual("char **", r.as_cast())
         s = r.gen_decl()
         self.assertEqual("char * * var1", s)
@@ -349,12 +358,13 @@ class CheckParse(unittest.TestCase):
         symtab = declast.SymbolTable()
 
         r = declast.check_decl("char var1[20]", symtab)
+        declarator = r.declarator
         self.assertEqual("char var1[20]", str(r))
-        self.assertEqual(0, r.is_indirect())
-        self.assertEqual(1, r.is_array())
+        self.assertEqual(0, declarator.is_indirect())
+        self.assertEqual(1, declarator.is_array())
         self.assertEqual("char *", r.as_cast())
-        self.assertEqual('[]', r.get_indirect_stmt())
-        self.assertEqual("20", r.get_array_size())
+        self.assertEqual('[]', declarator.get_indirect_stmt())
+        self.assertEqual("20", declarator.get_array_size())
         s = r.gen_decl()
         self.assertEqual("char var1[20]", s)
         self.assertEqual(
@@ -375,11 +385,12 @@ class CheckParse(unittest.TestCase):
             r.gen_arg_as_fortran())
         
         r = declast.check_decl("char var2[20][10][5]", symtab)
-        self.assertEqual(0, r.is_indirect())
-        self.assertEqual(1, r.is_array())
+        declarator = r.declarator
+        self.assertEqual(0, declarator.is_indirect())
+        self.assertEqual(1, declarator.is_array())
         self.assertEqual("char *", r.as_cast())
-        self.assertEqual('[]', r.get_indirect_stmt())
-        self.assertEqual("(20)*(10)*(5)", r.get_array_size())
+        self.assertEqual('[]', declarator.get_indirect_stmt())
+        self.assertEqual("(20)*(10)*(5)", declarator.get_array_size())
         self.assertEqual("char var2[20][10][5]", str(r))
         s = r.gen_decl()
         self.assertEqual("char var2[20][10][5]", s)
@@ -405,11 +416,12 @@ class CheckParse(unittest.TestCase):
             r.gen_arg_as_fortran())
         
         r = declast.check_decl("char var3[DEFINE + 3]", symtab)
-        self.assertEqual(0, r.is_indirect())
-        self.assertEqual(1, r.is_array())
+        declarator = r.declarator
+        self.assertEqual(0, declarator.is_indirect())
+        self.assertEqual(1, declarator.is_array())
         self.assertEqual("char *", r.as_cast())
-        self.assertEqual('[]', r.get_indirect_stmt())
-        self.assertEqual("DEFINE+3", r.get_array_size())
+        self.assertEqual('[]', declarator.get_indirect_stmt())
+        self.assertEqual("DEFINE+3", declarator.get_array_size())
         self.assertEqual("char var3[DEFINE+3]", str(r))
         s = r.gen_decl()
         self.assertEqual("char var3[DEFINE+3]", s)
@@ -435,12 +447,13 @@ class CheckParse(unittest.TestCase):
             r.gen_arg_as_fortran())
     
         r = declast.check_decl("char *var4[44]", symtab)
+        declarator = r.declarator
         self.assertEqual("char * var4[44]", str(r))
-        self.assertEqual(1, r.is_indirect())
-        self.assertEqual(2, r.is_array())
+        self.assertEqual(1, declarator.is_indirect())
+        self.assertEqual(2, declarator.is_array())
         self.assertEqual("char **", r.as_cast())
-        self.assertEqual('*[]', r.get_indirect_stmt())
-        self.assertEqual("44", r.get_array_size())
+        self.assertEqual('*[]', declarator.get_indirect_stmt())
+        self.assertEqual("44", declarator.get_array_size())
         s = r.gen_decl()
         self.assertEqual("char * var4[44]", s)
         self.assertEqual(
@@ -665,6 +678,7 @@ class CheckParse(unittest.TestCase):
         symtab = declast.SymbolTable()
 
         r = declast.check_decl("int var1(int arg1) const", symtab)
+        declarator = r.declarator
         s = r.gen_decl()
         self.assertEqual("int var1(int arg1) const", s)
 
@@ -675,8 +689,8 @@ class CheckParse(unittest.TestCase):
         self.assertEqual("int newname", s)
 
         self.assertEqual("int", r.typemap.name)
-        self.assertFalse(r.is_pointer())
-        self.assertEqual("function", r.get_subprogram())
+        self.assertFalse(declarator.is_pointer())
+        self.assertEqual("function", declarator.get_subprogram())
 
         self.assertIsNotNone(r.find_arg_by_name("arg1"))
         self.assertIsNone(r.find_arg_by_name("argnone"))
@@ -687,15 +701,16 @@ class CheckParse(unittest.TestCase):
         symtab = declast.SymbolTable()
 
         r = declast.check_decl("int (*func)(int)", symtab)
+        declarator = r.declarator
 
         s = r.gen_decl()
         self.assertEqual("int ( * func)(int)", s)
 
         self.assertEqual("int", r.typemap.name)
         self.assertEqual("func", r.name)
-        self.assertFalse(r.is_pointer())
-        self.assertFalse(r.is_reference())
-        self.assertTrue(r.is_function_pointer())
+        self.assertFalse(declarator.is_pointer())
+        self.assertFalse(declarator.is_reference())
+        self.assertTrue(declarator.is_function_pointer())
 
         self.assertNotEqual(None, r.params)
         self.assertEqual(1, len(r.params))
@@ -705,9 +720,9 @@ class CheckParse(unittest.TestCase):
         self.assertEqual("int", s)
         self.assertEqual("int", param0.typemap.name)
         self.assertEqual(None, param0.name)
-        self.assertFalse(param0.is_pointer())
-        self.assertFalse(param0.is_reference())
-        self.assertFalse(param0.is_function_pointer())
+        self.assertFalse(param0.declarator.is_pointer())
+        self.assertFalse(param0.declarator.is_reference())
+        self.assertFalse(param0.declarator.is_function_pointer())
 
         s = r.gen_decl()
         self.assertEqual("int ( * func)(int)", s)
@@ -747,15 +762,16 @@ class CheckParse(unittest.TestCase):
         symtab = declast.SymbolTable()
 
         r = declast.check_decl("int *(*func)(int *arg)", symtab)
+        declarator = r.declarator
 
         s = r.gen_decl()
         self.assertEqual("int * ( * func)(int * arg)", s)
 
         self.assertEqual("int", r.typemap.name)
         self.assertEqual("func", r.name)
-        self.assertTrue(r.is_pointer())
-        self.assertFalse(r.is_reference())
-        self.assertTrue(r.is_function_pointer())
+        self.assertTrue(declarator.is_pointer())
+        self.assertFalse(declarator.is_reference())
+        self.assertTrue(declarator.is_function_pointer())
 
         self.assertNotEqual(None, r.params)
         self.assertEqual(1, len(r.params))
@@ -765,9 +781,9 @@ class CheckParse(unittest.TestCase):
         self.assertEqual("int * arg", s)
         self.assertEqual("int", param0.typemap.name)
         self.assertEqual("arg", param0.name)
-        self.assertTrue(param0.is_pointer())
-        self.assertFalse(param0.is_reference())
-        self.assertFalse(param0.is_function_pointer())
+        self.assertTrue(param0.declarator.is_pointer())
+        self.assertFalse(param0.declarator.is_reference())
+        self.assertFalse(param0.declarator.is_function_pointer())
 
     # decl
     def test_decl01(self):
@@ -797,6 +813,7 @@ class CheckParse(unittest.TestCase):
         symtab = declast.SymbolTable()
 
         r = declast.check_decl("void foo +alias(junk)", symtab)
+        declarator = r.declarator
 
         s = r.gen_decl()
         self.assertEqual("void foo +alias(junk)", s)
@@ -820,6 +837,7 @@ class CheckParse(unittest.TestCase):
         symtab = declast.SymbolTable()
 
         r = declast.check_decl("void foo()", symtab)
+        declarator = r.declarator
 
         s = r.gen_decl()
         self.assertEqual("void foo(void)", s)
@@ -838,8 +856,8 @@ class CheckParse(unittest.TestCase):
         )
         self.assertEqual("foo", r.get_name())
         self.assertEqual("void", r.typemap.name)
-        self.assertFalse(r.is_pointer())
-        self.assertEqual("subroutine", r.get_subprogram())
+        self.assertFalse(declarator.is_pointer())
+        self.assertEqual("subroutine", declarator.get_subprogram())
         self.assertIsNone(r.find_arg_by_name("argnone"))
 
     def test_decl04(self):
@@ -847,6 +865,7 @@ class CheckParse(unittest.TestCase):
         symtab = declast.SymbolTable()
 
         r = declast.check_decl("void *foo() const", symtab)
+        declarator = r.declarator
 
         s = r.gen_decl()
         self.assertEqual("void * foo(void) const", s)
@@ -867,8 +886,8 @@ class CheckParse(unittest.TestCase):
         )
         self.assertEqual("foo", r.get_name())
         self.assertEqual("void", r.typemap.name)
-        self.assertTrue(r.is_pointer())
-        self.assertEqual("function", r.get_subprogram())
+        self.assertTrue(declarator.is_pointer())
+        self.assertEqual("function", declarator.get_subprogram())
 
     def test_decl05(self):
         """Single argument"""
@@ -952,12 +971,13 @@ class CheckParse(unittest.TestCase):
         symtab.create_std_namespace()
         
         r = declast.check_decl("const std::string& getName() const", symtab)
+        declarator = r.declarator
 
         s = r.gen_decl()
         self.assertEqual("const std::string & getName(void) const", s)
-        self.assertFalse(r.is_pointer())
-        self.assertTrue(r.is_reference())
-        self.assertEqual(1, r.is_indirect())
+        self.assertFalse(declarator.is_pointer())
+        self.assertTrue(declarator.is_reference())
+        self.assertEqual(1, declarator.is_indirect())
 
         self.assertEqual(
             todict.to_dict(r),
@@ -1037,6 +1057,7 @@ class CheckParse(unittest.TestCase):
         declast.check_decl("class Class1", symtab)
         
         r = declast.check_decl("Class1()", symtab)
+        declarator = r.declarator
 
         s = r.gen_decl()
         self.assertEqual("Class1(void)", s)
@@ -1054,8 +1075,8 @@ class CheckParse(unittest.TestCase):
             },
         )
         self.assertEqual("ctor", r.get_name())
-        self.assertFalse(r.is_pointer())
-        self.assertFalse(r.is_reference())
+        self.assertFalse(declarator.is_pointer())
+        self.assertFalse(declarator.is_reference())
         # must provide the name since the ctor has no name
         # cxx_type and c_type are not defined yet
         self.assertEqual("--NOTYPE-- ctor(void)", r.gen_arg_as_cxx())
@@ -1068,6 +1089,7 @@ class CheckParse(unittest.TestCase):
         declast.check_decl("class Class1", symtab)
 
         r = declast.check_decl("Class1() +name(new)", symtab)
+        declarator = r.declarator
 
         s = r.gen_decl()
         self.assertEqual("Class1(void) +name(new)", s)
@@ -1085,9 +1107,9 @@ class CheckParse(unittest.TestCase):
             },
         )
         self.assertEqual("new", r.get_name())
-        self.assertFalse(r.is_pointer())
-        self.assertFalse(r.is_reference())
-        self.assertEqual(0, r.is_indirect())
+        self.assertFalse(declarator.is_pointer())
+        self.assertFalse(declarator.is_reference())
+        self.assertEqual(0, declarator.is_indirect())
         self.assertEqual("--NOTYPE-- new", r.gen_arg_as_cxx(params=None))
         self.assertEqual("--NOTYPE-- * new(void)", r.gen_arg_as_c())
 
@@ -1098,6 +1120,7 @@ class CheckParse(unittest.TestCase):
         declast.check_decl("class Class1", symtab)
         
         r = declast.check_decl("~Class1(void)", symtab)
+        declarator = r.declarator
 
         s = r.gen_decl()
         self.assertEqual("~Class1(void)", s)
@@ -1115,9 +1138,9 @@ class CheckParse(unittest.TestCase):
             },
         )
         self.assertEqual("dtor", r.get_name())
-        self.assertFalse(r.is_pointer())
-        self.assertFalse(r.is_reference())
-        self.assertEqual(0, r.is_indirect())
+        self.assertFalse(declarator.is_pointer())
+        self.assertFalse(declarator.is_reference())
+        self.assertEqual(0, declarator.is_indirect())
         self.assertEqual("void dtor(void)", r.gen_arg_as_cxx())
         self.assertEqual("void dtor(void)", r.gen_arg_as_c())
 
@@ -1449,7 +1472,8 @@ class CheckParse(unittest.TestCase):
             "const std::string& arg2 )",
             symtab
         )
-        self.assertTrue(r.is_reference())
+        declarator = r.declarator
+        self.assertTrue(declarator.is_reference())
         self.assertEqual(r.name, "Function4b")
 
         r2 = copy.deepcopy(r)

--- a/tests/test_declast.py
+++ b/tests/test_declast.py
@@ -692,8 +692,8 @@ class CheckParse(unittest.TestCase):
         self.assertFalse(declarator.is_pointer())
         self.assertEqual("function", declarator.get_subprogram())
 
-        self.assertIsNotNone(r.find_arg_by_name("arg1"))
-        self.assertIsNone(r.find_arg_by_name("argnone"))
+        self.assertIsNotNone(declarator.find_arg_by_name("arg1"))
+        self.assertIsNone(declarator.find_arg_by_name("argnone"))
 
     def test_type_function_pointer1(self):
         """Function pointer
@@ -858,7 +858,7 @@ class CheckParse(unittest.TestCase):
         self.assertEqual("void", r.typemap.name)
         self.assertFalse(declarator.is_pointer())
         self.assertEqual("subroutine", declarator.get_subprogram())
-        self.assertIsNone(r.find_arg_by_name("argnone"))
+        self.assertIsNone(declarator.find_arg_by_name("argnone"))
 
     def test_decl04(self):
         """const method"""
@@ -926,6 +926,7 @@ class CheckParse(unittest.TestCase):
         symtab = declast.SymbolTable()
 
         r = declast.check_decl("void foo(int arg1, double arg2)", symtab)
+        declarator = r.declarator
 
         s = r.gen_decl()
         self.assertEqual("void foo(int arg1, double arg2)", s)
@@ -961,9 +962,9 @@ class CheckParse(unittest.TestCase):
         )
         self.assertEqual("foo", r.get_name())
 
-        self.assertIsNotNone(r.find_arg_by_name("arg1"))
-        self.assertIsNotNone(r.find_arg_by_name("arg2"))
-        self.assertIsNone(r.find_arg_by_name("argnone"))
+        self.assertIsNotNone(declarator.find_arg_by_name("arg1"))
+        self.assertIsNotNone(declarator.find_arg_by_name("arg2"))
+        self.assertIsNone(declarator.find_arg_by_name("argnone"))
 
     def test_decl07(self):
         """Return string"""

--- a/tests/test_declast.py
+++ b/tests/test_declast.py
@@ -67,7 +67,7 @@ class CheckParse(unittest.TestCase):
         )
         self.assertEqual("int", r.as_cast())
         self.assertEqual(
-            todict.to_dict(r), {
+            {
                 'const': True,
                 'declarator': {
                     'name': 'var1',
@@ -75,7 +75,9 @@ class CheckParse(unittest.TestCase):
                 },
                 'specifier': ['int'],
                 'typemap_name': 'int',
-            })
+            },
+            todict.to_dict(r)
+        )
         self.assertEqual("scalar", declarator.get_indirect_stmt())
 
         r = declast.check_decl("int const var1", symtab)
@@ -120,15 +122,16 @@ class CheckParse(unittest.TestCase):
         declarator = r.declarator
         s = r.gen_decl()
         self.assertEqual("int * const var1", s)
-        self.assertEqual(
-            todict.to_dict(r), {
-                'declarator': {
-                    'name': 'var1',
-                    'pointer': [{'const': True, 'ptr': '*'}],
-                    'typemap_name': 'int',
-                },
-                'specifier': ['int'],
-                'typemap_name': 'int'})
+        self.assertEqual({
+            'declarator': {
+                'name': 'var1',
+                'pointer': [{'const': True, 'ptr': '*'}],
+                'typemap_name': 'int',
+            },
+            'specifier': ['int'],
+            'typemap_name': 'int'},
+            todict.to_dict(r)
+        )
         self.assertEqual("*", declarator.get_indirect_stmt())
         self.assertEqual(None, declarator.get_array_size())
 
@@ -137,7 +140,7 @@ class CheckParse(unittest.TestCase):
         s = r.gen_decl()
         self.assertEqual("int * * var1", s)
         self.assertEqual(
-            todict.to_dict(r), {
+            {
                 'declarator': {
                     'name': 'var1',
                     'pointer': [{'ptr': '*'}, {'ptr': '*'}],
@@ -145,7 +148,9 @@ class CheckParse(unittest.TestCase):
                 },
                 'specifier': ['int'],
                 'typemap_name': 'int'
-            })
+            },
+            todict.to_dict(r)
+        )
         self.assertEqual("**", declarator.get_indirect_stmt())
         self.assertEqual(None, declarator.get_array_size())
 
@@ -154,7 +159,7 @@ class CheckParse(unittest.TestCase):
         s = r.gen_decl()
         self.assertEqual("int & * var1", s)
         self.assertEqual(
-            todict.to_dict(r), {
+            {
                 'declarator': {
                     'name': 'var1',
                     'pointer': [{   'ptr': '&'}, {   'ptr': '*'}],
@@ -162,7 +167,9 @@ class CheckParse(unittest.TestCase):
                 },
                 'specifier': ['int'],
                 'typemap_name': 'int',
-            })
+            },
+            todict.to_dict(r)
+        )
         self.assertEqual("&*", declarator.get_indirect_stmt())
         self.assertEqual("int **", r.as_cast())
 
@@ -171,7 +178,7 @@ class CheckParse(unittest.TestCase):
         s = r.gen_decl()
         self.assertEqual("const int * const * const var1", s)
         self.assertEqual(
-            todict.to_dict(r), {
+            {
                 'const': True,
                 'declarator': {
                     'name': 'var1',
@@ -183,7 +190,9 @@ class CheckParse(unittest.TestCase):
                 },
                 'specifier': ['int'],
                 'typemap_name': 'int',
-            })
+            },
+            todict.to_dict(r)
+        )
         self.assertEqual("**", declarator.get_indirect_stmt())
         self.assertEqual("int **", r.as_cast())
 
@@ -194,7 +203,6 @@ class CheckParse(unittest.TestCase):
         # test attributes
         r = declast.check_decl("int m_ivar +readonly +name(ivar)", symtab)
         self.assertEqual(
-            todict.to_dict(r),
             {
                 "declarator": {
                     "name": "m_ivar",
@@ -204,6 +212,7 @@ class CheckParse(unittest.TestCase):
                 "specifier": ["int"],
                 "typemap_name": "int",
             },
+            todict.to_dict(r)
         )
 
     def test_type_int_array(self):
@@ -486,7 +495,6 @@ class CheckParse(unittest.TestCase):
         s = r.gen_decl()
         self.assertEqual("std::vector<int> var1", s)
         self.assertEqual(
-            todict.to_dict(r),
             {
                 "declarator": {
                     "name": "var1",
@@ -503,6 +511,7 @@ class CheckParse(unittest.TestCase):
                 ],
                 "typemap_name": "std::vector",
             },
+            todict.to_dict(r)
         )
         # C
         s = r.gen_arg_as_c()
@@ -522,7 +531,6 @@ class CheckParse(unittest.TestCase):
         s = r.gen_decl()
         self.assertEqual("std::vector<long long> var1", s)
         self.assertEqual(
-            todict.to_dict(r),
             {
                 "declarator": {
                     "name": "var1",
@@ -540,13 +548,13 @@ class CheckParse(unittest.TestCase):
                 ],
                 "typemap_name": "std::vector",
             },
+            todict.to_dict(r)
         )
 
         r = declast.check_decl("std::vector<std::string> var1", symtab)
         s = r.gen_decl()
         self.assertEqual("std::vector<std::string> var1", s)
         self.assertEqual(
-            todict.to_dict(r),
             {
                 "declarator": {
                     "name": "var1",
@@ -564,6 +572,7 @@ class CheckParse(unittest.TestCase):
                 ],
                 "typemap_name": "std::vector",
             },
+            todict.to_dict(r)
         )
 
     def test_type_vector_ptr(self):
@@ -577,7 +586,6 @@ class CheckParse(unittest.TestCase):
         s = r.gen_decl()
         self.assertEqual("std::vector<int * > var1", s)
         self.assertEqual(
-            todict.to_dict(r),
             {
                 'declarator': {
                     'name': 'var1',
@@ -595,7 +603,8 @@ class CheckParse(unittest.TestCase):
                     }
                 ],
                 'typemap_name': 'std::vector'
-            }
+            },
+            todict.to_dict(r)
         )
         # C
         s = r.gen_arg_as_c()
@@ -619,7 +628,8 @@ class CheckParse(unittest.TestCase):
         parser = declast.Parser(decl, symtab)
         r = parser.template_argument_list()
         self.assertEqual(
-            todict.to_dict(r), [{"specifier": ["int"], "typemap_name": "int"}]
+            [{"specifier": ["int"], "typemap_name": "int"}],
+            todict.to_dict(r)
         )
 
         # self.library creates a global namespace with std::string
@@ -627,11 +637,11 @@ class CheckParse(unittest.TestCase):
         parser = declast.Parser(decl, symtab)
         r = parser.template_argument_list()
         self.assertEqual(
-            todict.to_dict(r),
             [
                 {"specifier": ["std::string"], "typemap_name": "std::string"},
                 {"specifier": ["int"], "typemap_name": "int"},
             ],
+            todict.to_dict(r)
         )
 
     def test_declaration_specifier_error(self):
@@ -707,7 +717,7 @@ class CheckParse(unittest.TestCase):
         self.assertEqual("int ( * func)(int)", s)
 
         self.assertEqual("int", r.typemap.name)
-        self.assertEqual("func", r.name)
+        self.assertEqual("func", declarator.name)
         self.assertFalse(declarator.is_pointer())
         self.assertFalse(declarator.is_reference())
         self.assertTrue(declarator.is_function_pointer())
@@ -717,12 +727,13 @@ class CheckParse(unittest.TestCase):
 
         param0 = declarator.params[0]
         s = param0.gen_decl()
+        pdecl = param0.declarator
         self.assertEqual("int", s)
         self.assertEqual("int", param0.typemap.name)
-        self.assertEqual(None, param0.name)
-        self.assertFalse(param0.declarator.is_pointer())
-        self.assertFalse(param0.declarator.is_reference())
-        self.assertFalse(param0.declarator.is_function_pointer())
+        self.assertEqual(None, pdecl.name)
+        self.assertFalse(pdecl.is_pointer())
+        self.assertFalse(pdecl.is_reference())
+        self.assertFalse(pdecl.is_function_pointer())
 
         s = r.gen_decl()
         self.assertEqual("int ( * func)(int)", s)
@@ -732,9 +743,9 @@ class CheckParse(unittest.TestCase):
         self.assertEqual("int ( * func)(int)", s)
 
         self.assertEqual(
-            todict.to_dict(r),
             {
                 "declarator": {
+                    "name": "func",
                     "func": {
                         "name": "func",
                         "pointer": [{"ptr": "*"}],
@@ -754,6 +765,7 @@ class CheckParse(unittest.TestCase):
                 "specifier": ["int"],
                 "typemap_name": "int",
             },
+            todict.to_dict(r),
         )
 
     def test_type_function_pointer2(self):
@@ -768,7 +780,7 @@ class CheckParse(unittest.TestCase):
         self.assertEqual("int * ( * func)(int * arg)", s)
 
         self.assertEqual("int", r.typemap.name)
-        self.assertEqual("func", r.name)
+        self.assertEqual("func", declarator.name)
         self.assertTrue(declarator.is_pointer())
         self.assertFalse(declarator.is_reference())
         self.assertTrue(declarator.is_function_pointer())
@@ -780,7 +792,7 @@ class CheckParse(unittest.TestCase):
         s = param0.gen_decl()
         self.assertEqual("int * arg", s)
         self.assertEqual("int", param0.typemap.name)
-        self.assertEqual("arg", param0.name)
+        self.assertEqual("arg", param0.declarator.name)
         self.assertTrue(param0.declarator.is_pointer())
         self.assertFalse(param0.declarator.is_reference())
         self.assertFalse(param0.declarator.is_function_pointer())
@@ -791,12 +803,12 @@ class CheckParse(unittest.TestCase):
         symtab = declast.SymbolTable()
 
         r = declast.check_decl("void foo", symtab)
+        declarator = r.declarator
 
         s = r.gen_decl()
         self.assertEqual("void foo", s)
 
         self.assertEqual(
-            todict.to_dict(r),
             {
                 "declarator": {
                     "name": "foo",
@@ -805,8 +817,9 @@ class CheckParse(unittest.TestCase):
                 "specifier": ["void"],
                 "typemap_name": "void",
             },
+            todict.to_dict(r),
         )
-        self.assertEqual("foo", r.get_name())
+        self.assertEqual("foo", declarator.name)
 
     def test_decl02(self):
         """Simple declaration with attribute"""
@@ -819,7 +832,6 @@ class CheckParse(unittest.TestCase):
         self.assertEqual("void foo +alias(junk)", s)
 
         self.assertEqual(
-            todict.to_dict(r),
             {
                 "declarator": {
                     "name": "foo",
@@ -829,8 +841,9 @@ class CheckParse(unittest.TestCase):
                 "specifier": ["void"],
                 "typemap_name": "void",
             },
+            todict.to_dict(r),
         )
-        self.assertEqual("foo", r.get_name())
+        self.assertEqual("foo", declarator.name)
 
     def test_decl03(self):
         """Empty parameter list"""
@@ -843,7 +856,6 @@ class CheckParse(unittest.TestCase):
         self.assertEqual("void foo(void)", s)
 
         self.assertEqual(
-            todict.to_dict(r),
             {
                 "declarator": {
                     "name": "foo",
@@ -853,8 +865,9 @@ class CheckParse(unittest.TestCase):
                 "specifier": ["void"],
                 "typemap_name": "void",
             },
+            todict.to_dict(r),
         )
-        self.assertEqual("foo", r.get_name())
+        self.assertEqual("foo", declarator.name)
         self.assertEqual("void", r.typemap.name)
         self.assertFalse(declarator.is_pointer())
         self.assertEqual("subroutine", declarator.get_subprogram())
@@ -871,7 +884,6 @@ class CheckParse(unittest.TestCase):
         self.assertEqual("void * foo(void) const", s)
 
         self.assertEqual(
-            todict.to_dict(r),
             {
                 "declarator": {
                     "name": "foo",
@@ -883,8 +895,9 @@ class CheckParse(unittest.TestCase):
                 "specifier": ["void"],
                 "typemap_name": "void",
             },
+            todict.to_dict(r),
         )
-        self.assertEqual("foo", r.get_name())
+        self.assertEqual("foo", declarator.name)
         self.assertEqual("void", r.typemap.name)
         self.assertTrue(declarator.is_pointer())
         self.assertEqual("function", declarator.get_subprogram())
@@ -894,12 +907,12 @@ class CheckParse(unittest.TestCase):
         symtab = declast.SymbolTable()
 
         r = declast.check_decl("void foo(int arg1)", symtab)
+        declarator = r.declarator
 
         s = r.gen_decl()
         self.assertEqual("void foo(int arg1)", s)
 
         self.assertEqual(
-            todict.to_dict(r),
             {
                 "declarator": {
                     "name": "foo",
@@ -918,8 +931,9 @@ class CheckParse(unittest.TestCase):
                 "specifier": ["void"],
                 "typemap_name": "void",
             },
+            todict.to_dict(r),
         )
-        self.assertEqual("foo", r.get_name())
+        self.assertEqual("foo", declarator.name)
 
     def test_decl06(self):
         """multiple arguments"""
@@ -932,7 +946,6 @@ class CheckParse(unittest.TestCase):
         self.assertEqual("void foo(int arg1, double arg2)", s)
 
         self.assertEqual(
-            todict.to_dict(r),
             {
                 "declarator": {
                     "name": "foo",
@@ -959,8 +972,9 @@ class CheckParse(unittest.TestCase):
                 "specifier": ["void"],
                 "typemap_name": "void",
             },
+            todict.to_dict(r),
         )
-        self.assertEqual("foo", r.get_name())
+        self.assertEqual("foo", declarator.name)
 
         self.assertIsNotNone(declarator.find_arg_by_name("arg1"))
         self.assertIsNotNone(declarator.find_arg_by_name("arg2"))
@@ -981,7 +995,6 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(1, declarator.is_indirect())
 
         self.assertEqual(
-            todict.to_dict(r),
             {
                 "const": True,
                 "declarator": {
@@ -994,8 +1007,9 @@ class CheckParse(unittest.TestCase):
                 "specifier": ["std::string"],
                 "typemap_name": "std::string",
             },
+            todict.to_dict(r),
         )
-        self.assertEqual("getName", r.get_name())
+        self.assertEqual("getName", declarator.name)
 
     def test_decl08(self):
         """Test attributes.
@@ -1007,6 +1021,7 @@ class CheckParse(unittest.TestCase):
             "int arg1+in, double arg2+out)"
             "+len=30 +attr2(True)",
             symtab)
+        declarator = r.declarator
 
         s = r.gen_decl()
         self.assertEqual(
@@ -1017,7 +1032,6 @@ class CheckParse(unittest.TestCase):
         )
 
         self.assertEqual(
-            todict.to_dict(r),
             {
                 "const": True,
                 "declarator": {
@@ -1048,8 +1062,9 @@ class CheckParse(unittest.TestCase):
                 "specifier": ["void"],
                 "typemap_name": "void",
             },
+            todict.to_dict(r),
         )
-        self.assertEqual("foo", r.get_name())
+        self.assertEqual("foo", declarator.name)
 
     def test_decl09a(self):
         """Test constructor
@@ -1064,7 +1079,6 @@ class CheckParse(unittest.TestCase):
         self.assertEqual("Class1(void)", s)
 
         self.assertEqual(
-            todict.to_dict(r),
             {
                 "specifier": ["Class1"],
                 "typemap_name": "Class1",
@@ -1074,8 +1088,9 @@ class CheckParse(unittest.TestCase):
                     "typemap_name": "Class1",
                 },
             },
+            todict.to_dict(r),
         )
-        self.assertEqual("ctor", r.get_name())
+        self.assertEqual("ctor", declarator.user_name)
         self.assertFalse(declarator.is_pointer())
         self.assertFalse(declarator.is_reference())
         # must provide the name since the ctor has no name
@@ -1096,7 +1111,6 @@ class CheckParse(unittest.TestCase):
         self.assertEqual("Class1(void) +name(new)", s)
 
         self.assertEqual(
-            todict.to_dict(r),
             {
                 "specifier": ["Class1"],
                 "typemap_name": "Class1",
@@ -1106,8 +1120,9 @@ class CheckParse(unittest.TestCase):
                     "typemap_name": "Class1",
                 },
             },
+            todict.to_dict(r),
         )
-        self.assertEqual("new", r.get_name())
+        self.assertEqual("new", declarator.user_name)
         self.assertFalse(declarator.is_pointer())
         self.assertFalse(declarator.is_reference())
         self.assertEqual(0, declarator.is_indirect())
@@ -1127,7 +1142,6 @@ class CheckParse(unittest.TestCase):
         self.assertEqual("~Class1(void)", s)
 
         self.assertEqual(
-            todict.to_dict(r),
             {
                 "specifier": ["void"],
                 "typemap_name": "void",
@@ -1137,8 +1151,9 @@ class CheckParse(unittest.TestCase):
                     "typemap_name": "void",
                 },
             },
+            todict.to_dict(r),
         )
-        self.assertEqual("dtor", r.get_name())
+        self.assertEqual("dtor", declarator.user_name)
         self.assertFalse(declarator.is_pointer())
         self.assertFalse(declarator.is_reference())
         self.assertEqual(0, declarator.is_indirect())
@@ -1156,7 +1171,6 @@ class CheckParse(unittest.TestCase):
         self.assertIsInstance(r2.class_specifier, declast.CXXClass)
         self.assertEqual("class Class2: public Class1", todict.print_node(r2))
         self.assertEqual(
-            todict.to_dict(r2),
             {
                 'class_specifier': {
                     'name': 'Class2',
@@ -1167,7 +1181,8 @@ class CheckParse(unittest.TestCase):
                 "declarator": {
                     'typemap_name': 'Class2',
                 },
-            }
+            },
+            todict.to_dict(r2),
         )
 
         with self.assertRaises(RuntimeError) as context:
@@ -1198,12 +1213,12 @@ class CheckParse(unittest.TestCase):
         declast.check_decl("class Class1", symtab)
 
         r = declast.check_decl("Class1 * make()", symtab)
+        declarator = r.declarator
 
         s = r.gen_decl()
         self.assertEqual("Class1 * make(void)", s)
 
         self.assertEqual(
-            todict.to_dict(r),
             {
                 "declarator": {
                     "name": "make",
@@ -1214,8 +1229,9 @@ class CheckParse(unittest.TestCase):
                 "specifier": ["Class1"],
                 "typemap_name": "Class1",
             },
+            todict.to_dict(r),
         )
-        self.assertEqual("make", r.get_name())
+        self.assertEqual("make", declarator.user_name)
 
     def test_decl10(self):
         """Test default arguments
@@ -1230,6 +1246,7 @@ class CheckParse(unittest.TestCase):
             "bool arg4 = true)",
             symtab
         )
+        declarator = r.declarator
 
         s = r.gen_decl()
         self.assertEqual(
@@ -1241,7 +1258,6 @@ class CheckParse(unittest.TestCase):
         )
 
         self.assertEqual(
-            todict.to_dict(r),
             {
                 "declarator": {
                     "name": "name",
@@ -1288,8 +1304,9 @@ class CheckParse(unittest.TestCase):
                 "specifier": ["void"],
                 "typemap_name": "void",
             },
+            todict.to_dict(r),
         )
-        self.assertEqual("name", r.get_name())
+        self.assertEqual("name", declarator.name)
 
     def test_decl11(self):
         """Test function template"""
@@ -1303,7 +1320,6 @@ class CheckParse(unittest.TestCase):
         self.assertEqual("void decl11(ArgType arg)", s)
 
         self.assertEqual(
-            todict.to_dict(r),
             {
                 "decl": {
                     "declarator": {
@@ -1324,8 +1340,9 @@ class CheckParse(unittest.TestCase):
                 },
                 "parameters": [{"name": "ArgType"}],
             },
+            todict.to_dict(r),
         )
-        self.assertEqual("decl11", r.decl.get_name())
+        self.assertEqual("decl11", r.decl.declarator.name)
 
     def test_decl12(self):
         """Test templates
@@ -1339,6 +1356,7 @@ class CheckParse(unittest.TestCase):
             "void decl12(std::vector<std::string> arg1, string arg2)",
             symtab
         )
+        declarator = r.declarator
 
         s = r.gen_decl()
         self.assertEqual(
@@ -1346,7 +1364,6 @@ class CheckParse(unittest.TestCase):
         )
 
         self.assertEqual(
-            todict.to_dict(r),
             {
                 "declarator": {
                     "name": "decl12",
@@ -1382,8 +1399,9 @@ class CheckParse(unittest.TestCase):
                 "specifier": ["void"],
                 "typemap_name": "void",
             },
+            todict.to_dict(r),
         )
-        self.assertEqual("decl12", r.get_name())
+        self.assertEqual("decl12", declarator.user_name)
 
     def test_decl13(self):
         """Test multi-specifier
@@ -1416,7 +1434,6 @@ class CheckParse(unittest.TestCase):
         #        self.assertEqual("template<typename T> vector", s)
 
         self.assertEqual(
-            todict.to_dict(r),
             {
                 'decl': {
                     'class_specifier': {'name': 'vector'},
@@ -1427,7 +1444,8 @@ class CheckParse(unittest.TestCase):
                     },
                 },
                 'parameters': [{'name': 'T'}]
-            }
+            },
+            todict.to_dict(r),
         )
 
         r = declast.check_decl("template<Key,T> class map", symtab)
@@ -1436,7 +1454,6 @@ class CheckParse(unittest.TestCase):
         #        self.assertEqual("template<typename Key, typename T> map", s)
 
         self.assertEqual(
-            todict.to_dict(r),
             {
                 'decl': {
                     'class_specifier': {'name': 'map'},
@@ -1447,7 +1464,8 @@ class CheckParse(unittest.TestCase):
                     },
                 },
                 'parameters': [{'name': 'Key'}, {'name': 'T'}]
-            }
+            },
+            todict.to_dict(r),
         )
 
     def test_as_arg(self):
@@ -1476,12 +1494,12 @@ class CheckParse(unittest.TestCase):
         )
         declarator = r.declarator
         self.assertTrue(declarator.is_reference())
-        self.assertEqual(r.name, "Function4b")
+        self.assertEqual("Function4b", declarator.name)
 
         r2 = copy.deepcopy(r)
 
         r2.name = "newname"
-        self.assertEqual(r.name, "Function4b")  # first is unchanged
+        self.assertEqual("Function4b", declarator.name)  # first is unchanged
         self.assertEqual(r2.name, "newname")
 
     def test_struct(self):
@@ -1499,17 +1517,19 @@ struct Cstruct_list {
         self.assertEqual(2, len(members))
         ast = members[0]
         self.assertEqual(
-            todict.to_dict(ast), {
+            {
                 'declarator': {
                     'name': 'nitems',
                     'typemap_name': 'int'
                 },
                 'specifier': ['int'],
                 'typemap_name': 'int'
-            })
+            },
+            todict.to_dict(ast),
+        )
         ast = members[1]
         self.assertEqual(
-            todict.to_dict(ast), {
+            {
                 'declarator': {
                     'name': 'ivalue',
                     'pointer': [{   'ptr': '*'}],
@@ -1517,7 +1537,9 @@ struct Cstruct_list {
                 },
                 'specifier': ['int'],
                 'typemap_name': 'int',
-            })
+            },
+            todict.to_dict(ast),
+        )
 
 
 class CheckExpr(unittest.TestCase):
@@ -1528,21 +1550,24 @@ class CheckExpr(unittest.TestCase):
         self.assertEqual("20", todict.print_node(r))
         self.assertEqual(
             {"constant": "20"},
-            todict.to_dict(r))
+            todict.to_dict(r)
+        )
 
     def test_identifier1(self):
         r = declast.check_expr("id")
         self.assertEqual("id", todict.print_node(r))
         self.assertEqual(
             {"name": "id"},
-            todict.to_dict(r))
+            todict.to_dict(r)
+        )
 
     def test_identifier_no_args(self):
         r = declast.check_expr("id()")
         self.assertEqual("id()", todict.print_node(r))
         self.assertEqual(
             {"name": "id", "args": []},
-            todict.to_dict(r))
+            todict.to_dict(r)
+        )
 
     def test_identifier_with_arg(self):
         r = declast.check_expr("id(arg1)")
@@ -1620,7 +1645,10 @@ class CheckNamespace(unittest.TestCase):
         symtab = declast.SymbolTable()
         r = declast.check_decl("namespace ns1", symtab)
         self.assertEqual("namespace ns1", todict.print_node(r))
-        self.assertEqual(todict.to_dict(r), {"name": "ns1"})
+        self.assertEqual(
+            {"name": "ns1"},
+            todict.to_dict(r),
+        )
 
 
 class CheckTypedef(unittest.TestCase):
@@ -1629,7 +1657,6 @@ class CheckTypedef(unittest.TestCase):
         r = declast.check_decl("typedef int TypeID;", symtab)
         self.assertEqual("typedef int TypeID", r.gen_decl())
         self.assertDictEqual(
-            todict.to_dict(r),
             {
                 "declarator": {
                     "name": "TypeID",
@@ -1639,6 +1666,7 @@ class CheckTypedef(unittest.TestCase):
                 "storage": ["typedef"],
                 "typemap_name": "TypeID",
             },
+            todict.to_dict(r),
         )
 
     def test_typedef2(self):
@@ -1680,7 +1708,6 @@ class CheckEnum(unittest.TestCase):
             "enum Color { RED = 1, BLUE, WHITE };", todict.print_node(r)
         )
         self.assertEqual(
-            todict.to_dict(r),
             {
                 'enum_specifier': {
                     'name': 'Color',
@@ -1695,7 +1722,8 @@ class CheckEnum(unittest.TestCase):
                     'typemap_name': 'Color',
                 },
                 'typemap_name': 'Color',
-            }
+            },
+            todict.to_dict(r),
         )
 
     def test_enum2(self):
@@ -1736,7 +1764,6 @@ class CheckStruct(unittest.TestCase):
         r = declast.check_decl("struct struct1 { int i; double d; };",
                                symtab)
         self.assertEqual(
-            todict.to_dict(r),
             {
                 'class_specifier': {
                     'members': [
@@ -1764,7 +1791,8 @@ class CheckStruct(unittest.TestCase):
                     'typemap_name': 'struct1',
                 },
                 'typemap_name': 'struct1',
-            }
+            },
+            todict.to_dict(r),
         )
 
 
@@ -1776,7 +1804,6 @@ class CheckClass(unittest.TestCase):
         self.assertIsInstance(r.class_specifier, declast.CXXClass)
         self.assertEqual("class Class1", todict.print_node(r))
         self.assertEqual(
-            todict.to_dict(r),
             {
                 'class_specifier': {'name': 'Class1'},
                 'specifier': ['class Class1'],
@@ -1784,7 +1811,8 @@ class CheckClass(unittest.TestCase):
                     'typemap_name': 'Class1',
                 },
                 'typemap_name': 'Class1',
-            }
+            },
+            todict.to_dict(r),
         )
 
     def test_class2(self):

--- a/tests/test_declast.py
+++ b/tests/test_declast.py
@@ -434,7 +434,10 @@ class CheckParse(unittest.TestCase):
                 "declarator": {"name": "var1"},
                 "specifier": ["std::vector"],
                 "template_arguments": [
-                    {"specifier": ["int"], "typemap_name": "int"}
+                    {"specifier": ["int"],
+                     "typemap_name": "int",
+                     "declarator": {},
+                    }
                 ],
                 "typemap_name": "std::vector",
             },
@@ -462,7 +465,11 @@ class CheckParse(unittest.TestCase):
                 "declarator": {"name": "var1"},
                 "specifier": ["std::vector"],
                 "template_arguments": [
-                    {"specifier": ["long", "long"], "typemap_name": "long_long"}
+                    {
+                        "specifier": ["long", "long"],
+                        "typemap_name": "long_long",
+                        "declarator": {},
+                    }
                 ],
                 "typemap_name": "std::vector",
             },
@@ -480,6 +487,7 @@ class CheckParse(unittest.TestCase):
                     {
                         "specifier": ["std::string"],
                         "typemap_name": "std::string",
+                        "declarator": {},
                     }
                 ],
                 "typemap_name": "std::vector",
@@ -646,7 +654,12 @@ class CheckParse(unittest.TestCase):
                 "declarator": {
                     "func": {"name": "func", "pointer": [{"ptr": "*"}]},
                 },
-                "params": [{"specifier": ["int"], "typemap_name": "int"}],
+                "params": [
+                    {
+                        "specifier": ["int"],
+                        "typemap_name": "int",
+                        "declarator": {},
+                    }],
                 "specifier": ["int"],
                 "typemap_name": "int",
             },
@@ -918,6 +931,7 @@ class CheckParse(unittest.TestCase):
                 "params": [],
                 "specifier": ["Class1"],
                 "typemap_name": "Class1",
+                'declarator': {},
             },
         )
         self.assertEqual("ctor", r.get_name())
@@ -946,6 +960,7 @@ class CheckParse(unittest.TestCase):
                 "params": [],
                 "specifier": ["Class1"],
                 "typemap_name": "Class1",
+                'declarator': {},
             },
         )
         self.assertEqual("new", r.get_name())
@@ -973,6 +988,7 @@ class CheckParse(unittest.TestCase):
                 "params": [],
                 "specifier": ["void"],
                 "typemap_name": "void",
+                'declarator': {},
             },
         )
         self.assertEqual("dtor", r.get_name())
@@ -1000,7 +1016,8 @@ class CheckParse(unittest.TestCase):
                     'baseclass': [('public', 'Class1', 'Class1')]
                 },
                 'specifier': ['class Class2'],
-                'typemap_name': 'Class2'
+                'typemap_name': 'Class2',
+                "declarator": {},
             }
         )
 
@@ -1167,6 +1184,7 @@ class CheckParse(unittest.TestCase):
                             {
                                 "specifier": ["std::string"],
                                 "typemap_name": "std::string",
+                                "declarator": {},
                             }
                         ],
                         "typemap_name": "std::vector",
@@ -1218,7 +1236,8 @@ class CheckParse(unittest.TestCase):
                 'decl': {
                     'class_specifier': {'name': 'vector'},
                     'specifier': ['class vector'],
-                    'typemap_name': 'vector'
+                    'typemap_name': 'vector',
+                    'declarator': {},
                 },
                 'parameters': [{'name': 'T'}]
             }
@@ -1235,7 +1254,9 @@ class CheckParse(unittest.TestCase):
                 'decl': {
                     'class_specifier': {'name': 'map'},
                     'specifier': ['class map'],
-                    'typemap_name': 'vector::map'},
+                    'typemap_name': 'vector::map',
+                    'declarator': {},
+                },
                 'parameters': [{'name': 'Key'}, {'name': 'T'}]
             }
         )
@@ -1473,7 +1494,8 @@ class CheckEnum(unittest.TestCase):
                     ],
                 },
                 'specifier': ['enum Color'],
-                'typemap_name': 'Color'
+                'typemap_name': 'Color',
+                "declarator": {},
             }
         )
 
@@ -1532,7 +1554,8 @@ class CheckStruct(unittest.TestCase):
                     'typemap_name': 'struct1'
                 },
                 'specifier': ['struct struct1'],
-                'typemap_name': 'struct1'
+                'typemap_name': 'struct1',
+                "declarator": {},
             }
         )
 
@@ -1549,7 +1572,8 @@ class CheckClass(unittest.TestCase):
             {
                 'class_specifier': {'name': 'Class1'},
                 'specifier': ['class Class1'],
-                'typemap_name': 'Class1'
+                'typemap_name': 'Class1',
+                'declarator': {},
             }
         )
 

--- a/tests/test_declast.py
+++ b/tests/test_declast.py
@@ -1082,6 +1082,7 @@ class CheckParse(unittest.TestCase):
             {
                 "specifier": ["Class1"],
                 "typemap_name": "Class1",
+                "is_ctor": True,
                 'declarator': {
                     "attrs": {"_constructor": True, "_name": "ctor"},
                     "params": [],
@@ -1114,6 +1115,7 @@ class CheckParse(unittest.TestCase):
             {
                 "specifier": ["Class1"],
                 "typemap_name": "Class1",
+                "is_ctor": True,
                 'declarator': {
                     "attrs": {"_constructor": True, "_name": "ctor", "name": "new"},
                     "params": [],
@@ -1145,6 +1147,7 @@ class CheckParse(unittest.TestCase):
             {
                 "specifier": ["void"],
                 "typemap_name": "void",
+                "is_dtor": "Class1",
                 'declarator': {
                     "attrs": {"_destructor": "Class1", "_name": "dtor"},
                     "params": [],

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -59,18 +59,18 @@ class CheckImplied(unittest.TestCase):
 
     def test_implied_attrs(self):
         func = self.func1
-        decls = self.func1.ast.params
+        decls = self.func1.ast.declarator.params
         generate.check_implied_attrs(func, decls)
 
     def test_implied(self):
         func = self.func1
-        decls = self.func1.ast.params
+        decls = self.func1.ast.declarator.params
         expr = generate.check_implied(func, "user(array)", decls)
         self.assertEqual("user(array)", expr)
 
     def test_errors(self):
         func = self.func1
-        decls = self.func1.ast.params
+        decls = self.func1.ast.declarator.params
 
         generate.check_implied(func, "size(array2,1)", decls)
 

--- a/tests/test_wrapp.py
+++ b/tests/test_wrapp.py
@@ -72,7 +72,8 @@ struct Cstruct_list {
         #####
         var = map['ivalue']
         # done in generate.VerifyAttrs.parse_attrs
-        generate.check_dimension(var.ast.attrs["dimension"], var.ast.metaattrs)
+        declarator = var.ast.declarator
+        generate.check_dimension(declarator.attrs["dimension"], declarator.metaattrs)
         
         fmt = var.fmtdict
         fmt.PY_struct_context = "struct."
@@ -84,7 +85,8 @@ struct Cstruct_list {
         #####
         var = map['dvalue']
         # done in generate.VerifyAttrs.parse_attrs
-        generate.check_dimension(var.ast.attrs["dimension"], var.ast.metaattrs)
+        declarator = var.ast.declarator
+        generate.check_dimension(declarator.attrs["dimension"], declarator.metaattrs)
         
         fmt = var.fmtdict
         fmt.PY_struct_context = "struct."


### PR DESCRIPTION
This is necessary to eventually allow multiple declarators on a declaration

    int i, j

The fields are `attrs`, `metaattrs`,  `params`,  `func_ctor`,  `array`,  `init`

And the methods `is_ctor`, `is_dtor`, `is_pointer`, `is_reference`, `is_indirect`, `is_array`,  `is_function_pointer`,  `get_indirect_stmt`,  `get_array_size`, `find_arg_by_name` and `find_arg_index_by_name`

Lots of changes to unit tests and reference files. But no wrapper changes.
