### PR TITLE
Use ClassNode.default_format with class instantiation

### DIFF
--- a/regression/input/templates.yaml
+++ b/regression/input/templates.yaml
@@ -25,6 +25,8 @@ declarations:
   declarations:
   - decl: template<typename T> class vector
     # std::vector class
+    format:
+       fmtsample: original
     cxx_header: <vector>
     cxx_template:
     - instantiation: <int>

--- a/regression/reference/names/names.json
+++ b/regression/reference/names/names.json
@@ -198,6 +198,9 @@
                     "T2"
                 ],
                 "typemap_name": "twoTs_instantiation4",
+                "user_fmt": {
+                    "template_suffix": "_instantiation4"
+                },
                 "wrap": {
                     "c": true,
                     "fortran": true,
@@ -3811,6 +3814,10 @@
                             "T"
                         ],
                         "typemap_name": "std::Vvv1",
+                        "user_fmt": {
+                            "F_derived_name": "FFvvv1",
+                            "cxx_class": "Vvv1"
+                        },
                         "wrap": {
                             "c": true,
                             "fortran": true,
@@ -4015,6 +4022,9 @@
                             "T"
                         ],
                         "typemap_name": "std::vector_instantiation5",
+                        "user_fmt": {
+                            "template_suffix": "_instantiation5"
+                        },
                         "wrap": {
                             "c": true,
                             "fortran": true,

--- a/regression/reference/templates/templates.json
+++ b/regression/reference/templates/templates.json
@@ -3531,6 +3531,10 @@
                             ]
                         ],
                         "typemap_name": "std::vector_int",
+                        "user_fmt": {
+                            "C_impl_filename": "wrapvectorforint.cpp",
+                            "fmtsample": "one"
+                        },
                         "wrap": {
                             "c": true,
                             "fortran": true,
@@ -4361,6 +4365,9 @@
                             ]
                         ],
                         "typemap_name": "std::vector_double",
+                        "user_fmt": {
+                            "fmtsample": "original"
+                        },
                         "wrap": {
                             "c": true,
                             "fortran": true,
@@ -4389,6 +4396,7 @@
                             "cxx_type": "vector<double>",
                             "f_capsule_data_type": "TEM_SHROUD_capsule_data",
                             "file_scope": "std_vector_double",
+                            "fmtsample": "original",
                             "hnamefunc0": "capsule_data_helper",
                             "lower_name": "vector_double",
                             "underscore_name": "vector_double",

--- a/shroud/ast.py
+++ b/shroud/ast.py
@@ -1227,10 +1227,11 @@ class ClassNode(AstNode, NamespaceMixin):
     def default_format(self):
         """Set format dictionary for a ClassNode."""
         name_api = self.name_api or self.name
+        name_instantiation = self.name_instantiation or self.name
 
         self.fmtdict.update(dict(
-            cxx_type=self.name_instantiation or name_api,
-            cxx_class=self.name,
+            cxx_type=name_instantiation,
+            cxx_class=name_api,
 
             underscore_name = util.un_camel(name_api),
             upper_name = name_api.upper(),
@@ -1238,7 +1239,7 @@ class ClassNode(AstNode, NamespaceMixin):
             C_name_api = self.apply_C_API_option(name_api),
             F_name_api = self.apply_F_API_option(name_api),
 
-            class_scope=name_api + "::",
+            class_scope=name_instantiation + "::",
 #            namespace_scope=self.parent.fmtdict.namespace_scope + name_api + "::",
 
             # The scope for things in the class.
@@ -1321,6 +1322,7 @@ class ClassNode(AstNode, NamespaceMixin):
         new.options = self.options.clone()
         new.wrap = WrapFlags(self.options)
         new.scope_file = self.scope_file[:]
+        new.user_fmt = self.user_fmt.copy()
 
         # Clone all functions.
         newfcns = []

--- a/shroud/generate.py
+++ b/shroud/generate.py
@@ -959,52 +959,24 @@ class GenFunctions(object):
                         class_suffix = "_" + str(i)
 
                     # Update name of class.
-                    #  cxx_class - vector_0 or vector_int     (Fortran and C names)
-                    #  cxx_type  - vector<int>
-                    cxx_class = "{}{}".format(
-                        newcls.fmtdict.cxx_class, class_suffix
-                    )
-                    cxx_type = "{}{}".format(
-                        newcls.fmtdict.cxx_class, targs.instantiation
-                    )
-
+                    #  name_api           - vector_0 or vector_int     (Fortran and C names)
+                    #  name_instantiation - vector<int>
                     if targs.fmtdict and "cxx_class" in targs.fmtdict:
-                        # Check if user has changed cxx_class.
-                        cxx_class = targs.fmtdict["cxx_class"]
-
-                    newcls.name_api = cxx_class           # ex. name_int
-                    newcls.name_instantiation = cxx_type  # ex. name<int>
-
+                        newcls.name_api = targs.fmtdict["cxx_class"]
+                    else:
+                        newcls.name_api = cls.name + class_suffix
+                    newcls.name_instantiation = cls.name + targs.instantiation
                     newcls.scope_file[-1] += class_suffix
-                    # Update default values to format dictionary.
-#TODO                    newcls.default_format()
-                    name_api = cxx_class
-                    newcls.fmtdict.update(
-                        dict(
-                            cxx_type=cxx_type,
-                            cxx_class=name_api,
-                            underscore_name=util.un_camel(name_api),
-                            upper_name=name_api.upper(),
-                            lower_name=name_api.lower(),
-                            C_name_api=newcls.apply_C_API_option(name_api),
-                            F_name_api=newcls.apply_F_API_option(name_api),
-                            class_scope=cxx_type + "::",
-                            C_name_scope=newcls.parent.fmtdict.C_name_scope + newcls.apply_C_API_option(name_api) + "_",
-                            F_name_scope=newcls.parent.fmtdict.F_name_scope + newcls.apply_F_API_option(name_api) + "_",
-                            file_scope="_".join(newcls.scope_file[1:]),
-                        )
-                    )
 
-                    # Remove defaulted attributes, load files from fmtdict, recompute defaults
-                    newcls.delete_format_templates()
-
-                    # Update format and options from template_arguments
                     if targs.fmtdict:
-                        newcls.fmtdict.update(targs.fmtdict)
+                        newcls.user_fmt.update(targs.fmtdict)
                     if targs.options:
                         newcls.options.update(targs.options)
+                    
+                    # Remove defaulted attributes then reset with current values.
+                    newcls.delete_format_templates()
+                    newcls.default_format()
 
-                    newcls.expand_format_templates()
                     newcls.typemap = typemap.create_class_typemap(newcls)
                     if targs.instantiation in orig_typemap.cxx_instantiation:
                         print("instantiate_classes: {} already in "


### PR DESCRIPTION
Removes duplicate code in `GenFunctions.instantiate_classes` in `generate.py`.  Fixed issues in `default_format` to allow it to work with instantiations.