### PR TITLE
Fix Python reference counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Statement field *c_need_wrapper*. Similar to *f_need_wrapper*.
 
+### Fixed
+- Avoid memory leaks by using 'N' instead of 'O' in `Py_BuildValue`
+  for objects which have just been created.
+
 ## v0.13.0 - 2023-08-23
 ### Added
 - Python hello-world-python example for a simple library in examples directory.

--- a/HACKING
+++ b/HACKING
@@ -130,6 +130,19 @@ to the VPATH.  For the Python tests, there is an explicit run to force
 the use of CXX.  The VPATH finds both the C and C++ files since they
 have the same stem.
 
+reference counting
+------------------
+
+``Python-3.9.12/Misc/valgrind-python.supp``
+
+```
+valgrind --tool=memcheck --suppressions=valgrind-python.supp \
+                                          python -E -tt ./my_python_script.py
+```
+
+Build Python with ``--with-address-sanitizer --with-pydebug``
+
+
 file dependency
 ---------------
 

--- a/docs/input.rst
+++ b/docs/input.rst
@@ -487,6 +487,10 @@ scalar
    Fortran, copy into existing argument.
    Python, useful for *intent(inout)*.
 
+.. Python provides a different set of values:
+     scalar, raw, numpy, list.
+   See option PY_array_arg.
+
 dimension
 ^^^^^^^^^
 

--- a/docs/python.rst
+++ b/docs/python.rst
@@ -341,7 +341,8 @@ cxx_local_var
 ^^^^^^^^^^^^^
 
 Set when a C++ variable is created by post_parse.
-*scalar*
+Set to *scalar* or *pointer* depending on the declaration in *post_declare*
+*post_parse* or *pre_call*.
 
 Used to set format fields *cxx_member*
 
@@ -392,12 +393,6 @@ parse_args
 
 A list of wrapper variables that are passed to ``PyArg_ParseTupleAndKeywords``.
 Used with *parse_format*.
-
-cxx_local_var
-^^^^^^^^^^^^^
-
-Set to *scalar* or *pointer* depending on the declaration in *post_declare*
-*post_parse* or *pre_call*.
 
 post_declare
 ^^^^^^^^^^^^
@@ -472,6 +467,17 @@ be inserted into the code/
 
 .. object conversion
 
+incref_on_return
+^^^^^^^^^^^^^^^^
+
+Used to control reference counting on returned objects.  When the
+format ``O`` is passed to ``PyArg_ParseTupleAndKeywords`` a ``PyObject
+*`` is returned without incrementing the reference count.  If the
+attribute *intent(inout)* is set, then the same object may be returned
+by the function. The reference count must be incremented before it is
+returned.  This can be done by ``Py_BuildValue`` with the ``O`` format
+field. But when there is only one return value, ``Py_INCREF`` will be
+called explicitly.
 
 object_created
 ^^^^^^^^^^^^^^
@@ -481,6 +487,8 @@ This prevents ``Py_BuildValue`` from converting it into an Object.
 For example, when a pointer is converted into a ``PyCapsule`` or
 when NumPy is used to create an object.
 
+.. Also when the returned object is also an input argument.
+   py_inout_struct_*_class
 
 Predefined Types
 ----------------

--- a/regression/do-test.py
+++ b/regression/do-test.py
@@ -421,6 +421,7 @@ if __name__ == "__main__":
                  cmdline=[
                      # Create literal blocks for documentation
                      "--option", "literalinclude2=true",
+                     "--option", "PY_array_arg=numpy",
                      "--option", "wrap_fortran=false",
                      "--option", "wrap_c=false",
                  ]),

--- a/regression/reference/arrayclass/arrayclass.json
+++ b/regression/reference/arrayclass/arrayclass.json
@@ -904,7 +904,7 @@
                                     "py_var": "SHTPy_rv",
                                     "rank": "1",
                                     "size_var": "SHSize_rv",
-                                    "stmt": "py_function_native_*_pointer_numpy",
+                                    "stmt": "py_function_native_*_numpy",
                                     "value_var": "SHValue_rv"
                                 }
                             }
@@ -1097,7 +1097,7 @@
                                     "py_var": "SHTPy_rv",
                                     "rank": "1",
                                     "size_var": "SHSize_rv",
-                                    "stmt": "py_function_native_*_pointer_numpy",
+                                    "stmt": "py_function_native_*_numpy",
                                     "value_var": "SHValue_rv"
                                 }
                             }
@@ -1289,7 +1289,7 @@
                                     "py_var": "SHTPy_rv",
                                     "rank": "1",
                                     "size_var": "SHSize_rv",
-                                    "stmt": "py_function_native_*_pointer_numpy",
+                                    "stmt": "py_function_native_*_numpy",
                                     "value_var": "SHValue_rv"
                                 }
                             }
@@ -1483,7 +1483,7 @@
                                     "py_var": "SHTPy_rv",
                                     "rank": "1",
                                     "size_var": "SHSize_rv",
-                                    "stmt": "py_function_native_*_pointer_numpy",
+                                    "stmt": "py_function_native_*_numpy",
                                     "value_var": "SHValue_rv"
                                 }
                             }
@@ -1749,7 +1749,7 @@
                                     "py_var": "SHPy_array",
                                     "rank": "1",
                                     "size_var": "SHSize_array",
-                                    "stmt": "py_out_native_**_pointer_numpy",
+                                    "stmt": "py_out_native_**_numpy",
                                     "value_var": "SHValue_array"
                                 }
                             },
@@ -2082,7 +2082,7 @@
                                     "py_var": "SHPy_array",
                                     "rank": "1",
                                     "size_var": "SHSize_array",
-                                    "stmt": "py_out_native_*&_pointer_numpy",
+                                    "stmt": "py_out_native_*&_numpy",
                                     "value_var": "SHValue_array"
                                 }
                             },
@@ -2416,7 +2416,7 @@
                                     "py_var": "SHPy_array",
                                     "rank": "1",
                                     "size_var": "SHSize_array",
-                                    "stmt": "py_out_native_**_pointer_numpy",
+                                    "stmt": "py_out_native_**_numpy",
                                     "value_var": "SHValue_array"
                                 }
                             },
@@ -2750,7 +2750,7 @@
                                     "py_var": "SHPy_array",
                                     "rank": "1",
                                     "size_var": "SHSize_array",
-                                    "stmt": "py_out_native_*&_pointer_numpy",
+                                    "stmt": "py_out_native_*&_numpy",
                                     "value_var": "SHValue_array"
                                 }
                             },

--- a/regression/reference/arrayclass/pyArrayWrappertype.cpp
+++ b/regression/reference/arrayclass/pyArrayWrappertype.cpp
@@ -167,7 +167,7 @@ PY_allocate(
 
 // ----------------------------------------
 // Function:  double * getArray +dimension(getSize())
-// Statement: py_function_native_*_pointer_numpy
+// Statement: py_function_native_*_numpy
 static char PY_getArray__doc__[] =
 "documentation"
 ;
@@ -200,7 +200,7 @@ fail:
 
 // ----------------------------------------
 // Function:  double * getArrayConst +dimension(getSize())
-// Statement: py_function_native_*_pointer_numpy
+// Statement: py_function_native_*_numpy
 static char PY_getArrayConst__doc__[] =
 "documentation"
 ;
@@ -233,7 +233,7 @@ fail:
 
 // ----------------------------------------
 // Function:  const double * getArrayC +dimension(getSize())
-// Statement: py_function_native_*_pointer_numpy
+// Statement: py_function_native_*_numpy
 static char PY_getArrayC__doc__[] =
 "documentation"
 ;
@@ -266,7 +266,7 @@ fail:
 
 // ----------------------------------------
 // Function:  const double * getArrayConstC +dimension(getSize())
-// Statement: py_function_native_*_pointer_numpy
+// Statement: py_function_native_*_numpy
 static char PY_getArrayConstC__doc__[] =
 "documentation"
 ;
@@ -302,7 +302,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  double * * array +dimension(isize)+intent(out)
-// Statement: py_out_native_**_pointer_numpy
+// Statement: py_out_native_**_numpy
 // ----------------------------------------
 // Argument:  int * isize +hidden
 // Statement: py_inout_native_*
@@ -343,7 +343,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  double * & array +dimension(isize)+intent(out)
-// Statement: py_out_native_*&_pointer_numpy
+// Statement: py_out_native_*&_numpy
 // ----------------------------------------
 // Argument:  int & isize +hidden
 // Statement: py_inout_native_&
@@ -384,7 +384,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  const double * * array +dimension(isize)+intent(out)
-// Statement: py_out_native_**_pointer_numpy
+// Statement: py_out_native_**_numpy
 // ----------------------------------------
 // Argument:  int * isize +hidden
 // Statement: py_inout_native_*
@@ -425,7 +425,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  const double * & array +dimension(isize)+intent(out)
-// Statement: py_out_native_*&_pointer_numpy
+// Statement: py_out_native_*&_numpy
 // ----------------------------------------
 // Argument:  int & isize +hidden
 // Statement: py_inout_native_&

--- a/regression/reference/clibrary/pyClibrarymodule.c
+++ b/regression/reference/clibrary/pyClibrarymodule.c
@@ -225,7 +225,7 @@ PY_checkBool(
     if (SHPy_arg2 == NULL) goto fail;
     SHPy_arg3 = PyBool_FromLong(arg3);
     if (SHPy_arg3 == NULL) goto fail;
-    SHTPy_rv = Py_BuildValue("OO", SHPy_arg2, SHPy_arg3);
+    SHTPy_rv = Py_BuildValue("NN", SHPy_arg2, SHPy_arg3);
 
     return SHTPy_rv;
 

--- a/regression/reference/cxxlibrary/cxxlibrary.json
+++ b/regression/reference/cxxlibrary/cxxlibrary.json
@@ -2894,7 +2894,7 @@
                             "pytmp_var": "SHTPy_data",
                             "rank": "1",
                             "size_var": "SHSize_data",
-                            "stmt": "py_in_native_*_pointer_numpy",
+                            "stmt": "py_in_native_*_numpy",
                             "value_var": "SHValue_data"
                         }
                     }

--- a/regression/reference/cxxlibrary/pycxxlibrary_structnsmodule.cpp
+++ b/regression/reference/cxxlibrary/pycxxlibrary_structnsmodule.cpp
@@ -86,7 +86,7 @@ PY_passStructByReference(
     SHCXX_rv = structns::passStructByReference(*arg);
 
     // post_call
-    SHTPy_rv = Py_BuildValue("iO", SHCXX_rv, SHPy_arg);
+    SHTPy_rv = Py_BuildValue("iN", SHCXX_rv, SHPy_arg);
 
     return SHTPy_rv;
 

--- a/regression/reference/cxxlibrary/pycxxlibrarymodule.cpp
+++ b/regression/reference/cxxlibrary/pycxxlibrarymodule.cpp
@@ -152,6 +152,10 @@ PY_passStructByReferenceInoutCls(
     Cstruct1_cls * arg = SHPy_arg ? SHPy_arg->obj : nullptr;
 
     passStructByReferenceInoutCls(*arg);
+
+    // post_call
+    Py_INCREF(SHPy_arg);
+
     return (PyObject *) SHPy_arg;
 // splicer end function.passStructByReferenceInoutCls
 }

--- a/regression/reference/cxxlibrary/pycxxlibrarymodule.cpp
+++ b/regression/reference/cxxlibrary/pycxxlibrarymodule.cpp
@@ -70,7 +70,7 @@ PY_passStructByReferenceCls(
     int SHCXX_rv = passStructByReferenceCls(*arg);
 
     // post_call
-    SHTPy_rv = Py_BuildValue("iO", SHCXX_rv, SHPy_arg);
+    SHTPy_rv = Py_BuildValue("iN", SHCXX_rv, SHPy_arg);
 
     return SHTPy_rv;
 // splicer end function.passStructByReferenceCls

--- a/regression/reference/cxxlibrary/pycxxlibrarymodule.cpp
+++ b/regression/reference/cxxlibrary/pycxxlibrarymodule.cpp
@@ -198,7 +198,7 @@ fail:
 // Statement: py_function_bool_scalar
 // ----------------------------------------
 // Argument:  double * data=nullptr +intent(IN)+rank(1)
-// Statement: py_in_native_*_pointer_numpy
+// Statement: py_in_native_*_numpy
 static char PY_defaultPtrIsNULL_1__doc__[] =
 "documentation"
 ;

--- a/regression/reference/error/output
+++ b/regression/reference/error/output
@@ -68,7 +68,6 @@ Phase: Wrapp.wrap_functions
 ----------------------------------------
 Node: AssumedRank
 line 51
-Statement: py_default
 Detected assumed-rank dimension
 Wrote pyerrormodule.cpp
 Wrote pyerrormodule.hpp

--- a/regression/reference/example/example.json
+++ b/regression/reference/example/example.json
@@ -12381,7 +12381,7 @@
                                             "pytmp_var": "SHTPy_in",
                                             "rank": "2",
                                             "size_var": "SHSize_in",
-                                            "stmt": "py_in_native_*_pointer_numpy",
+                                            "stmt": "py_in_native_*_numpy",
                                             "value_var": "SHValue_in"
                                         }
                                     },
@@ -12466,7 +12466,7 @@
                                             "py_var": "SHPy_out",
                                             "rank": "1",
                                             "size_var": "SHSize_out",
-                                            "stmt": "py_out_native_*_pointer_numpy",
+                                            "stmt": "py_out_native_*_numpy",
                                             "value_var": "SHValue_out"
                                         }
                                     },

--- a/regression/reference/example/pyUserLibrary_example_nestedmodule.cpp
+++ b/regression/reference/example/pyUserLibrary_example_nestedmodule.cpp
@@ -639,10 +639,10 @@ PP_verylongfunctionname2(
 // Statement: py_default
 // ----------------------------------------
 // Argument:  double * in +intent(in)+rank(2)
-// Statement: py_in_native_*_pointer_numpy
+// Statement: py_in_native_*_numpy
 // ----------------------------------------
 // Argument:  double * out +dimension(shape(in))+intent(out)
-// Statement: py_out_native_*_pointer_numpy
+// Statement: py_out_native_*_numpy
 // ----------------------------------------
 // Argument:  int sizein +implied(size(in))+value
 // Exact:     py_default

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -12581,6 +12581,7 @@ py_inout_struct_&_class:
   arg_call:
   - '*{cxx_var}'
   cxx_local_var: pointer
+  incref_on_return: true
   intent: inout
   name: py_inout_struct_&_class
   object_created: true
@@ -12623,6 +12624,7 @@ py_inout_struct_&_numpy:
   - "{cxx_var} = static_cast<{cxx_type} *>\t(PyArray_DATA({py_var}));"
 py_inout_struct_*_class:
   cxx_local_var: pointer
+  incref_on_return: true
   intent: inout
   name: py_inout_struct_*_class
   object_created: true

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -9651,6 +9651,8 @@ f_mixin_str_array:
 f_mixin_unknown:
   c_arg_decl:
   - ===>{c_var}<===
+  comments:
+  - Default returned by lookup_fc_stmts when group is not found.
   index: '28'
   intent: mixin
   name: f_mixin_unknown
@@ -11142,14 +11144,10 @@ root
         scalar -- py_function_char_scalar
       native
         &
-          pointer
-            numpy -- py_function_native_*/&_pointer_numpy
+          numpy -- py_function_native_*/&_numpy
         *
-          allocatable
-            numpy -- py_function_native_*/&_pointer_numpy
-          pointer
-            list -- py_function_native_*_pointer_list
-            numpy -- py_function_native_*/&_pointer_numpy
+          list -- py_function_native_*_list
+          numpy -- py_function_native_*/&_numpy
           scalar -- py_defaulttmp
         scalar -- py_defaulttmp
       shadow
@@ -11185,9 +11183,8 @@ root
       native
         & -- py_in_native_&
         * -- py_in_native_*
-          pointer
-            list -- py_in_native_*_pointer_list
-            numpy -- py_in_native_*_pointer_numpy
+          list -- py_in_native_*_list
+          numpy -- py_in_native_*_numpy
         scalar -- py_defaulttmp
       shadow
         & -- py_in_shadow_&
@@ -11225,9 +11222,8 @@ root
       native
         & -- py_inout_native_&
         * -- py_inout_native_*
-          pointer
-            list -- py_inout_native_*_pointer_list
-            numpy -- py_inout_native_*_pointer_numpy
+          list -- py_inout_native_*_list
+          numpy -- py_inout_native_*_numpy
       shadow
         * -- py_inout_shadow_*
       string
@@ -11243,6 +11239,8 @@ root
           list -- py_inout_struct_*_list
           numpy -- py_inout_struct_*_numpy
         list -- py_inout_struct_list
+    mixin
+      unknown -- py_mixin_unknown
     out
       bool -- py_out_bool
         * -- py_out_bool_*
@@ -11252,19 +11250,13 @@ root
       native
         & -- py_out_native_&
         * -- py_out_native_*
-          allocatable
-            list -- py_out_native_*_allocatable/pointer_list
-            numpy -- py_out_native_*_allocatable/pointer_numpy
-          pointer
-            list -- py_out_native_*_allocatable/pointer_list
-            numpy -- py_out_native_*_allocatable/pointer_numpy
+          list -- py_out_native_*_list
+          numpy -- py_out_native_*_numpy
         *&
-          pointer
-            numpy -- py_out_native_*&_pointer_numpy
+          numpy -- py_out_native_*&_numpy
         **
-          pointer
-            list -- py_out_native_**_pointer_list
-            numpy -- py_out_native_**_pointer_numpy
+          list -- py_out_native_**_list
+          numpy -- py_out_native_**_numpy
           raw -- py_out_native_**_raw
       shadow
         * -- py_out_shadow_*
@@ -11808,7 +11800,7 @@ py_function_char_scalar:
   object_created: true
   post_call:
   - '{py_var} = PyString_FromStringAndSize(&{cxx_var}, 1);'
-py_function_native_&_pointer_numpy:
+py_function_native_&_numpy:
   declare:
   - '{npy_intp_decl}PyObject * {py_var} = {nullptr};'
   declare_capsule:
@@ -11819,7 +11811,7 @@ py_function_native_&_pointer_numpy:
   - Py_XDECREF({py_capsule});
   goto_fail: true
   intent: function
-  name: py_function_native_&_pointer_numpy
+  name: py_function_native_&_numpy
   need_numpy: true
   object_created: true
   post_call:
@@ -11833,32 +11825,7 @@ py_function_native_&_pointer_numpy:
   - "PyCapsule_SetContext({py_capsule},\t {PY_fetch_context_function}({capsule_order}));"
   - "if (PyArray_SetBaseObject(\t{cast_reinterpret}PyArrayObject *{cast1}{py_var}{cast2},\t\
     \ {py_capsule}) < 0)\t goto fail;"
-py_function_native_*_allocatable_numpy:
-  declare:
-  - '{npy_intp_decl}PyObject * {py_var} = {nullptr};'
-  declare_capsule:
-  - PyObject *{py_capsule} = {nullptr};
-  fail:
-  - Py_XDECREF({py_var});
-  fail_capsule:
-  - Py_XDECREF({py_capsule});
-  goto_fail: true
-  intent: function
-  name: py_function_native_*_allocatable_numpy
-  need_numpy: true
-  object_created: true
-  post_call:
-  - "{npy_intp_asgn}{py_var} = PyArray_SimpleNewFromData({npy_rank},\t {npy_dims_var},\t\
-    \ {numpy_type},\t {cxx_nonconst_ptr});"
-  - if ({py_var} == {nullptr}) goto fail;
-  post_call_capsule:
-  - "{py_capsule} = PyCapsule_New({cxx_var}, \"{PY_numpy_array_capsule_name}\", \t\
-    {PY_capsule_destructor_function});"
-  - if ({py_capsule} == {nullptr}) goto fail;
-  - "PyCapsule_SetContext({py_capsule},\t {PY_fetch_context_function}({capsule_order}));"
-  - "if (PyArray_SetBaseObject(\t{cast_reinterpret}PyArrayObject *{cast1}{py_var}{cast2},\t\
-    \ {py_capsule}) < 0)\t goto fail;"
-py_function_native_*_pointer_list:
+py_function_native_*_list:
   c_helper: to_PyList_{cxx_type}
   declare:
   - PyObject *{py_var} = {nullptr};
@@ -11866,12 +11833,12 @@ py_function_native_*_pointer_list:
   - Py_XDECREF({py_var});
   goto_fail: true
   intent: function
-  name: py_function_native_*_pointer_list
+  name: py_function_native_*_list
   object_created: true
   post_call:
   - "{py_var} = {hnamefunc0}\t({cxx_var},\t {array_size});"
   - if ({py_var} == {nullptr}) goto fail;
-py_function_native_*_pointer_numpy:
+py_function_native_*_numpy:
   declare:
   - '{npy_intp_decl}PyObject * {py_var} = {nullptr};'
   declare_capsule:
@@ -11882,7 +11849,7 @@ py_function_native_*_pointer_numpy:
   - Py_XDECREF({py_capsule});
   goto_fail: true
   intent: function
-  name: py_function_native_*_pointer_numpy
+  name: py_function_native_*_numpy
   need_numpy: true
   object_created: true
   post_call:
@@ -12138,7 +12105,7 @@ py_in_native_*:
   - '{c_type} {c_var};'
   intent: in
   name: py_in_native_*
-py_in_native_*_pointer_list:
+py_in_native_*_list:
   arg_call:
   - '{cxx_var}'
   arg_declare:
@@ -12155,7 +12122,7 @@ py_in_native_*_pointer_list:
   - Py_XDECREF({value_var}.dataobj);
   goto_fail: true
   intent: in
-  name: py_in_native_*_pointer_list
+  name: py_in_native_*_list
   parse_args:
   - '&{pytmp_var}'
   parse_format: O
@@ -12164,7 +12131,7 @@ py_in_native_*_pointer_list:
   - +goto fail;-
   - '{cxx_var} = {cast_static}{cxx_type} *{cast1}{value_var}.data{cast2};'
   - '{size_var} = {value_var}.size;'
-py_in_native_*_pointer_numpy:
+py_in_native_*_numpy:
   arg_call:
   - '{c_var}'
   cleanup:
@@ -12182,7 +12149,7 @@ py_in_native_*_pointer_numpy:
   lang_cxx:
     pre_call:
     - "{cxx_var} = static_cast<{cxx_type} *>\t(PyArray_DATA({py_var}));"
-  name: py_in_native_*_pointer_numpy
+  name: py_in_native_*_numpy
   need_numpy: true
   parse_args:
   - '&{pytmp_var}'
@@ -12509,7 +12476,7 @@ py_inout_native_*:
     ctor_expr: '{c_var}'
   intent: inout
   name: py_inout_native_*
-py_inout_native_*_pointer_list:
+py_inout_native_*_list:
   arg_call:
   - '{cxx_var}'
   arg_declare:
@@ -12527,7 +12494,7 @@ py_inout_native_*_pointer_list:
   - Py_XDECREF({value_var}.dataobj);
   goto_fail: true
   intent: inout
-  name: py_inout_native_*_pointer_list
+  name: py_inout_native_*_list
   object_created: true
   parse_args:
   - '&{pytmp_var}'
@@ -12540,7 +12507,7 @@ py_inout_native_*_pointer_list:
   - +goto fail;-
   - '{cxx_var} = {cast_static}{cxx_type} *{cast1}{value_var}.data{cast2};'
   - '{size_var} = {value_var}.size;'
-py_inout_native_*_pointer_numpy:
+py_inout_native_*_numpy:
   arg_call:
   - '{c_var}'
   declare:
@@ -12556,7 +12523,7 @@ py_inout_native_*_pointer_numpy:
   lang_cxx:
     pre_call:
     - "{cxx_var} = static_cast<{cxx_type} *>\t(PyArray_DATA({py_var}));"
-  name: py_inout_native_*_pointer_numpy
+  name: py_inout_native_*_numpy
   need_numpy: true
   object_created: true
   parse_args:
@@ -12702,6 +12669,9 @@ py_inout_struct_*_numpy:
 py_inout_struct_list:
   intent: inout
   name: py_inout_struct_list
+py_mixin_unknown:
+  intent: mixin
+  name: py_mixin_unknown
 py_out_bool:
   arg_declare:
   - bool {cxx_var};
@@ -12755,7 +12725,7 @@ py_out_native_*:
     ctor_expr: '{c_var}'
   intent: out
   name: py_out_native_*
-py_out_native_*&_pointer_numpy:
+py_out_native_*&_numpy:
   arg_call:
   - '{cxx_var}'
   arg_declare:
@@ -12770,7 +12740,7 @@ py_out_native_*&_pointer_numpy:
   - Py_XDECREF({py_capsule});
   goto_fail: true
   intent: out
-  name: py_out_native_*&_pointer_numpy
+  name: py_out_native_*&_numpy
   need_numpy: true
   object_created: true
   post_call:
@@ -12784,7 +12754,7 @@ py_out_native_*&_pointer_numpy:
   - "PyCapsule_SetContext({py_capsule},\t {PY_fetch_context_function}({capsule_order}));"
   - "if (PyArray_SetBaseObject(\t{cast_reinterpret}PyArrayObject *{cast1}{py_var}{cast2},\t\
     \ {py_capsule}) < 0)\t goto fail;"
-py_out_native_**_pointer_list:
+py_out_native_**_list:
   arg_call:
   - '&{cxx_var}'
   arg_declare:
@@ -12796,12 +12766,12 @@ py_out_native_**_pointer_list:
   - Py_XDECREF({py_var});
   goto_fail: true
   intent: out
-  name: py_out_native_**_pointer_list
+  name: py_out_native_**_list
   object_created: true
   post_call:
   - "{py_var} = {hnamefunc0}\t({cxx_var},\t {array_size});"
   - if ({py_var} == {nullptr}) goto fail;
-py_out_native_**_pointer_numpy:
+py_out_native_**_numpy:
   arg_call:
   - '&{cxx_var}'
   arg_declare:
@@ -12816,7 +12786,7 @@ py_out_native_**_pointer_numpy:
   - Py_XDECREF({py_capsule});
   goto_fail: true
   intent: out
-  name: py_out_native_**_pointer_numpy
+  name: py_out_native_**_numpy
   need_numpy: true
   object_created: true
   post_call:
@@ -12842,7 +12812,7 @@ py_out_native_**_raw:
   object_created: true
   post_call:
   - '{py_var} = PyCapsule_New({cxx_var}, NULL, NULL);'
-py_out_native_*_allocatable_list:
+py_out_native_*_list:
   arg_call:
   - '{c_var}'
   arg_declare:
@@ -12877,7 +12847,7 @@ py_out_native_*_allocatable_list:
     - PyErr_NoMemory();
     - goto fail;
     - -}}
-  name: py_out_native_*_allocatable_list
+  name: py_out_native_*_list
   object_created: true
   post_call:
   - "{py_var} = {hnamefunc0}\t({cxx_var},\t {array_size});"
@@ -12888,7 +12858,7 @@ py_out_native_*_allocatable_list:
   - PyErr_NoMemory();
   - goto fail;
   - -}}
-py_out_native_*_allocatable_numpy:
+py_out_native_*_numpy:
   arg_call:
   - '{c_var}'
   declare:
@@ -12903,81 +12873,7 @@ py_out_native_*_allocatable_numpy:
   lang_cxx:
     pre_call:
     - "{cxx_var} = static_cast<{cxx_type} *>\t(PyArray_DATA({py_var}));"
-  name: py_out_native_*_allocatable_numpy
-  need_numpy: true
-  object_created: true
-  post_parse:
-  - '{npy_intp_asgn}{py_var} = {cast_reinterpret}PyArrayObject *{cast1}PyArray_SimpleNew({npy_rank},
-    {npy_dims_var}, {numpy_type}){cast2};'
-  - if ({py_var} == {nullptr}) {{+
-  - "PyErr_SetString(PyExc_ValueError,\t \"{c_var} must be a {rank}-D array of {c_type}\"\
-    );"
-  - goto fail;
-  - -}}
-  pre_call:
-  - "{cxx_var} = static_cast<{cxx_type} *>\t(PyArray_DATA({py_var}));"
-py_out_native_*_pointer_list:
-  arg_call:
-  - '{c_var}'
-  arg_declare:
-  - '{cxx_type} * {cxx_var} = {nullptr};'
-  c_header:
-  - <stdlib.h>
-  c_helper: to_PyList_{cxx_type}
-  cleanup:
-  - '{stdlib}free({cxx_var});'
-  - '{cxx_var} = {nullptr};'
-  cxx_header:
-  - <cstdlib>
-  declare:
-  - PyObject *{py_var} = {nullptr};
-  fail:
-  - Py_XDECREF({py_var});
-  - "if ({cxx_var} != {nullptr})\t {stdlib}free({cxx_var});"
-  goto_fail: true
-  intent: out
-  lang_c:
-    pre_call:
-    - "{c_var} = malloc(\tsizeof({c_type}) * ({array_size}));"
-    - if ({cxx_var} == {nullptr}) {{+
-    - PyErr_NoMemory();
-    - goto fail;
-    - -}}
-  lang_cxx:
-    pre_call:
-    - "{cxx_var} = static_cast<{cxx_type} *>\t(std::malloc(\tsizeof({cxx_type}) *\
-      \ ({array_size})));"
-    - if ({cxx_var} == {nullptr}) {{+
-    - PyErr_NoMemory();
-    - goto fail;
-    - -}}
-  name: py_out_native_*_pointer_list
-  object_created: true
-  post_call:
-  - "{py_var} = {hnamefunc0}\t({cxx_var},\t {array_size});"
-  - if ({py_var} == {nullptr}) goto fail;
-  pre_call:
-  - "{cxx_var} = static_cast<{cxx_type} *>\t(std::malloc(\tsizeof({cxx_type}) * ({array_size})));"
-  - if ({cxx_var} == {nullptr}) {{+
-  - PyErr_NoMemory();
-  - goto fail;
-  - -}}
-py_out_native_*_pointer_numpy:
-  arg_call:
-  - '{c_var}'
-  declare:
-  - '{npy_intp_decl}PyArrayObject * {py_var} = {nullptr};'
-  fail:
-  - Py_XDECREF({py_var});
-  goto_fail: true
-  intent: out
-  lang_c:
-    pre_call:
-    - '{c_var} = PyArray_DATA({py_var});'
-  lang_cxx:
-    pre_call:
-    - "{cxx_var} = static_cast<{cxx_type} *>\t(PyArray_DATA({py_var}));"
-  name: py_out_native_*_pointer_numpy
+  name: py_out_native_*_numpy
   need_numpy: true
   object_created: true
   post_parse:

--- a/regression/reference/ownership/ownership.json
+++ b/regression/reference/ownership/ownership.json
@@ -668,7 +668,7 @@
                             "numpy_type": "NPY_INT",
                             "py_var": "SHTPy_rv",
                             "size_var": "SHSize_rv",
-                            "stmt": "py_function_native_*_pointer_numpy",
+                            "stmt": "py_function_native_*_numpy",
                             "value_var": "SHValue_rv"
                         }
                     }
@@ -1036,7 +1036,7 @@
                             "py_var": "SHTPy_rv",
                             "rank": "1",
                             "size_var": "SHSize_rv",
-                            "stmt": "py_function_native_*_pointer_numpy",
+                            "stmt": "py_function_native_*_numpy",
                             "value_var": "SHValue_rv"
                         }
                     },
@@ -1341,7 +1341,7 @@
                             "py_var": "SHTPy_rv",
                             "rank": "1",
                             "size_var": "SHSize_rv",
-                            "stmt": "py_function_native_*_allocatable_numpy",
+                            "stmt": "py_function_native_*_numpy",
                             "value_var": "SHValue_rv"
                         }
                     },
@@ -1634,7 +1634,7 @@
                             "py_var": "SHTPy_rv",
                             "rank": "1",
                             "size_var": "SHSize_rv",
-                            "stmt": "py_function_native_*_pointer_numpy",
+                            "stmt": "py_function_native_*_numpy",
                             "value_var": "SHValue_rv"
                         }
                     },
@@ -2084,7 +2084,7 @@
                             "py_var": "SHTPy_rv",
                             "rank": "1",
                             "size_var": "SHSize_rv",
-                            "stmt": "py_function_native_*_pointer_numpy",
+                            "stmt": "py_function_native_*_numpy",
                             "value_var": "SHValue_rv"
                         }
                     },
@@ -2304,7 +2304,7 @@
                             "py_var": "SHTPy_rv",
                             "rank": "1",
                             "size_var": "SHSize_rv",
-                            "stmt": "py_function_native_*_allocatable_numpy",
+                            "stmt": "py_function_native_*_numpy",
                             "value_var": "SHValue_rv"
                         }
                     },
@@ -2576,7 +2576,7 @@
                             "py_var": "SHTPy_rv",
                             "rank": "1",
                             "size_var": "SHSize_rv",
-                            "stmt": "py_function_native_*_pointer_numpy",
+                            "stmt": "py_function_native_*_numpy",
                             "value_var": "SHValue_rv"
                         }
                     },

--- a/regression/reference/ownership/pyownershipmodule.cpp
+++ b/regression/reference/ownership/pyownershipmodule.cpp
@@ -61,7 +61,7 @@ PY_ReturnIntPtrScalar(
 
 // ----------------------------------------
 // Function:  int * ReturnIntPtrPointer +deref(pointer)
-// Statement: py_function_native_*_pointer_numpy
+// Statement: py_function_native_*_numpy
 static char PY_ReturnIntPtrPointer__doc__[] =
 "documentation"
 ;
@@ -91,7 +91,7 @@ fail:
 
 // ----------------------------------------
 // Function:  int * ReturnIntPtrDimPointer +deref(pointer)+dimension(len)
-// Statement: py_function_native_*_pointer_numpy
+// Statement: py_function_native_*_numpy
 // ----------------------------------------
 // Argument:  int * len +hidden+intent(out)
 // Statement: py_out_native_*
@@ -127,7 +127,7 @@ fail:
 
 // ----------------------------------------
 // Function:  int * ReturnIntPtrDimAlloc +deref(allocatable)+dimension(len)
-// Statement: py_function_native_*_allocatable_numpy
+// Statement: py_function_native_*_numpy
 // ----------------------------------------
 // Argument:  int * len +hidden+intent(out)
 // Statement: py_out_native_*
@@ -163,7 +163,7 @@ fail:
 
 // ----------------------------------------
 // Function:  int * ReturnIntPtrDimDefault +dimension(len)
-// Statement: py_function_native_*_pointer_numpy
+// Statement: py_function_native_*_numpy
 // ----------------------------------------
 // Argument:  int * len +hidden+intent(out)
 // Statement: py_out_native_*
@@ -199,7 +199,7 @@ fail:
 
 // ----------------------------------------
 // Function:  int * ReturnIntPtrDimPointerNew +deref(pointer)+dimension(len)+owner(caller)
-// Statement: py_function_native_*_pointer_numpy
+// Statement: py_function_native_*_numpy
 // ----------------------------------------
 // Argument:  int * len +hidden+intent(out)
 // Statement: py_out_native_*
@@ -235,7 +235,7 @@ fail:
 
 // ----------------------------------------
 // Function:  int * ReturnIntPtrDimAllocNew +deref(allocatable)+dimension(len)+owner(caller)
-// Statement: py_function_native_*_allocatable_numpy
+// Statement: py_function_native_*_numpy
 // ----------------------------------------
 // Argument:  int * len +hidden+intent(out)
 // Statement: py_out_native_*
@@ -271,7 +271,7 @@ fail:
 
 // ----------------------------------------
 // Function:  int * ReturnIntPtrDimDefaultNew +dimension(len)+owner(caller)
-// Statement: py_function_native_*_pointer_numpy
+// Statement: py_function_native_*_numpy
 // ----------------------------------------
 // Argument:  int * len +hidden+intent(out)
 // Statement: py_out_native_*

--- a/regression/reference/pointers-list-c/pointers.json
+++ b/regression/reference/pointers-list-c/pointers.json
@@ -510,7 +510,7 @@
                             "pytmp_var": "SHTPy_in",
                             "rank": "1",
                             "size_var": "SHSize_in",
-                            "stmt": "py_in_native_*_pointer_list",
+                            "stmt": "py_in_native_*_list",
                             "value_var": "SHValue_in"
                         }
                     },
@@ -537,7 +537,7 @@
                             "py_var": "SHPy_out",
                             "rank": "1",
                             "size_var": "SHSize_out",
-                            "stmt": "py_out_native_*_pointer_list",
+                            "stmt": "py_out_native_*_list",
                             "value_var": "SHValue_out"
                         }
                     },
@@ -688,7 +688,7 @@
                             "pytmp_var": "SHTPy_in",
                             "rank": "1",
                             "size_var": "SHSize_in",
-                            "stmt": "py_in_native_*_pointer_list",
+                            "stmt": "py_in_native_*_list",
                             "value_var": "SHValue_in"
                         }
                     },
@@ -715,7 +715,7 @@
                             "py_var": "SHPy_out",
                             "rank": "1",
                             "size_var": "SHSize_out",
-                            "stmt": "py_out_native_*_pointer_list",
+                            "stmt": "py_out_native_*_list",
                             "value_var": "SHValue_out"
                         }
                     },
@@ -868,7 +868,7 @@
                             "py_var": "SHPy_values",
                             "rank": "1",
                             "size_var": "SHSize_values",
-                            "stmt": "py_out_native_*_pointer_list",
+                            "stmt": "py_out_native_*_list",
                             "value_var": "SHValue_values"
                         }
                     }
@@ -986,7 +986,7 @@
                             "py_var": "SHPy_arg1",
                             "rank": "1",
                             "size_var": "SHSize_arg1",
-                            "stmt": "py_out_native_*_pointer_list",
+                            "stmt": "py_out_native_*_list",
                             "value_var": "SHValue_arg1"
                         }
                     },
@@ -1013,7 +1013,7 @@
                             "py_var": "SHPy_arg2",
                             "rank": "1",
                             "size_var": "SHSize_arg2",
-                            "stmt": "py_out_native_*_pointer_list",
+                            "stmt": "py_out_native_*_list",
                             "value_var": "SHValue_arg2"
                         }
                     }
@@ -1136,7 +1136,7 @@
                             "py_var": "SHPy_values",
                             "rank": "1",
                             "size_var": "SHSize_values",
-                            "stmt": "py_out_native_*_pointer_list",
+                            "stmt": "py_out_native_*_list",
                             "value_var": "SHValue_values"
                         }
                     }
@@ -1295,7 +1295,7 @@
                             "pytmp_var": "SHTPy_values",
                             "rank": "1",
                             "size_var": "SHSize_values",
-                            "stmt": "py_in_native_*_pointer_list",
+                            "stmt": "py_in_native_*_list",
                             "value_var": "SHValue_values"
                         }
                     }
@@ -1385,7 +1385,7 @@
                             "py_var": "SHPy_out",
                             "rank": "1",
                             "size_var": "SHSize_out",
-                            "stmt": "py_out_native_*_pointer_list",
+                            "stmt": "py_out_native_*_list",
                             "value_var": "SHValue_out"
                         }
                     }
@@ -1484,7 +1484,7 @@
                             "pytmp_var": "SHTPy_array",
                             "rank": "1",
                             "size_var": "SHSize_array",
-                            "stmt": "py_inout_native_*_pointer_list",
+                            "stmt": "py_inout_native_*_list",
                             "value_var": "SHValue_array"
                         }
                     },
@@ -1599,7 +1599,7 @@
                             "pytmp_var": "SHTPy_x",
                             "rank": "1",
                             "size_var": "SHSize_x",
-                            "stmt": "py_inout_native_*_pointer_list",
+                            "stmt": "py_inout_native_*_list",
                             "value_var": "SHValue_x"
                         }
                     },
@@ -1732,7 +1732,7 @@
                             "pytmp_var": "SHTPy_arr",
                             "rank": "1",
                             "size_var": "SHSize_arr",
-                            "stmt": "py_in_native_*_pointer_list",
+                            "stmt": "py_in_native_*_list",
                             "value_var": "SHValue_arr"
                         }
                     },
@@ -2125,7 +2125,7 @@
                             "py_var": "SHPy_count",
                             "rank": "1",
                             "size_var": "SHSize_count",
-                            "stmt": "py_out_native_**_pointer_list",
+                            "stmt": "py_out_native_**_list",
                             "value_var": "SHValue_count"
                         }
                     }
@@ -2241,7 +2241,7 @@
                             "py_var": "SHPy_count",
                             "rank": "1",
                             "size_var": "SHSize_count",
-                            "stmt": "py_out_native_**_pointer_list",
+                            "stmt": "py_out_native_**_list",
                             "value_var": "SHValue_count"
                         }
                     },
@@ -2357,7 +2357,7 @@
                             "py_var": "SHPy_count",
                             "rank": "1",
                             "size_var": "SHSize_count",
-                            "stmt": "py_out_native_**_pointer_list",
+                            "stmt": "py_out_native_**_list",
                             "value_var": "SHValue_count"
                         }
                     }
@@ -2505,7 +2505,7 @@
                             "py_var": "SHPy_count",
                             "rank": "1",
                             "size_var": "SHSize_count",
-                            "stmt": "py_out_native_**_pointer_list",
+                            "stmt": "py_out_native_**_list",
                             "value_var": "SHValue_count"
                         }
                     }
@@ -2619,7 +2619,7 @@
                             "py_var": "SHPy_count",
                             "rank": "1",
                             "size_var": "SHSize_count",
-                            "stmt": "py_out_native_**_pointer_list",
+                            "stmt": "py_out_native_**_list",
                             "value_var": "SHValue_count"
                         }
                     },
@@ -3606,7 +3606,7 @@
                             "numpy_type": "NPY_INT",
                             "py_var": "SHTPy_rv",
                             "size_var": "SHSize_rv",
-                            "stmt": "py_function_native_*_pointer_list",
+                            "stmt": "py_function_native_*_list",
                             "value_var": "SHValue_rv"
                         }
                     }
@@ -3677,7 +3677,7 @@
                             "py_var": "SHTPy_rv",
                             "rank": "1",
                             "size_var": "SHSize_rv",
-                            "stmt": "py_function_native_*_pointer_list",
+                            "stmt": "py_function_native_*_list",
                             "value_var": "SHValue_rv"
                         }
                     }
@@ -3736,7 +3736,7 @@
                             "numpy_type": "NPY_INT",
                             "py_var": "SHTPy_rv",
                             "size_var": "SHSize_rv",
-                            "stmt": "py_function_native_*_pointer_list",
+                            "stmt": "py_function_native_*_list",
                             "value_var": "SHValue_rv"
                         }
                     }
@@ -3808,7 +3808,7 @@
                             "py_var": "SHTPy_rv",
                             "rank": "1",
                             "size_var": "SHSize_rv",
-                            "stmt": "py_function_native_*_pointer_list",
+                            "stmt": "py_function_native_*_list",
                             "value_var": "SHValue_rv"
                         }
                     }

--- a/regression/reference/pointers-list-c/pypointersmodule.c
+++ b/regression/reference/pointers-list-c/pypointersmodule.c
@@ -414,10 +414,10 @@ PY_intargs(
 // Statement: py_default
 // ----------------------------------------
 // Argument:  double * in +intent(in)+rank(1)
-// Statement: py_in_native_*_pointer_list
+// Statement: py_in_native_*_list
 // ----------------------------------------
 // Argument:  double * out +dimension(size(in))+intent(out)
-// Statement: py_out_native_*_pointer_list
+// Statement: py_out_native_*_list
 // ----------------------------------------
 // Argument:  int sizein +implied(size(in))+value
 // Exact:     py_default
@@ -493,10 +493,10 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  double * in +intent(in)+rank(1)
-// Statement: py_in_native_*_pointer_list
+// Statement: py_in_native_*_list
 // ----------------------------------------
 // Argument:  int * out +dimension(size(in))+intent(out)
-// Statement: py_out_native_*_pointer_list
+// Statement: py_out_native_*_list
 // ----------------------------------------
 // Argument:  int sizein +implied(size(in))+value
 // Exact:     py_default
@@ -576,7 +576,7 @@ fail:
 // Statement: py_out_native_*
 // ----------------------------------------
 // Argument:  int * values +dimension(3)+intent(out)
-// Statement: py_out_native_*_pointer_list
+// Statement: py_out_native_*_list
 static char PY_get_values__doc__[] =
 "documentation"
 ;
@@ -633,10 +633,10 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  int * arg1 +dimension(3)+intent(out)
-// Statement: py_out_native_*_pointer_list
+// Statement: py_out_native_*_list
 // ----------------------------------------
 // Argument:  int * arg2 +dimension(3)+intent(out)
-// Statement: py_out_native_*_pointer_list
+// Statement: py_out_native_*_list
 static char PY_get_values2__doc__[] =
 "documentation"
 ;
@@ -706,7 +706,7 @@ fail:
 // Statement: py_in_native_scalar
 // ----------------------------------------
 // Argument:  int * values +dimension(nvar)+intent(out)
-// Statement: py_out_native_*_pointer_list
+// Statement: py_out_native_*_list
 static char PY_iota_dimension__doc__[] =
 "documentation"
 ;
@@ -763,7 +763,7 @@ fail:
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  const int * values +rank(1)
-// Statement: py_in_native_*_pointer_list
+// Statement: py_in_native_*_list
 // ----------------------------------------
 // Argument:  int * result +intent(out)
 // Statement: py_out_native_*
@@ -825,7 +825,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  int * out +dimension(3)+intent(out)
-// Statement: py_out_native_*_pointer_list
+// Statement: py_out_native_*_list
 static char PY_fillIntArray__doc__[] =
 "documentation"
 ;
@@ -874,7 +874,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  int * array +intent(inout)+rank(1)
-// Statement: py_inout_native_*_pointer_list
+// Statement: py_inout_native_*_list
 // ----------------------------------------
 // Argument:  int sizein +implied(size(array))+value
 // Exact:     py_default
@@ -939,7 +939,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  double * x +rank(1)
-// Statement: py_inout_native_*_pointer_list
+// Statement: py_inout_native_*_list
 // ----------------------------------------
 // Argument:  int x_length +implied(size(x))+value
 // Exact:     py_default
@@ -1000,7 +1000,7 @@ fail:
 // Statement: py_function_native_scalar
 // ----------------------------------------
 // Argument:  const int * arr +rank(1)
-// Statement: py_in_native_*_pointer_list
+// Statement: py_in_native_*_list
 // ----------------------------------------
 // Argument:  size_t len +implied(size(arr))+value
 // Exact:     py_default
@@ -1175,7 +1175,7 @@ PY_sumFixedArray(
 // Statement: py_default
 // ----------------------------------------
 // Argument:  int * * count +dimension(10)+intent(out)
-// Statement: py_out_native_**_pointer_list
+// Statement: py_out_native_**_list
 static char PY_getPtrToFixedArray__doc__[] =
 "documentation"
 ;
@@ -1212,7 +1212,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  int * * count +dimension(ncount)+intent(out)
-// Statement: py_out_native_**_pointer_list
+// Statement: py_out_native_**_list
 // ----------------------------------------
 // Argument:  int * ncount +hidden+intent(out)
 // Statement: py_out_native_*
@@ -1254,7 +1254,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  int * * count +dimension(getLen())+intent(out)
-// Statement: py_out_native_**_pointer_list
+// Statement: py_out_native_**_list
 static char PY_getPtrToFuncArray__doc__[] =
 "documentation"
 ;
@@ -1293,7 +1293,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  const int * * count +dimension(10)+intent(out)
-// Statement: py_out_native_**_pointer_list
+// Statement: py_out_native_**_list
 static char PY_getPtrToFixedConstArray__doc__[] =
 "documentation"
 ;
@@ -1327,7 +1327,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  const int * * count +dimension(ncount)+intent(out)
-// Statement: py_out_native_**_pointer_list
+// Statement: py_out_native_**_list
 // ----------------------------------------
 // Argument:  int * ncount +hidden+intent(out)
 // Statement: py_out_native_*
@@ -1529,7 +1529,7 @@ PY_fetchVoidPtr(
 
 // ----------------------------------------
 // Function:  int * returnIntPtrToScalar
-// Statement: py_function_native_*_pointer_list
+// Statement: py_function_native_*_list
 static char PY_returnIntPtrToScalar__doc__[] =
 "documentation"
 ;
@@ -1559,7 +1559,7 @@ fail:
 
 // ----------------------------------------
 // Function:  int * returnIntPtrToFixedArray +dimension(10)
-// Statement: py_function_native_*_pointer_list
+// Statement: py_function_native_*_list
 static char PY_returnIntPtrToFixedArray__doc__[] =
 "documentation"
 ;
@@ -1589,7 +1589,7 @@ fail:
 
 // ----------------------------------------
 // Function:  const int * returnIntPtrToConstScalar
-// Statement: py_function_native_*_pointer_list
+// Statement: py_function_native_*_list
 static char PY_returnIntPtrToConstScalar__doc__[] =
 "documentation"
 ;
@@ -1619,7 +1619,7 @@ fail:
 
 // ----------------------------------------
 // Function:  const int * returnIntPtrToFixedConstArray +dimension(10)
-// Statement: py_function_native_*_pointer_list
+// Statement: py_function_native_*_list
 static char PY_returnIntPtrToFixedConstArray__doc__[] =
 "documentation"
 ;

--- a/regression/reference/pointers-list-c/pypointersmodule.c
+++ b/regression/reference/pointers-list-c/pypointersmodule.c
@@ -613,7 +613,7 @@ PY_get_values(
     // post_call
     SHPy_values = SHROUD_to_PyList_int(values, 3);
     if (SHPy_values == NULL) goto fail;
-    SHTPy_rv = Py_BuildValue("iO", nvalues, SHPy_values);
+    SHTPy_rv = Py_BuildValue("iN", nvalues, SHPy_values);
 
     // cleanup
     free(values);
@@ -679,7 +679,7 @@ PY_get_values2(
     if (SHPy_arg1 == NULL) goto fail;
     SHPy_arg2 = SHROUD_to_PyList_int(arg2, 3);
     if (SHPy_arg2 == NULL) goto fail;
-    SHTPy_rv = Py_BuildValue("OO", SHPy_arg1, SHPy_arg2);
+    SHTPy_rv = Py_BuildValue("NN", SHPy_arg1, SHPy_arg2);
 
     // cleanup
     free(arg1);

--- a/regression/reference/pointers-list-cxx/pointers.json
+++ b/regression/reference/pointers-list-cxx/pointers.json
@@ -510,7 +510,7 @@
                             "pytmp_var": "SHTPy_in",
                             "rank": "1",
                             "size_var": "SHSize_in",
-                            "stmt": "py_in_native_*_pointer_list",
+                            "stmt": "py_in_native_*_list",
                             "value_var": "SHValue_in"
                         }
                     },
@@ -537,7 +537,7 @@
                             "py_var": "SHPy_out",
                             "rank": "1",
                             "size_var": "SHSize_out",
-                            "stmt": "py_out_native_*_pointer_list",
+                            "stmt": "py_out_native_*_list",
                             "value_var": "SHValue_out"
                         }
                     },
@@ -688,7 +688,7 @@
                             "pytmp_var": "SHTPy_in",
                             "rank": "1",
                             "size_var": "SHSize_in",
-                            "stmt": "py_in_native_*_pointer_list",
+                            "stmt": "py_in_native_*_list",
                             "value_var": "SHValue_in"
                         }
                     },
@@ -715,7 +715,7 @@
                             "py_var": "SHPy_out",
                             "rank": "1",
                             "size_var": "SHSize_out",
-                            "stmt": "py_out_native_*_pointer_list",
+                            "stmt": "py_out_native_*_list",
                             "value_var": "SHValue_out"
                         }
                     },
@@ -868,7 +868,7 @@
                             "py_var": "SHPy_values",
                             "rank": "1",
                             "size_var": "SHSize_values",
-                            "stmt": "py_out_native_*_pointer_list",
+                            "stmt": "py_out_native_*_list",
                             "value_var": "SHValue_values"
                         }
                     }
@@ -986,7 +986,7 @@
                             "py_var": "SHPy_arg1",
                             "rank": "1",
                             "size_var": "SHSize_arg1",
-                            "stmt": "py_out_native_*_pointer_list",
+                            "stmt": "py_out_native_*_list",
                             "value_var": "SHValue_arg1"
                         }
                     },
@@ -1013,7 +1013,7 @@
                             "py_var": "SHPy_arg2",
                             "rank": "1",
                             "size_var": "SHSize_arg2",
-                            "stmt": "py_out_native_*_pointer_list",
+                            "stmt": "py_out_native_*_list",
                             "value_var": "SHValue_arg2"
                         }
                     }
@@ -1136,7 +1136,7 @@
                             "py_var": "SHPy_values",
                             "rank": "1",
                             "size_var": "SHSize_values",
-                            "stmt": "py_out_native_*_pointer_list",
+                            "stmt": "py_out_native_*_list",
                             "value_var": "SHValue_values"
                         }
                     }
@@ -1295,7 +1295,7 @@
                             "pytmp_var": "SHTPy_values",
                             "rank": "1",
                             "size_var": "SHSize_values",
-                            "stmt": "py_in_native_*_pointer_list",
+                            "stmt": "py_in_native_*_list",
                             "value_var": "SHValue_values"
                         }
                     }
@@ -1385,7 +1385,7 @@
                             "py_var": "SHPy_out",
                             "rank": "1",
                             "size_var": "SHSize_out",
-                            "stmt": "py_out_native_*_pointer_list",
+                            "stmt": "py_out_native_*_list",
                             "value_var": "SHValue_out"
                         }
                     }
@@ -1484,7 +1484,7 @@
                             "pytmp_var": "SHTPy_array",
                             "rank": "1",
                             "size_var": "SHSize_array",
-                            "stmt": "py_inout_native_*_pointer_list",
+                            "stmt": "py_inout_native_*_list",
                             "value_var": "SHValue_array"
                         }
                     },
@@ -1599,7 +1599,7 @@
                             "pytmp_var": "SHTPy_x",
                             "rank": "1",
                             "size_var": "SHSize_x",
-                            "stmt": "py_inout_native_*_pointer_list",
+                            "stmt": "py_inout_native_*_list",
                             "value_var": "SHValue_x"
                         }
                     },
@@ -1732,7 +1732,7 @@
                             "pytmp_var": "SHTPy_arr",
                             "rank": "1",
                             "size_var": "SHSize_arr",
-                            "stmt": "py_in_native_*_pointer_list",
+                            "stmt": "py_in_native_*_list",
                             "value_var": "SHValue_arr"
                         }
                     },
@@ -2125,7 +2125,7 @@
                             "py_var": "SHPy_count",
                             "rank": "1",
                             "size_var": "SHSize_count",
-                            "stmt": "py_out_native_**_pointer_list",
+                            "stmt": "py_out_native_**_list",
                             "value_var": "SHValue_count"
                         }
                     }
@@ -2241,7 +2241,7 @@
                             "py_var": "SHPy_count",
                             "rank": "1",
                             "size_var": "SHSize_count",
-                            "stmt": "py_out_native_**_pointer_list",
+                            "stmt": "py_out_native_**_list",
                             "value_var": "SHValue_count"
                         }
                     },
@@ -2357,7 +2357,7 @@
                             "py_var": "SHPy_count",
                             "rank": "1",
                             "size_var": "SHSize_count",
-                            "stmt": "py_out_native_**_pointer_list",
+                            "stmt": "py_out_native_**_list",
                             "value_var": "SHValue_count"
                         }
                     }
@@ -2505,7 +2505,7 @@
                             "py_var": "SHPy_count",
                             "rank": "1",
                             "size_var": "SHSize_count",
-                            "stmt": "py_out_native_**_pointer_list",
+                            "stmt": "py_out_native_**_list",
                             "value_var": "SHValue_count"
                         }
                     }
@@ -2619,7 +2619,7 @@
                             "py_var": "SHPy_count",
                             "rank": "1",
                             "size_var": "SHSize_count",
-                            "stmt": "py_out_native_**_pointer_list",
+                            "stmt": "py_out_native_**_list",
                             "value_var": "SHValue_count"
                         }
                     },
@@ -3606,7 +3606,7 @@
                             "numpy_type": "NPY_INT",
                             "py_var": "SHTPy_rv",
                             "size_var": "SHSize_rv",
-                            "stmt": "py_function_native_*_pointer_list",
+                            "stmt": "py_function_native_*_list",
                             "value_var": "SHValue_rv"
                         }
                     }
@@ -3677,7 +3677,7 @@
                             "py_var": "SHTPy_rv",
                             "rank": "1",
                             "size_var": "SHSize_rv",
-                            "stmt": "py_function_native_*_pointer_list",
+                            "stmt": "py_function_native_*_list",
                             "value_var": "SHValue_rv"
                         }
                     }
@@ -3736,7 +3736,7 @@
                             "numpy_type": "NPY_INT",
                             "py_var": "SHTPy_rv",
                             "size_var": "SHSize_rv",
-                            "stmt": "py_function_native_*_pointer_list",
+                            "stmt": "py_function_native_*_list",
                             "value_var": "SHValue_rv"
                         }
                     }
@@ -3808,7 +3808,7 @@
                             "py_var": "SHTPy_rv",
                             "rank": "1",
                             "size_var": "SHSize_rv",
-                            "stmt": "py_function_native_*_pointer_list",
+                            "stmt": "py_function_native_*_list",
                             "value_var": "SHValue_rv"
                         }
                     }

--- a/regression/reference/pointers-list-cxx/pypointersmodule.cpp
+++ b/regression/reference/pointers-list-cxx/pypointersmodule.cpp
@@ -417,10 +417,10 @@ PY_intargs(
 // Statement: py_default
 // ----------------------------------------
 // Argument:  double * in +intent(in)+rank(1)
-// Statement: py_in_native_*_pointer_list
+// Statement: py_in_native_*_list
 // ----------------------------------------
 // Argument:  double * out +dimension(size(in))+intent(out)
-// Statement: py_out_native_*_pointer_list
+// Statement: py_out_native_*_list
 // ----------------------------------------
 // Argument:  int sizein +implied(size(in))+value
 // Exact:     py_default
@@ -497,10 +497,10 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  double * in +intent(in)+rank(1)
-// Statement: py_in_native_*_pointer_list
+// Statement: py_in_native_*_list
 // ----------------------------------------
 // Argument:  int * out +dimension(size(in))+intent(out)
-// Statement: py_out_native_*_pointer_list
+// Statement: py_out_native_*_list
 // ----------------------------------------
 // Argument:  int sizein +implied(size(in))+value
 // Exact:     py_default
@@ -580,7 +580,7 @@ fail:
 // Statement: py_out_native_*
 // ----------------------------------------
 // Argument:  int * values +dimension(3)+intent(out)
-// Statement: py_out_native_*_pointer_list
+// Statement: py_out_native_*_list
 static char PY_get_values__doc__[] =
 "documentation"
 ;
@@ -637,10 +637,10 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  int * arg1 +dimension(3)+intent(out)
-// Statement: py_out_native_*_pointer_list
+// Statement: py_out_native_*_list
 // ----------------------------------------
 // Argument:  int * arg2 +dimension(3)+intent(out)
-// Statement: py_out_native_*_pointer_list
+// Statement: py_out_native_*_list
 static char PY_get_values2__doc__[] =
 "documentation"
 ;
@@ -710,7 +710,7 @@ fail:
 // Statement: py_in_native_scalar
 // ----------------------------------------
 // Argument:  int * values +dimension(nvar)+intent(out)
-// Statement: py_out_native_*_pointer_list
+// Statement: py_out_native_*_list
 static char PY_iota_dimension__doc__[] =
 "documentation"
 ;
@@ -767,7 +767,7 @@ fail:
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  const int * values +rank(1)
-// Statement: py_in_native_*_pointer_list
+// Statement: py_in_native_*_list
 // ----------------------------------------
 // Argument:  int * result +intent(out)
 // Statement: py_out_native_*
@@ -829,7 +829,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  int * out +dimension(3)+intent(out)
-// Statement: py_out_native_*_pointer_list
+// Statement: py_out_native_*_list
 static char PY_fillIntArray__doc__[] =
 "documentation"
 ;
@@ -878,7 +878,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  int * array +intent(inout)+rank(1)
-// Statement: py_inout_native_*_pointer_list
+// Statement: py_inout_native_*_list
 // ----------------------------------------
 // Argument:  int sizein +implied(size(array))+value
 // Exact:     py_default
@@ -943,7 +943,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  double * x +rank(1)
-// Statement: py_inout_native_*_pointer_list
+// Statement: py_inout_native_*_list
 // ----------------------------------------
 // Argument:  int x_length +implied(size(x))+value
 // Exact:     py_default
@@ -1004,7 +1004,7 @@ fail:
 // Statement: py_function_native_scalar
 // ----------------------------------------
 // Argument:  const int * arr +rank(1)
-// Statement: py_in_native_*_pointer_list
+// Statement: py_in_native_*_list
 // ----------------------------------------
 // Argument:  size_t len +implied(size(arr))+value
 // Exact:     py_default
@@ -1179,7 +1179,7 @@ PY_sumFixedArray(
 // Statement: py_default
 // ----------------------------------------
 // Argument:  int * * count +dimension(10)+intent(out)
-// Statement: py_out_native_**_pointer_list
+// Statement: py_out_native_**_list
 static char PY_getPtrToFixedArray__doc__[] =
 "documentation"
 ;
@@ -1216,7 +1216,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  int * * count +dimension(ncount)+intent(out)
-// Statement: py_out_native_**_pointer_list
+// Statement: py_out_native_**_list
 // ----------------------------------------
 // Argument:  int * ncount +hidden+intent(out)
 // Statement: py_out_native_*
@@ -1258,7 +1258,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  int * * count +dimension(getLen())+intent(out)
-// Statement: py_out_native_**_pointer_list
+// Statement: py_out_native_**_list
 static char PY_getPtrToFuncArray__doc__[] =
 "documentation"
 ;
@@ -1297,7 +1297,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  const int * * count +dimension(10)+intent(out)
-// Statement: py_out_native_**_pointer_list
+// Statement: py_out_native_**_list
 static char PY_getPtrToFixedConstArray__doc__[] =
 "documentation"
 ;
@@ -1331,7 +1331,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  const int * * count +dimension(ncount)+intent(out)
-// Statement: py_out_native_**_pointer_list
+// Statement: py_out_native_**_list
 // ----------------------------------------
 // Argument:  int * ncount +hidden+intent(out)
 // Statement: py_out_native_*
@@ -1533,7 +1533,7 @@ PY_fetchVoidPtr(
 
 // ----------------------------------------
 // Function:  int * returnIntPtrToScalar
-// Statement: py_function_native_*_pointer_list
+// Statement: py_function_native_*_list
 static char PY_returnIntPtrToScalar__doc__[] =
 "documentation"
 ;
@@ -1563,7 +1563,7 @@ fail:
 
 // ----------------------------------------
 // Function:  int * returnIntPtrToFixedArray +dimension(10)
-// Statement: py_function_native_*_pointer_list
+// Statement: py_function_native_*_list
 static char PY_returnIntPtrToFixedArray__doc__[] =
 "documentation"
 ;
@@ -1593,7 +1593,7 @@ fail:
 
 // ----------------------------------------
 // Function:  const int * returnIntPtrToConstScalar
-// Statement: py_function_native_*_pointer_list
+// Statement: py_function_native_*_list
 static char PY_returnIntPtrToConstScalar__doc__[] =
 "documentation"
 ;
@@ -1623,7 +1623,7 @@ fail:
 
 // ----------------------------------------
 // Function:  const int * returnIntPtrToFixedConstArray +dimension(10)
-// Statement: py_function_native_*_pointer_list
+// Statement: py_function_native_*_list
 static char PY_returnIntPtrToFixedConstArray__doc__[] =
 "documentation"
 ;

--- a/regression/reference/pointers-list-cxx/pypointersmodule.cpp
+++ b/regression/reference/pointers-list-cxx/pypointersmodule.cpp
@@ -617,7 +617,7 @@ PY_get_values(
     // post_call
     SHPy_values = SHROUD_to_PyList_int(values, 3);
     if (SHPy_values == nullptr) goto fail;
-    SHTPy_rv = Py_BuildValue("iO", nvalues, SHPy_values);
+    SHTPy_rv = Py_BuildValue("iN", nvalues, SHPy_values);
 
     // cleanup
     std::free(values);
@@ -683,7 +683,7 @@ PY_get_values2(
     if (SHPy_arg1 == nullptr) goto fail;
     SHPy_arg2 = SHROUD_to_PyList_int(arg2, 3);
     if (SHPy_arg2 == nullptr) goto fail;
-    SHTPy_rv = Py_BuildValue("OO", SHPy_arg1, SHPy_arg2);
+    SHTPy_rv = Py_BuildValue("NN", SHPy_arg1, SHPy_arg2);
 
     // cleanup
     std::free(arg1);

--- a/regression/reference/pointers-numpy-c/pointers.json
+++ b/regression/reference/pointers-numpy-c/pointers.json
@@ -509,7 +509,7 @@
                             "pytmp_var": "SHTPy_in",
                             "rank": "1",
                             "size_var": "SHSize_in",
-                            "stmt": "py_in_native_*_pointer_numpy",
+                            "stmt": "py_in_native_*_numpy",
                             "value_var": "SHValue_in"
                         }
                     },
@@ -535,7 +535,7 @@
                             "py_var": "SHPy_out",
                             "rank": "1",
                             "size_var": "SHSize_out",
-                            "stmt": "py_out_native_*_pointer_numpy",
+                            "stmt": "py_out_native_*_numpy",
                             "value_var": "SHValue_out"
                         }
                     },
@@ -685,7 +685,7 @@
                             "pytmp_var": "SHTPy_in",
                             "rank": "1",
                             "size_var": "SHSize_in",
-                            "stmt": "py_in_native_*_pointer_numpy",
+                            "stmt": "py_in_native_*_numpy",
                             "value_var": "SHValue_in"
                         }
                     },
@@ -711,7 +711,7 @@
                             "py_var": "SHPy_out",
                             "rank": "1",
                             "size_var": "SHSize_out",
-                            "stmt": "py_out_native_*_pointer_numpy",
+                            "stmt": "py_out_native_*_numpy",
                             "value_var": "SHValue_out"
                         }
                     },
@@ -863,7 +863,7 @@
                             "py_var": "SHPy_values",
                             "rank": "1",
                             "size_var": "SHSize_values",
-                            "stmt": "py_out_native_*_pointer_numpy",
+                            "stmt": "py_out_native_*_numpy",
                             "value_var": "SHValue_values"
                         }
                     }
@@ -980,7 +980,7 @@
                             "py_var": "SHPy_arg1",
                             "rank": "1",
                             "size_var": "SHSize_arg1",
-                            "stmt": "py_out_native_*_pointer_numpy",
+                            "stmt": "py_out_native_*_numpy",
                             "value_var": "SHValue_arg1"
                         }
                     },
@@ -1006,7 +1006,7 @@
                             "py_var": "SHPy_arg2",
                             "rank": "1",
                             "size_var": "SHSize_arg2",
-                            "stmt": "py_out_native_*_pointer_numpy",
+                            "stmt": "py_out_native_*_numpy",
                             "value_var": "SHValue_arg2"
                         }
                     }
@@ -1128,7 +1128,7 @@
                             "py_var": "SHPy_values",
                             "rank": "1",
                             "size_var": "SHSize_values",
-                            "stmt": "py_out_native_*_pointer_numpy",
+                            "stmt": "py_out_native_*_numpy",
                             "value_var": "SHValue_values"
                         }
                     }
@@ -1286,7 +1286,7 @@
                             "pytmp_var": "SHTPy_values",
                             "rank": "1",
                             "size_var": "SHSize_values",
-                            "stmt": "py_in_native_*_pointer_numpy",
+                            "stmt": "py_in_native_*_numpy",
                             "value_var": "SHValue_values"
                         }
                     }
@@ -1375,7 +1375,7 @@
                             "py_var": "SHPy_out",
                             "rank": "1",
                             "size_var": "SHSize_out",
-                            "stmt": "py_out_native_*_pointer_numpy",
+                            "stmt": "py_out_native_*_numpy",
                             "value_var": "SHValue_out"
                         }
                     }
@@ -1472,7 +1472,7 @@
                             "pytmp_var": "SHTPy_array",
                             "rank": "1",
                             "size_var": "SHSize_array",
-                            "stmt": "py_inout_native_*_pointer_numpy",
+                            "stmt": "py_inout_native_*_numpy",
                             "value_var": "SHValue_array"
                         }
                     },
@@ -1585,7 +1585,7 @@
                             "pytmp_var": "SHTPy_x",
                             "rank": "1",
                             "size_var": "SHSize_x",
-                            "stmt": "py_inout_native_*_pointer_numpy",
+                            "stmt": "py_inout_native_*_numpy",
                             "value_var": "SHValue_x"
                         }
                     },
@@ -1717,7 +1717,7 @@
                             "pytmp_var": "SHTPy_arr",
                             "rank": "1",
                             "size_var": "SHSize_arr",
-                            "stmt": "py_in_native_*_pointer_numpy",
+                            "stmt": "py_in_native_*_numpy",
                             "value_var": "SHValue_arr"
                         }
                     },
@@ -2109,7 +2109,7 @@
                             "py_var": "SHPy_count",
                             "rank": "1",
                             "size_var": "SHSize_count",
-                            "stmt": "py_out_native_**_pointer_numpy",
+                            "stmt": "py_out_native_**_numpy",
                             "value_var": "SHValue_count"
                         }
                     }
@@ -2224,7 +2224,7 @@
                             "py_var": "SHPy_count",
                             "rank": "1",
                             "size_var": "SHSize_count",
-                            "stmt": "py_out_native_**_pointer_numpy",
+                            "stmt": "py_out_native_**_numpy",
                             "value_var": "SHValue_count"
                         }
                     },
@@ -2339,7 +2339,7 @@
                             "py_var": "SHPy_count",
                             "rank": "1",
                             "size_var": "SHSize_count",
-                            "stmt": "py_out_native_**_pointer_numpy",
+                            "stmt": "py_out_native_**_numpy",
                             "value_var": "SHValue_count"
                         }
                     }
@@ -2486,7 +2486,7 @@
                             "py_var": "SHPy_count",
                             "rank": "1",
                             "size_var": "SHSize_count",
-                            "stmt": "py_out_native_**_pointer_numpy",
+                            "stmt": "py_out_native_**_numpy",
                             "value_var": "SHValue_count"
                         }
                     }
@@ -2599,7 +2599,7 @@
                             "py_var": "SHPy_count",
                             "rank": "1",
                             "size_var": "SHSize_count",
-                            "stmt": "py_out_native_**_pointer_numpy",
+                            "stmt": "py_out_native_**_numpy",
                             "value_var": "SHValue_count"
                         }
                     },
@@ -3585,7 +3585,7 @@
                             "numpy_type": "NPY_INT",
                             "py_var": "SHTPy_rv",
                             "size_var": "SHSize_rv",
-                            "stmt": "py_function_native_*_pointer_numpy",
+                            "stmt": "py_function_native_*_numpy",
                             "value_var": "SHValue_rv"
                         }
                     }
@@ -3655,7 +3655,7 @@
                             "py_var": "SHTPy_rv",
                             "rank": "1",
                             "size_var": "SHSize_rv",
-                            "stmt": "py_function_native_*_pointer_numpy",
+                            "stmt": "py_function_native_*_numpy",
                             "value_var": "SHValue_rv"
                         }
                     }
@@ -3713,7 +3713,7 @@
                             "numpy_type": "NPY_INT",
                             "py_var": "SHTPy_rv",
                             "size_var": "SHSize_rv",
-                            "stmt": "py_function_native_*_pointer_numpy",
+                            "stmt": "py_function_native_*_numpy",
                             "value_var": "SHValue_rv"
                         }
                     }
@@ -3784,7 +3784,7 @@
                             "py_var": "SHTPy_rv",
                             "rank": "1",
                             "size_var": "SHSize_rv",
-                            "stmt": "py_function_native_*_pointer_numpy",
+                            "stmt": "py_function_native_*_numpy",
                             "value_var": "SHValue_rv"
                         }
                     }

--- a/regression/reference/pointers-numpy-c/pypointersmodule.c
+++ b/regression/reference/pointers-numpy-c/pypointersmodule.c
@@ -511,7 +511,7 @@ PY_get_values(
     get_values(&nvalues, values);
 
     // post_call
-    SHTPy_rv = Py_BuildValue("iO", nvalues, SHPy_values);
+    SHTPy_rv = Py_BuildValue("iN", nvalues, SHPy_values);
 
     return SHTPy_rv;
 
@@ -578,7 +578,7 @@ PY_get_values2(
     get_values2(arg1, arg2);
 
     // post_call
-    SHTPy_rv = Py_BuildValue("OO", SHPy_arg1, SHPy_arg2);
+    SHTPy_rv = Py_BuildValue("NN", SHPy_arg1, SHPy_arg2);
 
     return SHTPy_rv;
 

--- a/regression/reference/pointers-numpy-c/pypointersmodule.c
+++ b/regression/reference/pointers-numpy-c/pypointersmodule.c
@@ -310,10 +310,10 @@ PY_intargs(
 // Statement: py_default
 // ----------------------------------------
 // Argument:  double * in +intent(in)+rank(1)
-// Statement: py_in_native_*_pointer_numpy
+// Statement: py_in_native_*_numpy
 // ----------------------------------------
 // Argument:  double * out +dimension(size(in))+intent(out)
-// Statement: py_out_native_*_pointer_numpy
+// Statement: py_out_native_*_numpy
 // ----------------------------------------
 // Argument:  int sizein +implied(size(in))+value
 // Exact:     py_default
@@ -388,10 +388,10 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  double * in +intent(in)+rank(1)
-// Statement: py_in_native_*_pointer_numpy
+// Statement: py_in_native_*_numpy
 // ----------------------------------------
 // Argument:  int * out +dimension(size(in))+intent(out)
-// Statement: py_out_native_*_pointer_numpy
+// Statement: py_out_native_*_numpy
 // ----------------------------------------
 // Argument:  int sizein +implied(size(in))+value
 // Exact:     py_default
@@ -470,7 +470,7 @@ fail:
 // Statement: py_out_native_*
 // ----------------------------------------
 // Argument:  int * values +dimension(3)+intent(out)
-// Statement: py_out_native_*_pointer_numpy
+// Statement: py_out_native_*_numpy
 static char PY_get_values__doc__[] =
 "documentation"
 ;
@@ -526,10 +526,10 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  int * arg1 +dimension(3)+intent(out)
-// Statement: py_out_native_*_pointer_numpy
+// Statement: py_out_native_*_numpy
 // ----------------------------------------
 // Argument:  int * arg2 +dimension(3)+intent(out)
-// Statement: py_out_native_*_pointer_numpy
+// Statement: py_out_native_*_numpy
 static char PY_get_values2__doc__[] =
 "documentation"
 ;
@@ -597,7 +597,7 @@ fail:
 // Statement: py_in_native_scalar
 // ----------------------------------------
 // Argument:  int * values +dimension(nvar)+intent(out)
-// Statement: py_out_native_*_pointer_numpy
+// Statement: py_out_native_*_numpy
 static char PY_iota_dimension__doc__[] =
 "documentation"
 ;
@@ -650,7 +650,7 @@ fail:
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  const int * values +rank(1)
-// Statement: py_in_native_*_pointer_numpy
+// Statement: py_in_native_*_numpy
 // ----------------------------------------
 // Argument:  int * result +intent(out)
 // Statement: py_out_native_*
@@ -713,7 +713,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  int * out +dimension(3)+intent(out)
-// Statement: py_out_native_*_pointer_numpy
+// Statement: py_out_native_*_numpy
 static char PY_fillIntArray__doc__[] =
 "documentation"
 ;
@@ -758,7 +758,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  int * array +intent(inout)+rank(1)
-// Statement: py_inout_native_*_pointer_numpy
+// Statement: py_inout_native_*_numpy
 // ----------------------------------------
 // Argument:  int sizein +implied(size(array))+value
 // Exact:     py_default
@@ -815,7 +815,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  double * x +rank(1)
-// Statement: py_inout_native_*_pointer_numpy
+// Statement: py_inout_native_*_numpy
 // ----------------------------------------
 // Argument:  int x_length +implied(size(x))+value
 // Exact:     py_default
@@ -869,7 +869,7 @@ fail:
 // Statement: py_function_native_scalar
 // ----------------------------------------
 // Argument:  const int * arr +rank(1)
-// Statement: py_in_native_*_pointer_numpy
+// Statement: py_in_native_*_numpy
 // ----------------------------------------
 // Argument:  size_t len +implied(size(arr))+value
 // Exact:     py_default
@@ -1046,7 +1046,7 @@ PY_sumFixedArray(
 // Statement: py_default
 // ----------------------------------------
 // Argument:  int * * count +dimension(10)+intent(out)
-// Statement: py_out_native_**_pointer_numpy
+// Statement: py_out_native_**_numpy
 static char PY_getPtrToFixedArray__doc__[] =
 "documentation"
 ;
@@ -1086,7 +1086,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  int * * count +dimension(ncount)+intent(out)
-// Statement: py_out_native_**_pointer_numpy
+// Statement: py_out_native_**_numpy
 // ----------------------------------------
 // Argument:  int * ncount +hidden+intent(out)
 // Statement: py_out_native_*
@@ -1131,7 +1131,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  int * * count +dimension(getLen())+intent(out)
-// Statement: py_out_native_**_pointer_numpy
+// Statement: py_out_native_**_numpy
 static char PY_getPtrToFuncArray__doc__[] =
 "documentation"
 ;
@@ -1173,7 +1173,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  const int * * count +dimension(10)+intent(out)
-// Statement: py_out_native_**_pointer_numpy
+// Statement: py_out_native_**_numpy
 static char PY_getPtrToFixedConstArray__doc__[] =
 "documentation"
 ;
@@ -1210,7 +1210,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  const int * * count +dimension(ncount)+intent(out)
-// Statement: py_out_native_**_pointer_numpy
+// Statement: py_out_native_**_numpy
 // ----------------------------------------
 // Argument:  int * ncount +hidden+intent(out)
 // Statement: py_out_native_*
@@ -1415,7 +1415,7 @@ PY_fetchVoidPtr(
 
 // ----------------------------------------
 // Function:  int * returnIntPtrToScalar
-// Statement: py_function_native_*_pointer_numpy
+// Statement: py_function_native_*_numpy
 static char PY_returnIntPtrToScalar__doc__[] =
 "documentation"
 ;
@@ -1445,7 +1445,7 @@ fail:
 
 // ----------------------------------------
 // Function:  int * returnIntPtrToFixedArray +dimension(10)
-// Statement: py_function_native_*_pointer_numpy
+// Statement: py_function_native_*_numpy
 static char PY_returnIntPtrToFixedArray__doc__[] =
 "documentation"
 ;
@@ -1477,7 +1477,7 @@ fail:
 
 // ----------------------------------------
 // Function:  const int * returnIntPtrToConstScalar
-// Statement: py_function_native_*_pointer_numpy
+// Statement: py_function_native_*_numpy
 static char PY_returnIntPtrToConstScalar__doc__[] =
 "documentation"
 ;
@@ -1508,7 +1508,7 @@ fail:
 
 // ----------------------------------------
 // Function:  const int * returnIntPtrToFixedConstArray +dimension(10)
-// Statement: py_function_native_*_pointer_numpy
+// Statement: py_function_native_*_numpy
 static char PY_returnIntPtrToFixedConstArray__doc__[] =
 "documentation"
 ;

--- a/regression/reference/pointers-numpy-cxx/pointers.json
+++ b/regression/reference/pointers-numpy-cxx/pointers.json
@@ -509,7 +509,7 @@
                             "pytmp_var": "SHTPy_in",
                             "rank": "1",
                             "size_var": "SHSize_in",
-                            "stmt": "py_in_native_*_pointer_numpy",
+                            "stmt": "py_in_native_*_numpy",
                             "value_var": "SHValue_in"
                         }
                     },
@@ -535,7 +535,7 @@
                             "py_var": "SHPy_out",
                             "rank": "1",
                             "size_var": "SHSize_out",
-                            "stmt": "py_out_native_*_pointer_numpy",
+                            "stmt": "py_out_native_*_numpy",
                             "value_var": "SHValue_out"
                         }
                     },
@@ -685,7 +685,7 @@
                             "pytmp_var": "SHTPy_in",
                             "rank": "1",
                             "size_var": "SHSize_in",
-                            "stmt": "py_in_native_*_pointer_numpy",
+                            "stmt": "py_in_native_*_numpy",
                             "value_var": "SHValue_in"
                         }
                     },
@@ -711,7 +711,7 @@
                             "py_var": "SHPy_out",
                             "rank": "1",
                             "size_var": "SHSize_out",
-                            "stmt": "py_out_native_*_pointer_numpy",
+                            "stmt": "py_out_native_*_numpy",
                             "value_var": "SHValue_out"
                         }
                     },
@@ -863,7 +863,7 @@
                             "py_var": "SHPy_values",
                             "rank": "1",
                             "size_var": "SHSize_values",
-                            "stmt": "py_out_native_*_pointer_numpy",
+                            "stmt": "py_out_native_*_numpy",
                             "value_var": "SHValue_values"
                         }
                     }
@@ -980,7 +980,7 @@
                             "py_var": "SHPy_arg1",
                             "rank": "1",
                             "size_var": "SHSize_arg1",
-                            "stmt": "py_out_native_*_pointer_numpy",
+                            "stmt": "py_out_native_*_numpy",
                             "value_var": "SHValue_arg1"
                         }
                     },
@@ -1006,7 +1006,7 @@
                             "py_var": "SHPy_arg2",
                             "rank": "1",
                             "size_var": "SHSize_arg2",
-                            "stmt": "py_out_native_*_pointer_numpy",
+                            "stmt": "py_out_native_*_numpy",
                             "value_var": "SHValue_arg2"
                         }
                     }
@@ -1128,7 +1128,7 @@
                             "py_var": "SHPy_values",
                             "rank": "1",
                             "size_var": "SHSize_values",
-                            "stmt": "py_out_native_*_pointer_numpy",
+                            "stmt": "py_out_native_*_numpy",
                             "value_var": "SHValue_values"
                         }
                     }
@@ -1286,7 +1286,7 @@
                             "pytmp_var": "SHTPy_values",
                             "rank": "1",
                             "size_var": "SHSize_values",
-                            "stmt": "py_in_native_*_pointer_numpy",
+                            "stmt": "py_in_native_*_numpy",
                             "value_var": "SHValue_values"
                         }
                     }
@@ -1375,7 +1375,7 @@
                             "py_var": "SHPy_out",
                             "rank": "1",
                             "size_var": "SHSize_out",
-                            "stmt": "py_out_native_*_pointer_numpy",
+                            "stmt": "py_out_native_*_numpy",
                             "value_var": "SHValue_out"
                         }
                     }
@@ -1472,7 +1472,7 @@
                             "pytmp_var": "SHTPy_array",
                             "rank": "1",
                             "size_var": "SHSize_array",
-                            "stmt": "py_inout_native_*_pointer_numpy",
+                            "stmt": "py_inout_native_*_numpy",
                             "value_var": "SHValue_array"
                         }
                     },
@@ -1585,7 +1585,7 @@
                             "pytmp_var": "SHTPy_x",
                             "rank": "1",
                             "size_var": "SHSize_x",
-                            "stmt": "py_inout_native_*_pointer_numpy",
+                            "stmt": "py_inout_native_*_numpy",
                             "value_var": "SHValue_x"
                         }
                     },
@@ -1717,7 +1717,7 @@
                             "pytmp_var": "SHTPy_arr",
                             "rank": "1",
                             "size_var": "SHSize_arr",
-                            "stmt": "py_in_native_*_pointer_numpy",
+                            "stmt": "py_in_native_*_numpy",
                             "value_var": "SHValue_arr"
                         }
                     },
@@ -2109,7 +2109,7 @@
                             "py_var": "SHPy_count",
                             "rank": "1",
                             "size_var": "SHSize_count",
-                            "stmt": "py_out_native_**_pointer_numpy",
+                            "stmt": "py_out_native_**_numpy",
                             "value_var": "SHValue_count"
                         }
                     }
@@ -2224,7 +2224,7 @@
                             "py_var": "SHPy_count",
                             "rank": "1",
                             "size_var": "SHSize_count",
-                            "stmt": "py_out_native_**_pointer_numpy",
+                            "stmt": "py_out_native_**_numpy",
                             "value_var": "SHValue_count"
                         }
                     },
@@ -2339,7 +2339,7 @@
                             "py_var": "SHPy_count",
                             "rank": "1",
                             "size_var": "SHSize_count",
-                            "stmt": "py_out_native_**_pointer_numpy",
+                            "stmt": "py_out_native_**_numpy",
                             "value_var": "SHValue_count"
                         }
                     }
@@ -2486,7 +2486,7 @@
                             "py_var": "SHPy_count",
                             "rank": "1",
                             "size_var": "SHSize_count",
-                            "stmt": "py_out_native_**_pointer_numpy",
+                            "stmt": "py_out_native_**_numpy",
                             "value_var": "SHValue_count"
                         }
                     }
@@ -2599,7 +2599,7 @@
                             "py_var": "SHPy_count",
                             "rank": "1",
                             "size_var": "SHSize_count",
-                            "stmt": "py_out_native_**_pointer_numpy",
+                            "stmt": "py_out_native_**_numpy",
                             "value_var": "SHValue_count"
                         }
                     },
@@ -3585,7 +3585,7 @@
                             "numpy_type": "NPY_INT",
                             "py_var": "SHTPy_rv",
                             "size_var": "SHSize_rv",
-                            "stmt": "py_function_native_*_pointer_numpy",
+                            "stmt": "py_function_native_*_numpy",
                             "value_var": "SHValue_rv"
                         }
                     }
@@ -3655,7 +3655,7 @@
                             "py_var": "SHTPy_rv",
                             "rank": "1",
                             "size_var": "SHSize_rv",
-                            "stmt": "py_function_native_*_pointer_numpy",
+                            "stmt": "py_function_native_*_numpy",
                             "value_var": "SHValue_rv"
                         }
                     }
@@ -3713,7 +3713,7 @@
                             "numpy_type": "NPY_INT",
                             "py_var": "SHTPy_rv",
                             "size_var": "SHSize_rv",
-                            "stmt": "py_function_native_*_pointer_numpy",
+                            "stmt": "py_function_native_*_numpy",
                             "value_var": "SHValue_rv"
                         }
                     }
@@ -3784,7 +3784,7 @@
                             "py_var": "SHTPy_rv",
                             "rank": "1",
                             "size_var": "SHSize_rv",
-                            "stmt": "py_function_native_*_pointer_numpy",
+                            "stmt": "py_function_native_*_numpy",
                             "value_var": "SHValue_rv"
                         }
                     }

--- a/regression/reference/pointers-numpy-cxx/pypointersmodule.cpp
+++ b/regression/reference/pointers-numpy-cxx/pypointersmodule.cpp
@@ -516,7 +516,7 @@ PY_get_values(
     get_values(&nvalues, values);
 
     // post_call
-    SHTPy_rv = Py_BuildValue("iO", nvalues, SHPy_values);
+    SHTPy_rv = Py_BuildValue("iN", nvalues, SHPy_values);
 
     return SHTPy_rv;
 
@@ -585,7 +585,7 @@ PY_get_values2(
     get_values2(arg1, arg2);
 
     // post_call
-    SHTPy_rv = Py_BuildValue("OO", SHPy_arg1, SHPy_arg2);
+    SHTPy_rv = Py_BuildValue("NN", SHPy_arg1, SHPy_arg2);
 
     return SHTPy_rv;
 

--- a/regression/reference/pointers-numpy-cxx/pypointersmodule.cpp
+++ b/regression/reference/pointers-numpy-cxx/pypointersmodule.cpp
@@ -312,10 +312,10 @@ PY_intargs(
 // Statement: py_default
 // ----------------------------------------
 // Argument:  double * in +intent(in)+rank(1)
-// Statement: py_in_native_*_pointer_numpy
+// Statement: py_in_native_*_numpy
 // ----------------------------------------
 // Argument:  double * out +dimension(size(in))+intent(out)
-// Statement: py_out_native_*_pointer_numpy
+// Statement: py_out_native_*_numpy
 // ----------------------------------------
 // Argument:  int sizein +implied(size(in))+value
 // Exact:     py_default
@@ -391,10 +391,10 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  double * in +intent(in)+rank(1)
-// Statement: py_in_native_*_pointer_numpy
+// Statement: py_in_native_*_numpy
 // ----------------------------------------
 // Argument:  int * out +dimension(size(in))+intent(out)
-// Statement: py_out_native_*_pointer_numpy
+// Statement: py_out_native_*_numpy
 // ----------------------------------------
 // Argument:  int sizein +implied(size(in))+value
 // Exact:     py_default
@@ -474,7 +474,7 @@ fail:
 // Statement: py_out_native_*
 // ----------------------------------------
 // Argument:  int * values +dimension(3)+intent(out)
-// Statement: py_out_native_*_pointer_numpy
+// Statement: py_out_native_*_numpy
 static char PY_get_values__doc__[] =
 "documentation"
 ;
@@ -531,10 +531,10 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  int * arg1 +dimension(3)+intent(out)
-// Statement: py_out_native_*_pointer_numpy
+// Statement: py_out_native_*_numpy
 // ----------------------------------------
 // Argument:  int * arg2 +dimension(3)+intent(out)
-// Statement: py_out_native_*_pointer_numpy
+// Statement: py_out_native_*_numpy
 static char PY_get_values2__doc__[] =
 "documentation"
 ;
@@ -604,7 +604,7 @@ fail:
 // Statement: py_in_native_scalar
 // ----------------------------------------
 // Argument:  int * values +dimension(nvar)+intent(out)
-// Statement: py_out_native_*_pointer_numpy
+// Statement: py_out_native_*_numpy
 static char PY_iota_dimension__doc__[] =
 "documentation"
 ;
@@ -658,7 +658,7 @@ fail:
 // Exact:     py_default
 // ----------------------------------------
 // Argument:  const int * values +rank(1)
-// Statement: py_in_native_*_pointer_numpy
+// Statement: py_in_native_*_numpy
 // ----------------------------------------
 // Argument:  int * result +intent(out)
 // Statement: py_out_native_*
@@ -721,7 +721,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  int * out +dimension(3)+intent(out)
-// Statement: py_out_native_*_pointer_numpy
+// Statement: py_out_native_*_numpy
 static char PY_fillIntArray__doc__[] =
 "documentation"
 ;
@@ -767,7 +767,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  int * array +intent(inout)+rank(1)
-// Statement: py_inout_native_*_pointer_numpy
+// Statement: py_inout_native_*_numpy
 // ----------------------------------------
 // Argument:  int sizein +implied(size(array))+value
 // Exact:     py_default
@@ -824,7 +824,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  double * x +rank(1)
-// Statement: py_inout_native_*_pointer_numpy
+// Statement: py_inout_native_*_numpy
 // ----------------------------------------
 // Argument:  int x_length +implied(size(x))+value
 // Exact:     py_default
@@ -878,7 +878,7 @@ fail:
 // Statement: py_function_native_scalar
 // ----------------------------------------
 // Argument:  const int * arr +rank(1)
-// Statement: py_in_native_*_pointer_numpy
+// Statement: py_in_native_*_numpy
 // ----------------------------------------
 // Argument:  size_t len +implied(size(arr))+value
 // Exact:     py_default
@@ -1055,7 +1055,7 @@ PY_sumFixedArray(
 // Statement: py_default
 // ----------------------------------------
 // Argument:  int * * count +dimension(10)+intent(out)
-// Statement: py_out_native_**_pointer_numpy
+// Statement: py_out_native_**_numpy
 static char PY_getPtrToFixedArray__doc__[] =
 "documentation"
 ;
@@ -1095,7 +1095,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  int * * count +dimension(ncount)+intent(out)
-// Statement: py_out_native_**_pointer_numpy
+// Statement: py_out_native_**_numpy
 // ----------------------------------------
 // Argument:  int * ncount +hidden+intent(out)
 // Statement: py_out_native_*
@@ -1140,7 +1140,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  int * * count +dimension(getLen())+intent(out)
-// Statement: py_out_native_**_pointer_numpy
+// Statement: py_out_native_**_numpy
 static char PY_getPtrToFuncArray__doc__[] =
 "documentation"
 ;
@@ -1182,7 +1182,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  const int * * count +dimension(10)+intent(out)
-// Statement: py_out_native_**_pointer_numpy
+// Statement: py_out_native_**_numpy
 static char PY_getPtrToFixedConstArray__doc__[] =
 "documentation"
 ;
@@ -1219,7 +1219,7 @@ fail:
 // Statement: py_default
 // ----------------------------------------
 // Argument:  const int * * count +dimension(ncount)+intent(out)
-// Statement: py_out_native_**_pointer_numpy
+// Statement: py_out_native_**_numpy
 // ----------------------------------------
 // Argument:  int * ncount +hidden+intent(out)
 // Statement: py_out_native_*
@@ -1424,7 +1424,7 @@ PY_fetchVoidPtr(
 
 // ----------------------------------------
 // Function:  int * returnIntPtrToScalar
-// Statement: py_function_native_*_pointer_numpy
+// Statement: py_function_native_*_numpy
 static char PY_returnIntPtrToScalar__doc__[] =
 "documentation"
 ;
@@ -1454,7 +1454,7 @@ fail:
 
 // ----------------------------------------
 // Function:  int * returnIntPtrToFixedArray +dimension(10)
-// Statement: py_function_native_*_pointer_numpy
+// Statement: py_function_native_*_numpy
 static char PY_returnIntPtrToFixedArray__doc__[] =
 "documentation"
 ;
@@ -1486,7 +1486,7 @@ fail:
 
 // ----------------------------------------
 // Function:  const int * returnIntPtrToConstScalar
-// Statement: py_function_native_*_pointer_numpy
+// Statement: py_function_native_*_numpy
 static char PY_returnIntPtrToConstScalar__doc__[] =
 "documentation"
 ;
@@ -1517,7 +1517,7 @@ fail:
 
 // ----------------------------------------
 // Function:  const int * returnIntPtrToFixedConstArray +dimension(10)
-// Statement: py_function_native_*_pointer_numpy
+// Statement: py_function_native_*_numpy
 static char PY_returnIntPtrToFixedConstArray__doc__[] =
 "documentation"
 ;

--- a/regression/reference/strings/pystringsmodule.cpp
+++ b/regression/reference/strings/pystringsmodule.cpp
@@ -1258,7 +1258,7 @@ PY_CreturnChar(
 // Statement: py_default
 // ----------------------------------------
 // Argument:  int * count +intent(in)+rank(1)
-// Statement: py_in_native_*_pointer_list
+// Statement: py_in_native_*_list
 // ----------------------------------------
 // Argument:  std::string & name
 // Statement: py_inout_string_&

--- a/regression/reference/strings/strings.json
+++ b/regression/reference/strings/strings.json
@@ -8832,7 +8832,7 @@
                             "pytmp_var": "SHTPy_count",
                             "rank": "1",
                             "size_var": "SHSize_count",
-                            "stmt": "py_in_native_*_pointer_list",
+                            "stmt": "py_in_native_*_list",
                             "value_var": "SHValue_count"
                         }
                     },

--- a/regression/reference/struct-class-c/pystructmodule.c
+++ b/regression/reference/struct-class-c/pystructmodule.c
@@ -447,7 +447,7 @@ PY_returnStructPtr2(
     // post_call
     SHTPy_rv = PP_Cstruct1_to_Object_idtor(SHCXX_rv, 0);
     if (SHTPy_rv == NULL) goto fail;
-    SHPyResult = Py_BuildValue("Os", SHTPy_rv, outbuf);
+    SHPyResult = Py_BuildValue("Ns", SHTPy_rv, outbuf);
 
     return SHPyResult;
 

--- a/regression/reference/struct-class-c/pystructmodule.c
+++ b/regression/reference/struct-class-c/pystructmodule.c
@@ -284,6 +284,10 @@ PY_acceptStructInOutPtr(
     Cstruct1 * arg = SHPy_arg ? SHPy_arg->obj : NULL;
 
     acceptStructInOutPtr(arg);
+
+    // post_call
+    Py_INCREF(SHPy_arg);
+
     return (PyObject *) SHPy_arg;
 // splicer end function.acceptStructInOutPtr
 }

--- a/regression/reference/struct-class-cxx/pystructmodule.cpp
+++ b/regression/reference/struct-class-cxx/pystructmodule.cpp
@@ -449,7 +449,7 @@ PY_returnStructPtr2(
     // post_call
     SHTPy_rv = PP_Cstruct1_to_Object_idtor(SHCXX_rv, 0);
     if (SHTPy_rv == nullptr) goto fail;
-    SHPyResult = Py_BuildValue("Os", SHTPy_rv, outbuf);
+    SHPyResult = Py_BuildValue("Ns", SHTPy_rv, outbuf);
 
     return SHPyResult;
 

--- a/regression/reference/struct-class-cxx/pystructmodule.cpp
+++ b/regression/reference/struct-class-cxx/pystructmodule.cpp
@@ -285,6 +285,10 @@ PY_acceptStructInOutPtr(
     Cstruct1 * arg = SHPy_arg ? SHPy_arg->obj : nullptr;
 
     acceptStructInOutPtr(arg);
+
+    // post_call
+    Py_INCREF(SHPy_arg);
+
     return (PyObject *) SHPy_arg;
 // splicer end function.acceptStructInOutPtr
 }

--- a/regression/reference/struct-numpy-c/pystructmodule.c
+++ b/regression/reference/struct-numpy-c/pystructmodule.c
@@ -562,7 +562,7 @@ PY_returnStructPtr2(
     SHTPy_rv = PyArray_NewFromDescr(&PyArray_Type, 
         PY_Cstruct1_array_descr, 0, NULL, NULL, SHCXX_rv, 0, NULL);
     if (SHTPy_rv == NULL) goto fail;
-    SHPyResult = Py_BuildValue("Os", SHTPy_rv, outbuf);
+    SHPyResult = Py_BuildValue("Ns", SHTPy_rv, outbuf);
 
     return SHPyResult;
 

--- a/regression/reference/struct-numpy-cxx/pystructmodule.cpp
+++ b/regression/reference/struct-numpy-cxx/pystructmodule.cpp
@@ -574,7 +574,7 @@ PY_returnStructPtr2(
         PY_Cstruct1_array_descr, 0, nullptr, 
         nullptr, SHCXX_rv, 0, nullptr);
     if (SHTPy_rv == nullptr) goto fail;
-    SHPyResult = Py_BuildValue("Os", SHTPy_rv, outbuf);
+    SHPyResult = Py_BuildValue("Ns", SHTPy_rv, outbuf);
 
     return SHPyResult;
 

--- a/regression/reference/templates/pystd_vector_doubletype.cpp
+++ b/regression/reference/templates/pystd_vector_doubletype.cpp
@@ -94,7 +94,7 @@ PY_push_back(
 
 // ----------------------------------------
 // Function:  double & at
-// Statement: py_function_native_&_pointer_numpy
+// Statement: py_function_native_&_numpy
 // ----------------------------------------
 // Argument:  size_type n +value
 // Statement: py_in_native_scalar

--- a/regression/reference/templates/pystd_vector_inttype.cpp
+++ b/regression/reference/templates/pystd_vector_inttype.cpp
@@ -94,7 +94,7 @@ PY_push_back(
 
 // ----------------------------------------
 // Function:  int & at
-// Statement: py_function_native_&_pointer_numpy
+// Statement: py_function_native_&_numpy
 // ----------------------------------------
 // Argument:  size_type n +value
 // Statement: py_in_native_scalar

--- a/regression/reference/templates/templates.json
+++ b/regression/reference/templates/templates.json
@@ -4136,7 +4136,7 @@
                                             "numpy_type": "NPY_INT",
                                             "py_var": "SHTPy_rv",
                                             "size_var": "SHSize_rv",
-                                            "stmt": "py_function_native_&_pointer_numpy",
+                                            "stmt": "py_function_native_&_numpy",
                                             "value_var": "SHValue_rv"
                                         }
                                     },
@@ -5014,7 +5014,7 @@
                                             "numpy_type": "NPY_DOUBLE",
                                             "py_var": "SHTPy_rv",
                                             "size_var": "SHSize_rv",
-                                            "stmt": "py_function_native_&_pointer_numpy",
+                                            "stmt": "py_function_native_&_numpy",
                                             "value_var": "SHValue_rv"
                                         }
                                     },

--- a/regression/reference/types/pytypesmodule.cpp
+++ b/regression/reference/types/pytypesmodule.cpp
@@ -904,7 +904,7 @@ PY_returnBoolAndOthers(
     // post_call
     SHTPy_rv = PyBool_FromLong(SHCXX_rv);
     if (SHTPy_rv == nullptr) goto fail;
-    SHPyResult = Py_BuildValue("Oi", SHTPy_rv, flag);
+    SHPyResult = Py_BuildValue("Ni", SHTPy_rv, flag);
 
     return SHPyResult;
 

--- a/regression/reference/vectors-list/pyvectorsmodule.cpp
+++ b/regression/reference/vectors-list/pyvectorsmodule.cpp
@@ -312,7 +312,7 @@ fail:
 // Statement: py_function_native_scalar
 // ----------------------------------------
 // Argument:  int * arg +intent(in)+rank(2)
-// Statement: py_in_native_*_pointer_list
+// Statement: py_in_native_*_list
 // ----------------------------------------
 // Argument:  int len +implied(size(arg,2))+value
 // Exact:     py_default

--- a/regression/reference/vectors-list/vectors.json
+++ b/regression/reference/vectors-list/vectors.json
@@ -1346,7 +1346,7 @@
                             "pytmp_var": "SHTPy_arg",
                             "rank": "2",
                             "size_var": "SHSize_arg",
-                            "stmt": "py_in_native_*_pointer_list",
+                            "stmt": "py_in_native_*_list",
                             "value_var": "SHValue_arg"
                         }
                     },

--- a/regression/reference/vectors-numpy/pyvectorsmodule.cpp
+++ b/regression/reference/vectors-numpy/pyvectorsmodule.cpp
@@ -284,7 +284,7 @@ fail:
 // Statement: py_function_native_scalar
 // ----------------------------------------
 // Argument:  int * arg +intent(in)+rank(2)
-// Statement: py_in_native_*_pointer_numpy
+// Statement: py_in_native_*_numpy
 // ----------------------------------------
 // Argument:  int len +implied(size(arg,2))+value
 // Exact:     py_default

--- a/regression/reference/vectors-numpy/vectors.json
+++ b/regression/reference/vectors-numpy/vectors.json
@@ -1351,7 +1351,7 @@
                             "pytmp_var": "SHTPy_arg",
                             "rank": "2",
                             "size_var": "SHSize_arg",
-                            "stmt": "py_in_native_*_pointer_numpy",
+                            "stmt": "py_in_native_*_numpy",
                             "value_var": "SHValue_arg"
                         }
                     },

--- a/regression/run/struct-class-c/python/test.py
+++ b/regression/run/struct-class-c/python/test.py
@@ -11,6 +11,7 @@
 from __future__ import print_function
 
 import numpy as np
+import sys
 import unittest
 import cstruct
 
@@ -75,8 +76,10 @@ class Struct(unittest.TestCase):
 
     def test_acceptStructInOutPtr(self):
         str = cstruct.Cstruct1(22, 22.8)
+        self.assertEqual(1, sys.getrefcount(str) - 1)
         out = cstruct.acceptStructInOutPtr(str)
         self.assertIs(str, out)
+        self.assertEqual(2, sys.getrefcount(out) - 1)
         self.assertEqual(23,   out.ifield)
         self.assertEqual(23.8, out.dfield)
 
@@ -100,6 +103,7 @@ class Struct(unittest.TestCase):
 
     def test_returnStructPtr2(self):
         out, name = cstruct.returnStructPtr2(35, 35.5)
+        self.assertEqual(1, sys.getrefcount(out) - 1)
         self.assertIsInstance(out, cstruct.Cstruct1)
         self.assertEqual(35,   out.ifield)
         self.assertEqual(35.5, out.dfield)

--- a/regression/run/struct-class-cxx/python/test.py
+++ b/regression/run/struct-class-cxx/python/test.py
@@ -11,6 +11,7 @@
 from __future__ import print_function
 
 import numpy as np
+import sys
 import unittest
 import cstruct
 
@@ -75,12 +76,20 @@ class Struct(unittest.TestCase):
 
     def test_acceptStructInOutPtr(self):
         str = cstruct.Cstruct1(22, 22.8)
+        self.assertEqual(1, sys.getrefcount(str) - 1)
         out = cstruct.acceptStructInOutPtr(str)
         self.assertIs(str, out)
+        self.assertEqual(2, sys.getrefcount(out) - 1)
         self.assertEqual(23,   out.ifield)
         self.assertEqual(23.8, out.dfield)
 
     def test_returnStructByValue(self):
+        out = cstruct.returnStructByValue(1, 2.5)
+        self.assertIsInstance(out, cstruct.Cstruct1)
+        self.assertEqual(1,   out.ifield)
+        self.assertEqual(2.5, out.dfield)
+
+    def test_returnConstStructByValue(self):
         out = cstruct.returnStructByValue(1, 2.5)
         self.assertIsInstance(out, cstruct.Cstruct1)
         self.assertEqual(1,   out.ifield)
@@ -94,6 +103,7 @@ class Struct(unittest.TestCase):
 
     def test_returnStructPtr2(self):
         out, name = cstruct.returnStructPtr2(35, 35.5)
+        self.assertEqual(1, sys.getrefcount(out) - 1)
         self.assertIsInstance(out, cstruct.Cstruct1)
         self.assertEqual(35,   out.ifield)
         self.assertEqual(35.5, out.dfield)

--- a/shroud/statements.py
+++ b/shroud/statements.py
@@ -509,8 +509,10 @@ def process_mixin(stmts, defaults, stmtdict):
         intent = parts[1]
         if "base" in stmt:
             if stmt["base"] not in stmtdict:
-                print("XXX - base not found for", name, ":", stmt["base"])
-            node = util.Scope(stmtdict[stmt["base"]])
+                error.cursor.warning("Base not found for {}: {}".format(
+                    name, stmt["base"]))
+            else:
+                node = util.Scope(stmtdict[stmt["base"]])
         else:
             node = util.Scope(defaults[lang])
         node.update(stmt)
@@ -1300,8 +1302,10 @@ fc_statements = [
     ),
     
     dict(
-        # Default returned by lookup_fc_stmts when group is not found.
         name="f_mixin_unknown",
+        comments=[
+            "Default returned by lookup_fc_stmts when group is not found.",
+        ],
         # Point out where there are problems in the wrapper...
         c_arg_decl=["===>{c_var}<==="],
     ),

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -1047,7 +1047,7 @@ return 1;""",
             # Explicit code exists to create object.
             # For example, NumPy intent(OUT) arguments as part of pre-call.
             # If post_call is None, the Object has already been created
-            build_format = "O"  # increments reference; "N" does not.
+            build_format = "N"  # "O" increments reference; "N" does not.
             vargs = fmt.py_var
             blk0 = None
             if intent_blk.incref_on_return:
@@ -1738,7 +1738,7 @@ return 1;""",
             ttt0 = self.intent_out(result_typemap, result_blk, fmt_result)
             # Add result to front of return tuple.
             build_tuples.insert(0, ttt0)
-            if ttt0.format == "O":
+            if ttt0.format in ["O", "N"]:
                 # If an object has already been created,
                 # use another variable for the result.
                 fmt.PY_result = "SHPyResult"


### PR DESCRIPTION
Fixes a segfault caused by missing `Py_INCREF`

Avoid memory leaks caused by using `O` with `Py_BuildValue` instead of `N`

Remove use of deref attribute values pointer and allocatable since they are Fortran specific