### PR TITLE
Print class instantiation in log

### DIFF
--- a/regression/reference/names/names.log
+++ b/regression/reference/names/names.log
@@ -12,10 +12,10 @@ C void init_ns1(void)  +intent(subroutine)
 Close wraptestnames_ns1.hh
 Close wraptestnames_ns1.cc
 class ImplWorker1
-class vector
-class vector
-class vector
-class vector
+class vector<int>
+class vector<double>
+class vector<long>
+class vector<internal::ImplWorker1>
 class Class1
 C void Member1(void)  +intent(subroutine)
 Close wrapCAPI_Class1.hh
@@ -25,8 +25,8 @@ Close wraptestnames_CAPI.hh
 Close wraptestnames_CAPI.cc
 class Names2
 Close wrapNames2.cc
-class twoTs
-class twoTs
+class twoTs<int, long>
+class twoTs<float, double>
 class Cstruct_as_class
 class Cstruct_as_subclass
 C void getName(char * name +len(worklen)+len_trim(worktrim))  +intent(subroutine)
@@ -48,8 +48,8 @@ C void external_funcs(const char * rdbase, const char * pkg, const char * name, 
 Close top.h
 Close top.cpp
 class Names2
-class twoTs
-class twoTs
+class twoTs<int, long>
+class twoTs<float, double>
 class Cstruct_as_class
 class Cstruct_as_subclass
 Fortran void getName(char * name +len(worklen)+len_trim(worktrim))  +intent(subroutine)
@@ -94,10 +94,10 @@ Fortran void init_ns1(void)  +intent(subroutine)
 C-interface void init_ns1(void)  +intent(subroutine)
 Close wrapftestnames_ns1.F
 Close wrapftestnames_internal.F
-class vector
-class vector
-class vector
-class vector
+class vector<int>
+class vector<double>
+class vector<long>
+class vector<internal::ImplWorker1>
 Close wrapftestnames_std.F
 class Class1
 Fortran void Member1(void)  +intent(subroutine)

--- a/regression/reference/templates/templates.log
+++ b/regression/reference/templates/templates.log
@@ -1,6 +1,6 @@
 Read yaml templates.yaml
 Close templates_types.yaml
-class vector
+class vector<int>
 C vector(void)  +api(capptr)+intent(ctor)
 C ~vector(void)  +intent(dtor)
 C void push_back(const int & value +intent(in))  +intent(subroutine)
@@ -8,7 +8,7 @@ C int & at(size_type n +value)  +deref(pointer)+intent(function)
 C int & at(size_type n +value)  +api(buf)+deref(pointer)+intent(function)
 Close wrapstd_vector_int.h
 Close wrapvectorforint.cpp
-class vector
+class vector<double>
 C vector(void)  +api(capptr)+intent(ctor)
 C ~vector(void)  +intent(dtor)
 C void push_back(const double & value +intent(in))  +intent(subroutine)
@@ -19,11 +19,11 @@ Close wrapstd_vector_double.cpp
 class ImplWorker1
 class ImplWorker2
 class Worker
-class user
+class user<int>
 C void nested(int arg1 +value, double arg2 +value)  +intent(subroutine)
 Close wrapuser_int.h
 Close wrapuser_int.cpp
-class structAsClass
+class structAsClass<int>
 C structAsClass(void)  +api(capptr)+intent(ctor)
 C void set_npts(int n +value)  +intent(subroutine)
 C int get_npts(void)  +intent(function)
@@ -31,7 +31,7 @@ C void set_value(int v +value)  +intent(subroutine)
 C int get_value(void)  +intent(function)
 Close wrapstructAsClass_int.h
 Close wrapstructAsClass_int.cpp
-class structAsClass
+class structAsClass<double>
 C structAsClass(void)  +api(capptr)+intent(ctor)
 C void set_npts(int n +value)  +intent(subroutine)
 C int get_npts(void)  +intent(function)
@@ -47,10 +47,10 @@ C int UseImplWorker(void)  +intent(function)
 Close wraptemplates.h
 Close wraptemplates.cpp
 class Worker
-class user
+class user<int>
 Fortran void nested(int arg1 +value, double arg2 +value)  +intent(subroutine)
 C-interface void nested(int arg1 +value, double arg2 +value)  +intent(subroutine)
-class structAsClass
+class structAsClass<int>
 Fortran structAsClass(void)  +api(capptr)+intent(ctor)
 Fortran void set_npts(int n +value)  +intent(subroutine)
 Fortran int get_npts(void)  +intent(function)
@@ -61,7 +61,7 @@ C-interface void set_npts(int n +value)  +intent(subroutine)
 C-interface int get_npts(void)  +intent(function)
 C-interface void set_value(int v +value)  +intent(subroutine)
 C-interface int get_value(void)  +intent(function)
-class structAsClass
+class structAsClass<double>
 Fortran structAsClass(void)  +api(capptr)+intent(ctor)
 Fortran void set_npts(int n +value)  +intent(subroutine)
 Fortran int get_npts(void)  +intent(function)
@@ -82,7 +82,7 @@ C-interface void FunctionTU(int arg1 +value, long arg2 +value)  +intent(subrouti
 C-interface void FunctionTU(float arg1 +value, double arg2 +value)  +intent(subroutine)
 C-interface int UseImplWorker(void)  +intent(function)
 C-interface int UseImplWorker(void)  +intent(function)
-class vector
+class vector<int>
 typedef size_type
 Fortran vector(void)  +api(capptr)+intent(ctor)
 Fortran ~vector(void)  +intent(dtor)
@@ -93,7 +93,7 @@ C-interface ~vector(void)  +intent(dtor)
 C-interface void push_back(const int & value +intent(in))  +intent(subroutine)
 C-interface int & at(size_type n +value)  +deref(pointer)+intent(function)
 C-interface int & at(size_type n +value)  +api(buf)+deref(pointer)+intent(function)
-class vector
+class vector<double>
 typedef size_type
 Fortran vector(void)  +api(capptr)+intent(ctor)
 Fortran ~vector(void)  +intent(dtor)

--- a/shroud/wrapc.py
+++ b/shroud/wrapc.py
@@ -573,7 +573,7 @@ class Wrapc(util.WrapperMixin):
         Args:
             node - ast.ClassNode.
         """
-        self.log.write("class {1.name}\n".format(self, node))
+        self.log.write("class {}\n".format(node.name_instantiation or node.name))
 
         fmt_class = node.fmtdict
         # call method syntax

--- a/shroud/wrapf.py
+++ b/shroud/wrapf.py
@@ -235,7 +235,7 @@ class Wrapf(util.WrapperMixin):
             fileinfo - ModuleInfo
         """
 
-        self.log.write("class {1.name}\n".format(self, node))
+        self.log.write("class {}\n".format(node.name_instantiation or node.name))
 
         options = node.options
         fmt_class = node.fmtdict


### PR DESCRIPTION
Instead of listing some classes the same multiple time, now include the template arguments.

names.log Before
```
  class vector
  class vector
```
Now
```
  class vector<int>
  class vector<double>
```