### PR TITLE
Add additional_declarations splicer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add generic interfaces for class methods.  Generic functions where only being added
   to the type-bound procedures.  ``class_generic(obj)`` now works instead of only
   ``obj%generic()``.
+- Replaced the *additional_interfaces* splicer with *additional_declarations*.
+  This new splicer is outside of an interface block and can be used to add
+  add a generic interface that could not be added to *additional_interfaces*.
 
 ### Changed
 - Changed name of C and Python function splicers to use *function_name* instead of

--- a/docs/input.rst
+++ b/docs/input.rst
@@ -1016,10 +1016,8 @@ code for helper functions or declarations:
          ! class.{cxx_class}.type_bound_procedure_part
        end type class1
 
-       interface
-          ! additional_interfaces
-       end interface
-
+       ! additional_declarations
+       
        contains
 
        ! function.{F_name_function}

--- a/regression/input/ftutorialsplicer.f
+++ b/regression/input/ftutorialsplicer.f
@@ -5,9 +5,11 @@
 ! SPDX-License-Identifier: (BSD-3-Clause)
 !########################################################################
 
-! splicer begin additional_interfaces
-subroutine all_test1(array)
-  implicit none
-  integer, dimension(:), allocatable :: array
-end subroutine all_test1
-! splicer end additional_interfaces
+! splicer begin additional_declarations
+interface
+  subroutine all_test1(array)
+    implicit none
+    integer, dimension(:), allocatable :: array
+  end subroutine all_test1
+end interface
+! splicer end additional_declarations

--- a/regression/reference/arrayclass/wrapfarrayclass.f
+++ b/regression/reference/arrayclass/wrapfarrayclass.f
@@ -521,17 +521,14 @@ module arrayclass_mod
             type(ARR_SHROUD_capsule_data), intent(IN) :: self
             real(C_DOUBLE) :: SHT_rv
         end function c_ArrayWrapper_sumArray
-
-        ! splicer begin class.ArrayWrapper.additional_interfaces
-        ! splicer end class.ArrayWrapper.additional_interfaces
-
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
     end interface
 
     interface ArrayWrapper
         module procedure ArrayWrapper_ctor
     end interface ArrayWrapper
+
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/ccomplex/wrapfccomplex.f
+++ b/regression/reference/ccomplex/wrapfccomplex.f
@@ -102,10 +102,8 @@ module ccomplex_mod
         end subroutine accept_double_complex_out_ptr_flag
     end interface
 
-    interface
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
-    end interface
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/cdesc/wrapfcdesc.f
+++ b/regression/reference/cdesc/wrapfcdesc.f
@@ -207,9 +207,6 @@ module cdesc_mod
             implicit none
             real(C_DOUBLE) :: SHT_rv
         end function c_get_data_double
-
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
     end interface
 
     interface get_scalar1
@@ -221,6 +218,9 @@ module cdesc_mod
         module procedure get_scalar2_0
         module procedure get_scalar2_1
     end interface get_scalar2
+
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/classes/wrapfclasses.f
+++ b/regression/reference/classes/wrapfclasses.f
@@ -519,9 +519,6 @@ module classes_mod
     end interface
     ! end c_class1_set_m_name_bufferify
 
-    ! splicer begin class.Class1.additional_interfaces
-    ! splicer end class.Class1.additional_interfaces
-
     ! ----------------------------------------
     ! Function:  const std::string & getName
     ! Attrs:     +deref(allocatable)+intent(function)
@@ -553,9 +550,6 @@ module classes_mod
         end subroutine c_class2_get_name_bufferify
     end interface
 
-    ! splicer begin class.Class2.additional_interfaces
-    ! splicer end class.Class2.additional_interfaces
-
     ! ----------------------------------------
     ! Function:  static Singleton & getReference
     ! Attrs:     +api(capptr)+intent(function)
@@ -573,9 +567,6 @@ module classes_mod
         end function c_singleton_get_reference
     end interface
     ! end c_singleton_get_reference
-
-    ! splicer begin class.Singleton.additional_interfaces
-    ! splicer end class.Singleton.additional_interfaces
 
     ! ----------------------------------------
     ! Function:  Shape
@@ -610,9 +601,6 @@ module classes_mod
         end function c_shape_get_ivar
     end interface
 
-    ! splicer begin class.Shape.additional_interfaces
-    ! splicer end class.Shape.additional_interfaces
-
     ! ----------------------------------------
     ! Function:  Circle
     ! Attrs:     +api(capptr)+intent(ctor)
@@ -628,9 +616,6 @@ module classes_mod
             type(C_PTR) SHT_prv
         end function c_circle_ctor
     end interface
-
-    ! splicer begin class.Circle.additional_interfaces
-    ! splicer end class.Circle.additional_interfaces
 
     ! ----------------------------------------
     ! Function:  void allocate
@@ -783,9 +768,6 @@ module classes_mod
         end subroutine c_data_set_items
     end interface
     ! end c_data_set_items
-
-    ! splicer begin class.Data.additional_interfaces
-    ! splicer end class.Data.additional_interfaces
 
     ! ----------------------------------------
     ! Function:  Class1::DIRECTION directionFunc
@@ -1023,11 +1005,6 @@ module classes_mod
         end subroutine c_last_function_called_bufferify
     end interface
 
-    interface
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
-    end interface
-
     interface circle
         module procedure circle_ctor
     end interface circle
@@ -1061,6 +1038,9 @@ module classes_mod
             integer(C_SIZE_T), value :: c_var_size
         end subroutine CLA_SHROUD_copy_string_and_free
     end interface
+
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/clibrary/wrapfclibrary.f
+++ b/regression/reference/clibrary/wrapfclibrary.f
@@ -944,10 +944,8 @@ module clibrary_mod
         end subroutine callback_set_alloc
     end interface
 
-    interface
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
-    end interface
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/cxxlibrary/wrapfcxxlibrary.f
+++ b/regression/reference/cxxlibrary/wrapfcxxlibrary.f
@@ -176,9 +176,6 @@ module cxxlibrary_mod
             character(kind=C_CHAR), intent(OUT) :: SHT_rv(*)
             integer(C_INT), value, intent(IN) :: SHT_rv_len
         end subroutine c_get_group_name_int64_t_bufferify
-
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
     end interface
 
     interface default_args_in_out
@@ -195,6 +192,9 @@ module cxxlibrary_mod
         module procedure get_group_name_int32_t
         module procedure get_group_name_int64_t
     end interface get_group_name
+
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/cxxlibrary/wrapfcxxlibrary_structns.f
+++ b/regression/reference/cxxlibrary/wrapfcxxlibrary_structns.f
@@ -102,10 +102,10 @@ module cxxlibrary_structns_mod
             implicit none
             type(cstruct1), intent(OUT) :: arg
         end subroutine pass_struct_by_reference_out
-
-        ! splicer begin namespace.structns.additional_interfaces
-        ! splicer end namespace.structns.additional_interfaces
     end interface
+
+    ! splicer begin namespace.structns.additional_declarations
+    ! splicer end namespace.structns.additional_declarations
 
 contains
 

--- a/regression/reference/debugfalse/wrapftutorial.f
+++ b/regression/reference/debugfalse/wrapftutorial.f
@@ -413,15 +413,6 @@ module tutorial_mod
         end subroutine c_last_function_called_bufferify
     end interface
 
-    interface
-        ! splicer begin additional_interfaces
-        subroutine all_test1(array)
-          implicit none
-          integer, dimension(:), allocatable :: array
-        end subroutine all_test1
-        ! splicer end additional_interfaces
-    end interface
-
     interface fortran_generic_overloaded
         module procedure fortran_generic_overloaded_0
         module procedure fortran_generic_overloaded_1_float
@@ -467,6 +458,15 @@ module tutorial_mod
             integer(C_SIZE_T), value :: c_var_size
         end subroutine TUT_SHROUD_copy_string_and_free
     end interface
+
+    ! splicer begin additional_declarations
+    interface
+      subroutine all_test1(array)
+        implicit none
+        integer, dimension(:), allocatable :: array
+      end subroutine all_test1
+    end interface
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/defaultarg/wrapfdefaultarg.f
+++ b/regression/reference/defaultarg/wrapfdefaultarg.f
@@ -295,9 +295,6 @@ module defaultarg_mod
         end function c_class1_get_field3
     end interface
 
-    ! splicer begin class.Class1.additional_interfaces
-    ! splicer end class.Class1.additional_interfaces
-
     ! ----------------------------------------
     ! Function:  void apply_generic
     ! Attrs:     +intent(subroutine)
@@ -613,11 +610,6 @@ module defaultarg_mod
     end interface
 #endif
 
-    interface
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
-    end interface
-
     interface apply_generic
         module procedure apply_generic_nelems
         module procedure apply_generic_nelems_offset
@@ -656,6 +648,9 @@ module defaultarg_mod
         module procedure class1_default_arguments_1
         module procedure class1_default_arguments_2
     end interface class1_default_arguments
+
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/enum-c/wrapfenum.f
+++ b/regression/reference/enum-c/wrapfenum.f
@@ -56,10 +56,10 @@ module enum_mod
             integer(C_INT), value, intent(IN) :: in
             integer(C_INT) :: SHT_rv
         end function convert_to_int
-
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
     end interface
+
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/enum-cxx/wrapfenum.f
+++ b/regression/reference/enum-cxx/wrapfenum.f
@@ -56,10 +56,10 @@ module enum_mod
             integer(C_INT), value, intent(IN) :: in
             integer(C_INT) :: SHT_rv
         end function convert_to_int
-
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
     end interface
+
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/example/wrapfUserLibrary_example.f
+++ b/regression/reference/example/wrapfUserLibrary_example.f
@@ -21,11 +21,8 @@ module userlibrary_example_mod
     top of module namespace example splicer  2
     ! splicer end namespace.example.module_top
 
-    interface
-
-        ! splicer begin namespace.example.additional_interfaces
-        ! splicer end namespace.example.additional_interfaces
-    end interface
+    ! splicer begin namespace.example.additional_declarations
+    ! splicer end namespace.example.additional_declarations
 
 contains
 

--- a/regression/reference/example/wrapfUserLibrary_example_nested.f
+++ b/regression/reference/example/wrapfUserLibrary_example_nested.f
@@ -386,9 +386,6 @@ module userlibrary_example_nested_mod
             type(AA_SHROUD_capsule_data), intent(IN) :: self
         end subroutine c_ex_class1_splicer_special
 
-        ! splicer begin namespace.example::nested.class.ExClass1.additional_interfaces
-        ! splicer end namespace.example::nested.class.ExClass1.additional_interfaces
-
         ! ----------------------------------------
         ! Function:  ExClass2
         ! Attrs:     +api(capptr)+intent(ctor)
@@ -760,9 +757,6 @@ module userlibrary_example_nested_mod
             type(AA_SHROUD_capsule_data), intent(IN) :: self
             real(C_DOUBLE) :: SHT_rv
         end function c_ex_class2_get_value_double
-
-        ! splicer begin namespace.example::nested.class.ExClass2.additional_interfaces
-        ! splicer end namespace.example::nested.class.ExClass2.additional_interfaces
 
         ! ----------------------------------------
         ! Function:  void local_function1
@@ -1259,9 +1253,6 @@ module userlibrary_example_nested_mod
             real(C_DOUBLE), intent(OUT) :: out(*)
             integer(C_INT), value, intent(IN) :: sizein
         end subroutine c_cos_doubles
-
-        ! splicer begin namespace.example::nested.additional_interfaces
-        ! splicer end namespace.example::nested.additional_interfaces
     end interface
 
     interface ex_class1
@@ -1324,6 +1315,9 @@ module userlibrary_example_nested_mod
             integer(C_SIZE_T), value :: c_var_size
         end subroutine AA_SHROUD_copy_string_and_free
     end interface
+
+    ! splicer begin namespace.example::nested.additional_declarations
+    ! splicer end namespace.example::nested.additional_declarations
 
 contains
 

--- a/regression/reference/example/wrapfuserlibrary.f
+++ b/regression/reference/example/wrapfuserlibrary.f
@@ -32,11 +32,8 @@ module userlibrary_mod
     integer, parameter :: type_id = C_INT
     ! splicer end typedef.TypeID
 
-    interface
-
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
-    end interface
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/forward/wrapfforward.f
+++ b/regression/reference/forward/wrapfforward.f
@@ -66,9 +66,6 @@ module forward_mod
 
     interface
 
-        ! splicer begin class.Class3.additional_interfaces
-        ! splicer end class.Class3.additional_interfaces
-
         ! ----------------------------------------
         ! Function:  Class2
         ! Attrs:     +api(capptr)+intent(ctor)
@@ -130,9 +127,6 @@ module forward_mod
             type(FOR_SHROUD_capsule_data), intent(IN) :: arg
         end subroutine c_class2_accept_class3
 
-        ! splicer begin class.Class2.additional_interfaces
-        ! splicer end class.Class2.additional_interfaces
-
         ! ----------------------------------------
         ! Function:  int passStruct1
         ! Attrs:     +intent(function)
@@ -152,14 +146,14 @@ module forward_mod
             type(cstruct1), intent(IN) :: arg
             integer(C_INT) :: SHT_rv
         end function c_pass_struct1
-
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
     end interface
 
     interface class2
         module procedure class2_ctor
     end interface class2
+
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/generic-cfi/wrapfgeneric.f
+++ b/regression/reference/generic-cfi/wrapfgeneric.f
@@ -86,9 +86,6 @@ module generic_mod
         module procedure struct_as_class_ne
     end interface
 
-    ! splicer begin class.StructAsClass.additional_interfaces
-    ! splicer end class.StructAsClass.additional_interfaces
-
     ! ----------------------------------------
     ! Function:  void UpdateAsFloat
     ! Attrs:     +intent(subroutine)
@@ -775,11 +772,6 @@ module generic_mod
         end function c_update_struct_as_class_long
     end interface
 
-    interface
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
-    end interface
-
     interface assign_values
         module procedure assign_values_scalar
         module procedure assign_values_broadcast
@@ -830,6 +822,9 @@ module generic_mod
         module procedure update_struct_as_class_int
         module procedure update_struct_as_class_long
     end interface update_struct_as_class
+
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/generic/wrapfgeneric.f
+++ b/regression/reference/generic/wrapfgeneric.f
@@ -105,9 +105,6 @@ module generic_mod
         module procedure struct_as_class_ne
     end interface
 
-    ! splicer begin class.StructAsClass.additional_interfaces
-    ! splicer end class.StructAsClass.additional_interfaces
-
     ! ----------------------------------------
     ! Function:  void UpdateAsFloat
     ! Attrs:     +intent(subroutine)
@@ -860,11 +857,6 @@ module generic_mod
         end function c_update_struct_as_class_long
     end interface
 
-    interface
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
-    end interface
-
     interface assign_values
         module procedure assign_values_scalar
         module procedure assign_values_broadcast
@@ -921,6 +913,9 @@ module generic_mod
         module procedure update_struct_as_class_int
         module procedure update_struct_as_class_long
     end interface update_struct_as_class
+
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/include/wrapflibrary.f
+++ b/regression/reference/include/wrapflibrary.f
@@ -79,9 +79,8 @@ module library_mod
             type(LIB_SHROUD_capsule_data), intent(IN) :: self
             type(LIB_SHROUD_capsule_data), intent(INOUT) :: c2
         end subroutine c_class2_method2
-
-
     end interface
+
 
 contains
 

--- a/regression/reference/include/wrapflibrary_one.f
+++ b/regression/reference/include/wrapflibrary_one.f
@@ -14,9 +14,6 @@ module library_one_mod
     implicit none
 
 
-    interface
-
-    end interface
 
 contains
 

--- a/regression/reference/include/wrapflibrary_one_two.f
+++ b/regression/reference/include/wrapflibrary_one_two.f
@@ -25,8 +25,8 @@ module library_one_two_mod
                 bind(C, name="LIB_one_two_function1")
             implicit none
         end subroutine function1
-
     end interface
+
 
 contains
 

--- a/regression/reference/include/wrapflibrary_outer1.f
+++ b/regression/reference/include/wrapflibrary_outer1.f
@@ -52,7 +52,6 @@ module library_outer1_mod
             type(LIB_SHROUD_capsule_data), intent(IN) :: self
         end subroutine c_class0_method
 
-
         ! ----------------------------------------
         ! Function:  void outer_func
         ! Attrs:     +intent(subroutine)
@@ -62,8 +61,8 @@ module library_outer1_mod
                 bind(C, name="LIB_outer1_outer_func")
             implicit none
         end subroutine outer_func
-
     end interface
+
 
 contains
 

--- a/regression/reference/include/wrapflibrary_outer2.f
+++ b/regression/reference/include/wrapflibrary_outer2.f
@@ -52,7 +52,6 @@ module library_outer2_mod
             type(LIB_SHROUD_capsule_data), intent(IN) :: self
         end subroutine c_class0_method
 
-
         ! ----------------------------------------
         ! Function:  void outer_func
         ! Attrs:     +intent(subroutine)
@@ -62,8 +61,8 @@ module library_outer2_mod
                 bind(C, name="LIB_outer2_outer_func")
             implicit none
         end subroutine outer_func
-
     end interface
+
 
 contains
 

--- a/regression/reference/include/wrapflibrary_three.f
+++ b/regression/reference/include/wrapflibrary_three.f
@@ -57,9 +57,8 @@ module library_three_mod
             type(LIB_SHROUD_capsule_data), intent(IN) :: self
             integer(custom_type), value, intent(IN) :: arg1
         end subroutine c_class1_method1
-
-
     end interface
+
 
 contains
 

--- a/regression/reference/interface/wrapfinterface.f
+++ b/regression/reference/interface/wrapfinterface.f
@@ -56,10 +56,10 @@ module interface_mod
             integer(C_INT), value, intent(IN) :: arg2
             real(C_DOUBLE) :: SHT_rv
         end function function2
-
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
     end interface
+
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/memdoc/wrapfmemdoc.f
+++ b/regression/reference/memdoc/wrapfmemdoc.f
@@ -81,11 +81,6 @@ module memdoc_mod
     ! end c_get_const_string_ptr_alloc_bufferify
 
     interface
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
-    end interface
-
-    interface
         ! helper copy_string
         ! Copy the char* or std::string in context into c_var.
         subroutine STR_SHROUD_copy_string_and_free(context, c_var, c_var_size) &
@@ -97,6 +92,9 @@ module memdoc_mod
             integer(C_SIZE_T), value :: c_var_size
         end subroutine STR_SHROUD_copy_string_and_free
     end interface
+
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/names/foo.f
+++ b/regression/reference/names/foo.f
@@ -88,17 +88,14 @@ module name_module
             implicit none
             type(TES_SHROUD_capsule_data), intent(IN) :: self2
         end subroutine XXX_TES_names_method2
-
-        ! splicer begin namespace.ns0.class.Names.additional_interfaces
-        ! splicer end namespace.ns0.class.Names.additional_interfaces
-
-        ! splicer begin namespace.ns0.additional_interfaces
-        ! splicer end namespace.ns0.additional_interfaces
     end interface
 
     interface FNames
         module procedure names_defaultctor
     end interface FNames
+
+    ! splicer begin namespace.ns0.additional_declarations
+    ! splicer end namespace.ns0.additional_declarations
 
 contains
 

--- a/regression/reference/names/top.f
+++ b/regression/reference/names/top.f
@@ -134,21 +134,6 @@ module top_module
 
     interface
 
-        ! splicer begin class.Names2.additional_interfaces
-        ! splicer end class.Names2.additional_interfaces
-
-        ! splicer begin class.twoTs_0.additional_interfaces
-        ! splicer end class.twoTs_0.additional_interfaces
-
-        ! splicer begin class.twoTs_instantiation4.additional_interfaces
-        ! splicer end class.twoTs_instantiation4.additional_interfaces
-
-        ! splicer begin class.Cstruct_as_class.additional_interfaces
-        ! splicer end class.Cstruct_as_class.additional_interfaces
-
-        ! splicer begin class.Cstruct_as_subclass.additional_interfaces
-        ! splicer end class.Cstruct_as_subclass.additional_interfaces
-
         ! ----------------------------------------
         ! Function:  void getName
         ! Attrs:     +intent(subroutine)
@@ -457,9 +442,6 @@ module top_module
             procedure(external_funcs_afree) :: afree
             procedure(external_funcs_assoc) :: assoc
         end subroutine c_external_funcs
-
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
     end interface
 
     interface function_tu
@@ -471,6 +453,9 @@ module top_module
         module procedure F_name_function3a_int
         module procedure F_name_function3a_long
     end interface generic3
+
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/names/wrapftestnames_CAPI.F
+++ b/regression/reference/names/wrapftestnames_CAPI.F
@@ -62,9 +62,6 @@ module testnames_capi_mod
             type(TES_SHROUD_capsule_data), intent(IN) :: self
         end subroutine c_class1_member1
 
-        ! splicer begin namespace.CAPI.class.Class1.additional_interfaces
-        ! splicer end namespace.CAPI.class.Class1.additional_interfaces
-
         ! ----------------------------------------
         ! Function:  void Worker1
         ! Attrs:     +intent(subroutine)
@@ -74,10 +71,10 @@ module testnames_capi_mod
                 bind(C, name="TES_capi_worker1")
             implicit none
         end subroutine c_worker1
-
-        ! splicer begin namespace.CAPI.additional_interfaces
-        ! splicer end namespace.CAPI.additional_interfaces
     end interface
+
+    ! splicer begin namespace.CAPI.additional_declarations
+    ! splicer end namespace.CAPI.additional_declarations
 
 contains
 

--- a/regression/reference/names/wrapftestnames_CAPI2.F
+++ b/regression/reference/names/wrapftestnames_CAPI2.F
@@ -31,10 +31,10 @@ module testnames_capi2_mod
                 bind(C, name="TES_CAPItwo_Worker1")
             implicit none
         end subroutine c_worker1
-
-        ! splicer begin namespace.CAPI2.additional_interfaces
-        ! splicer end namespace.CAPI2.additional_interfaces
     end interface
+
+    ! splicer begin namespace.CAPI2.additional_declarations
+    ! splicer end namespace.CAPI2.additional_declarations
 
 contains
 

--- a/regression/reference/names/wrapftestnames_internal.F
+++ b/regression/reference/names/wrapftestnames_internal.F
@@ -20,11 +20,8 @@ module testnames_internal_mod
     ! splicer begin namespace.internal.module_top
     ! splicer end namespace.internal.module_top
 
-    interface
-
-        ! splicer begin namespace.internal.additional_interfaces
-        ! splicer end namespace.internal.additional_interfaces
-    end interface
+    ! splicer begin namespace.internal.additional_declarations
+    ! splicer end namespace.internal.additional_declarations
 
 contains
 

--- a/regression/reference/names/wrapftestnames_ns0_inner.F
+++ b/regression/reference/names/wrapftestnames_ns0_inner.F
@@ -21,11 +21,8 @@ module testnames_ns0_inner_mod
     ! splicer begin namespace.ns0::inner.module_top
     ! splicer end namespace.ns0::inner.module_top
 
-    interface
-
-        ! splicer begin namespace.ns0::inner.additional_interfaces
-        ! splicer end namespace.ns0::inner.additional_interfaces
-    end interface
+    ! splicer begin namespace.ns0::inner.additional_declarations
+    ! splicer end namespace.ns0::inner.additional_declarations
 
 contains
 

--- a/regression/reference/names/wrapftestnames_ns1.F
+++ b/regression/reference/names/wrapftestnames_ns1.F
@@ -31,10 +31,10 @@ module testnames_ns1_mod
                 bind(C, name="TES_ns1_init_ns1")
             implicit none
         end subroutine c_init_ns1
-
-        ! splicer begin namespace.ns1.additional_interfaces
-        ! splicer end namespace.ns1.additional_interfaces
     end interface
+
+    ! splicer begin namespace.ns1.additional_declarations
+    ! splicer end namespace.ns1.additional_declarations
 
 contains
 

--- a/regression/reference/names/wrapftestnames_std.F
+++ b/regression/reference/names/wrapftestnames_std.F
@@ -89,23 +89,8 @@ module testnames_std_mod
         module procedure vector_instantiation3_ne
     end interface
 
-    interface
-
-        ! splicer begin namespace.std.class.Vvv1.additional_interfaces
-        ! splicer end namespace.std.class.Vvv1.additional_interfaces
-
-        ! splicer begin namespace.std.class.vector_double.additional_interfaces
-        ! splicer end namespace.std.class.vector_double.additional_interfaces
-
-        ! splicer begin namespace.std.class.vector_instantiation5.additional_interfaces
-        ! splicer end namespace.std.class.vector_instantiation5.additional_interfaces
-
-        ! splicer begin namespace.std.class.vector_instantiation3.additional_interfaces
-        ! splicer end namespace.std.class.vector_instantiation3.additional_interfaces
-
-        ! splicer begin namespace.std.additional_interfaces
-        ! splicer end namespace.std.additional_interfaces
-    end interface
+    ! splicer begin namespace.std.additional_declarations
+    ! splicer end namespace.std.additional_declarations
 
 contains
 

--- a/regression/reference/names2/wrapfnames.f
+++ b/regression/reference/names2/wrapfnames.f
@@ -31,10 +31,10 @@ module worker_names
                 bind(C, name="NAM_AFunction")
             implicit none
         end subroutine a_function
-
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
     end interface
+
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/namespace/wrapfns.f
+++ b/regression/reference/namespace/wrapfns.f
@@ -103,12 +103,6 @@ module ns_mod
                 bind(C, name="NS_One")
             implicit none
         end subroutine one
-
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
-
-        ! splicer begin namespace.outer.class.ClassWork.additional_interfaces
-        ! splicer end namespace.outer.class.ClassWork.additional_interfaces
     end interface
 
     interface
@@ -123,6 +117,9 @@ module ns_mod
             integer(C_SIZE_T), value :: c_var_size
         end subroutine NS_SHROUD_copy_string_and_free
     end interface
+
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/namespace/wrapfns_outer.f
+++ b/regression/reference/namespace/wrapfns_outer.f
@@ -38,10 +38,10 @@ module ns_outer_mod
                 bind(C, name="NS_outer_One")
             implicit none
         end subroutine one
-
-        ! splicer begin namespace.outer.additional_interfaces
-        ! splicer end namespace.outer.additional_interfaces
     end interface
+
+    ! splicer begin namespace.outer.additional_declarations
+    ! splicer end namespace.outer.additional_declarations
 
 contains
 

--- a/regression/reference/namespacedoc/wrapfwrapped.f
+++ b/regression/reference/namespacedoc/wrapfwrapped.f
@@ -42,9 +42,6 @@ module wrapped_mod
             implicit none
         end subroutine worker
 
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
-
         ! ----------------------------------------
         ! Function:  void worker4
         ! Attrs:     +intent(subroutine)
@@ -55,6 +52,9 @@ module wrapped_mod
             implicit none
         end subroutine inner4_worker4
     end interface
+
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/namespacedoc/wrapfwrapped_inner1.f
+++ b/regression/reference/namespacedoc/wrapfwrapped_inner1.f
@@ -31,10 +31,10 @@ module wrapped_inner1_mod
                 bind(C, name="WWW_inner1_worker")
             implicit none
         end subroutine worker
-
-        ! splicer begin namespace.inner1.additional_interfaces
-        ! splicer end namespace.inner1.additional_interfaces
     end interface
+
+    ! splicer begin namespace.inner1.additional_declarations
+    ! splicer end namespace.inner1.additional_declarations
 
 contains
 

--- a/regression/reference/namespacedoc/wrapfwrapped_inner2.f
+++ b/regression/reference/namespacedoc/wrapfwrapped_inner2.f
@@ -31,10 +31,10 @@ module wrapped_inner2_mod
                 bind(C, name="WWW_inner2_worker")
             implicit none
         end subroutine worker
-
-        ! splicer begin namespace.inner2.additional_interfaces
-        ! splicer end namespace.inner2.additional_interfaces
     end interface
+
+    ! splicer begin namespace.inner2.additional_declarations
+    ! splicer end namespace.inner2.additional_declarations
 
 contains
 

--- a/regression/reference/none/wrapflibrary.f
+++ b/regression/reference/none/wrapflibrary.f
@@ -20,11 +20,8 @@ module library_mod
     ! splicer begin module_top
     ! splicer end module_top
 
-    interface
-
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
-    end interface
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/ownership/wrapfownership.f
+++ b/regression/reference/ownership/wrapfownership.f
@@ -103,9 +103,6 @@ module ownership_mod
             integer(C_INT) :: SHT_rv
         end function c_class1_get_flag
 
-        ! splicer begin class.Class1.additional_interfaces
-        ! splicer end class.Class1.additional_interfaces
-
         ! ----------------------------------------
         ! Function:  int * ReturnIntPtrRaw +deref(raw)
         ! Attrs:     +deref(raw)+intent(function)
@@ -414,9 +411,6 @@ module ownership_mod
             type(OWN_SHROUD_capsule_data), intent(OUT) :: SHT_rv
             type(C_PTR) :: SHT_prv
         end function c_get_class_new
-
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
     end interface
 
     interface
@@ -442,6 +436,9 @@ module ownership_mod
             integer(C_SIZE_T), value :: c_var_size
         end subroutine OWN_SHROUD_copy_array
     end interface
+
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/pointers-c/wrapfpointers.f
+++ b/regression/reference/pointers-c/wrapfpointers.f
@@ -1326,11 +1326,6 @@ module pointers_mod
     ! end c_return_int_alloc_to_fixed_array_bufferify
 
     interface
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
-    end interface
-
-    interface
         ! helper copy_array
         ! Copy contents of context into c_var.
         subroutine POI_SHROUD_copy_array(context, c_var, c_var_size) &
@@ -1342,6 +1337,9 @@ module pointers_mod
             integer(C_SIZE_T), value :: c_var_size
         end subroutine POI_SHROUD_copy_array
     end interface
+
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/pointers-cfi/wrapfpointers.f
+++ b/regression/reference/pointers-cfi/wrapfpointers.f
@@ -1531,10 +1531,8 @@ module pointers_mod
     end interface
     ! end c_return_int_alloc_to_fixed_array_CFI
 
-    interface
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
-    end interface
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/pointers-cxx/wrapfpointers.f
+++ b/regression/reference/pointers-cxx/wrapfpointers.f
@@ -1326,11 +1326,6 @@ module pointers_mod
     ! end c_return_int_alloc_to_fixed_array_bufferify
 
     interface
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
-    end interface
-
-    interface
         ! helper copy_array
         ! Copy contents of context into c_var.
         subroutine POI_SHROUD_copy_array(context, c_var, c_var_size) &
@@ -1342,6 +1337,9 @@ module pointers_mod
             integer(C_SIZE_T), value :: c_var_size
         end subroutine POI_SHROUD_copy_array
     end interface
+
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/preprocess/wrapfpreprocess.f
+++ b/regression/reference/preprocess/wrapfpreprocess.f
@@ -157,9 +157,6 @@ module preprocess_mod
             integer(C_INT), value, intent(IN) :: i
         end subroutine c_user1_method3def_1
 #endif
-
-        ! splicer begin class.User1.additional_interfaces
-        ! splicer end class.User1.additional_interfaces
 #ifdef USE_USER2
 
 #ifdef USE_CLASS3_A
@@ -197,12 +194,6 @@ module preprocess_mod
         end subroutine c_user2_exfunc_1
 #endif
 #endif
-
-        ! splicer begin class.User2.additional_interfaces
-        ! splicer end class.User2.additional_interfaces
-
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
     end interface
 
 #if defined(USE_THREE)
@@ -222,6 +213,9 @@ module preprocess_mod
 #endif
     end interface user2_exfunc
 #endif
+
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/scope/wrapfscope.f
+++ b/regression/reference/scope/wrapfscope.f
@@ -111,12 +111,6 @@ module scope_mod
 
     interface
 
-        ! splicer begin class.Class1.additional_interfaces
-        ! splicer end class.Class1.additional_interfaces
-
-        ! splicer begin class.Class2.additional_interfaces
-        ! splicer end class.Class2.additional_interfaces
-
         ! ----------------------------------------
         ! Function:  int * DataPointer_get_items
         ! Attrs:     +api(cdesc)+deref(pointer)+intent(getter)+struct(ns3_DataPointer)
@@ -157,10 +151,10 @@ module scope_mod
             type(data_pointer), intent(INOUT) :: SH_this
             integer(C_INT), intent(IN) :: val(*)
         end subroutine data_pointer_set_items
-
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
     end interface
+
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/scope/wrapfscope_ns1.f
+++ b/regression/reference/scope/wrapfscope_ns1.f
@@ -97,10 +97,10 @@ module scope_ns1_mod
             type(data_pointer), intent(INOUT) :: SH_this
             integer(C_INT), intent(IN) :: val(*)
         end subroutine data_pointer_set_items
-
-        ! splicer begin namespace.ns1.additional_interfaces
-        ! splicer end namespace.ns1.additional_interfaces
     end interface
+
+    ! splicer begin namespace.ns1.additional_declarations
+    ! splicer end namespace.ns1.additional_declarations
 
 contains
 

--- a/regression/reference/scope/wrapfscope_ns2.f
+++ b/regression/reference/scope/wrapfscope_ns2.f
@@ -97,10 +97,10 @@ module scope_ns2_mod
             type(data_pointer), intent(INOUT) :: SH_this
             integer(C_INT), intent(IN) :: val(*)
         end subroutine data_pointer_set_items
-
-        ! splicer begin namespace.ns2.additional_interfaces
-        ! splicer end namespace.ns2.additional_interfaces
     end interface
+
+    ! splicer begin namespace.ns2.additional_declarations
+    ! splicer end namespace.ns2.additional_declarations
 
 contains
 

--- a/regression/reference/statement/wrapfstatement.f
+++ b/regression/reference/statement/wrapfstatement.f
@@ -61,10 +61,10 @@ module statement_mod
             character(kind=C_CHAR), intent(OUT) :: SHT_rv(*)
             integer(C_INT), value, intent(IN) :: SHT_rv_len
         end subroutine c_get_name_error_pattern_bufferify
-
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
     end interface
+
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/strings-cfi/wrapfstrings.f
+++ b/regression/reference/strings-cfi/wrapfstrings.f
@@ -1499,10 +1499,8 @@ module strings_mod
         end function cpass_char_ptr_capi2
     end interface
 
-    interface
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
-    end interface
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/strings/wrapfstrings.f
+++ b/regression/reference/strings/wrapfstrings.f
@@ -1589,11 +1589,6 @@ module strings_mod
     end interface
 
     interface
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
-    end interface
-
-    interface
         ! helper array_string_allocatable
         ! Copy the char* or std::string in context into c_var.
         subroutine STR_SHROUD_array_string_allocatable(out, in) &
@@ -1616,6 +1611,9 @@ module strings_mod
             integer(C_SIZE_T), value :: c_var_size
         end subroutine STR_SHROUD_copy_string_and_free
     end interface
+
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/struct-c/wrapfstruct.f
+++ b/regression/reference/struct-c/wrapfstruct.f
@@ -206,9 +206,6 @@ module struct_mod
     end interface
     ! end c_cstruct_as_class_set_y1
 
-    ! splicer begin class.Cstruct_as_class.additional_interfaces
-    ! splicer end class.Cstruct_as_class.additional_interfaces
-
     ! ----------------------------------------
     ! Function:  int get_x1
     ! Attrs:     +intent(getter)
@@ -328,9 +325,6 @@ module struct_mod
         end subroutine c_cstruct_as_subclass_set_z1
     end interface
     ! end c_cstruct_as_subclass_set_z1
-
-    ! splicer begin class.Cstruct_as_subclass.additional_interfaces
-    ! splicer end class.Cstruct_as_subclass.additional_interfaces
 
     ! ----------------------------------------
     ! Function:  int passStructByValue
@@ -882,11 +876,6 @@ module struct_mod
         end subroutine cstruct_list_set_dvalue
     end interface
 
-    interface
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
-    end interface
-
     ! start generic interface cstruct_as_class
     interface cstruct_as_class
         module procedure create_cstruct_as_class
@@ -897,6 +886,9 @@ module struct_mod
     interface cstruct_as_subclass
         module procedure create_cstruct_as_subclass_args
     end interface cstruct_as_subclass
+
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/struct-cxx/wrapfstruct.f
+++ b/regression/reference/struct-cxx/wrapfstruct.f
@@ -196,9 +196,6 @@ module struct_mod
         end subroutine c_cstruct_as_class_set_y1
         ! end c_cstruct_as_class_set_y1
 
-        ! splicer begin class.Cstruct_as_class.additional_interfaces
-        ! splicer end class.Cstruct_as_class.additional_interfaces
-
         ! ----------------------------------------
         ! Function:  int get_x1
         ! Attrs:     +intent(getter)
@@ -306,9 +303,6 @@ module struct_mod
             integer(C_INT), value, intent(IN) :: val
         end subroutine c_cstruct_as_subclass_set_z1
         ! end c_cstruct_as_subclass_set_z1
-
-        ! splicer begin class.Cstruct_as_subclass.additional_interfaces
-        ! splicer end class.Cstruct_as_subclass.additional_interfaces
 
         ! ----------------------------------------
         ! Function:  int passStructByValue
@@ -815,9 +809,6 @@ module struct_mod
             type(cstruct_list), intent(INOUT) :: SH_this
             real(C_DOUBLE), intent(IN) :: val(*)
         end subroutine cstruct_list_set_dvalue
-
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
     end interface
 
     ! start generic interface cstruct_as_class
@@ -830,6 +821,9 @@ module struct_mod
     interface cstruct_as_subclass
         module procedure create_cstruct_as_subclass_args
     end interface cstruct_as_subclass
+
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/templates/wrapftemplates.f
+++ b/regression/reference/templates/wrapftemplates.f
@@ -100,9 +100,6 @@ module templates_mod
 
     interface
 
-        ! splicer begin class.Worker.additional_interfaces
-        ! splicer end class.Worker.additional_interfaces
-
         ! ----------------------------------------
         ! Function:  void nested
         ! Attrs:     +intent(subroutine)
@@ -127,9 +124,6 @@ module templates_mod
             integer(C_INT), value, intent(IN) :: arg1
             real(C_DOUBLE), value, intent(IN) :: arg2
         end subroutine c_user_int_nested_double
-
-        ! splicer begin class.user_int.additional_interfaces
-        ! splicer end class.user_int.additional_interfaces
 
         ! ----------------------------------------
         ! Function:  structAsClass
@@ -213,9 +207,6 @@ module templates_mod
             integer(C_INT) :: SHT_rv
         end function c_struct_as_class_int_get_value
 
-        ! splicer begin class.structAsClass_int.additional_interfaces
-        ! splicer end class.structAsClass_int.additional_interfaces
-
         ! ----------------------------------------
         ! Function:  structAsClass
         ! Attrs:     +api(capptr)+intent(ctor)
@@ -297,9 +288,6 @@ module templates_mod
             type(TEM_SHROUD_capsule_data), intent(IN) :: self
             real(C_DOUBLE) :: SHT_rv
         end function c_struct_as_class_double_get_value
-
-        ! splicer begin class.structAsClass_double.additional_interfaces
-        ! splicer end class.structAsClass_double.additional_interfaces
 
         ! ----------------------------------------
         ! Function:  user<int> returnUserType
@@ -387,9 +375,6 @@ module templates_mod
             implicit none
             integer(C_INT) :: SHT_rv
         end function c_use_impl_worker_internal_ImplWorker2
-
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
     end interface
 
     interface function_tu
@@ -404,6 +389,9 @@ module templates_mod
     interface struct_as_class_int
         module procedure struct_as_class_int_ctor
     end interface struct_as_class_int
+
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/templates/wrapftemplates_internal.f
+++ b/regression/reference/templates/wrapftemplates_internal.f
@@ -20,11 +20,8 @@ module templates_internal_mod
     ! splicer begin namespace.internal.module_top
     ! splicer end namespace.internal.module_top
 
-    interface
-
-        ! splicer begin namespace.internal.additional_interfaces
-        ! splicer end namespace.internal.additional_interfaces
-    end interface
+    ! splicer begin namespace.internal.additional_declarations
+    ! splicer end namespace.internal.additional_declarations
 
 contains
 

--- a/regression/reference/templates/wrapftemplates_std.f
+++ b/regression/reference/templates/wrapftemplates_std.f
@@ -145,9 +145,6 @@ module templates_std_mod
             type(C_PTR) SHT_rv
         end function c_vector_int_at
 
-        ! splicer begin namespace.std.class.vector_int.additional_interfaces
-        ! splicer end namespace.std.class.vector_int.additional_interfaces
-
         ! ----------------------------------------
         ! Function:  vector
         ! Attrs:     +api(capptr)+intent(ctor)
@@ -213,12 +210,6 @@ module templates_std_mod
             integer(vector_double_size_type), value, intent(IN) :: n
             type(C_PTR) SHT_rv
         end function c_vector_double_at
-
-        ! splicer begin namespace.std.class.vector_double.additional_interfaces
-        ! splicer end namespace.std.class.vector_double.additional_interfaces
-
-        ! splicer begin namespace.std.additional_interfaces
-        ! splicer end namespace.std.additional_interfaces
     end interface
 
     interface vector_double
@@ -228,6 +219,9 @@ module templates_std_mod
     interface vector_int
         module procedure vector_int_ctor
     end interface vector_int
+
+    ! splicer begin namespace.std.additional_declarations
+    ! splicer end namespace.std.additional_declarations
 
 contains
 

--- a/regression/reference/tutorial/wrapftutorial.f
+++ b/regression/reference/tutorial/wrapftutorial.f
@@ -755,15 +755,6 @@ module tutorial_mod
         end subroutine c_last_function_called_bufferify
     end interface
 
-    interface
-        ! splicer begin additional_interfaces
-        subroutine all_test1(array)
-          implicit none
-          integer, dimension(:), allocatable :: array
-        end subroutine all_test1
-        ! splicer end additional_interfaces
-    end interface
-
     interface fortran_generic_overloaded
         module procedure fortran_generic_overloaded_0
         module procedure fortran_generic_overloaded_1_float
@@ -809,6 +800,15 @@ module tutorial_mod
             integer(C_SIZE_T), value :: c_var_size
         end subroutine TUT_SHROUD_copy_string_and_free
     end interface
+
+    ! splicer begin additional_declarations
+    interface
+      subroutine all_test1(array)
+        implicit none
+        integer, dimension(:), allocatable :: array
+      end subroutine all_test1
+    end interface
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/typedefs-c/wrapftypedefs.f
+++ b/regression/reference/typedefs-c/wrapftypedefs.f
@@ -115,10 +115,8 @@ module typedefs_mod
     end interface
     ! end return_bytes_for_index_type
 
-    interface
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
-    end interface
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/typedefs-cxx/wrapftypedefs.f
+++ b/regression/reference/typedefs-cxx/wrapftypedefs.f
@@ -115,10 +115,8 @@ module typedefs_mod
     end interface
     ! end return_bytes_for_index_type
 
-    interface
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
-    end interface
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/typemap/wrapftypemap.f
+++ b/regression/reference/typemap/wrapftypemap.f
@@ -80,9 +80,6 @@ module typemap_mod
             implicit none
             real(FLOATTYPE), value, intent(IN) :: f1
         end subroutine c_pass_float
-
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
     end interface
 
     interface pass_float
@@ -99,6 +96,9 @@ module typemap_mod
         module procedure pass_index2_32
         module procedure pass_index2_64
     end interface pass_index2
+
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/types/wrapftypes.f
+++ b/regression/reference/types/wrapftypes.f
@@ -477,10 +477,10 @@ module types_mod
             integer(C_INT), intent(OUT) :: flag
             logical(C_BOOL) :: SHT_rv
         end function c_return_bool_and_others
-
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
     end interface
+
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/vectors/wrapfvectors.f
+++ b/regression/reference/vectors/wrapfvectors.f
@@ -410,11 +410,6 @@ module vectors_mod
     end interface
 
     interface
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
-    end interface
-
-    interface
         ! helper copy_array
         ! Copy contents of context into c_var.
         subroutine VEC_SHROUD_copy_array(context, c_var, c_var_size) &
@@ -437,6 +432,9 @@ module vectors_mod
             type(VEC_SHROUD_array), intent(IN) :: in
         end subroutine VEC_SHROUD_vector_string_allocatable
     end interface
+
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 

--- a/regression/reference/wrap/wrapfwrap.f
+++ b/regression/reference/wrap/wrapfwrap.f
@@ -48,14 +48,8 @@ module wrap_mod
         module procedure class1_ne
     end interface
 
-    interface
-
-        ! splicer begin class.Class1.additional_interfaces
-        ! splicer end class.Class1.additional_interfaces
-
-        ! splicer begin additional_interfaces
-        ! splicer end additional_interfaces
-    end interface
+    ! splicer begin additional_declarations
+    ! splicer end additional_declarations
 
 contains
 


### PR DESCRIPTION
Replaced the *additional_interfaces* splicer with *additional_declarations*.  This new splicer is outside of an interface block and can be used to add add a generic interface that could not be added to *additional_interfaces*.