### PR TITLE
Control when to set default Typedefs fields

### DIFF
--- a/regression/reference/clibrary/clibrary.json
+++ b/regression/reference/clibrary/clibrary.json
@@ -6105,6 +6105,7 @@
                             "F_C_var": "arr",
                             "c_var": "arr",
                             "f_intent": "INOUT",
+                            "f_kind": "array_info",
                             "f_type": "type(array_info)",
                             "f_var": "arr",
                             "sh_type": "SH_TYPE_STRUCT",
@@ -6355,6 +6356,7 @@
                 ]
             },
             "f_derived_type": "array_info",
+            "f_kind": "array_info",
             "f_module": {
                 "clibrary_mod": [
                     "array_info"

--- a/regression/reference/cxxlibrary/cxxlibrary.json
+++ b/regression/reference/cxxlibrary/cxxlibrary.json
@@ -2280,6 +2280,7 @@
                                     "F_C_var": "arg",
                                     "c_var": "arg",
                                     "f_intent": "INOUT",
+                                    "f_kind": "cstruct1",
                                     "f_type": "type(cstruct1)",
                                     "f_var": "arg",
                                     "sh_type": "SH_TYPE_STRUCT",
@@ -2460,6 +2461,7 @@
                                     "F_C_var": "arg",
                                     "c_var": "arg",
                                     "f_intent": "IN",
+                                    "f_kind": "cstruct1",
                                     "f_type": "type(cstruct1)",
                                     "f_var": "arg",
                                     "sh_type": "SH_TYPE_STRUCT",
@@ -2639,6 +2641,7 @@
                                     "F_C_var": "arg",
                                     "c_var": "arg",
                                     "f_intent": "INOUT",
+                                    "f_kind": "cstruct1",
                                     "f_type": "type(cstruct1)",
                                     "f_var": "arg",
                                     "sh_type": "SH_TYPE_STRUCT",
@@ -2770,6 +2773,7 @@
                                     "F_C_var": "arg",
                                     "c_var": "arg",
                                     "f_intent": "OUT",
+                                    "f_kind": "cstruct1",
                                     "f_type": "type(cstruct1)",
                                     "f_var": "arg",
                                     "sh_type": "SH_TYPE_STRUCT",
@@ -2898,6 +2902,7 @@
                 ]
             },
             "f_derived_type": "cstruct1_cls",
+            "f_kind": "cstruct1_cls",
             "f_module": {
                 "cxxlibrary_mod": [
                     "cstruct1_cls"
@@ -2929,6 +2934,7 @@
                 ]
             },
             "f_derived_type": "cstruct1",
+            "f_kind": "cstruct1",
             "f_module": {
                 "cxxlibrary_structns_mod": [
                     "cstruct1"

--- a/regression/reference/forward/forward.json
+++ b/regression/reference/forward/forward.json
@@ -699,7 +699,8 @@
                             "F_C_var": "arg",
                             "c_var": "arg",
                             "f_intent": "IN",
-                            "f_type": "type(Cstruct1)",
+                            "f_kind": "cstruct1",
+                            "f_type": "type(cstruct1)",
                             "f_var": "arg",
                             "sh_type": "SH_TYPE_OTHER",
                             "stmt0": "f_in_struct_*",
@@ -794,6 +795,7 @@
             ],
             "cxx_type": "Cstruct1",
             "f_derived_type": "cstruct1",
+            "f_kind": "cstruct1",
             "f_module": {
                 "struct_mod": [
                     "cstruct1"
@@ -801,7 +803,7 @@
             },
             "f_module_name": "struct_mod",
             "f_to_c": "{f_var}",
-            "f_type": "type(Cstruct1)",
+            "f_type": "type(cstruct1)",
             "flat_name": "Cstruct1",
             "sgroup": "struct",
             "wrap_header": [

--- a/regression/reference/forward/wrapfforward.f
+++ b/regression/reference/forward/wrapfforward.f
@@ -149,7 +149,7 @@ module forward_mod
             use iso_c_binding, only : C_INT
             use struct_mod, only : cstruct1
             implicit none
-            type(Cstruct1), intent(IN) :: arg
+            type(cstruct1), intent(IN) :: arg
             integer(C_INT) :: SHT_rv
         end function c_pass_struct1
 
@@ -307,7 +307,7 @@ contains
             result(SHT_rv)
         use iso_c_binding, only : C_INT
         use struct_mod, only : cstruct1
-        type(Cstruct1), intent(IN) :: arg
+        type(cstruct1), intent(IN) :: arg
         integer(C_INT) :: SHT_rv
         ! splicer begin function.pass_struct1
         SHT_rv = c_pass_struct1(arg)

--- a/regression/reference/namespace/namespace.json
+++ b/regression/reference/namespace/namespace.json
@@ -832,6 +832,7 @@
                 ]
             },
             "f_derived_type": "cstruct1",
+            "f_kind": "cstruct1",
             "f_module": {
                 "ns_outer_mod": [
                     "cstruct1"

--- a/regression/reference/scope/scope.json
+++ b/regression/reference/scope/scope.json
@@ -694,6 +694,7 @@
                             "F_C_var": "SH_this",
                             "c_var": "SH_this",
                             "f_intent": "IN",
+                            "f_kind": "datapointer",
                             "f_type": "type(datapointer)",
                             "f_var": "SH_this",
                             "sh_type": "SH_TYPE_STRUCT",
@@ -861,6 +862,7 @@
                             "F_C_var": "SH_this",
                             "c_var": "SH_this",
                             "f_intent": "INOUT",
+                            "f_kind": "datapointer",
                             "f_type": "type(datapointer)",
                             "f_var": "SH_this",
                             "sh_type": "SH_TYPE_STRUCT",
@@ -1301,6 +1303,7 @@
                                     "F_C_var": "SH_this",
                                     "c_var": "SH_this",
                                     "f_intent": "IN",
+                                    "f_kind": "datapointer",
                                     "f_type": "type(datapointer)",
                                     "f_var": "SH_this",
                                     "sh_type": "SH_TYPE_STRUCT",
@@ -1468,6 +1471,7 @@
                                     "F_C_var": "SH_this",
                                     "c_var": "SH_this",
                                     "f_intent": "INOUT",
+                                    "f_kind": "datapointer",
                                     "f_type": "type(datapointer)",
                                     "f_var": "SH_this",
                                     "sh_type": "SH_TYPE_STRUCT",
@@ -1933,6 +1937,7 @@
                                     "F_C_var": "SH_this",
                                     "c_var": "SH_this",
                                     "f_intent": "IN",
+                                    "f_kind": "datapointer",
                                     "f_type": "type(datapointer)",
                                     "f_var": "SH_this",
                                     "sh_type": "SH_TYPE_STRUCT",
@@ -2100,6 +2105,7 @@
                                     "F_C_var": "SH_this",
                                     "c_var": "SH_this",
                                     "f_intent": "INOUT",
+                                    "f_kind": "datapointer",
                                     "f_type": "type(datapointer)",
                                     "f_var": "SH_this",
                                     "sh_type": "SH_TYPE_STRUCT",
@@ -2452,6 +2458,7 @@
                 ]
             },
             "f_derived_type": "datapointer",
+            "f_kind": "datapointer",
             "f_module": {
                 "scope_ns1_mod": [
                     "datapointer"
@@ -2504,6 +2511,7 @@
                 ]
             },
             "f_derived_type": "datapointer",
+            "f_kind": "datapointer",
             "f_module": {
                 "scope_ns2_mod": [
                     "datapointer"
@@ -2556,6 +2564,7 @@
                 ]
             },
             "f_derived_type": "datapointer",
+            "f_kind": "datapointer",
             "f_module": {
                 "scope_ns3_mod": [
                     "datapointer"

--- a/regression/reference/struct-c/struct.json
+++ b/regression/reference/struct-c/struct.json
@@ -1996,6 +1996,7 @@
                             "F_C_var": "arg",
                             "c_var": "arg",
                             "f_intent": "IN",
+                            "f_kind": "cstruct1",
                             "f_type": "type(cstruct1)",
                             "f_var": "arg",
                             "sh_type": "SH_TYPE_STRUCT",
@@ -2131,6 +2132,7 @@
                             "F_C_var": "arg",
                             "c_var": "arg",
                             "f_intent": "IN",
+                            "f_kind": "cstruct1",
                             "f_type": "type(cstruct1)",
                             "f_var": "arg",
                             "sh_type": "SH_TYPE_STRUCT",
@@ -2321,6 +2323,7 @@
                             "F_C_var": "s1",
                             "c_var": "s1",
                             "f_intent": "IN",
+                            "f_kind": "cstruct1",
                             "f_type": "type(cstruct1)",
                             "f_var": "s1",
                             "sh_type": "SH_TYPE_STRUCT"
@@ -2513,6 +2516,7 @@
                             "F_C_var": "s1",
                             "c_var": "s1",
                             "f_intent": "IN",
+                            "f_kind": "cstruct1",
                             "f_type": "type(cstruct1)",
                             "f_var": "s1",
                             "sh_type": "SH_TYPE_STRUCT",
@@ -2636,6 +2640,7 @@
                             "F_C_var": "arg",
                             "c_var": "arg",
                             "f_intent": "IN",
+                            "f_kind": "cstruct1",
                             "f_type": "type(cstruct1)",
                             "f_var": "arg",
                             "sh_type": "SH_TYPE_STRUCT",
@@ -2806,6 +2811,7 @@
                             "F_C_var": "arg",
                             "c_var": "arg",
                             "f_intent": "OUT",
+                            "f_kind": "cstruct1",
                             "f_type": "type(cstruct1)",
                             "f_var": "arg",
                             "sh_type": "SH_TYPE_STRUCT",
@@ -2976,6 +2982,7 @@
                             "F_C_var": "arg",
                             "c_var": "arg",
                             "f_intent": "INOUT",
+                            "f_kind": "cstruct1",
                             "f_type": "type(cstruct1)",
                             "f_var": "arg",
                             "sh_type": "SH_TYPE_STRUCT",
@@ -3178,6 +3185,7 @@
                         "c_var": "SHT_rv",
                         "cxx_type": "Cstruct1",
                         "f_intent": "OUT",
+                        "f_kind": "cstruct1",
                         "f_type": "type(cstruct1)",
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_STRUCT",
@@ -3363,6 +3371,7 @@
                         "c_var": "SHT_rv",
                         "cxx_type": "Cstruct1",
                         "f_intent": "OUT",
+                        "f_kind": "cstruct1",
                         "f_type": "type(cstruct1)",
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_STRUCT",
@@ -3547,6 +3556,7 @@
                         "F_C_var": "SHT_rv",
                         "c_var": "SHT_rv",
                         "f_intent": "OUT",
+                        "f_kind": "cstruct1",
                         "f_type": "type(cstruct1)",
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_STRUCT"
@@ -3779,6 +3789,7 @@
                         "c_var": "SHT_rv",
                         "cxx_type": "Cstruct1",
                         "f_intent": "OUT",
+                        "f_kind": "cstruct1",
                         "f_type": "type(cstruct1)",
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_STRUCT",
@@ -4021,6 +4032,7 @@
                         "F_C_var": "SHT_rv",
                         "c_var": "SHT_rv",
                         "f_intent": "OUT",
+                        "f_kind": "cstruct1",
                         "f_type": "type(cstruct1)",
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_STRUCT"
@@ -4103,6 +4115,7 @@
                         "c_var": "SHT_rv",
                         "cxx_type": "Cstruct_list",
                         "f_intent": "OUT",
+                        "f_kind": "cstruct_list",
                         "f_type": "type(cstruct_list)",
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_STRUCT",
@@ -4181,6 +4194,7 @@
                         "F_C_var": "SHT_rv",
                         "c_var": "SHT_rv",
                         "f_intent": "OUT",
+                        "f_kind": "cstruct_list",
                         "f_type": "type(cstruct_list)",
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_STRUCT"
@@ -5030,6 +5044,7 @@
                             "F_C_var": "SH_this",
                             "c_var": "SH_this",
                             "f_intent": "IN",
+                            "f_kind": "cstruct_ptr",
                             "f_type": "type(cstruct_ptr)",
                             "f_var": "SH_this",
                             "sh_type": "SH_TYPE_STRUCT",
@@ -5184,6 +5199,7 @@
                             "F_C_var": "SH_this",
                             "c_var": "SH_this",
                             "f_intent": "INOUT",
+                            "f_kind": "cstruct_ptr",
                             "f_type": "type(cstruct_ptr)",
                             "f_var": "SH_this",
                             "sh_type": "SH_TYPE_STRUCT",
@@ -5458,6 +5474,7 @@
                             "F_C_var": "SH_this",
                             "c_var": "SH_this",
                             "f_intent": "IN",
+                            "f_kind": "cstruct_list",
                             "f_type": "type(cstruct_list)",
                             "f_var": "SH_this",
                             "sh_type": "SH_TYPE_STRUCT",
@@ -5631,6 +5648,7 @@
                             "F_C_var": "SH_this",
                             "c_var": "SH_this",
                             "f_intent": "INOUT",
+                            "f_kind": "cstruct_list",
                             "f_type": "type(cstruct_list)",
                             "f_var": "SH_this",
                             "sh_type": "SH_TYPE_STRUCT",
@@ -5910,6 +5928,7 @@
                             "F_C_var": "SH_this",
                             "c_var": "SH_this",
                             "f_intent": "IN",
+                            "f_kind": "cstruct_list",
                             "f_type": "type(cstruct_list)",
                             "f_var": "SH_this",
                             "sh_type": "SH_TYPE_STRUCT",
@@ -6083,6 +6102,7 @@
                             "F_C_var": "SH_this",
                             "c_var": "SH_this",
                             "f_intent": "INOUT",
+                            "f_kind": "cstruct_list",
                             "f_type": "type(cstruct_list)",
                             "f_var": "SH_this",
                             "sh_type": "SH_TYPE_STRUCT",
@@ -6209,6 +6229,7 @@
                 ]
             },
             "f_derived_type": "arrays1",
+            "f_kind": "arrays1",
             "f_module": {
                 "struct_mod": [
                     "arrays1"
@@ -6238,6 +6259,7 @@
                 ]
             },
             "f_derived_type": "cstruct1",
+            "f_kind": "cstruct1",
             "f_module": {
                 "struct_mod": [
                     "cstruct1"
@@ -6339,6 +6361,7 @@
                 ]
             },
             "f_derived_type": "cstruct_list",
+            "f_kind": "cstruct_list",
             "f_module": {
                 "struct_mod": [
                     "cstruct_list"
@@ -6368,6 +6391,7 @@
                 ]
             },
             "f_derived_type": "cstruct_numpy",
+            "f_kind": "cstruct_numpy",
             "f_module": {
                 "struct_mod": [
                     "cstruct_numpy"
@@ -6397,6 +6421,7 @@
                 ]
             },
             "f_derived_type": "cstruct_ptr",
+            "f_kind": "cstruct_ptr",
             "f_module": {
                 "struct_mod": [
                     "cstruct_ptr"

--- a/regression/reference/struct-class-c/struct.json
+++ b/regression/reference/struct-class-c/struct.json
@@ -3412,6 +3412,7 @@
                 ]
             },
             "f_derived_type": "arrays1",
+            "f_kind": "arrays1",
             "f_module": {
                 "struct_mod": [
                     "arrays1"
@@ -3446,6 +3447,7 @@
                 ]
             },
             "f_derived_type": "cstruct1",
+            "f_kind": "cstruct1",
             "f_module": {
                 "struct_mod": [
                     "cstruct1"
@@ -3552,6 +3554,7 @@
                 ]
             },
             "f_derived_type": "cstruct_list",
+            "f_kind": "cstruct_list",
             "f_module": {
                 "struct_mod": [
                     "cstruct_list"
@@ -3586,6 +3589,7 @@
                 ]
             },
             "f_derived_type": "cstruct_numpy",
+            "f_kind": "cstruct_numpy",
             "f_module": {
                 "struct_mod": [
                     "cstruct_numpy"
@@ -3620,6 +3624,7 @@
                 ]
             },
             "f_derived_type": "cstruct_ptr",
+            "f_kind": "cstruct_ptr",
             "f_module": {
                 "struct_mod": [
                     "cstruct_ptr"

--- a/regression/reference/struct-class-cxx/struct.json
+++ b/regression/reference/struct-class-cxx/struct.json
@@ -3409,6 +3409,7 @@
                 ]
             },
             "f_derived_type": "arrays1",
+            "f_kind": "arrays1",
             "f_module": {
                 "struct_mod": [
                     "arrays1"
@@ -3440,6 +3441,7 @@
                 ]
             },
             "f_derived_type": "cstruct1",
+            "f_kind": "cstruct1",
             "f_module": {
                 "struct_mod": [
                     "cstruct1"
@@ -3543,6 +3545,7 @@
                 ]
             },
             "f_derived_type": "cstruct_list",
+            "f_kind": "cstruct_list",
             "f_module": {
                 "struct_mod": [
                     "cstruct_list"
@@ -3574,6 +3577,7 @@
                 ]
             },
             "f_derived_type": "cstruct_numpy",
+            "f_kind": "cstruct_numpy",
             "f_module": {
                 "struct_mod": [
                     "cstruct_numpy"
@@ -3605,6 +3609,7 @@
                 ]
             },
             "f_derived_type": "cstruct_ptr",
+            "f_kind": "cstruct_ptr",
             "f_module": {
                 "struct_mod": [
                     "cstruct_ptr"

--- a/regression/reference/struct-cxx/struct.json
+++ b/regression/reference/struct-cxx/struct.json
@@ -1996,6 +1996,7 @@
                             "F_C_var": "arg",
                             "c_var": "arg",
                             "f_intent": "IN",
+                            "f_kind": "cstruct1",
                             "f_type": "type(cstruct1)",
                             "f_var": "arg",
                             "sh_type": "SH_TYPE_STRUCT",
@@ -2131,6 +2132,7 @@
                             "F_C_var": "arg",
                             "c_var": "arg",
                             "f_intent": "IN",
+                            "f_kind": "cstruct1",
                             "f_type": "type(cstruct1)",
                             "f_var": "arg",
                             "sh_type": "SH_TYPE_STRUCT",
@@ -2321,6 +2323,7 @@
                             "F_C_var": "s1",
                             "c_var": "s1",
                             "f_intent": "IN",
+                            "f_kind": "cstruct1",
                             "f_type": "type(cstruct1)",
                             "f_var": "s1",
                             "sh_type": "SH_TYPE_STRUCT"
@@ -2513,6 +2516,7 @@
                             "F_C_var": "s1",
                             "c_var": "s1",
                             "f_intent": "IN",
+                            "f_kind": "cstruct1",
                             "f_type": "type(cstruct1)",
                             "f_var": "s1",
                             "sh_type": "SH_TYPE_STRUCT",
@@ -2636,6 +2640,7 @@
                             "F_C_var": "arg",
                             "c_var": "arg",
                             "f_intent": "IN",
+                            "f_kind": "cstruct1",
                             "f_type": "type(cstruct1)",
                             "f_var": "arg",
                             "sh_type": "SH_TYPE_STRUCT",
@@ -2806,6 +2811,7 @@
                             "F_C_var": "arg",
                             "c_var": "arg",
                             "f_intent": "OUT",
+                            "f_kind": "cstruct1",
                             "f_type": "type(cstruct1)",
                             "f_var": "arg",
                             "sh_type": "SH_TYPE_STRUCT",
@@ -2976,6 +2982,7 @@
                             "F_C_var": "arg",
                             "c_var": "arg",
                             "f_intent": "INOUT",
+                            "f_kind": "cstruct1",
                             "f_type": "type(cstruct1)",
                             "f_var": "arg",
                             "sh_type": "SH_TYPE_STRUCT",
@@ -3178,6 +3185,7 @@
                         "c_var": "SHT_rv",
                         "cxx_type": "Cstruct1",
                         "f_intent": "OUT",
+                        "f_kind": "cstruct1",
                         "f_type": "type(cstruct1)",
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_STRUCT",
@@ -3363,6 +3371,7 @@
                         "c_var": "SHT_rv",
                         "cxx_type": "Cstruct1",
                         "f_intent": "OUT",
+                        "f_kind": "cstruct1",
                         "f_type": "type(cstruct1)",
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_STRUCT",
@@ -3547,6 +3556,7 @@
                         "F_C_var": "SHT_rv",
                         "c_var": "SHT_rv",
                         "f_intent": "OUT",
+                        "f_kind": "cstruct1",
                         "f_type": "type(cstruct1)",
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_STRUCT"
@@ -3779,6 +3789,7 @@
                         "c_var": "SHT_rv",
                         "cxx_type": "Cstruct1",
                         "f_intent": "OUT",
+                        "f_kind": "cstruct1",
                         "f_type": "type(cstruct1)",
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_STRUCT",
@@ -4021,6 +4032,7 @@
                         "F_C_var": "SHT_rv",
                         "c_var": "SHT_rv",
                         "f_intent": "OUT",
+                        "f_kind": "cstruct1",
                         "f_type": "type(cstruct1)",
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_STRUCT"
@@ -4103,6 +4115,7 @@
                         "c_var": "SHT_rv",
                         "cxx_type": "Cstruct_list",
                         "f_intent": "OUT",
+                        "f_kind": "cstruct_list",
                         "f_type": "type(cstruct_list)",
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_STRUCT",
@@ -4181,6 +4194,7 @@
                         "F_C_var": "SHT_rv",
                         "c_var": "SHT_rv",
                         "f_intent": "OUT",
+                        "f_kind": "cstruct_list",
                         "f_type": "type(cstruct_list)",
                         "f_var": "SHT_rv",
                         "sh_type": "SH_TYPE_STRUCT"
@@ -5030,6 +5044,7 @@
                             "F_C_var": "SH_this",
                             "c_var": "SH_this",
                             "f_intent": "IN",
+                            "f_kind": "cstruct_ptr",
                             "f_type": "type(cstruct_ptr)",
                             "f_var": "SH_this",
                             "sh_type": "SH_TYPE_STRUCT",
@@ -5184,6 +5199,7 @@
                             "F_C_var": "SH_this",
                             "c_var": "SH_this",
                             "f_intent": "INOUT",
+                            "f_kind": "cstruct_ptr",
                             "f_type": "type(cstruct_ptr)",
                             "f_var": "SH_this",
                             "sh_type": "SH_TYPE_STRUCT",
@@ -5458,6 +5474,7 @@
                             "F_C_var": "SH_this",
                             "c_var": "SH_this",
                             "f_intent": "IN",
+                            "f_kind": "cstruct_list",
                             "f_type": "type(cstruct_list)",
                             "f_var": "SH_this",
                             "sh_type": "SH_TYPE_STRUCT",
@@ -5631,6 +5648,7 @@
                             "F_C_var": "SH_this",
                             "c_var": "SH_this",
                             "f_intent": "INOUT",
+                            "f_kind": "cstruct_list",
                             "f_type": "type(cstruct_list)",
                             "f_var": "SH_this",
                             "sh_type": "SH_TYPE_STRUCT",
@@ -5910,6 +5928,7 @@
                             "F_C_var": "SH_this",
                             "c_var": "SH_this",
                             "f_intent": "IN",
+                            "f_kind": "cstruct_list",
                             "f_type": "type(cstruct_list)",
                             "f_var": "SH_this",
                             "sh_type": "SH_TYPE_STRUCT",
@@ -6083,6 +6102,7 @@
                             "F_C_var": "SH_this",
                             "c_var": "SH_this",
                             "f_intent": "INOUT",
+                            "f_kind": "cstruct_list",
                             "f_type": "type(cstruct_list)",
                             "f_var": "SH_this",
                             "sh_type": "SH_TYPE_STRUCT",
@@ -6206,6 +6226,7 @@
                 ]
             },
             "f_derived_type": "arrays1",
+            "f_kind": "arrays1",
             "f_module": {
                 "struct_mod": [
                     "arrays1"
@@ -6232,6 +6253,7 @@
                 ]
             },
             "f_derived_type": "cstruct1",
+            "f_kind": "cstruct1",
             "f_module": {
                 "struct_mod": [
                     "cstruct1"
@@ -6330,6 +6352,7 @@
                 ]
             },
             "f_derived_type": "cstruct_list",
+            "f_kind": "cstruct_list",
             "f_module": {
                 "struct_mod": [
                     "cstruct_list"
@@ -6356,6 +6379,7 @@
                 ]
             },
             "f_derived_type": "cstruct_numpy",
+            "f_kind": "cstruct_numpy",
             "f_module": {
                 "struct_mod": [
                     "cstruct_numpy"
@@ -6382,6 +6406,7 @@
                 ]
             },
             "f_derived_type": "cstruct_ptr",
+            "f_kind": "cstruct_ptr",
             "f_module": {
                 "struct_mod": [
                     "cstruct_ptr"

--- a/regression/reference/struct-list-cxx/struct.json
+++ b/regression/reference/struct-list-cxx/struct.json
@@ -2353,6 +2353,7 @@
                 ]
             },
             "f_derived_type": "arrays1",
+            "f_kind": "arrays1",
             "f_module": {
                 "struct_mod": [
                     "arrays1"
@@ -2384,6 +2385,7 @@
                 ]
             },
             "f_derived_type": "cstruct1",
+            "f_kind": "cstruct1",
             "f_module": {
                 "struct_mod": [
                     "cstruct1"
@@ -2487,6 +2489,7 @@
                 ]
             },
             "f_derived_type": "cstruct_list",
+            "f_kind": "cstruct_list",
             "f_module": {
                 "struct_mod": [
                     "cstruct_list"
@@ -2518,6 +2521,7 @@
                 ]
             },
             "f_derived_type": "cstruct_numpy",
+            "f_kind": "cstruct_numpy",
             "f_module": {
                 "struct_mod": [
                     "cstruct_numpy"
@@ -2549,6 +2553,7 @@
                 ]
             },
             "f_derived_type": "cstruct_ptr",
+            "f_kind": "cstruct_ptr",
             "f_module": {
                 "struct_mod": [
                     "cstruct_ptr"

--- a/regression/reference/struct-numpy-c/struct.json
+++ b/regression/reference/struct-numpy-c/struct.json
@@ -2347,6 +2347,7 @@
                 ]
             },
             "f_derived_type": "arrays1",
+            "f_kind": "arrays1",
             "f_module": {
                 "struct_mod": [
                     "arrays1"
@@ -2381,6 +2382,7 @@
                 ]
             },
             "f_derived_type": "cstruct1",
+            "f_kind": "cstruct1",
             "f_module": {
                 "struct_mod": [
                     "cstruct1"
@@ -2487,6 +2489,7 @@
                 ]
             },
             "f_derived_type": "cstruct_list",
+            "f_kind": "cstruct_list",
             "f_module": {
                 "struct_mod": [
                     "cstruct_list"
@@ -2521,6 +2524,7 @@
                 ]
             },
             "f_derived_type": "cstruct_numpy",
+            "f_kind": "cstruct_numpy",
             "f_module": {
                 "struct_mod": [
                     "cstruct_numpy"
@@ -2555,6 +2559,7 @@
                 ]
             },
             "f_derived_type": "cstruct_ptr",
+            "f_kind": "cstruct_ptr",
             "f_module": {
                 "struct_mod": [
                     "cstruct_ptr"

--- a/regression/reference/struct-numpy-cxx/struct.json
+++ b/regression/reference/struct-numpy-cxx/struct.json
@@ -2344,6 +2344,7 @@
                 ]
             },
             "f_derived_type": "arrays1",
+            "f_kind": "arrays1",
             "f_module": {
                 "struct_mod": [
                     "arrays1"
@@ -2375,6 +2376,7 @@
                 ]
             },
             "f_derived_type": "cstruct1",
+            "f_kind": "cstruct1",
             "f_module": {
                 "struct_mod": [
                     "cstruct1"
@@ -2478,6 +2480,7 @@
                 ]
             },
             "f_derived_type": "cstruct_list",
+            "f_kind": "cstruct_list",
             "f_module": {
                 "struct_mod": [
                     "cstruct_list"
@@ -2509,6 +2512,7 @@
                 ]
             },
             "f_derived_type": "cstruct_numpy",
+            "f_kind": "cstruct_numpy",
             "f_module": {
                 "struct_mod": [
                     "cstruct_numpy"
@@ -2540,6 +2544,7 @@
                 ]
             },
             "f_derived_type": "cstruct_ptr",
+            "f_kind": "cstruct_ptr",
             "f_module": {
                 "struct_mod": [
                     "cstruct_ptr"

--- a/regression/reference/struct-py-c/struct-py.json
+++ b/regression/reference/struct-py-c/struct-py.json
@@ -543,6 +543,7 @@
                 ]
             },
             "f_derived_type": "cstruct_as_class",
+            "f_kind": "cstruct_as_class",
             "f_module": {
                 "struct_mod": [
                     "cstruct_as_class"
@@ -577,6 +578,7 @@
                 ]
             },
             "f_derived_type": "cstruct_as_numpy",
+            "f_kind": "cstruct_as_numpy",
             "f_module": {
                 "struct_mod": [
                     "cstruct_as_numpy"

--- a/regression/reference/struct-py-cxx/struct-py.json
+++ b/regression/reference/struct-py-cxx/struct-py.json
@@ -540,6 +540,7 @@
                 ]
             },
             "f_derived_type": "cstruct_as_class",
+            "f_kind": "cstruct_as_class",
             "f_module": {
                 "struct_mod": [
                     "cstruct_as_class"
@@ -571,6 +572,7 @@
                 ]
             },
             "f_derived_type": "cstruct_as_numpy",
+            "f_kind": "cstruct_as_numpy",
             "f_module": {
                 "struct_mod": [
                     "cstruct_as_numpy"

--- a/regression/reference/structlist/structlist.json
+++ b/regression/reference/structlist/structlist.json
@@ -333,6 +333,7 @@
                 ]
             },
             "f_derived_type": "arrays1",
+            "f_kind": "arrays1",
             "f_module": {
                 "struct_mod": [
                     "arrays1"

--- a/regression/reference/typedefs-c/typedefs.json
+++ b/regression/reference/typedefs-c/typedefs.json
@@ -469,6 +469,7 @@
                     ],
                     "typemap_name": "Struct1Rename"
                 },
+                "f_kind": "s_struct1",
                 "f_module": {
                     "typedefs_mod": [
                         "s_struct1"
@@ -596,6 +597,7 @@
                 ]
             },
             "f_derived_type": "s_struct1",
+            "f_kind": "s_struct1",
             "f_module": {
                 "typedefs_mod": [
                     "s_struct1"

--- a/regression/reference/typedefs-c/wrapftypedefs.f
+++ b/regression/reference/typedefs-c/wrapftypedefs.f
@@ -28,7 +28,7 @@ module typedefs_mod
 
     ! start typedef Struct1Rename
     ! typedef Struct1Rename
-    integer, parameter :: struct1_rename = None
+    integer, parameter :: struct1_rename = s_struct1
     ! end typedef Struct1Rename
 
 

--- a/regression/reference/typedefs-cxx/typedefs.json
+++ b/regression/reference/typedefs-cxx/typedefs.json
@@ -469,6 +469,7 @@
                     ],
                     "typemap_name": "Struct1Rename"
                 },
+                "f_kind": "s_struct1",
                 "f_module": {
                     "typedefs_mod": [
                         "s_struct1"
@@ -590,6 +591,7 @@
                 ]
             },
             "f_derived_type": "s_struct1",
+            "f_kind": "s_struct1",
             "f_module": {
                 "typedefs_mod": [
                     "s_struct1"

--- a/regression/reference/typedefs-cxx/wrapftypedefs.f
+++ b/regression/reference/typedefs-cxx/wrapftypedefs.f
@@ -28,7 +28,7 @@ module typedefs_mod
 
     ! start typedef Struct1Rename
     ! typedef Struct1Rename
-    integer, parameter :: struct1_rename = None
+    integer, parameter :: struct1_rename = s_struct1
     ! end typedef Struct1Rename
 
 

--- a/shroud/ast.py
+++ b/shroud/ast.py
@@ -156,7 +156,7 @@ class AstNode(object):
 ######################################################################
 
 class NamespaceMixin(object):
-    def add_class(self, decl, ast=None, fields=None,
+    def add_class(self, decl, ast=None, fields={},
                   base=[], template_parameters=None,
                   **kwargs):
         """Add a class.
@@ -177,7 +177,7 @@ class NamespaceMixin(object):
         self.classes.append(node)
         return node
 
-    def add_declaration(self, decl, fields=None, **kwargs):
+    def add_declaration(self, decl, fields={}, **kwargs):
         """parse decl and add corresponding node.
         decl - declaration
 
@@ -277,7 +277,7 @@ class NamespaceMixin(object):
             self.namespaces.append(node)
         return node
 
-    def add_struct(self, decl, ast=None, fields=None,
+    def add_struct(self, decl, ast=None, fields={},
                    template_parameters=None, **kwargs):
         """Add a struct.
 
@@ -307,7 +307,7 @@ class NamespaceMixin(object):
         self.classes.append(node)
         return node
 
-    def add_typedef(self, decl, ast=None, fields=None, **kwargs):
+    def add_typedef(self, decl, ast=None, fields={}, **kwargs):
         """Add a TypedefNode to the typedefs list.
 
         This may be the YAML file as a typemap which may have 'fields',
@@ -1054,7 +1054,7 @@ class ClassNode(AstNode, NamespaceMixin):
         base=[],
         cxx_header="",
         format={},
-        fields=None,
+        fields={},
         options=None,
         parse_keyword="class",
         template_parameters=None,


### PR DESCRIPTION
If the Typemap field is set via the fields dictionary, then do not compute a default value. Typically only f_derived_type is explicitly set. Then f_class, f_type, f_c_type, f_module and f_c_module are computed.  This is for class and struct Typemaps.

Set default argument value for fields to {} instead of None to allow it to always be treated as a dictionary (IN and UPDATE operations)