### PR TITLE
Capsule cxx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   meta["is_result"].
 - Remove stmt.c_result_var. Remove custom code in wrapf and replaced
   with data in FStmts.
-- *f_temps* and *f_local* now create format fields which start with **f**
-  instead of **c**. They are intented to be used the Fortran wrapper
-  and are based off of *f_var* name.
-- Structs now create a ``using`` statement to set the C struct name to the
-  C++ struct name.  This is used when compiling the wrapper implementation
-  to avoid adding `static_casts` in the wrappers.  The users will continue
-  to use the generated C structs which parallel the C++ structs.
+- *f_temps* and *f_local* now create format fields which start with
+  **f** instead of **c**. They are intented to be used the Fortran
+  wrapper and are based off of *f_var* name.
+- Structs now create a ``using`` statement to set the C struct name to
+  the C++ struct name.  This is used when compiling the wrapper
+  implementation to avoid adding `static_casts` in the wrappers.  The
+  users will continue to use the generated C structs which parallel
+  the C++ structs.
+- Class capsule structs are now created by explicit code instead of a
+  helper.  This removes a layer of abstraction to understand how
+  they're written.
 
 ### Removed
 - Removed attribute *+cdesc*. Replace by *+api(cdesc)*

--- a/docs/pointers.rst
+++ b/docs/pointers.rst
@@ -252,8 +252,8 @@ In the Tutorial these types are defined in :file:`typesTutorial.h` as:
 
 .. literalinclude:: ../regression/reference/classes/typesclasses.h
    :language: c++
-   :start-after: start struct CLA_Class1
-   :end-before: end struct CLA_Class1
+   :start-after: start C capsule CLA_Class1
+   :end-before: end C capsule CLA_Class1
 
 And :file:`wrapftutorial.f`:
 

--- a/docs/struct.rst
+++ b/docs/struct.rst
@@ -83,8 +83,8 @@ Shroud refers to this as a capsule.
 
 .. literalinclude:: ../regression/reference/classes/typesclasses.h
    :language: c
-   :start-after: start struct CLA_Class1
-   :end-before: end struct CLA_Class1
+   :start-after: start C capsule CLA_Class1
+   :end-before: end C capsule CLA_Class1
 
 The C wrapper will extract the address of the instance then call the
 method.

--- a/regression/input/error-generate.yaml
+++ b/regression/input/error-generate.yaml
@@ -9,7 +9,7 @@ copyright:
 # Test error messages from generate.py
 
 library: error
-cxx_header: error
+cxx_header: error.hpp
 
 options:
   debug: True

--- a/regression/input/error.yaml
+++ b/regression/input/error.yaml
@@ -9,7 +9,7 @@ copyright:
 # Test error messages
 
 library: error
-cxx_header: error
+cxx_header: error.hpp
 
 options:
   debug: True

--- a/regression/reference/arrayclass/typesarrayclass.h
+++ b/regression/reference/arrayclass/typesarrayclass.h
@@ -86,6 +86,15 @@ struct s_ARR_SHROUD_array {
     long shape[7];
 };
 typedef struct s_ARR_SHROUD_array ARR_SHROUD_array;
+#if 0
+
+// C++ capsule ARR_ArrayWrapper
+struct s_ARR_ArrayWrapper {
+    ArrayWrapper *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_ARR_ArrayWrapper ARR_ArrayWrapper;
+#endif
 
 // C capsule ARR_ArrayWrapper
 struct s_ARR_ArrayWrapper {

--- a/regression/reference/arrayclass/typesarrayclass.h
+++ b/regression/reference/arrayclass/typesarrayclass.h
@@ -87,7 +87,7 @@ struct s_ARR_SHROUD_array {
 };
 typedef struct s_ARR_SHROUD_array ARR_SHROUD_array;
 
-// helper capsule_ARR_ArrayWrapper
+// C capsule ARR_ArrayWrapper
 struct s_ARR_ArrayWrapper {
     void *addr;     /* address of C++ memory */
     int idtor;      /* index of destructor */

--- a/regression/reference/classes/typesclasses.h
+++ b/regression/reference/classes/typesclasses.h
@@ -89,53 +89,53 @@ struct s_CLA_SHROUD_array {
 typedef struct s_CLA_SHROUD_array CLA_SHROUD_array;
 // end array_context
 
-// helper capsule_CLA_Circle
-struct s_CLA_Circle {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_CLA_Circle CLA_Circle;
-
-// start struct CLA_Class1
-// helper capsule_CLA_Class1
+// start C capsule CLA_Class1
+// C capsule CLA_Class1
 struct s_CLA_Class1 {
     void *addr;     /* address of C++ memory */
     int idtor;      /* index of destructor */
 };
 typedef struct s_CLA_Class1 CLA_Class1;
-// end struct CLA_Class1
+// end C capsule CLA_Class1
 
-// helper capsule_CLA_Class2
+// C capsule CLA_Class2
 struct s_CLA_Class2 {
     void *addr;     /* address of C++ memory */
     int idtor;      /* index of destructor */
 };
 typedef struct s_CLA_Class2 CLA_Class2;
 
-// start struct CLA_Data
-// helper capsule_CLA_Data
-struct s_CLA_Data {
+// start C capsule CLA_Singleton
+// C capsule CLA_Singleton
+struct s_CLA_Singleton {
     void *addr;     /* address of C++ memory */
     int idtor;      /* index of destructor */
 };
-typedef struct s_CLA_Data CLA_Data;
-// end struct CLA_Data
+typedef struct s_CLA_Singleton CLA_Singleton;
+// end C capsule CLA_Singleton
 
-// helper capsule_CLA_Shape
+// C capsule CLA_Shape
 struct s_CLA_Shape {
     void *addr;     /* address of C++ memory */
     int idtor;      /* index of destructor */
 };
 typedef struct s_CLA_Shape CLA_Shape;
 
-// start struct CLA_Singleton
-// helper capsule_CLA_Singleton
-struct s_CLA_Singleton {
+// C capsule CLA_Circle
+struct s_CLA_Circle {
     void *addr;     /* address of C++ memory */
     int idtor;      /* index of destructor */
 };
-typedef struct s_CLA_Singleton CLA_Singleton;
-// end struct CLA_Singleton
+typedef struct s_CLA_Circle CLA_Circle;
+
+// start C capsule CLA_Data
+// C capsule CLA_Data
+struct s_CLA_Data {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_CLA_Data CLA_Data;
+// end C capsule CLA_Data
 
 void CLA_SHROUD_memory_destructor(CLA_SHROUD_capsule_data *cap);
 

--- a/regression/reference/classes/typesclasses.h
+++ b/regression/reference/classes/typesclasses.h
@@ -88,6 +88,56 @@ struct s_CLA_SHROUD_array {
 };
 typedef struct s_CLA_SHROUD_array CLA_SHROUD_array;
 // end array_context
+#if 0
+
+// start C++ capsule CLA_Class1
+// C++ capsule CLA_Class1
+struct s_CLA_Class1 {
+    classes::Class1 *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_CLA_Class1 CLA_Class1;
+// end C++ capsule CLA_Class1
+
+// C++ capsule CLA_Class2
+struct s_CLA_Class2 {
+    classes::Class2 *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_CLA_Class2 CLA_Class2;
+
+// start C++ capsule CLA_Singleton
+// C++ capsule CLA_Singleton
+struct s_CLA_Singleton {
+    classes::Singleton *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_CLA_Singleton CLA_Singleton;
+// end C++ capsule CLA_Singleton
+
+// C++ capsule CLA_Shape
+struct s_CLA_Shape {
+    classes::Shape *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_CLA_Shape CLA_Shape;
+
+// C++ capsule CLA_Circle
+struct s_CLA_Circle {
+    classes::Circle *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_CLA_Circle CLA_Circle;
+
+// start C++ capsule CLA_Data
+// C++ capsule CLA_Data
+struct s_CLA_Data {
+    classes::Data *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_CLA_Data CLA_Data;
+// end C++ capsule CLA_Data
+#endif
 
 // start C capsule CLA_Class1
 // C capsule CLA_Class1

--- a/regression/reference/defaultarg/typesdefaultarg.h
+++ b/regression/reference/defaultarg/typesdefaultarg.h
@@ -28,19 +28,19 @@ typedef int32_t IndexType;
 #endif
 // splicer end types.C_declarations
 
-// helper capsule_DEF_Class1
-struct s_DEF_Class1 {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_DEF_Class1 DEF_Class1;
-
 // helper capsule_data_helper
 struct s_DEF_SHROUD_capsule_data {
     void *addr;     /* address of C++ memory */
     int idtor;      /* index of destructor */
 };
 typedef struct s_DEF_SHROUD_capsule_data DEF_SHROUD_capsule_data;
+
+// C capsule DEF_Class1
+struct s_DEF_Class1 {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_DEF_Class1 DEF_Class1;
 
 void DEF_SHROUD_memory_destructor(DEF_SHROUD_capsule_data *cap);
 

--- a/regression/reference/defaultarg/typesdefaultarg.h
+++ b/regression/reference/defaultarg/typesdefaultarg.h
@@ -34,6 +34,15 @@ struct s_DEF_SHROUD_capsule_data {
     int idtor;      /* index of destructor */
 };
 typedef struct s_DEF_SHROUD_capsule_data DEF_SHROUD_capsule_data;
+#if 0
+
+// C++ capsule DEF_Class1
+struct s_DEF_Class1 {
+    Class1 *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_DEF_Class1 DEF_Class1;
+#endif
 
 // C capsule DEF_Class1
 struct s_DEF_Class1 {

--- a/regression/reference/error-ast/error-ast.json
+++ b/regression/reference/error-ast/error-ast.json
@@ -10,7 +10,7 @@
             ""
         ],
         "cxx_header": [
-            "error"
+            "error.hpp"
         ],
         "functions": [
             {

--- a/regression/reference/error-ast/pyerrormodule.hpp
+++ b/regression/reference/error-ast/pyerrormodule.hpp
@@ -12,7 +12,7 @@
 #include <Python.h>
 
 // cxx_header
-#include "error"
+#include "error.hpp"
 
 // splicer begin header.include
 // splicer end header.include

--- a/regression/reference/error-generate/error-generate.json
+++ b/regression/reference/error-generate/error-generate.json
@@ -179,7 +179,7 @@
             ""
         ],
         "cxx_header": [
-            "error"
+            "error.hpp"
         ],
         "functions": [
             {

--- a/regression/reference/error-generate/pyerrormodule.hpp
+++ b/regression/reference/error-generate/pyerrormodule.hpp
@@ -12,7 +12,7 @@
 #include <Python.h>
 
 // cxx_header
-#include "error"
+#include "error.hpp"
 
 // splicer begin header.include
 // splicer end header.include

--- a/regression/reference/error/error.json
+++ b/regression/reference/error/error.json
@@ -756,7 +756,7 @@
             ""
         ],
         "cxx_header": [
-            "error"
+            "error.hpp"
         ],
         "functions": [
             {
@@ -1439,7 +1439,7 @@
             },
             "i_type": "type(ERR_SHROUD_capsule_data)",
             "impl_header": [
-                "error"
+                "error.hpp"
             ],
             "sgroup": "shadow",
             "wrap_header": [

--- a/regression/reference/error/pyerrormodule.hpp
+++ b/regression/reference/error/pyerrormodule.hpp
@@ -12,7 +12,7 @@
 #include <Python.h>
 
 // cxx_header
-#include "error"
+#include "error.hpp"
 
 // splicer begin header.include
 // splicer end header.include

--- a/regression/reference/error/typeserror.h
+++ b/regression/reference/error/typeserror.h
@@ -27,6 +27,15 @@ struct s_ERR_SHROUD_capsule_data {
     int idtor;      /* index of destructor */
 };
 typedef struct s_ERR_SHROUD_capsule_data ERR_SHROUD_capsule_data;
+#if 0
+
+// C++ capsule ERR_Cstruct_as_subclass
+struct s_ERR_Cstruct_as_subclass {
+    Cstruct_as_subclass *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_ERR_Cstruct_as_subclass ERR_Cstruct_as_subclass;
+#endif
 
 // C capsule ERR_Cstruct_as_subclass
 struct s_ERR_Cstruct_as_subclass {

--- a/regression/reference/error/typeserror.h
+++ b/regression/reference/error/typeserror.h
@@ -21,19 +21,19 @@ extern "C" {
 // splicer begin types.C_declarations
 // splicer end types.C_declarations
 
-// helper capsule_ERR_Cstruct_as_subclass
-struct s_ERR_Cstruct_as_subclass {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_ERR_Cstruct_as_subclass ERR_Cstruct_as_subclass;
-
 // helper capsule_data_helper
 struct s_ERR_SHROUD_capsule_data {
     void *addr;     /* address of C++ memory */
     int idtor;      /* index of destructor */
 };
 typedef struct s_ERR_SHROUD_capsule_data ERR_SHROUD_capsule_data;
+
+// C capsule ERR_Cstruct_as_subclass
+struct s_ERR_Cstruct_as_subclass {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_ERR_Cstruct_as_subclass ERR_Cstruct_as_subclass;
 
 void ERR_SHROUD_memory_destructor(ERR_SHROUD_capsule_data *cap);
 

--- a/regression/reference/error/wrapCstruct_as_subclass.cpp
+++ b/regression/reference/error/wrapCstruct_as_subclass.cpp
@@ -8,7 +8,7 @@
 //
 
 // cxx_header
-#include "error"
+#include "error.hpp"
 // shroud
 #include "wrapCstruct_as_subclass.h"
 

--- a/regression/reference/example/typesUserLibrary.h
+++ b/regression/reference/example/typesUserLibrary.h
@@ -86,6 +86,22 @@ struct s_AA_SHROUD_array {
     long shape[7];
 };
 typedef struct s_AA_SHROUD_array AA_SHROUD_array;
+#if 0
+
+// C++ capsule AA_example_nested_ExClass1
+struct s_AA_example_nested_ExClass1 {
+    example::nested::ExClass1 *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_AA_example_nested_ExClass1 AA_example_nested_ExClass1;
+
+// C++ capsule AA_example_nested_ExClass2
+struct s_AA_example_nested_ExClass2 {
+    example::nested::ExClass2 *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_AA_example_nested_ExClass2 AA_example_nested_ExClass2;
+#endif
 
 // C capsule AA_example_nested_ExClass1
 struct s_AA_example_nested_ExClass1 {

--- a/regression/reference/example/typesUserLibrary.h
+++ b/regression/reference/example/typesUserLibrary.h
@@ -24,20 +24,6 @@ extern "C" {
 // splicer begin types.C_declarations
 // splicer end types.C_declarations
 
-// helper capsule_AA_example_nested_ExClass1
-struct s_AA_example_nested_ExClass1 {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_AA_example_nested_ExClass1 AA_example_nested_ExClass1;
-
-// helper capsule_AA_example_nested_ExClass2
-struct s_AA_example_nested_ExClass2 {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_AA_example_nested_ExClass2 AA_example_nested_ExClass2;
-
 // helper capsule_data_helper
 struct s_AA_SHROUD_capsule_data {
     void *addr;     /* address of C++ memory */
@@ -100,6 +86,20 @@ struct s_AA_SHROUD_array {
     long shape[7];
 };
 typedef struct s_AA_SHROUD_array AA_SHROUD_array;
+
+// C capsule AA_example_nested_ExClass1
+struct s_AA_example_nested_ExClass1 {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_AA_example_nested_ExClass1 AA_example_nested_ExClass1;
+
+// C capsule AA_example_nested_ExClass2
+struct s_AA_example_nested_ExClass2 {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_AA_example_nested_ExClass2 AA_example_nested_ExClass2;
 
 void AA_SHROUD_memory_destructor(AA_SHROUD_capsule_data *cap);
 

--- a/regression/reference/forward/typesforward.h
+++ b/regression/reference/forward/typesforward.h
@@ -21,26 +21,26 @@ extern "C" {
 // splicer begin types.C_declarations
 // splicer end types.C_declarations
 
-// helper capsule_FOR_Class2
-struct s_FOR_Class2 {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_FOR_Class2 FOR_Class2;
-
-// helper capsule_FOR_Class3
-struct s_FOR_Class3 {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_FOR_Class3 FOR_Class3;
-
 // helper capsule_data_helper
 struct s_FOR_SHROUD_capsule_data {
     void *addr;     /* address of C++ memory */
     int idtor;      /* index of destructor */
 };
 typedef struct s_FOR_SHROUD_capsule_data FOR_SHROUD_capsule_data;
+
+// C capsule FOR_Class3
+struct s_FOR_Class3 {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_FOR_Class3 FOR_Class3;
+
+// C capsule FOR_Class2
+struct s_FOR_Class2 {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_FOR_Class2 FOR_Class2;
 
 void FOR_SHROUD_memory_destructor(FOR_SHROUD_capsule_data *cap);
 

--- a/regression/reference/forward/typesforward.h
+++ b/regression/reference/forward/typesforward.h
@@ -27,6 +27,22 @@ struct s_FOR_SHROUD_capsule_data {
     int idtor;      /* index of destructor */
 };
 typedef struct s_FOR_SHROUD_capsule_data FOR_SHROUD_capsule_data;
+#if 0
+
+// C++ capsule FOR_Class3
+struct s_FOR_Class3 {
+    forward::Class3 *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_FOR_Class3 FOR_Class3;
+
+// C++ capsule FOR_Class2
+struct s_FOR_Class2 {
+    forward::Class2 *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_FOR_Class2 FOR_Class2;
+#endif
 
 // C capsule FOR_Class3
 struct s_FOR_Class3 {

--- a/regression/reference/generic-cfi/typesgeneric.h
+++ b/regression/reference/generic-cfi/typesgeneric.h
@@ -14,13 +14,6 @@
 // splicer begin types.CXX_declarations
 // splicer end types.CXX_declarations
 
-// helper capsule_GEN_StructAsClass
-struct s_GEN_StructAsClass {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_GEN_StructAsClass GEN_StructAsClass;
-
 // helper capsule_data_helper
 struct s_GEN_SHROUD_capsule_data {
     void *addr;     /* address of C++ memory */
@@ -68,6 +61,13 @@ typedef struct s_GEN_SHROUD_capsule_data GEN_SHROUD_capsule_data;
 #define SH_TYPE_CPTR       30
 #define SH_TYPE_STRUCT     31
 #define SH_TYPE_OTHER      32
+
+// C capsule GEN_StructAsClass
+struct s_GEN_StructAsClass {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_GEN_StructAsClass GEN_StructAsClass;
 
 void GEN_SHROUD_memory_destructor(GEN_SHROUD_capsule_data *cap);
 

--- a/regression/reference/generic-cfi/typesgeneric.h
+++ b/regression/reference/generic-cfi/typesgeneric.h
@@ -61,6 +61,15 @@ typedef struct s_GEN_SHROUD_capsule_data GEN_SHROUD_capsule_data;
 #define SH_TYPE_CPTR       30
 #define SH_TYPE_STRUCT     31
 #define SH_TYPE_OTHER      32
+#if 0
+
+// C++ capsule GEN_StructAsClass
+struct s_GEN_StructAsClass {
+    StructAsClass *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_GEN_StructAsClass GEN_StructAsClass;
+#endif
 
 // C capsule GEN_StructAsClass
 struct s_GEN_StructAsClass {

--- a/regression/reference/generic/typesgeneric.h
+++ b/regression/reference/generic/typesgeneric.h
@@ -82,7 +82,7 @@ struct s_GEN_SHROUD_array {
 typedef struct s_GEN_SHROUD_array GEN_SHROUD_array;
 // end array_context
 
-// helper capsule_GEN_StructAsClass
+// C capsule GEN_StructAsClass
 struct s_GEN_StructAsClass {
     void *addr;     /* address of C++ memory */
     int idtor;      /* index of destructor */

--- a/regression/reference/generic/typesgeneric.h
+++ b/regression/reference/generic/typesgeneric.h
@@ -81,6 +81,15 @@ struct s_GEN_SHROUD_array {
 };
 typedef struct s_GEN_SHROUD_array GEN_SHROUD_array;
 // end array_context
+#if 0
+
+// C++ capsule GEN_StructAsClass
+struct s_GEN_StructAsClass {
+    StructAsClass *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_GEN_StructAsClass GEN_StructAsClass;
+#endif
 
 // C capsule GEN_StructAsClass
 struct s_GEN_StructAsClass {

--- a/regression/reference/include/typeslibrary.h
+++ b/regression/reference/include/typeslibrary.h
@@ -23,6 +23,36 @@ struct s_LIB_SHROUD_capsule_data {
     int idtor;      /* index of destructor */
 };
 typedef struct s_LIB_SHROUD_capsule_data LIB_SHROUD_capsule_data;
+#if 0
+
+// C++ capsule LIB_three_Class1
+struct s_LIB_three_Class1 {
+    three::Class1 *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_LIB_three_Class1 LIB_three_Class1;
+
+// C++ capsule LIB_outer1_class0
+struct s_LIB_outer1_class0 {
+    outer1::class0 *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_LIB_outer1_class0 LIB_outer1_class0;
+
+// C++ capsule LIB_outer2_class0
+struct s_LIB_outer2_class0 {
+    outer2::class0 *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_LIB_outer2_class0 LIB_outer2_class0;
+
+// C++ capsule LIB_Class2
+struct s_LIB_Class2 {
+    Class2 *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_LIB_Class2 LIB_Class2;
+#endif
 
 // C capsule LIB_three_Class1
 struct s_LIB_three_Class1 {

--- a/regression/reference/include/typeslibrary.h
+++ b/regression/reference/include/typeslibrary.h
@@ -17,40 +17,40 @@ extern "C" {
 #endif
 
 
-// helper capsule_LIB_Class2
-struct s_LIB_Class2 {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_LIB_Class2 LIB_Class2;
-
-// helper capsule_LIB_outer1_class0
-struct s_LIB_outer1_class0 {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_LIB_outer1_class0 LIB_outer1_class0;
-
-// helper capsule_LIB_outer2_class0
-struct s_LIB_outer2_class0 {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_LIB_outer2_class0 LIB_outer2_class0;
-
-// helper capsule_LIB_three_Class1
-struct s_LIB_three_Class1 {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_LIB_three_Class1 LIB_three_Class1;
-
 // helper capsule_data_helper
 struct s_LIB_SHROUD_capsule_data {
     void *addr;     /* address of C++ memory */
     int idtor;      /* index of destructor */
 };
 typedef struct s_LIB_SHROUD_capsule_data LIB_SHROUD_capsule_data;
+
+// C capsule LIB_three_Class1
+struct s_LIB_three_Class1 {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_LIB_three_Class1 LIB_three_Class1;
+
+// C capsule LIB_outer1_class0
+struct s_LIB_outer1_class0 {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_LIB_outer1_class0 LIB_outer1_class0;
+
+// C capsule LIB_outer2_class0
+struct s_LIB_outer2_class0 {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_LIB_outer2_class0 LIB_outer2_class0;
+
+// C capsule LIB_Class2
+struct s_LIB_Class2 {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_LIB_Class2 LIB_Class2;
 
 void LIB_SHROUD_memory_destructor(LIB_SHROUD_capsule_data *cap);
 

--- a/regression/reference/names/typestestnames.hh
+++ b/regression/reference/names/typestestnames.hh
@@ -27,6 +27,92 @@ struct s_TES_SHROUD_capsule_data {
     int idtor;      /* index of destructor */
 };
 typedef struct s_TES_SHROUD_capsule_data TES_SHROUD_capsule_data;
+#if 0
+
+// C++ capsule TES_ns0_Names
+struct s_TES_ns0_Names {
+    ns0::Names *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TES_ns0_Names TES_ns0_Names;
+
+// C++ capsule TES_internal_ImplWorker1
+struct s_TES_internal_ImplWorker1 {
+    internal::ImplWorker1 *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TES_internal_ImplWorker1 TES_internal_ImplWorker1;
+
+// C++ capsule TES_std_Vvv1
+struct s_TES_std_Vvv1 {
+    std::vector<int> *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TES_std_Vvv1 TES_std_Vvv1;
+
+// C++ capsule TES_std_vector_double
+struct s_TES_std_vector_double {
+    std::vector<double> *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TES_std_vector_double TES_std_vector_double;
+
+// C++ capsule TES_std_vector_instantiation5
+struct s_TES_std_vector_instantiation5 {
+    std::vector<long> *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TES_std_vector_instantiation5 TES_std_vector_instantiation5;
+
+// C++ capsule TES_std_vector_instantiation3
+struct s_TES_std_vector_instantiation3 {
+    std::vector<internal::ImplWorker1> *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TES_std_vector_instantiation3 TES_std_vector_instantiation3;
+
+// C++ capsule TES_capi_class1
+struct s_TES_capi_class1 {
+    CAPI::Class1 *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TES_capi_class1 TES_capi_class1;
+
+// C++ capsule TES_Names2
+struct s_TES_Names2 {
+    Names2 *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TES_Names2 TES_Names2;
+
+// C++ capsule TES_twoTs_0
+struct s_TES_twoTs_0 {
+    twoTs<int, long> *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TES_twoTs_0 TES_twoTs_0;
+
+// C++ capsule TES_twoTs_instantiation4
+struct s_TES_twoTs_instantiation4 {
+    twoTs<float, double> *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TES_twoTs_instantiation4 TES_twoTs_instantiation4;
+
+// C++ capsule TES_Cstruct_as_class
+struct s_TES_Cstruct_as_class {
+    Cstruct_as_class *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TES_Cstruct_as_class TES_Cstruct_as_class;
+
+// C++ capsule TES_Cstruct_as_subclass
+struct s_TES_Cstruct_as_subclass {
+    Cstruct_as_subclass *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TES_Cstruct_as_subclass TES_Cstruct_as_subclass;
+#endif
 
 // C capsule TES_ns0_Names
 struct s_TES_ns0_Names {

--- a/regression/reference/names/typestestnames.hh
+++ b/regression/reference/names/typestestnames.hh
@@ -21,96 +21,96 @@ extern "C" {
 // splicer begin types.C_declarations
 // splicer end types.C_declarations
 
-// helper capsule_TES_Cstruct_as_class
-struct s_TES_Cstruct_as_class {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_TES_Cstruct_as_class TES_Cstruct_as_class;
-
-// helper capsule_TES_Cstruct_as_subclass
-struct s_TES_Cstruct_as_subclass {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_TES_Cstruct_as_subclass TES_Cstruct_as_subclass;
-
-// helper capsule_TES_Names2
-struct s_TES_Names2 {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_TES_Names2 TES_Names2;
-
-// helper capsule_TES_capi_class1
-struct s_TES_capi_class1 {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_TES_capi_class1 TES_capi_class1;
-
-// helper capsule_TES_internal_ImplWorker1
-struct s_TES_internal_ImplWorker1 {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_TES_internal_ImplWorker1 TES_internal_ImplWorker1;
-
-// helper capsule_TES_ns0_Names
-struct s_TES_ns0_Names {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_TES_ns0_Names TES_ns0_Names;
-
-// helper capsule_TES_std_Vvv1
-struct s_TES_std_Vvv1 {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_TES_std_Vvv1 TES_std_Vvv1;
-
-// helper capsule_TES_std_vector_double
-struct s_TES_std_vector_double {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_TES_std_vector_double TES_std_vector_double;
-
-// helper capsule_TES_std_vector_instantiation3
-struct s_TES_std_vector_instantiation3 {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_TES_std_vector_instantiation3 TES_std_vector_instantiation3;
-
-// helper capsule_TES_std_vector_instantiation5
-struct s_TES_std_vector_instantiation5 {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_TES_std_vector_instantiation5 TES_std_vector_instantiation5;
-
-// helper capsule_TES_twoTs_0
-struct s_TES_twoTs_0 {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_TES_twoTs_0 TES_twoTs_0;
-
-// helper capsule_TES_twoTs_instantiation4
-struct s_TES_twoTs_instantiation4 {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_TES_twoTs_instantiation4 TES_twoTs_instantiation4;
-
 // helper capsule_data_helper
 struct s_TES_SHROUD_capsule_data {
     void *addr;     /* address of C++ memory */
     int idtor;      /* index of destructor */
 };
 typedef struct s_TES_SHROUD_capsule_data TES_SHROUD_capsule_data;
+
+// C capsule TES_ns0_Names
+struct s_TES_ns0_Names {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TES_ns0_Names TES_ns0_Names;
+
+// C capsule TES_internal_ImplWorker1
+struct s_TES_internal_ImplWorker1 {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TES_internal_ImplWorker1 TES_internal_ImplWorker1;
+
+// C capsule TES_std_Vvv1
+struct s_TES_std_Vvv1 {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TES_std_Vvv1 TES_std_Vvv1;
+
+// C capsule TES_std_vector_double
+struct s_TES_std_vector_double {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TES_std_vector_double TES_std_vector_double;
+
+// C capsule TES_std_vector_instantiation5
+struct s_TES_std_vector_instantiation5 {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TES_std_vector_instantiation5 TES_std_vector_instantiation5;
+
+// C capsule TES_std_vector_instantiation3
+struct s_TES_std_vector_instantiation3 {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TES_std_vector_instantiation3 TES_std_vector_instantiation3;
+
+// C capsule TES_capi_class1
+struct s_TES_capi_class1 {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TES_capi_class1 TES_capi_class1;
+
+// C capsule TES_Names2
+struct s_TES_Names2 {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TES_Names2 TES_Names2;
+
+// C capsule TES_twoTs_0
+struct s_TES_twoTs_0 {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TES_twoTs_0 TES_twoTs_0;
+
+// C capsule TES_twoTs_instantiation4
+struct s_TES_twoTs_instantiation4 {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TES_twoTs_instantiation4 TES_twoTs_instantiation4;
+
+// C capsule TES_Cstruct_as_class
+struct s_TES_Cstruct_as_class {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TES_Cstruct_as_class TES_Cstruct_as_class;
+
+// C capsule TES_Cstruct_as_subclass
+struct s_TES_Cstruct_as_subclass {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TES_Cstruct_as_subclass TES_Cstruct_as_subclass;
 
 void TES_SHROUD_memory_destructor(TES_SHROUD_capsule_data *cap);
 

--- a/regression/reference/namespace/typesns.h
+++ b/regression/reference/namespace/typesns.h
@@ -86,6 +86,15 @@ struct s_NS_SHROUD_array {
     long shape[7];
 };
 typedef struct s_NS_SHROUD_array NS_SHROUD_array;
+#if 0
+
+// C++ capsule NS_nswork_ClassWork
+struct s_NS_nswork_ClassWork {
+    nswork::ClassWork *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_NS_nswork_ClassWork NS_nswork_ClassWork;
+#endif
 
 // C capsule NS_nswork_ClassWork
 struct s_NS_nswork_ClassWork {

--- a/regression/reference/namespace/typesns.h
+++ b/regression/reference/namespace/typesns.h
@@ -24,13 +24,6 @@ extern "C" {
 // splicer begin types.C_declarations
 // splicer end types.C_declarations
 
-// helper capsule_NS_nswork_ClassWork
-struct s_NS_nswork_ClassWork {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_NS_nswork_ClassWork NS_nswork_ClassWork;
-
 // helper capsule_data_helper
 struct s_NS_SHROUD_capsule_data {
     void *addr;     /* address of C++ memory */
@@ -93,6 +86,13 @@ struct s_NS_SHROUD_array {
     long shape[7];
 };
 typedef struct s_NS_SHROUD_array NS_SHROUD_array;
+
+// C capsule NS_nswork_ClassWork
+struct s_NS_nswork_ClassWork {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_NS_nswork_ClassWork NS_nswork_ClassWork;
 
 void NS_SHROUD_memory_destructor(NS_SHROUD_capsule_data *cap);
 

--- a/regression/reference/ownership/typesownership.h
+++ b/regression/reference/ownership/typesownership.h
@@ -87,7 +87,7 @@ struct s_OWN_SHROUD_array {
 };
 typedef struct s_OWN_SHROUD_array OWN_SHROUD_array;
 
-// helper capsule_OWN_Class1
+// C capsule OWN_Class1
 struct s_OWN_Class1 {
     void *addr;     /* address of C++ memory */
     int idtor;      /* index of destructor */

--- a/regression/reference/ownership/typesownership.h
+++ b/regression/reference/ownership/typesownership.h
@@ -86,6 +86,15 @@ struct s_OWN_SHROUD_array {
     long shape[7];
 };
 typedef struct s_OWN_SHROUD_array OWN_SHROUD_array;
+#if 0
+
+// C++ capsule OWN_Class1
+struct s_OWN_Class1 {
+    Class1 *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_OWN_Class1 OWN_Class1;
+#endif
 
 // C capsule OWN_Class1
 struct s_OWN_Class1 {

--- a/regression/reference/preprocess/typespreprocess.h
+++ b/regression/reference/preprocess/typespreprocess.h
@@ -21,14 +21,21 @@ extern "C" {
 // splicer begin types.C_declarations
 // splicer end types.C_declarations
 
-// helper capsule_PRE_User1
+// helper capsule_data_helper
+struct s_PRE_SHROUD_capsule_data {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_PRE_SHROUD_capsule_data PRE_SHROUD_capsule_data;
+
+// C capsule PRE_User1
 struct s_PRE_User1 {
     void *addr;     /* address of C++ memory */
     int idtor;      /* index of destructor */
 };
 typedef struct s_PRE_User1 PRE_User1;
 
-// helper capsule_PRE_User2
+// C capsule PRE_User2
 #ifdef USE_USER2
 struct s_PRE_User2 {
     void *addr;     /* address of C++ memory */
@@ -36,13 +43,6 @@ struct s_PRE_User2 {
 };
 typedef struct s_PRE_User2 PRE_User2;
 #endif  // ifdef USE_USER2
-
-// helper capsule_data_helper
-struct s_PRE_SHROUD_capsule_data {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_PRE_SHROUD_capsule_data PRE_SHROUD_capsule_data;
 
 void PRE_SHROUD_memory_destructor(PRE_SHROUD_capsule_data *cap);
 

--- a/regression/reference/preprocess/typespreprocess.h
+++ b/regression/reference/preprocess/typespreprocess.h
@@ -27,6 +27,24 @@ struct s_PRE_SHROUD_capsule_data {
     int idtor;      /* index of destructor */
 };
 typedef struct s_PRE_SHROUD_capsule_data PRE_SHROUD_capsule_data;
+#if 0
+
+// C++ capsule PRE_User1
+struct s_PRE_User1 {
+    User1 *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_PRE_User1 PRE_User1;
+
+// C++ capsule PRE_User2
+#ifdef USE_USER2
+struct s_PRE_User2 {
+    User2 *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_PRE_User2 PRE_User2;
+#endif  // ifdef USE_USER2
+#endif
 
 // C capsule PRE_User1
 struct s_PRE_User1 {

--- a/regression/reference/scope/typesscope.h
+++ b/regression/reference/scope/typesscope.h
@@ -86,6 +86,22 @@ struct s_SCO_SHROUD_array {
     long shape[7];
 };
 typedef struct s_SCO_SHROUD_array SCO_SHROUD_array;
+#if 0
+
+// C++ capsule SCO_Class1
+struct s_SCO_Class1 {
+    Class1 *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_SCO_Class1 SCO_Class1;
+
+// C++ capsule SCO_Class2
+struct s_SCO_Class2 {
+    Class2 *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_SCO_Class2 SCO_Class2;
+#endif
 
 // C capsule SCO_Class1
 struct s_SCO_Class1 {

--- a/regression/reference/scope/typesscope.h
+++ b/regression/reference/scope/typesscope.h
@@ -87,14 +87,14 @@ struct s_SCO_SHROUD_array {
 };
 typedef struct s_SCO_SHROUD_array SCO_SHROUD_array;
 
-// helper capsule_SCO_Class1
+// C capsule SCO_Class1
 struct s_SCO_Class1 {
     void *addr;     /* address of C++ memory */
     int idtor;      /* index of destructor */
 };
 typedef struct s_SCO_Class1 SCO_Class1;
 
-// helper capsule_SCO_Class2
+// C capsule SCO_Class2
 struct s_SCO_Class2 {
     void *addr;     /* address of C++ memory */
     int idtor;      /* index of destructor */

--- a/regression/reference/struct-c/typesstruct.h
+++ b/regression/reference/struct-c/typesstruct.h
@@ -82,23 +82,23 @@ struct s_STR_SHROUD_array {
 typedef struct s_STR_SHROUD_array STR_SHROUD_array;
 // end array_context
 
-// start struct STR_Cstruct_as_class
-// helper capsule_STR_Cstruct_as_class
+// start C capsule STR_Cstruct_as_class
+// C capsule STR_Cstruct_as_class
 struct s_STR_Cstruct_as_class {
     void *addr;     /* address of C++ memory */
     int idtor;      /* index of destructor */
 };
 typedef struct s_STR_Cstruct_as_class STR_Cstruct_as_class;
-// end struct STR_Cstruct_as_class
+// end C capsule STR_Cstruct_as_class
 
-// start struct STR_Cstruct_as_subclass
-// helper capsule_STR_Cstruct_as_subclass
+// start C capsule STR_Cstruct_as_subclass
+// C capsule STR_Cstruct_as_subclass
 struct s_STR_Cstruct_as_subclass {
     void *addr;     /* address of C++ memory */
     int idtor;      /* index of destructor */
 };
 typedef struct s_STR_Cstruct_as_subclass STR_Cstruct_as_subclass;
-// end struct STR_Cstruct_as_subclass
+// end C capsule STR_Cstruct_as_subclass
 
 void STR_SHROUD_memory_destructor(STR_SHROUD_capsule_data *cap);
 

--- a/regression/reference/struct-c/typesstruct.h
+++ b/regression/reference/struct-c/typesstruct.h
@@ -81,6 +81,26 @@ struct s_STR_SHROUD_array {
 };
 typedef struct s_STR_SHROUD_array STR_SHROUD_array;
 // end array_context
+#if 0
+
+// start C++ capsule STR_Cstruct_as_class
+// C++ capsule STR_Cstruct_as_class
+struct s_STR_Cstruct_as_class {
+    Cstruct_as_class *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_STR_Cstruct_as_class STR_Cstruct_as_class;
+// end C++ capsule STR_Cstruct_as_class
+
+// start C++ capsule STR_Cstruct_as_subclass
+// C++ capsule STR_Cstruct_as_subclass
+struct s_STR_Cstruct_as_subclass {
+    Cstruct_as_subclass *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_STR_Cstruct_as_subclass STR_Cstruct_as_subclass;
+// end C++ capsule STR_Cstruct_as_subclass
+#endif
 
 // start C capsule STR_Cstruct_as_class
 // C capsule STR_Cstruct_as_class

--- a/regression/reference/struct-cxx/typesstruct.h
+++ b/regression/reference/struct-cxx/typesstruct.h
@@ -86,6 +86,26 @@ struct s_STR_SHROUD_array {
     long shape[7];
 };
 typedef struct s_STR_SHROUD_array STR_SHROUD_array;
+#if 0
+
+// start C++ capsule STR_Cstruct_as_class
+// C++ capsule STR_Cstruct_as_class
+struct s_STR_Cstruct_as_class {
+    Cstruct_as_class *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_STR_Cstruct_as_class STR_Cstruct_as_class;
+// end C++ capsule STR_Cstruct_as_class
+
+// start C++ capsule STR_Cstruct_as_subclass
+// C++ capsule STR_Cstruct_as_subclass
+struct s_STR_Cstruct_as_subclass {
+    Cstruct_as_subclass *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_STR_Cstruct_as_subclass STR_Cstruct_as_subclass;
+// end C++ capsule STR_Cstruct_as_subclass
+#endif
 
 // start C capsule STR_Cstruct_as_class
 // C capsule STR_Cstruct_as_class

--- a/regression/reference/struct-cxx/typesstruct.h
+++ b/regression/reference/struct-cxx/typesstruct.h
@@ -87,23 +87,23 @@ struct s_STR_SHROUD_array {
 };
 typedef struct s_STR_SHROUD_array STR_SHROUD_array;
 
-// start struct STR_Cstruct_as_class
-// helper capsule_STR_Cstruct_as_class
+// start C capsule STR_Cstruct_as_class
+// C capsule STR_Cstruct_as_class
 struct s_STR_Cstruct_as_class {
     void *addr;     /* address of C++ memory */
     int idtor;      /* index of destructor */
 };
 typedef struct s_STR_Cstruct_as_class STR_Cstruct_as_class;
-// end struct STR_Cstruct_as_class
+// end C capsule STR_Cstruct_as_class
 
-// start struct STR_Cstruct_as_subclass
-// helper capsule_STR_Cstruct_as_subclass
+// start C capsule STR_Cstruct_as_subclass
+// C capsule STR_Cstruct_as_subclass
 struct s_STR_Cstruct_as_subclass {
     void *addr;     /* address of C++ memory */
     int idtor;      /* index of destructor */
 };
 typedef struct s_STR_Cstruct_as_subclass STR_Cstruct_as_subclass;
-// end struct STR_Cstruct_as_subclass
+// end C capsule STR_Cstruct_as_subclass
 
 void STR_SHROUD_memory_destructor(STR_SHROUD_capsule_data *cap);
 

--- a/regression/reference/templates/typestemplates.h
+++ b/regression/reference/templates/typestemplates.h
@@ -27,6 +27,64 @@ struct s_TEM_SHROUD_capsule_data {
     int idtor;      /* index of destructor */
 };
 typedef struct s_TEM_SHROUD_capsule_data TEM_SHROUD_capsule_data;
+#if 0
+
+// C++ capsule TEM_vector_int
+struct s_TEM_vector_int {
+    std::vector<int> *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TEM_vector_int TEM_vector_int;
+
+// C++ capsule TEM_vector_double
+struct s_TEM_vector_double {
+    std::vector<double> *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TEM_vector_double TEM_vector_double;
+
+// C++ capsule TEM_internal_ImplWorker1
+struct s_TEM_internal_ImplWorker1 {
+    internal::ImplWorker1 *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TEM_internal_ImplWorker1 TEM_internal_ImplWorker1;
+
+// C++ capsule TEM_internal_ImplWorker2
+struct s_TEM_internal_ImplWorker2 {
+    internal::ImplWorker2 *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TEM_internal_ImplWorker2 TEM_internal_ImplWorker2;
+
+// C++ capsule TEM_Worker
+struct s_TEM_Worker {
+    Worker *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TEM_Worker TEM_Worker;
+
+// C++ capsule TEM_user_int
+struct s_TEM_user_int {
+    user<int> *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TEM_user_int TEM_user_int;
+
+// C++ capsule TEM_structAsClass_int
+struct s_TEM_structAsClass_int {
+    structAsClass<int> *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TEM_structAsClass_int TEM_structAsClass_int;
+
+// C++ capsule TEM_structAsClass_double
+struct s_TEM_structAsClass_double {
+    structAsClass<double> *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TEM_structAsClass_double TEM_structAsClass_double;
+#endif
 
 // C capsule TEM_vector_int
 struct s_TEM_vector_int {

--- a/regression/reference/templates/typestemplates.h
+++ b/regression/reference/templates/typestemplates.h
@@ -21,68 +21,68 @@ extern "C" {
 // splicer begin types.C_declarations
 // splicer end types.C_declarations
 
-// helper capsule_TEM_Worker
-struct s_TEM_Worker {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_TEM_Worker TEM_Worker;
-
-// helper capsule_TEM_internal_ImplWorker1
-struct s_TEM_internal_ImplWorker1 {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_TEM_internal_ImplWorker1 TEM_internal_ImplWorker1;
-
-// helper capsule_TEM_internal_ImplWorker2
-struct s_TEM_internal_ImplWorker2 {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_TEM_internal_ImplWorker2 TEM_internal_ImplWorker2;
-
-// helper capsule_TEM_structAsClass_double
-struct s_TEM_structAsClass_double {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_TEM_structAsClass_double TEM_structAsClass_double;
-
-// helper capsule_TEM_structAsClass_int
-struct s_TEM_structAsClass_int {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_TEM_structAsClass_int TEM_structAsClass_int;
-
-// helper capsule_TEM_user_int
-struct s_TEM_user_int {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_TEM_user_int TEM_user_int;
-
-// helper capsule_TEM_vector_double
-struct s_TEM_vector_double {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_TEM_vector_double TEM_vector_double;
-
-// helper capsule_TEM_vector_int
-struct s_TEM_vector_int {
-    void *addr;     /* address of C++ memory */
-    int idtor;      /* index of destructor */
-};
-typedef struct s_TEM_vector_int TEM_vector_int;
-
 // helper capsule_data_helper
 struct s_TEM_SHROUD_capsule_data {
     void *addr;     /* address of C++ memory */
     int idtor;      /* index of destructor */
 };
 typedef struct s_TEM_SHROUD_capsule_data TEM_SHROUD_capsule_data;
+
+// C capsule TEM_vector_int
+struct s_TEM_vector_int {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TEM_vector_int TEM_vector_int;
+
+// C capsule TEM_vector_double
+struct s_TEM_vector_double {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TEM_vector_double TEM_vector_double;
+
+// C capsule TEM_internal_ImplWorker1
+struct s_TEM_internal_ImplWorker1 {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TEM_internal_ImplWorker1 TEM_internal_ImplWorker1;
+
+// C capsule TEM_internal_ImplWorker2
+struct s_TEM_internal_ImplWorker2 {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TEM_internal_ImplWorker2 TEM_internal_ImplWorker2;
+
+// C capsule TEM_Worker
+struct s_TEM_Worker {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TEM_Worker TEM_Worker;
+
+// C capsule TEM_user_int
+struct s_TEM_user_int {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TEM_user_int TEM_user_int;
+
+// C capsule TEM_structAsClass_int
+struct s_TEM_structAsClass_int {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TEM_structAsClass_int TEM_structAsClass_int;
+
+// C capsule TEM_structAsClass_double
+struct s_TEM_structAsClass_double {
+    void *addr;     /* address of C++ memory */
+    int idtor;      /* index of destructor */
+};
+typedef struct s_TEM_structAsClass_double TEM_structAsClass_double;
 
 void TEM_SHROUD_memory_destructor(TEM_SHROUD_capsule_data *cap);
 

--- a/shroud/whelpers.py
+++ b/shroud/whelpers.py
@@ -915,48 +915,6 @@ size_t size;
     
 ######################################################################
 
-def add_shadow_helper(node):
-    """
-    Add helper functions for each shadow type.
-
-    Args:
-        node -
-    """
-    cname = node.typemap.c_type
-
-    name = "capsule_{}".format(cname)
-    if name not in CHelpers:
-        if node.options.literalinclude:
-            lstart = "{}struct {}\n".format(cstart, cname)
-            lend = "\n{}struct {}".format(cend, cname)
-        else:
-            lstart = ""
-            lend = ""
-        if node.cpp_if:
-            cpp_if = "#" + node.cpp_if + "\n"
-            cpp_endif = "\n#endif  // " + node.cpp_if
-        else:
-            cpp_if = ""
-            cpp_endif = ""
-        helper = dict(
-            scope="cwrap_include",
-            # h_shared_code
-            source="""
-{lstart}// helper {hname}
-{cpp_if}struct s_{C_type_name} {{+
-void *addr;     /* address of C++ memory */
-int idtor;      /* index of destructor */
--}};
-typedef struct s_{C_type_name} {C_type_name};{cpp_endif}{lend}""".format(
-                hname=name, C_type_name=cname,
-                cpp_if=cpp_if, cpp_endif=cpp_endif,
-                lstart=lstart, lend=lend,
-            )
-        )
-        CHelpers[name] = helper
-    return name
-
-
 def add_capsule_helper():
     """Share info with C++ to allow Fortran to release memory.
 

--- a/shroud/wrapc.py
+++ b/shroud/wrapc.py
@@ -27,7 +27,7 @@ default_owner = "library"
 
 lang_map = {"c": "C", "cxx": "C++"}
 
-CPlusPlus = namedtuple("CPlusPlus", "start_cxx, else_cxx, end_cxx start_extern_c end_extern_c")
+CPlusPlus = namedtuple("CPlusPlus", "start_cxx else_cxx end_cxx start_extern_c end_extern_c")
 cplusplus = CPlusPlus([], [], [], [], [])
 
 class Wrapc(util.WrapperMixin):
@@ -60,6 +60,7 @@ class Wrapc(util.WrapperMixin):
         self.shared_helper = config.fc_shared_helpers  # Shared between Fortran and C.
         self.capsule_impl_cxx = []
         self.capsule_impl_c = []
+        self.header_types = util.Header(self.newlibrary) # shared type header
         self.helper_summary = None
         # Include files required by wrapper implementations.
         self.capsule_typedef_nodes = OrderedDict()  # [typemap.name] = typemap
@@ -405,7 +406,7 @@ class Wrapc(util.WrapperMixin):
             ]
         )
 
-        headers = util.Header(self.newlibrary)
+        headers = self.header_types
         headers.add_shroud_dict(self.helper_include["cwrap_include"])
         headers.write_headers(output)
 
@@ -688,14 +689,25 @@ typedef struct s_{C_type_name} {C_type_name};{cpp_endif}""",
 
         fmt.lang = "C++"
         fmt.capsule_type = node.typemap.cxx_type
-#        self.add_class_capsule_worker(self.capsule_impl_cxx, fmt, literalinclude)
+        self.add_class_capsule_worker(self.capsule_impl_cxx, fmt, literalinclude)
+
+#        self.header_types.add_cxx_header(node)
 
     def write_class_capsule_structs(self, output):
-#        output.append("")
-#        output.append("#if 0")
-        output.extend(self.capsule_impl_cxx)
-#        output.append("#endif")
+        if self.capsule_impl_cxx:
+            output.append("#if 0")
+            #        output.extend(cplusplus.start_cxx)
+            output.extend(self.capsule_impl_cxx)
+            output.append("#endif")
+#        output.extend(cplusplus.end_extern_c)
+
+#        output.extend(cplusplus.start_cxx)
+#        output.extend(self.capsule_impl_cxx)
+#        output.extend(cplusplus.else_cxx)
         output.extend(self.capsule_impl_c)
+#        output.extend(cplusplus.end_cxx)
+
+#        output.extend(cplusplus.start_extern_c)
         
     def wrap_class(self, node):
         """


### PR DESCRIPTION
Change how class capsule structs are created.  Generate code
explicitly instead of via a helper.  This is similar to how wrapped C
structs are created.  Code is created for a C++ version of the capsule
to help eliminate some casts in the generated code but need to sort
out how header files are inserted since the C++ version will require
the cxx_headers.