### PR TITLE
Add metaattributes to function pointer arguments

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -15,6 +15,9 @@ Unreleased
 Changes to YAML input
 ^^^^^^^^^^^^^^^^^^^^^
 
+* Attribute *+allocatable* is now *+deref(allocatable)*.
+  This avoids setting *+allocatable* inconsistent with *+deref*.
+
 * C wrappers can now be generated independent of Fortran wrappers
   instead of just as a side effect of creating Fortran Wrappers.
 

--- a/regression/reference/arrayclass/arrayclass.json
+++ b/regression/reference/arrayclass/arrayclass.json
@@ -209,7 +209,8 @@
                                 },
                                 "size": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_native_scalar"
                                 }
@@ -223,7 +224,8 @@
                                 },
                                 "size": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 }
@@ -236,7 +238,8 @@
                                 },
                                 "size": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             },
@@ -248,7 +251,8 @@
                                 },
                                 "size": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -3654,7 +3658,8 @@
                                 },
                                 "array": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_void_*"
                                 }
@@ -3668,7 +3673,8 @@
                                 },
                                 "array": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_void_*"
                                 }
@@ -3681,7 +3687,8 @@
                                 },
                                 "array": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             },
@@ -3693,7 +3700,8 @@
                                 },
                                 "array": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }

--- a/regression/reference/cdesc/cdesc.json
+++ b/regression/reference/cdesc/cdesc.json
@@ -416,7 +416,8 @@
                         "value": {
                             "meta": {
                                 "intent": "in",
-                                "rank": 0
+                                "rank": 0,
+                                "value": true
                             },
                             "stmt": "c_in_void_*"
                         }
@@ -435,7 +436,8 @@
                         "value": {
                             "meta": {
                                 "intent": "in",
-                                "rank": 0
+                                "rank": 0,
+                                "value": true
                             }
                         }
                     }
@@ -1562,7 +1564,8 @@
                         },
                         "value": {
                             "meta": {
-                                "intent": "out"
+                                "intent": "out",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/classes/classes.json
+++ b/regression/reference/classes/classes.json
@@ -327,7 +327,8 @@
                                 },
                                 "flag": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_native_scalar"
                                 }
@@ -342,7 +343,8 @@
                                 },
                                 "flag": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 }
@@ -355,7 +357,8 @@
                                 },
                                 "flag": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             },
@@ -367,7 +370,8 @@
                                 },
                                 "flag": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             },
@@ -379,7 +383,8 @@
                                 },
                                 "flag": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -1324,7 +1329,8 @@
                                 },
                                 "flag": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_bool_scalar"
                                 },
@@ -1345,7 +1351,8 @@
                                 },
                                 "flag": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_bool_scalar"
                                 },
@@ -1365,7 +1372,8 @@
                                 },
                                 "flag": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "name": {
@@ -1995,7 +2003,8 @@
                                 },
                                 "arg": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_native_scalar"
                                 }
@@ -2009,7 +2018,8 @@
                                 },
                                 "arg": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 }
@@ -2022,7 +2032,8 @@
                                 },
                                 "arg": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             },
@@ -2034,7 +2045,8 @@
                                 },
                                 "arg": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             },
@@ -2046,7 +2058,8 @@
                                 },
                                 "arg": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -2502,7 +2515,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     },
                                     "stmt": "f_setter_native_scalar"
                                 }
@@ -2515,7 +2529,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     }
                                 }
                             }
@@ -2740,7 +2755,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     },
                                     "stmt": "f_setter_bool_scalar"
                                 }
@@ -2753,7 +2769,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     }
                                 }
                             }
@@ -3000,7 +3017,8 @@
                                 "val": {
                                     "meta": {
                                         "api": "buf",
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     },
                                     "stmt": "f_setter_string_scalar_buf"
                                 }
@@ -3013,7 +3031,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     }
                                 }
                             }
@@ -4432,7 +4451,8 @@
                                 },
                                 "n": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_native_scalar"
                                 }
@@ -4446,7 +4466,8 @@
                                 },
                                 "n": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 }
@@ -4459,7 +4480,8 @@
                                 },
                                 "n": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -5005,7 +5027,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     },
                                     "stmt": "f_setter_native_scalar"
                                 }
@@ -5018,7 +5041,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     }
                                 }
                             }
@@ -5552,7 +5576,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -5566,7 +5591,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -5579,7 +5605,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -5591,7 +5618,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -5603,7 +5631,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -5841,7 +5870,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_shadow_scalar"
                         }
@@ -5855,7 +5885,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_shadow_scalar"
                         }
@@ -5868,7 +5899,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -5880,7 +5912,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -5892,7 +5925,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -7162,7 +7196,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -7177,7 +7212,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -7190,7 +7226,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -7356,7 +7393,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -7370,7 +7408,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -7383,7 +7422,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -7395,7 +7435,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -7407,7 +7448,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/clibrary/clibrary.json
+++ b/regression/reference/clibrary/clibrary.json
@@ -229,13 +229,15 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -249,13 +251,15 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -268,12 +272,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -285,12 +291,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -853,7 +861,8 @@
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -867,7 +876,8 @@
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -880,7 +890,8 @@
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -892,7 +903,8 @@
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1132,7 +1144,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_bool_scalar"
                         },
@@ -1158,7 +1171,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_bool_scalar"
                         },
@@ -1183,7 +1197,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
@@ -1205,7 +1220,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
@@ -2894,7 +2910,8 @@
                         },
                         "ltext": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
@@ -2914,7 +2931,8 @@
                         },
                         "ltext": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -2934,7 +2952,8 @@
                         },
                         "ltext": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "text": {
@@ -2951,7 +2970,8 @@
                         },
                         "ltext": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "text": {
@@ -3224,13 +3244,15 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_bool_scalar"
                         },
                         "ltext": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
@@ -3250,13 +3272,15 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_bool_scalar"
                         },
                         "ltext": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -3276,12 +3300,14 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "ltext": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "text": {
@@ -3298,12 +3324,14 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "ltext": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "text": {
@@ -3671,13 +3699,15 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_bool_scalar"
                         },
                         "ltext": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
@@ -3697,13 +3727,15 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_bool_scalar"
                         },
                         "ltext": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -3723,12 +3755,14 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "ltext": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "text": {
@@ -3745,12 +3779,14 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "ltext": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "text": {
@@ -4086,7 +4122,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_bool_scalar"
                         }
@@ -4100,7 +4137,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_bool_scalar"
                         }
@@ -4113,7 +4151,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -4125,7 +4164,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4333,7 +4373,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_bool_scalar"
                         }
@@ -4347,7 +4388,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_bool_scalar"
                         }
@@ -4360,7 +4402,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -4372,7 +4415,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4890,7 +4934,8 @@
                         },
                         "in": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_void_*"
                         },
@@ -4910,7 +4955,8 @@
                         },
                         "in": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_void_*"
                         },
@@ -4929,7 +4975,8 @@
                         },
                         "in": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "out": {
@@ -5118,7 +5165,8 @@
                         "arg": {
                             "meta": {
                                 "assumedtype": true,
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_void_*"
                         }
@@ -5133,7 +5181,8 @@
                         "arg": {
                             "meta": {
                                 "assumedtype": true,
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_void_*"
                         }
@@ -5147,7 +5196,8 @@
                         "arg": {
                             "meta": {
                                 "assumedtype": true,
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -5325,7 +5375,8 @@
                             "meta": {
                                 "assumedtype": true,
                                 "intent": "in",
-                                "rank": 1
+                                "rank": 1,
+                                "value": true
                             },
                             "stmt": "c_in_void_*"
                         }
@@ -5341,7 +5392,8 @@
                             "meta": {
                                 "assumedtype": true,
                                 "intent": "in",
-                                "rank": 1
+                                "rank": 1,
+                                "value": true
                             },
                             "stmt": "f_in_void_*"
                         }
@@ -5356,7 +5408,8 @@
                             "meta": {
                                 "assumedtype": true,
                                 "intent": "in",
-                                "rank": 1
+                                "rank": 1,
+                                "value": true
                             }
                         }
                     }
@@ -5524,7 +5577,8 @@
                         "arg": {
                             "meta": {
                                 "assumedtype": true,
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_void_*"
                         },
@@ -5545,7 +5599,8 @@
                         "arg": {
                             "meta": {
                                 "assumedtype": true,
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_void_*"
                         },
@@ -5566,7 +5621,8 @@
                         "arg": {
                             "meta": {
                                 "assumedtype": true,
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "outbuf": {
@@ -5830,13 +5886,53 @@
                         },
                         "incr": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "incr  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "attrs": {
+                                                "external": true
+                                            },
+                                            "func": {
+                                                "name": "incr",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
+                                            },
+                                            "name": "incr",
+                                            "params": [],
+                                            "typemap_name": "void"
+                                        },
+                                        "specifier": [
+                                            "void"
+                                        ],
+                                        "typemap_name": "void"
+                                    },
+                                    "decl": "void ( * incr)(void) +external",
+                                    "name": "incr",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "incr",
+                                        "F_name_api": "incr",
+                                        "function_name": "incr"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_void_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -5850,13 +5946,53 @@
                         },
                         "incr": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "incr  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "attrs": {
+                                                "external": true
+                                            },
+                                            "func": {
+                                                "name": "incr",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
+                                            },
+                                            "name": "incr",
+                                            "params": [],
+                                            "typemap_name": "void"
+                                        },
+                                        "specifier": [
+                                            "void"
+                                        ],
+                                        "typemap_name": "void"
+                                    },
+                                    "decl": "void ( * incr)(void) +external",
+                                    "name": "incr",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "incr",
+                                        "F_name_api": "incr",
+                                        "function_name": "incr"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_void_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -5869,12 +6005,52 @@
                         },
                         "incr": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "incr  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "attrs": {
+                                                "external": true
+                                            },
+                                            "func": {
+                                                "name": "incr",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
+                                            },
+                                            "name": "incr",
+                                            "params": [],
+                                            "typemap_name": "void"
+                                        },
+                                        "specifier": [
+                                            "void"
+                                        ],
+                                        "typemap_name": "void"
+                                    },
+                                    "decl": "void ( * incr)(void) +external",
+                                    "name": "incr",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "incr",
+                                        "F_name_api": "incr",
+                                        "function_name": "incr"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -6075,13 +6251,53 @@
                         },
                         "incr": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "incr  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "attrs": {
+                                                "external": true
+                                            },
+                                            "func": {
+                                                "name": "incr",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
+                                            },
+                                            "name": "incr",
+                                            "params": [],
+                                            "typemap_name": "void"
+                                        },
+                                        "specifier": [
+                                            "void"
+                                        ],
+                                        "typemap_name": "void"
+                                    },
+                                    "decl": "void ( * incr)(void) +external",
+                                    "name": "incr",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "incr",
+                                        "F_name_api": "incr",
+                                        "function_name": "incr"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_void_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -6095,13 +6311,53 @@
                         },
                         "incr": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "incr  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "attrs": {
+                                                "external": true
+                                            },
+                                            "func": {
+                                                "name": "incr",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
+                                            },
+                                            "name": "incr",
+                                            "params": [],
+                                            "typemap_name": "void"
+                                        },
+                                        "specifier": [
+                                            "void"
+                                        ],
+                                        "typemap_name": "void"
+                                    },
+                                    "decl": "void ( * incr)(void) +external",
+                                    "name": "incr",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "incr",
+                                        "F_name_api": "incr",
+                                        "function_name": "incr"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_void_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -6114,12 +6370,52 @@
                         },
                         "incr": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "incr  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "attrs": {
+                                                "external": true
+                                            },
+                                            "func": {
+                                                "name": "incr",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
+                                            },
+                                            "name": "incr",
+                                            "params": [],
+                                            "typemap_name": "void"
+                                        },
+                                        "specifier": [
+                                            "void"
+                                        ],
+                                        "typemap_name": "void"
+                                    },
+                                    "decl": "void ( * incr)(void) +external",
+                                    "name": "incr",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "incr",
+                                        "F_name_api": "incr",
+                                        "function_name": "incr"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -6351,19 +6647,83 @@
                         "in": {
                             "meta": {
                                 "assumedtype": true,
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_void_*"
                         },
                         "incr": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "incr  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "attrs": {
+                                                "external": true
+                                            },
+                                            "func": {
+                                                "name": "incr",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
+                                            },
+                                            "name": "incr",
+                                            "params": [
+                                                {
+                                                    "declarator": {
+                                                        "pointer": [
+                                                            {
+                                                                "ptr": "*"
+                                                            }
+                                                        ],
+                                                        "typemap_name": "int"
+                                                    },
+                                                    "specifier": [
+                                                        "int"
+                                                    ],
+                                                    "typemap_name": "int"
+                                                }
+                                            ],
+                                            "typemap_name": "void"
+                                        },
+                                        "specifier": [
+                                            "void"
+                                        ],
+                                        "typemap_name": "void"
+                                    },
+                                    "decl": "void ( * incr)(int *) +external",
+                                    "name": "incr",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true
+                                    },
+                                    "zz_bind": {
+                                        "f": {
+                                            "arg1": {}
+                                        },
+                                        "share": {
+                                            "arg1": {}
+                                        }
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "incr",
+                                        "F_name_api": "incr",
+                                        "function_name": "incr"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_void_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -6378,19 +6738,83 @@
                         "in": {
                             "meta": {
                                 "assumedtype": true,
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_void_*"
                         },
                         "incr": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "incr  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "attrs": {
+                                                "external": true
+                                            },
+                                            "func": {
+                                                "name": "incr",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
+                                            },
+                                            "name": "incr",
+                                            "params": [
+                                                {
+                                                    "declarator": {
+                                                        "pointer": [
+                                                            {
+                                                                "ptr": "*"
+                                                            }
+                                                        ],
+                                                        "typemap_name": "int"
+                                                    },
+                                                    "specifier": [
+                                                        "int"
+                                                    ],
+                                                    "typemap_name": "int"
+                                                }
+                                            ],
+                                            "typemap_name": "void"
+                                        },
+                                        "specifier": [
+                                            "void"
+                                        ],
+                                        "typemap_name": "void"
+                                    },
+                                    "decl": "void ( * incr)(int *) +external",
+                                    "name": "incr",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true
+                                    },
+                                    "zz_bind": {
+                                        "f": {
+                                            "arg1": {}
+                                        },
+                                        "share": {
+                                            "arg1": {}
+                                        }
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "incr",
+                                        "F_name_api": "incr",
+                                        "function_name": "incr"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_void_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -6404,17 +6828,81 @@
                         "in": {
                             "meta": {
                                 "assumedtype": true,
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "incr": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "incr  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "attrs": {
+                                                "external": true
+                                            },
+                                            "func": {
+                                                "name": "incr",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
+                                            },
+                                            "name": "incr",
+                                            "params": [
+                                                {
+                                                    "declarator": {
+                                                        "pointer": [
+                                                            {
+                                                                "ptr": "*"
+                                                            }
+                                                        ],
+                                                        "typemap_name": "int"
+                                                    },
+                                                    "specifier": [
+                                                        "int"
+                                                    ],
+                                                    "typemap_name": "int"
+                                                }
+                                            ],
+                                            "typemap_name": "void"
+                                        },
+                                        "specifier": [
+                                            "void"
+                                        ],
+                                        "typemap_name": "void"
+                                    },
+                                    "decl": "void ( * incr)(int *) +external",
+                                    "name": "incr",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true
+                                    },
+                                    "zz_bind": {
+                                        "f": {
+                                            "arg1": {}
+                                        },
+                                        "share": {
+                                            "arg1": {}
+                                        }
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "incr",
+                                        "F_name_api": "incr",
+                                        "function_name": "incr"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -6718,13 +7206,76 @@
                         "in": {
                             "meta": {
                                 "assumedtype": true,
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_void_*"
                         },
                         "incr": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "incr  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "attrs": {
+                                                "external": true
+                                            },
+                                            "func": {
+                                                "name": "incr",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
+                                            },
+                                            "name": "incr",
+                                            "params": [
+                                                {
+                                                    "declarator": {
+                                                        "pointer": [
+                                                            {
+                                                                "ptr": "*"
+                                                            }
+                                                        ],
+                                                        "typemap_name": "int"
+                                                    },
+                                                    "specifier": [
+                                                        "int"
+                                                    ],
+                                                    "typemap_name": "int"
+                                                }
+                                            ],
+                                            "typemap_name": "void"
+                                        },
+                                        "specifier": [
+                                            "void"
+                                        ],
+                                        "typemap_name": "void"
+                                    },
+                                    "decl": "void ( * incr)(int *) +external",
+                                    "name": "incr",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true
+                                    },
+                                    "zz_bind": {
+                                        "f": {
+                                            "arg1": {}
+                                        },
+                                        "share": {
+                                            "arg1": {}
+                                        }
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "incr",
+                                        "F_name_api": "incr",
+                                        "function_name": "incr"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_void_scalar"
                         },
@@ -6751,13 +7302,76 @@
                         "in": {
                             "meta": {
                                 "assumedtype": true,
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_void_*"
                         },
                         "incr": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "incr  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "attrs": {
+                                                "external": true
+                                            },
+                                            "func": {
+                                                "name": "incr",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
+                                            },
+                                            "name": "incr",
+                                            "params": [
+                                                {
+                                                    "declarator": {
+                                                        "pointer": [
+                                                            {
+                                                                "ptr": "*"
+                                                            }
+                                                        ],
+                                                        "typemap_name": "int"
+                                                    },
+                                                    "specifier": [
+                                                        "int"
+                                                    ],
+                                                    "typemap_name": "int"
+                                                }
+                                            ],
+                                            "typemap_name": "void"
+                                        },
+                                        "specifier": [
+                                            "void"
+                                        ],
+                                        "typemap_name": "void"
+                                    },
+                                    "decl": "void ( * incr)(int *) +external",
+                                    "name": "incr",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true
+                                    },
+                                    "zz_bind": {
+                                        "f": {
+                                            "arg1": {}
+                                        },
+                                        "share": {
+                                            "arg1": {}
+                                        }
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "incr",
+                                        "F_name_api": "incr",
+                                        "function_name": "incr"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_void_scalar"
                         },
@@ -6785,12 +7399,75 @@
                         "in": {
                             "meta": {
                                 "assumedtype": true,
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "incr": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "incr  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "attrs": {
+                                                "external": true
+                                            },
+                                            "func": {
+                                                "name": "incr",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
+                                            },
+                                            "name": "incr",
+                                            "params": [
+                                                {
+                                                    "declarator": {
+                                                        "pointer": [
+                                                            {
+                                                                "ptr": "*"
+                                                            }
+                                                        ],
+                                                        "typemap_name": "int"
+                                                    },
+                                                    "specifier": [
+                                                        "int"
+                                                    ],
+                                                    "typemap_name": "int"
+                                                }
+                                            ],
+                                            "typemap_name": "void"
+                                        },
+                                        "specifier": [
+                                            "void"
+                                        ],
+                                        "typemap_name": "void"
+                                    },
+                                    "decl": "void ( * incr)(int *) +external",
+                                    "name": "incr",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true
+                                    },
+                                    "zz_bind": {
+                                        "f": {
+                                            "arg1": {}
+                                        },
+                                        "share": {
+                                            "arg1": {}
+                                        }
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "incr",
+                                        "F_name_api": "incr",
+                                        "function_name": "incr"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "outbuf": {
@@ -7091,8 +7768,7 @@
                                         {
                                             "declarator": {
                                                 "attrs": {
-                                                    "intent": "in",
-                                                    "value": true
+                                                    "intent": "in"
                                                 },
                                                 "name": "tc",
                                                 "typemap_name": "int"
@@ -7160,7 +7836,103 @@
                         },
                         "alloc": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "alloc  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "func": {
+                                                "name": "alloc",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
+                                            },
+                                            "name": "alloc",
+                                            "params": [
+                                                {
+                                                    "declarator": {
+                                                        "attrs": {
+                                                            "intent": "in"
+                                                        },
+                                                        "name": "tc",
+                                                        "typemap_name": "int"
+                                                    },
+                                                    "specifier": [
+                                                        "int"
+                                                    ],
+                                                    "typemap_name": "int"
+                                                },
+                                                {
+                                                    "declarator": {
+                                                        "attrs": {
+                                                            "intent": "inout"
+                                                        },
+                                                        "name": "arr",
+                                                        "pointer": [
+                                                            {
+                                                                "ptr": "*"
+                                                            }
+                                                        ],
+                                                        "typemap_name": "array_info"
+                                                    },
+                                                    "specifier": [
+                                                        "array_info"
+                                                    ],
+                                                    "typemap_name": "array_info"
+                                                }
+                                            ],
+                                            "typemap_name": "void"
+                                        },
+                                        "specifier": [
+                                            "void"
+                                        ],
+                                        "typemap_name": "void"
+                                    },
+                                    "decl": "void ( * alloc)(int tc +intent(in), array_info * arr +intent(inout))",
+                                    "name": "alloc",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true
+                                    },
+                                    "zz_bind": {
+                                        "f": {
+                                            "arr": {
+                                                "meta": {
+                                                    "intent": "inout"
+                                                }
+                                            },
+                                            "tc": {
+                                                "meta": {
+                                                    "intent": "in",
+                                                    "value": true
+                                                }
+                                            }
+                                        },
+                                        "share": {
+                                            "arr": {
+                                                "meta": {
+                                                    "intent": "inout"
+                                                }
+                                            },
+                                            "tc": {
+                                                "meta": {
+                                                    "intent": "in",
+                                                    "value": true
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "alloc",
+                                        "F_name_api": "alloc",
+                                        "function_name": "alloc"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_void_scalar"
                         },
@@ -7172,7 +7944,8 @@
                         },
                         "tc": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -7186,7 +7959,103 @@
                         },
                         "alloc": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "alloc  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "func": {
+                                                "name": "alloc",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
+                                            },
+                                            "name": "alloc",
+                                            "params": [
+                                                {
+                                                    "declarator": {
+                                                        "attrs": {
+                                                            "intent": "in"
+                                                        },
+                                                        "name": "tc",
+                                                        "typemap_name": "int"
+                                                    },
+                                                    "specifier": [
+                                                        "int"
+                                                    ],
+                                                    "typemap_name": "int"
+                                                },
+                                                {
+                                                    "declarator": {
+                                                        "attrs": {
+                                                            "intent": "inout"
+                                                        },
+                                                        "name": "arr",
+                                                        "pointer": [
+                                                            {
+                                                                "ptr": "*"
+                                                            }
+                                                        ],
+                                                        "typemap_name": "array_info"
+                                                    },
+                                                    "specifier": [
+                                                        "array_info"
+                                                    ],
+                                                    "typemap_name": "array_info"
+                                                }
+                                            ],
+                                            "typemap_name": "void"
+                                        },
+                                        "specifier": [
+                                            "void"
+                                        ],
+                                        "typemap_name": "void"
+                                    },
+                                    "decl": "void ( * alloc)(int tc +intent(in), array_info * arr +intent(inout))",
+                                    "name": "alloc",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true
+                                    },
+                                    "zz_bind": {
+                                        "f": {
+                                            "arr": {
+                                                "meta": {
+                                                    "intent": "inout"
+                                                }
+                                            },
+                                            "tc": {
+                                                "meta": {
+                                                    "intent": "in",
+                                                    "value": true
+                                                }
+                                            }
+                                        },
+                                        "share": {
+                                            "arr": {
+                                                "meta": {
+                                                    "intent": "inout"
+                                                }
+                                            },
+                                            "tc": {
+                                                "meta": {
+                                                    "intent": "in",
+                                                    "value": true
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "alloc",
+                                        "F_name_api": "alloc",
+                                        "function_name": "alloc"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_void_scalar"
                         },
@@ -7198,7 +8067,8 @@
                         },
                         "tc": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -7211,7 +8081,103 @@
                         },
                         "alloc": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "alloc  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "func": {
+                                                "name": "alloc",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
+                                            },
+                                            "name": "alloc",
+                                            "params": [
+                                                {
+                                                    "declarator": {
+                                                        "attrs": {
+                                                            "intent": "in"
+                                                        },
+                                                        "name": "tc",
+                                                        "typemap_name": "int"
+                                                    },
+                                                    "specifier": [
+                                                        "int"
+                                                    ],
+                                                    "typemap_name": "int"
+                                                },
+                                                {
+                                                    "declarator": {
+                                                        "attrs": {
+                                                            "intent": "inout"
+                                                        },
+                                                        "name": "arr",
+                                                        "pointer": [
+                                                            {
+                                                                "ptr": "*"
+                                                            }
+                                                        ],
+                                                        "typemap_name": "array_info"
+                                                    },
+                                                    "specifier": [
+                                                        "array_info"
+                                                    ],
+                                                    "typemap_name": "array_info"
+                                                }
+                                            ],
+                                            "typemap_name": "void"
+                                        },
+                                        "specifier": [
+                                            "void"
+                                        ],
+                                        "typemap_name": "void"
+                                    },
+                                    "decl": "void ( * alloc)(int tc +intent(in), array_info * arr +intent(inout))",
+                                    "name": "alloc",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true
+                                    },
+                                    "zz_bind": {
+                                        "f": {
+                                            "arr": {
+                                                "meta": {
+                                                    "intent": "inout"
+                                                }
+                                            },
+                                            "tc": {
+                                                "meta": {
+                                                    "intent": "in",
+                                                    "value": true
+                                                }
+                                            }
+                                        },
+                                        "share": {
+                                            "arr": {
+                                                "meta": {
+                                                    "intent": "inout"
+                                                }
+                                            },
+                                            "tc": {
+                                                "meta": {
+                                                    "intent": "in",
+                                                    "value": true
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "alloc",
+                                        "F_name_api": "alloc",
+                                        "function_name": "alloc"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arr": {
@@ -7221,7 +8187,8 @@
                         },
                         "tc": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/clibrary/wrapfclibrary.f
+++ b/regression/reference/clibrary/wrapfclibrary.f
@@ -749,7 +749,7 @@ module clibrary_mod
     ! Argument:  array_info * arr +intent(inout)
     ! Statement: f_inout_struct_*
     ! ----------------------------------------
-    ! Argument:  void ( * alloc)(int tc +intent(in)+value, array_info * arr +intent(inout))
+    ! Argument:  void ( * alloc)(int tc +intent(in), array_info * arr +intent(inout))
     ! Statement: f_in_void_scalar
     interface
         subroutine callback_set_alloc(tc, arr, alloc) &

--- a/regression/reference/cxxlibrary/cxxlibrary.json
+++ b/regression/reference/cxxlibrary/cxxlibrary.json
@@ -74,12 +74,14 @@
                                 },
                                 "dfield": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "ifield": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             },
@@ -91,12 +93,14 @@
                                 },
                                 "dfield": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "ifield": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -867,7 +871,8 @@
                                 },
                                 "length": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_native_scalar"
                                 }
@@ -880,7 +885,8 @@
                                 },
                                 "length": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -1016,7 +1022,8 @@
                                 },
                                 "length": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 }
@@ -1029,7 +1036,8 @@
                                 },
                                 "length": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -1170,7 +1178,8 @@
                                 },
                                 "length": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 }
@@ -1183,7 +1192,8 @@
                                 },
                                 "length": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -1319,7 +1329,8 @@
                                 },
                                 "flag": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_native_scalar"
                                 }
@@ -1334,7 +1345,8 @@
                                 },
                                 "flag": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 }
@@ -1347,7 +1359,8 @@
                                 },
                                 "flag": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -1591,13 +1604,15 @@
                                 },
                                 "flag": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_native_scalar"
                                 },
                                 "length": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_native_scalar"
                                 }
@@ -1610,12 +1625,14 @@
                                 },
                                 "flag": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "length": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -1789,13 +1806,15 @@
                                 },
                                 "flag": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 },
                                 "length": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 }
@@ -1808,12 +1827,14 @@
                                 },
                                 "flag": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "length": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -1984,13 +2005,15 @@
                                 },
                                 "flag": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 },
                                 "length": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 }
@@ -2003,12 +2026,14 @@
                                 },
                                 "flag": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "length": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -3195,7 +3220,8 @@
                         },
                         "in1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
@@ -3221,7 +3247,8 @@
                         },
                         "in1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -3246,7 +3273,8 @@
                         },
                         "in1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "out1": {
@@ -3527,13 +3555,15 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_bool_scalar"
                         },
                         "in1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
@@ -3559,13 +3589,15 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_bool_scalar"
                         },
                         "in1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -3590,12 +3622,14 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "in1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "out1": {
@@ -3617,12 +3651,14 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "in1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "out1": {
@@ -4021,7 +4057,8 @@
                         },
                         "idx": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -4034,7 +4071,8 @@
                         },
                         "idx": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4178,7 +4216,8 @@
                         },
                         "idx": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -4191,7 +4230,8 @@
                         },
                         "idx": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4349,7 +4389,8 @@
                         },
                         "idx": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -4362,7 +4403,8 @@
                         },
                         "idx": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/debugfalse/tutorial.json
+++ b/regression/reference/debugfalse/tutorial.json
@@ -238,13 +238,15 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -258,13 +260,15 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -277,12 +281,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -294,12 +300,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -311,12 +319,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1220,7 +1230,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -1234,7 +1245,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -1247,7 +1259,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1441,13 +1454,15 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_bool_scalar"
                         }
@@ -1461,13 +1476,15 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_bool_scalar"
                         }
@@ -1480,12 +1497,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1497,12 +1516,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1514,12 +1535,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2075,7 +2098,8 @@
                         },
                         "indx": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -2089,7 +2113,8 @@
                         },
                         "indx": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -2102,7 +2127,8 @@
                         },
                         "indx": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2114,7 +2140,8 @@
                         },
                         "indx": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2126,7 +2153,8 @@
                         },
                         "indx": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2319,7 +2347,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2408,7 +2437,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -2422,7 +2452,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -2435,7 +2466,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2447,7 +2479,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2459,7 +2492,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2666,7 +2700,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -2680,7 +2715,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -2693,7 +2729,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2705,7 +2742,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2717,7 +2755,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3461,7 +3500,8 @@
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
@@ -3480,7 +3520,8 @@
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "name": {
@@ -3497,7 +3538,8 @@
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "name": {
@@ -3514,7 +3556,8 @@
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "name": {
@@ -3735,7 +3778,8 @@
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -3755,7 +3799,8 @@
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "name": {
@@ -3923,7 +3968,8 @@
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -3943,7 +3989,8 @@
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "name": {
@@ -4092,7 +4139,8 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -4106,7 +4154,8 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -4119,7 +4168,8 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4304,13 +4354,15 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -4324,13 +4376,15 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -4343,12 +4397,14 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4593,19 +4649,22 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -4619,19 +4678,22 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -4644,17 +4706,20 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -4666,17 +4731,20 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -4688,17 +4756,20 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -5086,13 +5157,15 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -5106,13 +5179,15 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -5125,12 +5200,14 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -5363,19 +5440,22 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -5389,19 +5469,22 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -5414,17 +5497,20 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -5717,25 +5803,29 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -5749,25 +5839,29 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -5780,22 +5874,26 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -5807,22 +5905,26 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -5834,22 +5936,26 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -6294,7 +6400,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -6308,7 +6415,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -6321,7 +6429,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -6333,7 +6442,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -6345,7 +6455,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -6569,7 +6680,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -6583,7 +6695,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -6596,7 +6709,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -6608,7 +6722,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -6620,7 +6735,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -6854,7 +6970,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -6868,7 +6985,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -6881,7 +6999,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -6893,7 +7012,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -6905,7 +7025,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -7446,9 +7567,6 @@
                                     "params": [
                                         {
                                             "declarator": {
-                                                "attrs": {
-                                                    "value": true
-                                                },
                                                 "typemap_name": "int"
                                             },
                                             "specifier": [
@@ -7497,13 +7615,76 @@
                         },
                         "in": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "incr": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "incr  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "func": {
+                                                "name": "incr",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            "name": "incr",
+                                            "params": [
+                                                {
+                                                    "declarator": {
+                                                        "typemap_name": "int"
+                                                    },
+                                                    "specifier": [
+                                                        "int"
+                                                    ],
+                                                    "typemap_name": "int"
+                                                }
+                                            ],
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    },
+                                    "decl": "int ( * incr)(int)",
+                                    "name": "incr",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true
+                                    },
+                                    "zz_bind": {
+                                        "f": {
+                                            "arg1": {
+                                                "meta": {
+                                                    "value": true
+                                                }
+                                            }
+                                        },
+                                        "share": {
+                                            "arg1": {
+                                                "meta": {
+                                                    "value": true
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "incr",
+                                        "F_name_api": "incr",
+                                        "function_name": "incr"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -7517,13 +7698,76 @@
                         },
                         "in": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "incr": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "incr  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "func": {
+                                                "name": "incr",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            "name": "incr",
+                                            "params": [
+                                                {
+                                                    "declarator": {
+                                                        "typemap_name": "int"
+                                                    },
+                                                    "specifier": [
+                                                        "int"
+                                                    ],
+                                                    "typemap_name": "int"
+                                                }
+                                            ],
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    },
+                                    "decl": "int ( * incr)(int)",
+                                    "name": "incr",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true
+                                    },
+                                    "zz_bind": {
+                                        "f": {
+                                            "arg1": {
+                                                "meta": {
+                                                    "value": true
+                                                }
+                                            }
+                                        },
+                                        "share": {
+                                            "arg1": {
+                                                "meta": {
+                                                    "value": true
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "incr",
+                                        "F_name_api": "incr",
+                                        "function_name": "incr"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -7536,12 +7780,75 @@
                         },
                         "in": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "incr": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "incr  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "func": {
+                                                "name": "incr",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            "name": "incr",
+                                            "params": [
+                                                {
+                                                    "declarator": {
+                                                        "typemap_name": "int"
+                                                    },
+                                                    "specifier": [
+                                                        "int"
+                                                    ],
+                                                    "typemap_name": "int"
+                                                }
+                                            ],
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    },
+                                    "decl": "int ( * incr)(int)",
+                                    "name": "incr",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true
+                                    },
+                                    "zz_bind": {
+                                        "f": {
+                                            "arg1": {
+                                                "meta": {
+                                                    "value": true
+                                                }
+                                            }
+                                        },
+                                        "share": {
+                                            "arg1": {
+                                                "meta": {
+                                                    "value": true
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "incr",
+                                        "F_name_api": "incr",
+                                        "function_name": "incr"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/defaultarg/defaultarg.json
+++ b/regression/reference/defaultarg/defaultarg.json
@@ -68,7 +68,8 @@
                                 },
                                 "arg1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_native_scalar"
                                 }
@@ -83,7 +84,8 @@
                                 },
                                 "arg1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 }
@@ -96,7 +98,8 @@
                                 },
                                 "arg1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -289,13 +292,15 @@
                                 },
                                 "arg1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_native_scalar"
                                 },
                                 "arg2": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_native_scalar"
                                 }
@@ -310,13 +315,15 @@
                                 },
                                 "arg1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 },
                                 "arg2": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 }
@@ -329,12 +336,14 @@
                                 },
                                 "arg1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "arg2": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -585,19 +594,22 @@
                                 },
                                 "arg1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_native_scalar"
                                 },
                                 "arg2": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_native_scalar"
                                 },
                                 "arg3": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_native_scalar"
                                 }
@@ -612,19 +624,22 @@
                                 },
                                 "arg1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 },
                                 "arg2": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 },
                                 "arg3": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 }
@@ -637,17 +652,20 @@
                                 },
                                 "arg1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "arg2": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "arg3": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -998,7 +1016,8 @@
                                 },
                                 "arg1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_native_scalar"
                                 }
@@ -1012,7 +1031,8 @@
                                 },
                                 "arg1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 }
@@ -1025,7 +1045,8 @@
                                 },
                                 "arg1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -1177,13 +1198,15 @@
                                 },
                                 "arg1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_native_scalar"
                                 },
                                 "arg2": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_native_scalar"
                                 }
@@ -1197,13 +1220,15 @@
                                 },
                                 "arg1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 },
                                 "arg2": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 }
@@ -1216,12 +1241,14 @@
                                 },
                                 "arg1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "arg2": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -1431,19 +1458,22 @@
                                 },
                                 "arg1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_native_scalar"
                                 },
                                 "arg2": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_native_scalar"
                                 },
                                 "arg3": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_native_scalar"
                                 }
@@ -1457,19 +1487,22 @@
                                 },
                                 "arg1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 },
                                 "arg2": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 },
                                 "arg3": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 }
@@ -1482,17 +1515,20 @@
                                 },
                                 "arg1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "arg2": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "arg3": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -2177,7 +2213,8 @@
                         },
                         "num_elems": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -2191,7 +2228,8 @@
                         },
                         "num_elems": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -2204,7 +2242,8 @@
                         },
                         "num_elems": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2356,13 +2395,15 @@
                         },
                         "num_elems": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -2376,13 +2417,15 @@
                         },
                         "num_elems": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -2395,12 +2438,14 @@
                         },
                         "num_elems": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2610,19 +2655,22 @@
                         },
                         "num_elems": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -2636,19 +2684,22 @@
                         },
                         "num_elems": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -2661,17 +2712,20 @@
                         },
                         "num_elems": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2908,13 +2962,15 @@
                         },
                         "num_elems": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -2928,13 +2984,15 @@
                         },
                         "num_elems": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -2947,12 +3005,14 @@
                         },
                         "num_elems": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3161,19 +3221,22 @@
                         },
                         "num_elems": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -3187,19 +3250,22 @@
                         },
                         "num_elems": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -3212,17 +3278,20 @@
                         },
                         "num_elems": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3489,25 +3558,29 @@
                         },
                         "num_elems": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -3521,25 +3594,29 @@
                         },
                         "num_elems": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -3552,22 +3629,26 @@
                         },
                         "num_elems": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3857,19 +3938,22 @@
                         },
                         "num_elems": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -3883,19 +3967,22 @@
                         },
                         "num_elems": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -3908,17 +3995,20 @@
                         },
                         "num_elems": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4171,25 +4261,29 @@
                         },
                         "num_elems": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -4203,25 +4297,29 @@
                         },
                         "num_elems": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -4234,22 +4332,26 @@
                         },
                         "num_elems": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4539,19 +4641,22 @@
                         },
                         "num_elems": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -4565,19 +4670,22 @@
                         },
                         "num_elems": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -4590,17 +4698,20 @@
                         },
                         "num_elems": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4855,25 +4966,29 @@
                         },
                         "num_elems": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -4887,25 +5002,29 @@
                         },
                         "num_elems": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -4918,22 +5037,26 @@
                         },
                         "num_elems": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/enum-c/enum.json
+++ b/regression/reference/enum-c/enum.json
@@ -255,7 +255,8 @@
                         },
                         "in": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -269,7 +270,8 @@
                         },
                         "in": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -282,7 +284,8 @@
                         },
                         "in": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -294,7 +297,8 @@
                         },
                         "in": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/enum-cxx/enum.json
+++ b/regression/reference/enum-cxx/enum.json
@@ -255,7 +255,8 @@
                         },
                         "in": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -269,7 +270,8 @@
                         },
                         "in": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -282,7 +284,8 @@
                         },
                         "in": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -294,7 +297,8 @@
                         },
                         "in": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/error-ast/error-ast.json
+++ b/regression/reference/error-ast/error-ast.json
@@ -122,7 +122,8 @@
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/error-generate/error-generate.json
+++ b/regression/reference/error-generate/error-generate.json
@@ -341,9 +341,10 @@
                                 "intent": "subroutine"
                             }
                         },
-                        "no-name": {
+                        "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -591,7 +592,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -645,7 +647,8 @@
                         "arg1": {
                             "meta": {
                                 "assumedtype": true,
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -697,7 +700,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -749,7 +753,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1056,7 +1061,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "inout"
+                                "intent": "inout",
+                                "value": true
                             }
                         }
                     }
@@ -1108,7 +1114,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "out"
+                                "intent": "out",
+                                "value": true
                             }
                         }
                     }
@@ -1416,7 +1423,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -1429,7 +1437,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1441,7 +1450,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1493,7 +1503,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1665,7 +1676,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1720,7 +1732,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1776,7 +1789,8 @@
                         "arg1": {
                             "meta": {
                                 "intent": "in",
-                                "rank": 2
+                                "rank": 2,
+                                "value": true
                             }
                         }
                     }
@@ -1916,7 +1930,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1993,7 +2008,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2074,12 +2090,14 @@
                         },
                         "mtext": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "ntext": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "text": {
@@ -2165,12 +2183,14 @@
                         },
                         "mtext": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "ntext": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "text": {
@@ -2208,8 +2228,7 @@
                                         {
                                             "declarator": {
                                                 "attrs": {
-                                                    "intent": "inout",
-                                                    "value": true
+                                                    "intent": "none"
                                                 },
                                                 "name": "tc",
                                                 "typemap_name": "int"
@@ -2249,7 +2268,68 @@
                         },
                         "alloc": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "alloc  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "func": {
+                                                "name": "alloc",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
+                                            },
+                                            "name": "alloc",
+                                            "params": [
+                                                {
+                                                    "declarator": {
+                                                        "attrs": {
+                                                            "intent": "none"
+                                                        },
+                                                        "name": "tc",
+                                                        "typemap_name": "int"
+                                                    },
+                                                    "specifier": [
+                                                        "int"
+                                                    ],
+                                                    "typemap_name": "int"
+                                                }
+                                            ],
+                                            "typemap_name": "void"
+                                        },
+                                        "specifier": [
+                                            "void"
+                                        ],
+                                        "typemap_name": "void"
+                                    },
+                                    "decl": "void ( * alloc)(int tc +intent(none))",
+                                    "name": "alloc",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true,
+                                        "python": true
+                                    },
+                                    "zz_bind": {
+                                        "share": {
+                                            "tc": {
+                                                "meta": {
+                                                    "intent": "inout",
+                                                    "value": true
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "alloc",
+                                        "F_name_api": "alloc",
+                                        "function_name": "alloc"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2473,12 +2553,14 @@
                         },
                         "nfrom": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "nto": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "to": {
@@ -2592,12 +2674,14 @@
                         },
                         "nfrom": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "nto": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "to": {
@@ -2713,12 +2797,14 @@
                         },
                         "nfrom": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "nto": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "to": {
@@ -2740,12 +2826,14 @@
                         },
                         "nfrom": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "nto": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "to": {

--- a/regression/reference/error/error.json
+++ b/regression/reference/error/error.json
@@ -168,7 +168,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     },
                                     "stmt": "f_setter_native_scalar"
                                 }
@@ -181,7 +182,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     }
                                 }
                             }
@@ -406,7 +408,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     },
                                     "stmt": "f_setter_native_scalar"
                                 }
@@ -419,7 +422,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     }
                                 }
                             }
@@ -644,7 +648,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     },
                                     "stmt": "f_setter_native_scalar"
                                 }
@@ -657,7 +662,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     }
                                 }
                             }

--- a/regression/reference/example/example.json
+++ b/regression/reference/example/example.json
@@ -693,7 +693,8 @@
                                                 },
                                                 "incr": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     },
                                                     "stmt": "c_in_native_scalar"
                                                 }
@@ -707,7 +708,8 @@
                                                 },
                                                 "incr": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     },
                                                     "stmt": "f_in_native_scalar"
                                                 }
@@ -720,7 +722,8 @@
                                                 },
                                                 "incr": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             },
@@ -732,7 +735,8 @@
                                                 },
                                                 "incr": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             },
@@ -744,7 +748,8 @@
                                                 },
                                                 "incr": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             }
@@ -1384,7 +1389,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     },
                                                     "stmt": "c_in_native_scalar"
                                                 }
@@ -1398,7 +1404,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     },
                                                     "stmt": "f_in_native_scalar"
                                                 }
@@ -1411,7 +1418,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             },
@@ -1423,7 +1431,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             },
@@ -1435,7 +1444,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             }
@@ -1665,7 +1675,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     },
                                                     "stmt": "c_in_native_scalar"
                                                 }
@@ -1679,7 +1690,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     },
                                                     "stmt": "f_in_native_scalar"
                                                 }
@@ -1692,7 +1704,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             },
@@ -1704,7 +1717,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             },
@@ -1716,7 +1730,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             }
@@ -1942,7 +1957,8 @@
                                                 },
                                                 "in": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     },
                                                     "stmt": "c_in_bool_scalar"
                                                 }
@@ -1956,7 +1972,8 @@
                                                 },
                                                 "in": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     },
                                                     "stmt": "f_in_bool_scalar"
                                                 }
@@ -1969,7 +1986,8 @@
                                                 },
                                                 "in": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             },
@@ -1981,7 +1999,8 @@
                                                 },
                                                 "in": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             },
@@ -1993,7 +2012,8 @@
                                                 },
                                                 "in": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             }
@@ -4191,7 +4211,8 @@
                                                 },
                                                 "type": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     },
                                                     "stmt": "c_in_native_scalar"
                                                 }
@@ -4206,7 +4227,8 @@
                                                 },
                                                 "type": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     },
                                                     "stmt": "f_in_native_scalar"
                                                 }
@@ -4219,7 +4241,8 @@
                                                 },
                                                 "type": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             }
@@ -4469,13 +4492,15 @@
                                                 },
                                                 "len": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     },
                                                     "stmt": "c_in_native_scalar"
                                                 },
                                                 "type": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     },
                                                     "stmt": "c_in_native_scalar"
                                                 }
@@ -4488,12 +4513,14 @@
                                                 },
                                                 "len": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 },
                                                 "type": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             },
@@ -4505,12 +4532,14 @@
                                                 },
                                                 "len": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 },
                                                 "type": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             },
@@ -4522,12 +4551,14 @@
                                                 },
                                                 "len": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 },
                                                 "type": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             }
@@ -4801,13 +4832,15 @@
                                                 },
                                                 "len": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     },
                                                     "stmt": "f_in_native_scalar"
                                                 },
                                                 "type": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     },
                                                     "stmt": "f_in_native_scalar"
                                                 }
@@ -4820,12 +4853,14 @@
                                                 },
                                                 "len": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 },
                                                 "type": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             }
@@ -4998,13 +5033,15 @@
                                                 },
                                                 "len": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     },
                                                     "stmt": "f_in_native_scalar"
                                                 },
                                                 "type": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     },
                                                     "stmt": "f_in_native_scalar"
                                                 }
@@ -5017,12 +5054,14 @@
                                                 },
                                                 "len": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 },
                                                 "type": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             }
@@ -5496,7 +5535,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             }
@@ -5607,7 +5647,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     },
                                                     "stmt": "c_in_native_scalar"
                                                 }
@@ -5621,7 +5662,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     },
                                                     "stmt": "f_in_native_scalar"
                                                 }
@@ -5634,7 +5676,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             },
@@ -5646,7 +5689,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             },
@@ -5658,7 +5702,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             }
@@ -5887,7 +5932,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     },
                                                     "stmt": "c_in_native_scalar"
                                                 }
@@ -5901,7 +5947,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     },
                                                     "stmt": "f_in_native_scalar"
                                                 }
@@ -5914,7 +5961,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             },
@@ -5926,7 +5974,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             },
@@ -5938,7 +5987,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             }
@@ -6164,7 +6214,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     },
                                                     "stmt": "c_in_native_scalar"
                                                 }
@@ -6178,7 +6229,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     },
                                                     "stmt": "f_in_native_scalar"
                                                 }
@@ -6191,7 +6243,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             },
@@ -6203,7 +6256,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             },
@@ -6215,7 +6269,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             }
@@ -6447,7 +6502,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     },
                                                     "stmt": "c_in_native_scalar"
                                                 }
@@ -6461,7 +6517,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     },
                                                     "stmt": "f_in_native_scalar"
                                                 }
@@ -6474,7 +6531,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             },
@@ -6486,7 +6544,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             },
@@ -6498,7 +6557,8 @@
                                                 },
                                                 "value": {
                                                     "meta": {
-                                                        "intent": "in"
+                                                        "intent": "in",
+                                                        "value": true
                                                     }
                                                 }
                                             }
@@ -8068,7 +8128,8 @@
                                         },
                                         "flag": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "c_in_native_scalar"
                                         },
@@ -8088,7 +8149,8 @@
                                         },
                                         "flag": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "f_in_native_scalar"
                                         },
@@ -8108,7 +8170,8 @@
                                         },
                                         "flag": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "name": {
@@ -8125,7 +8188,8 @@
                                         },
                                         "flag": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "name": {
@@ -8142,7 +8206,8 @@
                                         },
                                         "flag": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "name": {
@@ -8498,7 +8563,8 @@
                                         },
                                         "i": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "c_in_native_scalar"
                                         }
@@ -8512,7 +8578,8 @@
                                         },
                                         "i": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "f_in_native_scalar"
                                         }
@@ -8525,7 +8592,8 @@
                                         },
                                         "i": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     }
@@ -8677,13 +8745,15 @@
                                         },
                                         "i": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "c_in_native_scalar"
                                         },
                                         "j": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "c_in_native_scalar"
                                         }
@@ -8697,13 +8767,15 @@
                                         },
                                         "i": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "f_in_native_scalar"
                                         },
                                         "j": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "f_in_native_scalar"
                                         }
@@ -8716,12 +8788,14 @@
                                         },
                                         "i": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "j": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     },
@@ -8733,12 +8807,14 @@
                                         },
                                         "i": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "j": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     },
@@ -8750,12 +8826,14 @@
                                         },
                                         "i": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "j": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     }
@@ -9162,7 +9240,8 @@
                                         },
                                         "comm": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "c_in_unknown_scalar"
                                         }
@@ -9176,7 +9255,8 @@
                                         },
                                         "comm": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "f_in_unknown_scalar"
                                         }
@@ -9189,7 +9269,8 @@
                                         },
                                         "comm": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     },
@@ -9201,7 +9282,8 @@
                                         },
                                         "comm": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     },
@@ -9213,7 +9295,8 @@
                                         },
                                         "comm": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     }
@@ -9505,7 +9588,45 @@
                                         },
                                         "get": {
                                             "meta": {
-                                                "intent": "in"
+                                                "fptr": {
+                                                    "<FUNCTION>": "get  None ****************************************",
+                                                    "ast": {
+                                                        "declarator": {
+                                                            "func": {
+                                                                "name": "get",
+                                                                "pointer": [
+                                                                    {
+                                                                        "ptr": "*"
+                                                                    }
+                                                                ],
+                                                                "typemap_name": "void"
+                                                            },
+                                                            "name": "get",
+                                                            "params": [],
+                                                            "typemap_name": "void"
+                                                        },
+                                                        "specifier": [
+                                                            "void"
+                                                        ],
+                                                        "typemap_name": "void"
+                                                    },
+                                                    "decl": "void ( * get)(void)",
+                                                    "name": "get",
+                                                    "options": {},
+                                                    "wrap": {
+                                                        "c": true,
+                                                        "fortran": true,
+                                                        "lua": true,
+                                                        "python": true
+                                                    },
+                                                    "zz_fmtdict": {
+                                                        "C_name_api": "get",
+                                                        "F_name_api": "get",
+                                                        "function_name": "get"
+                                                    }
+                                                },
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "c_in_void_scalar"
                                         }
@@ -9519,7 +9640,45 @@
                                         },
                                         "get": {
                                             "meta": {
-                                                "intent": "in"
+                                                "fptr": {
+                                                    "<FUNCTION>": "get  None ****************************************",
+                                                    "ast": {
+                                                        "declarator": {
+                                                            "func": {
+                                                                "name": "get",
+                                                                "pointer": [
+                                                                    {
+                                                                        "ptr": "*"
+                                                                    }
+                                                                ],
+                                                                "typemap_name": "void"
+                                                            },
+                                                            "name": "get",
+                                                            "params": [],
+                                                            "typemap_name": "void"
+                                                        },
+                                                        "specifier": [
+                                                            "void"
+                                                        ],
+                                                        "typemap_name": "void"
+                                                    },
+                                                    "decl": "void ( * get)(void)",
+                                                    "name": "get",
+                                                    "options": {},
+                                                    "wrap": {
+                                                        "c": true,
+                                                        "fortran": true,
+                                                        "lua": true,
+                                                        "python": true
+                                                    },
+                                                    "zz_fmtdict": {
+                                                        "C_name_api": "get",
+                                                        "F_name_api": "get",
+                                                        "function_name": "get"
+                                                    }
+                                                },
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "f_in_void_scalar"
                                         }
@@ -9532,7 +9691,45 @@
                                         },
                                         "get": {
                                             "meta": {
-                                                "intent": "in"
+                                                "fptr": {
+                                                    "<FUNCTION>": "get  None ****************************************",
+                                                    "ast": {
+                                                        "declarator": {
+                                                            "func": {
+                                                                "name": "get",
+                                                                "pointer": [
+                                                                    {
+                                                                        "ptr": "*"
+                                                                    }
+                                                                ],
+                                                                "typemap_name": "void"
+                                                            },
+                                                            "name": "get",
+                                                            "params": [],
+                                                            "typemap_name": "void"
+                                                        },
+                                                        "specifier": [
+                                                            "void"
+                                                        ],
+                                                        "typemap_name": "void"
+                                                    },
+                                                    "decl": "void ( * get)(void)",
+                                                    "name": "get",
+                                                    "options": {},
+                                                    "wrap": {
+                                                        "c": true,
+                                                        "fortran": true,
+                                                        "lua": true,
+                                                        "python": true
+                                                    },
+                                                    "zz_fmtdict": {
+                                                        "C_name_api": "get",
+                                                        "F_name_api": "get",
+                                                        "function_name": "get"
+                                                    }
+                                                },
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     },
@@ -9544,7 +9741,45 @@
                                         },
                                         "get": {
                                             "meta": {
-                                                "intent": "in"
+                                                "fptr": {
+                                                    "<FUNCTION>": "get  None ****************************************",
+                                                    "ast": {
+                                                        "declarator": {
+                                                            "func": {
+                                                                "name": "get",
+                                                                "pointer": [
+                                                                    {
+                                                                        "ptr": "*"
+                                                                    }
+                                                                ],
+                                                                "typemap_name": "void"
+                                                            },
+                                                            "name": "get",
+                                                            "params": [],
+                                                            "typemap_name": "void"
+                                                        },
+                                                        "specifier": [
+                                                            "void"
+                                                        ],
+                                                        "typemap_name": "void"
+                                                    },
+                                                    "decl": "void ( * get)(void)",
+                                                    "name": "get",
+                                                    "options": {},
+                                                    "wrap": {
+                                                        "c": true,
+                                                        "fortran": true,
+                                                        "lua": true,
+                                                        "python": true
+                                                    },
+                                                    "zz_fmtdict": {
+                                                        "C_name_api": "get",
+                                                        "F_name_api": "get",
+                                                        "function_name": "get"
+                                                    }
+                                                },
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     },
@@ -9556,7 +9791,45 @@
                                         },
                                         "get": {
                                             "meta": {
-                                                "intent": "in"
+                                                "fptr": {
+                                                    "<FUNCTION>": "get  None ****************************************",
+                                                    "ast": {
+                                                        "declarator": {
+                                                            "func": {
+                                                                "name": "get",
+                                                                "pointer": [
+                                                                    {
+                                                                        "ptr": "*"
+                                                                    }
+                                                                ],
+                                                                "typemap_name": "void"
+                                                            },
+                                                            "name": "get",
+                                                            "params": [],
+                                                            "typemap_name": "void"
+                                                        },
+                                                        "specifier": [
+                                                            "void"
+                                                        ],
+                                                        "typemap_name": "void"
+                                                    },
+                                                    "decl": "void ( * get)(void)",
+                                                    "name": "get",
+                                                    "options": {},
+                                                    "wrap": {
+                                                        "c": true,
+                                                        "fortran": true,
+                                                        "lua": true,
+                                                        "python": true
+                                                    },
+                                                    "zz_fmtdict": {
+                                                        "C_name_api": "get",
+                                                        "F_name_api": "get",
+                                                        "function_name": "get"
+                                                    }
+                                                },
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     }
@@ -9739,6 +10012,48 @@
                                         },
                                         "get": {
                                             "meta": {
+                                                "fptr": {
+                                                    "<FUNCTION>": "get  None ****************************************",
+                                                    "ast": {
+                                                        "declarator": {
+                                                            "func": {
+                                                                "name": "get",
+                                                                "pointer": [
+                                                                    {
+                                                                        "ptr": "*"
+                                                                    }
+                                                                ],
+                                                                "typemap_name": "double"
+                                                            },
+                                                            "name": "get",
+                                                            "params": [],
+                                                            "pointer": [
+                                                                {
+                                                                    "ptr": "*"
+                                                                }
+                                                            ],
+                                                            "typemap_name": "double"
+                                                        },
+                                                        "specifier": [
+                                                            "double"
+                                                        ],
+                                                        "typemap_name": "double"
+                                                    },
+                                                    "decl": "double * ( * get)(void)",
+                                                    "name": "get",
+                                                    "options": {},
+                                                    "wrap": {
+                                                        "c": true,
+                                                        "fortran": true,
+                                                        "lua": true,
+                                                        "python": true
+                                                    },
+                                                    "zz_fmtdict": {
+                                                        "C_name_api": "get",
+                                                        "F_name_api": "get",
+                                                        "function_name": "get"
+                                                    }
+                                                },
                                                 "intent": "in"
                                             },
                                             "stmt": "c_in_native_*"
@@ -9753,6 +10068,48 @@
                                         },
                                         "get": {
                                             "meta": {
+                                                "fptr": {
+                                                    "<FUNCTION>": "get  None ****************************************",
+                                                    "ast": {
+                                                        "declarator": {
+                                                            "func": {
+                                                                "name": "get",
+                                                                "pointer": [
+                                                                    {
+                                                                        "ptr": "*"
+                                                                    }
+                                                                ],
+                                                                "typemap_name": "double"
+                                                            },
+                                                            "name": "get",
+                                                            "params": [],
+                                                            "pointer": [
+                                                                {
+                                                                    "ptr": "*"
+                                                                }
+                                                            ],
+                                                            "typemap_name": "double"
+                                                        },
+                                                        "specifier": [
+                                                            "double"
+                                                        ],
+                                                        "typemap_name": "double"
+                                                    },
+                                                    "decl": "double * ( * get)(void)",
+                                                    "name": "get",
+                                                    "options": {},
+                                                    "wrap": {
+                                                        "c": true,
+                                                        "fortran": true,
+                                                        "lua": true,
+                                                        "python": true
+                                                    },
+                                                    "zz_fmtdict": {
+                                                        "C_name_api": "get",
+                                                        "F_name_api": "get",
+                                                        "function_name": "get"
+                                                    }
+                                                },
                                                 "intent": "in"
                                             },
                                             "stmt": "f_in_native_*"
@@ -9766,6 +10123,48 @@
                                         },
                                         "get": {
                                             "meta": {
+                                                "fptr": {
+                                                    "<FUNCTION>": "get  None ****************************************",
+                                                    "ast": {
+                                                        "declarator": {
+                                                            "func": {
+                                                                "name": "get",
+                                                                "pointer": [
+                                                                    {
+                                                                        "ptr": "*"
+                                                                    }
+                                                                ],
+                                                                "typemap_name": "double"
+                                                            },
+                                                            "name": "get",
+                                                            "params": [],
+                                                            "pointer": [
+                                                                {
+                                                                    "ptr": "*"
+                                                                }
+                                                            ],
+                                                            "typemap_name": "double"
+                                                        },
+                                                        "specifier": [
+                                                            "double"
+                                                        ],
+                                                        "typemap_name": "double"
+                                                    },
+                                                    "decl": "double * ( * get)(void)",
+                                                    "name": "get",
+                                                    "options": {},
+                                                    "wrap": {
+                                                        "c": true,
+                                                        "fortran": true,
+                                                        "lua": true,
+                                                        "python": true
+                                                    },
+                                                    "zz_fmtdict": {
+                                                        "C_name_api": "get",
+                                                        "F_name_api": "get",
+                                                        "function_name": "get"
+                                                    }
+                                                },
                                                 "intent": "in"
                                             }
                                         }
@@ -9778,6 +10177,48 @@
                                         },
                                         "get": {
                                             "meta": {
+                                                "fptr": {
+                                                    "<FUNCTION>": "get  None ****************************************",
+                                                    "ast": {
+                                                        "declarator": {
+                                                            "func": {
+                                                                "name": "get",
+                                                                "pointer": [
+                                                                    {
+                                                                        "ptr": "*"
+                                                                    }
+                                                                ],
+                                                                "typemap_name": "double"
+                                                            },
+                                                            "name": "get",
+                                                            "params": [],
+                                                            "pointer": [
+                                                                {
+                                                                    "ptr": "*"
+                                                                }
+                                                            ],
+                                                            "typemap_name": "double"
+                                                        },
+                                                        "specifier": [
+                                                            "double"
+                                                        ],
+                                                        "typemap_name": "double"
+                                                    },
+                                                    "decl": "double * ( * get)(void)",
+                                                    "name": "get",
+                                                    "options": {},
+                                                    "wrap": {
+                                                        "c": true,
+                                                        "fortran": true,
+                                                        "lua": true,
+                                                        "python": true
+                                                    },
+                                                    "zz_fmtdict": {
+                                                        "C_name_api": "get",
+                                                        "F_name_api": "get",
+                                                        "function_name": "get"
+                                                    }
+                                                },
                                                 "intent": "in"
                                             }
                                         }
@@ -9790,6 +10231,48 @@
                                         },
                                         "get": {
                                             "meta": {
+                                                "fptr": {
+                                                    "<FUNCTION>": "get  None ****************************************",
+                                                    "ast": {
+                                                        "declarator": {
+                                                            "func": {
+                                                                "name": "get",
+                                                                "pointer": [
+                                                                    {
+                                                                        "ptr": "*"
+                                                                    }
+                                                                ],
+                                                                "typemap_name": "double"
+                                                            },
+                                                            "name": "get",
+                                                            "params": [],
+                                                            "pointer": [
+                                                                {
+                                                                    "ptr": "*"
+                                                                }
+                                                            ],
+                                                            "typemap_name": "double"
+                                                        },
+                                                        "specifier": [
+                                                            "double"
+                                                        ],
+                                                        "typemap_name": "double"
+                                                    },
+                                                    "decl": "double * ( * get)(void)",
+                                                    "name": "get",
+                                                    "options": {},
+                                                    "wrap": {
+                                                        "c": true,
+                                                        "fortran": true,
+                                                        "lua": true,
+                                                        "python": true
+                                                    },
+                                                    "zz_fmtdict": {
+                                                        "C_name_api": "get",
+                                                        "F_name_api": "get",
+                                                        "function_name": "get"
+                                                    }
+                                                },
                                                 "intent": "in"
                                             }
                                         }
@@ -9934,9 +10417,6 @@
                                                     "params": [
                                                         {
                                                             "declarator": {
-                                                                "attrs": {
-                                                                    "value": true
-                                                                },
                                                                 "name": "i",
                                                                 "typemap_name": "int"
                                                             },
@@ -9947,9 +10427,6 @@
                                                         },
                                                         {
                                                             "declarator": {
-                                                                "attrs": {
-                                                                    "value": true
-                                                                },
                                                                 "typemap_name": "int"
                                                             },
                                                             "specifier": [
@@ -9998,7 +10475,91 @@
                                         },
                                         "get": {
                                             "meta": {
-                                                "intent": "in"
+                                                "fptr": {
+                                                    "<FUNCTION>": "get  None ****************************************",
+                                                    "ast": {
+                                                        "declarator": {
+                                                            "func": {
+                                                                "name": "get",
+                                                                "pointer": [
+                                                                    {
+                                                                        "ptr": "*"
+                                                                    }
+                                                                ],
+                                                                "typemap_name": "double"
+                                                            },
+                                                            "name": "get",
+                                                            "params": [
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "i",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                }
+                                                            ],
+                                                            "typemap_name": "double"
+                                                        },
+                                                        "specifier": [
+                                                            "double"
+                                                        ],
+                                                        "typemap_name": "double"
+                                                    },
+                                                    "decl": "double ( * get)(int i, int)",
+                                                    "name": "get",
+                                                    "options": {},
+                                                    "wrap": {
+                                                        "c": true,
+                                                        "fortran": true,
+                                                        "lua": true,
+                                                        "python": true
+                                                    },
+                                                    "zz_bind": {
+                                                        "f": {
+                                                            "arg2": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "i": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            }
+                                                        },
+                                                        "share": {
+                                                            "arg2": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "i": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "zz_fmtdict": {
+                                                        "C_name_api": "get",
+                                                        "F_name_api": "get",
+                                                        "function_name": "get"
+                                                    }
+                                                },
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "c_in_native_scalar"
                                         }
@@ -10012,7 +10573,91 @@
                                         },
                                         "get": {
                                             "meta": {
-                                                "intent": "in"
+                                                "fptr": {
+                                                    "<FUNCTION>": "get  None ****************************************",
+                                                    "ast": {
+                                                        "declarator": {
+                                                            "func": {
+                                                                "name": "get",
+                                                                "pointer": [
+                                                                    {
+                                                                        "ptr": "*"
+                                                                    }
+                                                                ],
+                                                                "typemap_name": "double"
+                                                            },
+                                                            "name": "get",
+                                                            "params": [
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "i",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                }
+                                                            ],
+                                                            "typemap_name": "double"
+                                                        },
+                                                        "specifier": [
+                                                            "double"
+                                                        ],
+                                                        "typemap_name": "double"
+                                                    },
+                                                    "decl": "double ( * get)(int i, int)",
+                                                    "name": "get",
+                                                    "options": {},
+                                                    "wrap": {
+                                                        "c": true,
+                                                        "fortran": true,
+                                                        "lua": true,
+                                                        "python": true
+                                                    },
+                                                    "zz_bind": {
+                                                        "f": {
+                                                            "arg2": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "i": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            }
+                                                        },
+                                                        "share": {
+                                                            "arg2": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "i": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "zz_fmtdict": {
+                                                        "C_name_api": "get",
+                                                        "F_name_api": "get",
+                                                        "function_name": "get"
+                                                    }
+                                                },
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "f_in_native_scalar"
                                         }
@@ -10025,7 +10670,91 @@
                                         },
                                         "get": {
                                             "meta": {
-                                                "intent": "in"
+                                                "fptr": {
+                                                    "<FUNCTION>": "get  None ****************************************",
+                                                    "ast": {
+                                                        "declarator": {
+                                                            "func": {
+                                                                "name": "get",
+                                                                "pointer": [
+                                                                    {
+                                                                        "ptr": "*"
+                                                                    }
+                                                                ],
+                                                                "typemap_name": "double"
+                                                            },
+                                                            "name": "get",
+                                                            "params": [
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "i",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                }
+                                                            ],
+                                                            "typemap_name": "double"
+                                                        },
+                                                        "specifier": [
+                                                            "double"
+                                                        ],
+                                                        "typemap_name": "double"
+                                                    },
+                                                    "decl": "double ( * get)(int i, int)",
+                                                    "name": "get",
+                                                    "options": {},
+                                                    "wrap": {
+                                                        "c": true,
+                                                        "fortran": true,
+                                                        "lua": true,
+                                                        "python": true
+                                                    },
+                                                    "zz_bind": {
+                                                        "f": {
+                                                            "arg2": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "i": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            }
+                                                        },
+                                                        "share": {
+                                                            "arg2": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "i": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "zz_fmtdict": {
+                                                        "C_name_api": "get",
+                                                        "F_name_api": "get",
+                                                        "function_name": "get"
+                                                    }
+                                                },
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     },
@@ -10037,7 +10766,91 @@
                                         },
                                         "get": {
                                             "meta": {
-                                                "intent": "in"
+                                                "fptr": {
+                                                    "<FUNCTION>": "get  None ****************************************",
+                                                    "ast": {
+                                                        "declarator": {
+                                                            "func": {
+                                                                "name": "get",
+                                                                "pointer": [
+                                                                    {
+                                                                        "ptr": "*"
+                                                                    }
+                                                                ],
+                                                                "typemap_name": "double"
+                                                            },
+                                                            "name": "get",
+                                                            "params": [
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "i",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                }
+                                                            ],
+                                                            "typemap_name": "double"
+                                                        },
+                                                        "specifier": [
+                                                            "double"
+                                                        ],
+                                                        "typemap_name": "double"
+                                                    },
+                                                    "decl": "double ( * get)(int i, int)",
+                                                    "name": "get",
+                                                    "options": {},
+                                                    "wrap": {
+                                                        "c": true,
+                                                        "fortran": true,
+                                                        "lua": true,
+                                                        "python": true
+                                                    },
+                                                    "zz_bind": {
+                                                        "f": {
+                                                            "arg2": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "i": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            }
+                                                        },
+                                                        "share": {
+                                                            "arg2": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "i": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "zz_fmtdict": {
+                                                        "C_name_api": "get",
+                                                        "F_name_api": "get",
+                                                        "function_name": "get"
+                                                    }
+                                                },
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     },
@@ -10049,7 +10862,91 @@
                                         },
                                         "get": {
                                             "meta": {
-                                                "intent": "in"
+                                                "fptr": {
+                                                    "<FUNCTION>": "get  None ****************************************",
+                                                    "ast": {
+                                                        "declarator": {
+                                                            "func": {
+                                                                "name": "get",
+                                                                "pointer": [
+                                                                    {
+                                                                        "ptr": "*"
+                                                                    }
+                                                                ],
+                                                                "typemap_name": "double"
+                                                            },
+                                                            "name": "get",
+                                                            "params": [
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "i",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                }
+                                                            ],
+                                                            "typemap_name": "double"
+                                                        },
+                                                        "specifier": [
+                                                            "double"
+                                                        ],
+                                                        "typemap_name": "double"
+                                                    },
+                                                    "decl": "double ( * get)(int i, int)",
+                                                    "name": "get",
+                                                    "options": {},
+                                                    "wrap": {
+                                                        "c": true,
+                                                        "fortran": true,
+                                                        "lua": true,
+                                                        "python": true
+                                                    },
+                                                    "zz_bind": {
+                                                        "f": {
+                                                            "arg2": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "i": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            }
+                                                        },
+                                                        "share": {
+                                                            "arg2": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "i": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "zz_fmtdict": {
+                                                        "C_name_api": "get",
+                                                        "F_name_api": "get",
+                                                        "function_name": "get"
+                                                    }
+                                                },
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     }
@@ -10192,9 +11089,6 @@
                                                     "params": [
                                                         {
                                                             "declarator": {
-                                                                "attrs": {
-                                                                    "value": true
-                                                                },
                                                                 "typemap_name": "double"
                                                             },
                                                             "specifier": [
@@ -10204,9 +11098,6 @@
                                                         },
                                                         {
                                                             "declarator": {
-                                                                "attrs": {
-                                                                    "value": true
-                                                                },
                                                                 "typemap_name": "int"
                                                             },
                                                             "specifier": [
@@ -10257,7 +11148,88 @@
                                         },
                                         "get": {
                                             "meta": {
-                                                "intent": "in"
+                                                "fptr": {
+                                                    "<FUNCTION>": "get  None ****************************************",
+                                                    "ast": {
+                                                        "declarator": {
+                                                            "func": {
+                                                                "name": "get",
+                                                                "pointer": [
+                                                                    {
+                                                                        "ptr": "*"
+                                                                    }
+                                                                ],
+                                                                "typemap_name": "double"
+                                                            },
+                                                            "name": "get",
+                                                            "params": [
+                                                                {
+                                                                    "declarator": {
+                                                                        "typemap_name": "double"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "double"
+                                                                    ],
+                                                                    "typemap_name": "double"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                }
+                                                            ],
+                                                            "typemap_name": "double"
+                                                        },
+                                                        "specifier": [
+                                                            "double"
+                                                        ],
+                                                        "typemap_name": "double"
+                                                    },
+                                                    "decl": "double ( * get)(double, int)",
+                                                    "name": "get",
+                                                    "options": {},
+                                                    "wrap": {
+                                                        "c": true,
+                                                        "fortran": true
+                                                    },
+                                                    "zz_bind": {
+                                                        "f": {
+                                                            "arg1": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "arg2": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            }
+                                                        },
+                                                        "share": {
+                                                            "arg1": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "arg2": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "zz_fmtdict": {
+                                                        "C_name_api": "get",
+                                                        "F_name_api": "get",
+                                                        "function_name": "get"
+                                                    }
+                                                },
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "c_in_native_scalar"
                                         }
@@ -10271,7 +11243,88 @@
                                         },
                                         "get": {
                                             "meta": {
-                                                "intent": "in"
+                                                "fptr": {
+                                                    "<FUNCTION>": "get  None ****************************************",
+                                                    "ast": {
+                                                        "declarator": {
+                                                            "func": {
+                                                                "name": "get",
+                                                                "pointer": [
+                                                                    {
+                                                                        "ptr": "*"
+                                                                    }
+                                                                ],
+                                                                "typemap_name": "double"
+                                                            },
+                                                            "name": "get",
+                                                            "params": [
+                                                                {
+                                                                    "declarator": {
+                                                                        "typemap_name": "double"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "double"
+                                                                    ],
+                                                                    "typemap_name": "double"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                }
+                                                            ],
+                                                            "typemap_name": "double"
+                                                        },
+                                                        "specifier": [
+                                                            "double"
+                                                        ],
+                                                        "typemap_name": "double"
+                                                    },
+                                                    "decl": "double ( * get)(double, int)",
+                                                    "name": "get",
+                                                    "options": {},
+                                                    "wrap": {
+                                                        "c": true,
+                                                        "fortran": true
+                                                    },
+                                                    "zz_bind": {
+                                                        "f": {
+                                                            "arg1": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "arg2": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            }
+                                                        },
+                                                        "share": {
+                                                            "arg1": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "arg2": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "zz_fmtdict": {
+                                                        "C_name_api": "get",
+                                                        "F_name_api": "get",
+                                                        "function_name": "get"
+                                                    }
+                                                },
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "f_in_native_scalar"
                                         }
@@ -10284,7 +11337,88 @@
                                         },
                                         "get": {
                                             "meta": {
-                                                "intent": "in"
+                                                "fptr": {
+                                                    "<FUNCTION>": "get  None ****************************************",
+                                                    "ast": {
+                                                        "declarator": {
+                                                            "func": {
+                                                                "name": "get",
+                                                                "pointer": [
+                                                                    {
+                                                                        "ptr": "*"
+                                                                    }
+                                                                ],
+                                                                "typemap_name": "double"
+                                                            },
+                                                            "name": "get",
+                                                            "params": [
+                                                                {
+                                                                    "declarator": {
+                                                                        "typemap_name": "double"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "double"
+                                                                    ],
+                                                                    "typemap_name": "double"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                }
+                                                            ],
+                                                            "typemap_name": "double"
+                                                        },
+                                                        "specifier": [
+                                                            "double"
+                                                        ],
+                                                        "typemap_name": "double"
+                                                    },
+                                                    "decl": "double ( * get)(double, int)",
+                                                    "name": "get",
+                                                    "options": {},
+                                                    "wrap": {
+                                                        "c": true,
+                                                        "fortran": true
+                                                    },
+                                                    "zz_bind": {
+                                                        "f": {
+                                                            "arg1": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "arg2": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            }
+                                                        },
+                                                        "share": {
+                                                            "arg1": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "arg2": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "zz_fmtdict": {
+                                                        "C_name_api": "get",
+                                                        "F_name_api": "get",
+                                                        "function_name": "get"
+                                                    }
+                                                },
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     }
@@ -10390,9 +11524,6 @@
                                                     "params": [
                                                         {
                                                             "declarator": {
-                                                                "attrs": {
-                                                                    "value": true
-                                                                },
                                                                 "name": "verylongname1",
                                                                 "typemap_name": "int"
                                                             },
@@ -10403,9 +11534,6 @@
                                                         },
                                                         {
                                                             "declarator": {
-                                                                "attrs": {
-                                                                    "value": true
-                                                                },
                                                                 "name": "verylongname2",
                                                                 "typemap_name": "int"
                                                             },
@@ -10416,9 +11544,6 @@
                                                         },
                                                         {
                                                             "declarator": {
-                                                                "attrs": {
-                                                                    "value": true
-                                                                },
                                                                 "name": "verylongname3",
                                                                 "typemap_name": "int"
                                                             },
@@ -10429,9 +11554,6 @@
                                                         },
                                                         {
                                                             "declarator": {
-                                                                "attrs": {
-                                                                    "value": true
-                                                                },
                                                                 "name": "verylongname4",
                                                                 "typemap_name": "int"
                                                             },
@@ -10442,9 +11564,6 @@
                                                         },
                                                         {
                                                             "declarator": {
-                                                                "attrs": {
-                                                                    "value": true
-                                                                },
                                                                 "name": "verylongname5",
                                                                 "typemap_name": "int"
                                                             },
@@ -10455,9 +11574,6 @@
                                                         },
                                                         {
                                                             "declarator": {
-                                                                "attrs": {
-                                                                    "value": true
-                                                                },
                                                                 "name": "verylongname6",
                                                                 "typemap_name": "int"
                                                             },
@@ -10468,9 +11584,6 @@
                                                         },
                                                         {
                                                             "declarator": {
-                                                                "attrs": {
-                                                                    "value": true
-                                                                },
                                                                 "name": "verylongname7",
                                                                 "typemap_name": "int"
                                                             },
@@ -10481,9 +11594,6 @@
                                                         },
                                                         {
                                                             "declarator": {
-                                                                "attrs": {
-                                                                    "value": true
-                                                                },
                                                                 "name": "verylongname8",
                                                                 "typemap_name": "int"
                                                             },
@@ -10494,9 +11604,6 @@
                                                         },
                                                         {
                                                             "declarator": {
-                                                                "attrs": {
-                                                                    "value": true
-                                                                },
                                                                 "name": "verylongname9",
                                                                 "typemap_name": "int"
                                                             },
@@ -10507,9 +11614,6 @@
                                                         },
                                                         {
                                                             "declarator": {
-                                                                "attrs": {
-                                                                    "value": true
-                                                                },
                                                                 "name": "verylongname10",
                                                                 "typemap_name": "int"
                                                             },
@@ -10554,7 +11658,252 @@
                                         },
                                         "get": {
                                             "meta": {
-                                                "intent": "in"
+                                                "fptr": {
+                                                    "<FUNCTION>": "get  None ****************************************",
+                                                    "ast": {
+                                                        "declarator": {
+                                                            "func": {
+                                                                "name": "get",
+                                                                "pointer": [
+                                                                    {
+                                                                        "ptr": "*"
+                                                                    }
+                                                                ],
+                                                                "typemap_name": "void"
+                                                            },
+                                                            "name": "get",
+                                                            "params": [
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname1",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname2",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname3",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname4",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname5",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname6",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname7",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname8",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname9",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname10",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                }
+                                                            ],
+                                                            "typemap_name": "void"
+                                                        },
+                                                        "specifier": [
+                                                            "void"
+                                                        ],
+                                                        "typemap_name": "void"
+                                                    },
+                                                    "decl": "void ( * get)(int verylongname1, int verylongname2, int verylongname3, int verylongname4, int verylongname5, int verylongname6, int verylongname7, int verylongname8, int verylongname9, int verylongname10)",
+                                                    "name": "get",
+                                                    "options": {},
+                                                    "wrap": {
+                                                        "c": true,
+                                                        "fortran": true,
+                                                        "lua": true,
+                                                        "python": true
+                                                    },
+                                                    "zz_bind": {
+                                                        "f": {
+                                                            "verylongname1": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname10": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname2": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname3": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname4": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname5": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname6": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname7": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname8": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname9": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            }
+                                                        },
+                                                        "share": {
+                                                            "verylongname1": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname10": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname2": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname3": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname4": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname5": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname6": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname7": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname8": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname9": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "zz_fmtdict": {
+                                                        "C_name_api": "get",
+                                                        "F_name_api": "get",
+                                                        "function_name": "get"
+                                                    }
+                                                },
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "c_in_void_scalar"
                                         }
@@ -10568,7 +11917,252 @@
                                         },
                                         "get": {
                                             "meta": {
-                                                "intent": "in"
+                                                "fptr": {
+                                                    "<FUNCTION>": "get  None ****************************************",
+                                                    "ast": {
+                                                        "declarator": {
+                                                            "func": {
+                                                                "name": "get",
+                                                                "pointer": [
+                                                                    {
+                                                                        "ptr": "*"
+                                                                    }
+                                                                ],
+                                                                "typemap_name": "void"
+                                                            },
+                                                            "name": "get",
+                                                            "params": [
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname1",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname2",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname3",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname4",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname5",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname6",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname7",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname8",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname9",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname10",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                }
+                                                            ],
+                                                            "typemap_name": "void"
+                                                        },
+                                                        "specifier": [
+                                                            "void"
+                                                        ],
+                                                        "typemap_name": "void"
+                                                    },
+                                                    "decl": "void ( * get)(int verylongname1, int verylongname2, int verylongname3, int verylongname4, int verylongname5, int verylongname6, int verylongname7, int verylongname8, int verylongname9, int verylongname10)",
+                                                    "name": "get",
+                                                    "options": {},
+                                                    "wrap": {
+                                                        "c": true,
+                                                        "fortran": true,
+                                                        "lua": true,
+                                                        "python": true
+                                                    },
+                                                    "zz_bind": {
+                                                        "f": {
+                                                            "verylongname1": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname10": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname2": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname3": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname4": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname5": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname6": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname7": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname8": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname9": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            }
+                                                        },
+                                                        "share": {
+                                                            "verylongname1": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname10": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname2": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname3": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname4": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname5": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname6": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname7": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname8": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname9": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "zz_fmtdict": {
+                                                        "C_name_api": "get",
+                                                        "F_name_api": "get",
+                                                        "function_name": "get"
+                                                    }
+                                                },
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "f_in_void_scalar"
                                         }
@@ -10581,7 +12175,252 @@
                                         },
                                         "get": {
                                             "meta": {
-                                                "intent": "in"
+                                                "fptr": {
+                                                    "<FUNCTION>": "get  None ****************************************",
+                                                    "ast": {
+                                                        "declarator": {
+                                                            "func": {
+                                                                "name": "get",
+                                                                "pointer": [
+                                                                    {
+                                                                        "ptr": "*"
+                                                                    }
+                                                                ],
+                                                                "typemap_name": "void"
+                                                            },
+                                                            "name": "get",
+                                                            "params": [
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname1",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname2",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname3",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname4",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname5",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname6",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname7",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname8",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname9",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname10",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                }
+                                                            ],
+                                                            "typemap_name": "void"
+                                                        },
+                                                        "specifier": [
+                                                            "void"
+                                                        ],
+                                                        "typemap_name": "void"
+                                                    },
+                                                    "decl": "void ( * get)(int verylongname1, int verylongname2, int verylongname3, int verylongname4, int verylongname5, int verylongname6, int verylongname7, int verylongname8, int verylongname9, int verylongname10)",
+                                                    "name": "get",
+                                                    "options": {},
+                                                    "wrap": {
+                                                        "c": true,
+                                                        "fortran": true,
+                                                        "lua": true,
+                                                        "python": true
+                                                    },
+                                                    "zz_bind": {
+                                                        "f": {
+                                                            "verylongname1": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname10": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname2": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname3": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname4": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname5": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname6": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname7": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname8": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname9": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            }
+                                                        },
+                                                        "share": {
+                                                            "verylongname1": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname10": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname2": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname3": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname4": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname5": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname6": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname7": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname8": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname9": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "zz_fmtdict": {
+                                                        "C_name_api": "get",
+                                                        "F_name_api": "get",
+                                                        "function_name": "get"
+                                                    }
+                                                },
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     },
@@ -10593,7 +12432,252 @@
                                         },
                                         "get": {
                                             "meta": {
-                                                "intent": "in"
+                                                "fptr": {
+                                                    "<FUNCTION>": "get  None ****************************************",
+                                                    "ast": {
+                                                        "declarator": {
+                                                            "func": {
+                                                                "name": "get",
+                                                                "pointer": [
+                                                                    {
+                                                                        "ptr": "*"
+                                                                    }
+                                                                ],
+                                                                "typemap_name": "void"
+                                                            },
+                                                            "name": "get",
+                                                            "params": [
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname1",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname2",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname3",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname4",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname5",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname6",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname7",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname8",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname9",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname10",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                }
+                                                            ],
+                                                            "typemap_name": "void"
+                                                        },
+                                                        "specifier": [
+                                                            "void"
+                                                        ],
+                                                        "typemap_name": "void"
+                                                    },
+                                                    "decl": "void ( * get)(int verylongname1, int verylongname2, int verylongname3, int verylongname4, int verylongname5, int verylongname6, int verylongname7, int verylongname8, int verylongname9, int verylongname10)",
+                                                    "name": "get",
+                                                    "options": {},
+                                                    "wrap": {
+                                                        "c": true,
+                                                        "fortran": true,
+                                                        "lua": true,
+                                                        "python": true
+                                                    },
+                                                    "zz_bind": {
+                                                        "f": {
+                                                            "verylongname1": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname10": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname2": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname3": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname4": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname5": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname6": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname7": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname8": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname9": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            }
+                                                        },
+                                                        "share": {
+                                                            "verylongname1": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname10": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname2": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname3": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname4": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname5": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname6": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname7": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname8": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname9": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "zz_fmtdict": {
+                                                        "C_name_api": "get",
+                                                        "F_name_api": "get",
+                                                        "function_name": "get"
+                                                    }
+                                                },
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     },
@@ -10605,7 +12689,252 @@
                                         },
                                         "get": {
                                             "meta": {
-                                                "intent": "in"
+                                                "fptr": {
+                                                    "<FUNCTION>": "get  None ****************************************",
+                                                    "ast": {
+                                                        "declarator": {
+                                                            "func": {
+                                                                "name": "get",
+                                                                "pointer": [
+                                                                    {
+                                                                        "ptr": "*"
+                                                                    }
+                                                                ],
+                                                                "typemap_name": "void"
+                                                            },
+                                                            "name": "get",
+                                                            "params": [
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname1",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname2",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname3",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname4",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname5",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname6",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname7",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname8",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname9",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                },
+                                                                {
+                                                                    "declarator": {
+                                                                        "name": "verylongname10",
+                                                                        "typemap_name": "int"
+                                                                    },
+                                                                    "specifier": [
+                                                                        "int"
+                                                                    ],
+                                                                    "typemap_name": "int"
+                                                                }
+                                                            ],
+                                                            "typemap_name": "void"
+                                                        },
+                                                        "specifier": [
+                                                            "void"
+                                                        ],
+                                                        "typemap_name": "void"
+                                                    },
+                                                    "decl": "void ( * get)(int verylongname1, int verylongname2, int verylongname3, int verylongname4, int verylongname5, int verylongname6, int verylongname7, int verylongname8, int verylongname9, int verylongname10)",
+                                                    "name": "get",
+                                                    "options": {},
+                                                    "wrap": {
+                                                        "c": true,
+                                                        "fortran": true,
+                                                        "lua": true,
+                                                        "python": true
+                                                    },
+                                                    "zz_bind": {
+                                                        "f": {
+                                                            "verylongname1": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname10": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname2": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname3": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname4": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname5": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname6": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname7": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname8": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname9": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            }
+                                                        },
+                                                        "share": {
+                                                            "verylongname1": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname10": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname2": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname3": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname4": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname5": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname6": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname7": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname8": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            },
+                                                            "verylongname9": {
+                                                                "meta": {
+                                                                    "value": true
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "zz_fmtdict": {
+                                                        "C_name_api": "get",
+                                                        "F_name_api": "get",
+                                                        "function_name": "get"
+                                                    }
+                                                },
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     }
@@ -12173,61 +14502,71 @@
                                         },
                                         "verylongname1": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "c_in_native_scalar"
                                         },
                                         "verylongname10": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "c_in_native_scalar"
                                         },
                                         "verylongname2": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "c_in_native_scalar"
                                         },
                                         "verylongname3": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "c_in_native_scalar"
                                         },
                                         "verylongname4": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "c_in_native_scalar"
                                         },
                                         "verylongname5": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "c_in_native_scalar"
                                         },
                                         "verylongname6": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "c_in_native_scalar"
                                         },
                                         "verylongname7": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "c_in_native_scalar"
                                         },
                                         "verylongname8": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "c_in_native_scalar"
                                         },
                                         "verylongname9": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "c_in_native_scalar"
                                         }
@@ -12241,61 +14580,71 @@
                                         },
                                         "verylongname1": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "f_in_native_scalar"
                                         },
                                         "verylongname10": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "f_in_native_scalar"
                                         },
                                         "verylongname2": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "f_in_native_scalar"
                                         },
                                         "verylongname3": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "f_in_native_scalar"
                                         },
                                         "verylongname4": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "f_in_native_scalar"
                                         },
                                         "verylongname5": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "f_in_native_scalar"
                                         },
                                         "verylongname6": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "f_in_native_scalar"
                                         },
                                         "verylongname7": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "f_in_native_scalar"
                                         },
                                         "verylongname8": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "f_in_native_scalar"
                                         },
                                         "verylongname9": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "f_in_native_scalar"
                                         }
@@ -12308,52 +14657,62 @@
                                         },
                                         "verylongname1": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "verylongname10": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "verylongname2": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "verylongname3": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "verylongname4": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "verylongname5": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "verylongname6": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "verylongname7": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "verylongname8": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "verylongname9": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     },
@@ -12365,52 +14724,62 @@
                                         },
                                         "verylongname1": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "verylongname10": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "verylongname2": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "verylongname3": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "verylongname4": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "verylongname5": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "verylongname6": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "verylongname7": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "verylongname8": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "verylongname9": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     },
@@ -12422,52 +14791,62 @@
                                         },
                                         "verylongname1": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "verylongname10": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "verylongname2": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "verylongname3": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "verylongname4": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "verylongname5": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "verylongname6": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "verylongname7": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "verylongname8": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "verylongname9": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     }
@@ -13427,7 +15806,8 @@
                                         },
                                         "sizein": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "c_in_native_scalar"
                                         }
@@ -13465,7 +15845,8 @@
                                         },
                                         "sizein": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "f_in_native_scalar"
                                         }
@@ -13500,7 +15881,8 @@
                                         },
                                         "sizein": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     },
@@ -13534,7 +15916,8 @@
                                         },
                                         "sizein": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     },
@@ -13568,7 +15951,8 @@
                                         },
                                         "sizein": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     }

--- a/regression/reference/example/luaUserLibrarymodule.cpp
+++ b/regression/reference/example/luaUserLibrarymodule.cpp
@@ -881,7 +881,7 @@ static int l_example_nested_FuncPtr2(lua_State *)
 // Function:  void FuncPtr3
 // Statement: lua_subroutine
 // ----------------------------------------
-// Argument:  double ( * get)(int i +value, int +value)
+// Argument:  double ( * get)(int i, int)
 // Statement: lua_in_native_scalar
 /**
  * \brief abstract argument
@@ -901,7 +901,7 @@ static int l_example_nested_FuncPtr3(lua_State *L)
 // Function:  void FuncPtr5
 // Statement: lua_subroutine
 // ----------------------------------------
-// Argument:  void ( * get)(int verylongname1 +value, int verylongname2 +value, int verylongname3 +value, int verylongname4 +value, int verylongname5 +value, int verylongname6 +value, int verylongname7 +value, int verylongname8 +value, int verylongname9 +value, int verylongname10 +value)
+// Argument:  void ( * get)(int verylongname1, int verylongname2, int verylongname3, int verylongname4, int verylongname5, int verylongname6, int verylongname7, int verylongname8, int verylongname9, int verylongname10)
 // Statement: lua_in_void_scalar
 static int l_example_nested_FuncPtr5(lua_State *)
 {

--- a/regression/reference/example/pyUserLibrary_example_nestedmodule.cpp
+++ b/regression/reference/example/pyUserLibrary_example_nestedmodule.cpp
@@ -391,7 +391,7 @@ PP_FuncPtr2(
 // Function:  void FuncPtr3
 // Statement: py_default
 // ----------------------------------------
-// Argument:  double ( * get)(int i +value, int +value)
+// Argument:  double ( * get)(int i, int)
 // Exact:     py_default
 static char PP_FuncPtr3__doc__[] =
 "documentation"
@@ -426,7 +426,7 @@ PP_FuncPtr3(
 // Function:  void FuncPtr5
 // Statement: py_default
 // ----------------------------------------
-// Argument:  void ( * get)(int verylongname1 +value, int verylongname2 +value, int verylongname3 +value, int verylongname4 +value, int verylongname5 +value, int verylongname6 +value, int verylongname7 +value, int verylongname8 +value, int verylongname9 +value, int verylongname10 +value)
+// Argument:  void ( * get)(int verylongname1, int verylongname2, int verylongname3, int verylongname4, int verylongname5, int verylongname6, int verylongname7, int verylongname8, int verylongname9, int verylongname10)
 // Exact:     py_default
 static char PP_FuncPtr5__doc__[] =
 "documentation"

--- a/regression/reference/example/wrapUserLibrary_example_nested.cpp
+++ b/regression/reference/example/wrapUserLibrary_example_nested.cpp
@@ -272,7 +272,7 @@ void AA_example_nested_FuncPtr2(double * ( * get)(void))
 // Function:  void FuncPtr3
 // Statement: c_subroutine
 // ----------------------------------------
-// Argument:  double ( * get)(int i +value, int +value)
+// Argument:  double ( * get)(int i, int)
 // Statement: c_in_native_scalar
 void AA_example_nested_FuncPtr3(double ( * get)(int i, int))
 {
@@ -289,7 +289,7 @@ void AA_example_nested_FuncPtr3(double ( * get)(int i, int))
 // Function:  void FuncPtr4
 // Statement: c_subroutine
 // ----------------------------------------
-// Argument:  double ( * get)(double +value, int +value)
+// Argument:  double ( * get)(double, int)
 // Statement: c_in_native_scalar
 void AA_example_nested_FuncPtr4(double ( * get)(double, int))
 {
@@ -302,7 +302,7 @@ void AA_example_nested_FuncPtr4(double ( * get)(double, int))
 // Function:  void FuncPtr5
 // Statement: c_subroutine
 // ----------------------------------------
-// Argument:  void ( * get)(int verylongname1 +value, int verylongname2 +value, int verylongname3 +value, int verylongname4 +value, int verylongname5 +value, int verylongname6 +value, int verylongname7 +value, int verylongname8 +value, int verylongname9 +value, int verylongname10 +value)
+// Argument:  void ( * get)(int verylongname1, int verylongname2, int verylongname3, int verylongname4, int verylongname5, int verylongname6, int verylongname7, int verylongname8, int verylongname9, int verylongname10)
 // Statement: c_in_void_scalar
 void AA_example_nested_FuncPtr5(void ( * get)(int verylongname1,
     int verylongname2, int verylongname3, int verylongname4,

--- a/regression/reference/example/wrapfUserLibrary_example_nested.f
+++ b/regression/reference/example/wrapfUserLibrary_example_nested.f
@@ -928,7 +928,7 @@ module userlibrary_example_nested_mod
         ! Function:  void FuncPtr3
         ! Statement: f_subroutine
         ! ----------------------------------------
-        ! Argument:  double ( * get)(int i +value, int +value)
+        ! Argument:  double ( * get)(int i, int)
         ! Statement: f_in_native_scalar
         subroutine c_func_ptr3(get) &
                 bind(C, name="AA_example_nested_FuncPtr3")
@@ -941,7 +941,7 @@ module userlibrary_example_nested_mod
         ! Function:  void FuncPtr4
         ! Statement: f_subroutine
         ! ----------------------------------------
-        ! Argument:  double ( * get)(double +value, int +value)
+        ! Argument:  double ( * get)(double, int)
         ! Statement: f_in_native_scalar
         subroutine c_func_ptr4(get) &
                 bind(C, name="AA_example_nested_FuncPtr4")
@@ -954,7 +954,7 @@ module userlibrary_example_nested_mod
         ! Function:  void FuncPtr5
         ! Statement: f_subroutine
         ! ----------------------------------------
-        ! Argument:  void ( * get)(int verylongname1 +value, int verylongname2 +value, int verylongname3 +value, int verylongname4 +value, int verylongname5 +value, int verylongname6 +value, int verylongname7 +value, int verylongname8 +value, int verylongname9 +value, int verylongname10 +value)
+        ! Argument:  void ( * get)(int verylongname1, int verylongname2, int verylongname3, int verylongname4, int verylongname5, int verylongname6, int verylongname7, int verylongname8, int verylongname9, int verylongname10)
         ! Statement: f_in_void_scalar
         subroutine func_ptr5(get) &
                 bind(C, name="AA_example_nested_FuncPtr5")

--- a/regression/reference/generic-cfi/generic.json
+++ b/regression/reference/generic-cfi/generic.json
@@ -102,7 +102,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -116,7 +117,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -129,7 +131,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -261,7 +264,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -275,7 +279,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -288,7 +293,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -569,7 +575,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -582,7 +589,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -686,7 +694,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -699,7 +708,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -809,7 +819,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -822,7 +833,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -989,13 +1001,15 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -1008,12 +1022,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1171,13 +1187,15 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -1190,12 +1208,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1359,13 +1379,15 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -1378,12 +1400,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1552,7 +1576,8 @@
                         },
                         "nvalues": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
@@ -1576,7 +1601,8 @@
                         },
                         "nvalues": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -1600,7 +1626,8 @@
                         },
                         "nvalues": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "values": {
@@ -2076,13 +2103,15 @@
                         },
                         "nfrom": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "nto": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
@@ -2106,12 +2135,14 @@
                         },
                         "nfrom": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "nto": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "to": {
@@ -2341,13 +2372,15 @@
                         },
                         "nfrom": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "nto": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -2371,12 +2404,14 @@
                         },
                         "nfrom": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "nto": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "to": {
@@ -2622,13 +2657,15 @@
                         },
                         "nfrom": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "nto": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -2654,12 +2691,14 @@
                         },
                         "nfrom": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "nto": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "to": {
@@ -2917,13 +2956,15 @@
                         },
                         "nfrom": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "nto": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -2950,12 +2991,14 @@
                         },
                         "nfrom": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "nto": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "to": {
@@ -3286,19 +3329,22 @@
                         },
                         "addr": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_void_*"
                         },
                         "size": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -3311,17 +3357,20 @@
                         },
                         "addr": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "size": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3513,13 +3562,15 @@
                         },
                         "size": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -3538,12 +3589,14 @@
                         },
                         "size": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3756,13 +3809,15 @@
                         },
                         "size": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -3781,12 +3836,14 @@
                         },
                         "size": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4112,19 +4169,22 @@
                         },
                         "addr": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_void_*"
                         },
                         "size": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -4137,17 +4197,20 @@
                         },
                         "addr": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "size": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4367,13 +4430,15 @@
                         },
                         "size": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -4392,12 +4457,14 @@
                         },
                         "size": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4638,13 +4705,15 @@
                         },
                         "size": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -4663,12 +4732,14 @@
                         },
                         "size": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -6266,7 +6337,8 @@
                         },
                         "inew": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -6284,7 +6356,8 @@
                         },
                         "inew": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -6451,7 +6524,8 @@
                         },
                         "inew": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -6469,7 +6543,8 @@
                         },
                         "inew": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -6649,7 +6724,8 @@
                         },
                         "inew": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -6667,7 +6743,8 @@
                         },
                         "inew": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/generic/generic.json
+++ b/regression/reference/generic/generic.json
@@ -102,7 +102,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -116,7 +117,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -129,7 +131,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -261,7 +264,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -275,7 +279,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -288,7 +293,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -569,7 +575,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -582,7 +589,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -686,7 +694,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -699,7 +708,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -809,7 +819,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -822,7 +833,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -989,13 +1001,15 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -1008,12 +1022,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1171,13 +1187,15 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -1190,12 +1208,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1359,13 +1379,15 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -1378,12 +1400,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1656,7 +1680,8 @@
                         },
                         "nvalues": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
@@ -1675,7 +1700,8 @@
                         },
                         "nvalues": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "values": {
@@ -1850,7 +1876,8 @@
                         },
                         "nvalues": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -1870,7 +1897,8 @@
                         },
                         "nvalues": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "values": {
@@ -2061,7 +2089,8 @@
                         },
                         "nvalues": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -2081,7 +2110,8 @@
                         },
                         "nvalues": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "values": {
@@ -2274,7 +2304,8 @@
                         },
                         "nvalues": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -2294,7 +2325,8 @@
                         },
                         "nvalues": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "values": {
@@ -2687,13 +2719,15 @@
                         },
                         "nfrom": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "nto": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
@@ -2717,12 +2751,14 @@
                         },
                         "nfrom": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "nto": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "to": {
@@ -2952,13 +2988,15 @@
                         },
                         "nfrom": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "nto": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -2982,12 +3020,14 @@
                         },
                         "nfrom": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "nto": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "to": {
@@ -3233,13 +3273,15 @@
                         },
                         "nfrom": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "nto": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -3264,12 +3306,14 @@
                         },
                         "nfrom": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "nto": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "to": {
@@ -3524,13 +3568,15 @@
                         },
                         "nfrom": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "nto": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -3556,12 +3602,14 @@
                         },
                         "nfrom": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "nto": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "to": {
@@ -3888,19 +3936,22 @@
                         },
                         "addr": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_void_*"
                         },
                         "size": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -3913,17 +3964,20 @@
                         },
                         "addr": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "size": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4114,13 +4168,15 @@
                         },
                         "size": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -4139,12 +4195,14 @@
                         },
                         "size": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4354,13 +4412,15 @@
                         },
                         "size": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -4379,12 +4439,14 @@
                         },
                         "size": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4708,19 +4770,22 @@
                         },
                         "addr": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_void_*"
                         },
                         "size": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -4733,17 +4798,20 @@
                         },
                         "addr": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "size": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4962,13 +5030,15 @@
                         },
                         "size": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -4987,12 +5057,14 @@
                         },
                         "size": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -5230,13 +5302,15 @@
                         },
                         "size": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -5255,12 +5329,14 @@
                         },
                         "size": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -6864,7 +6940,8 @@
                         },
                         "inew": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -6882,7 +6959,8 @@
                         },
                         "inew": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -7049,7 +7127,8 @@
                         },
                         "inew": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -7067,7 +7146,8 @@
                         },
                         "inew": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -7247,7 +7327,8 @@
                         },
                         "inew": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -7265,7 +7346,8 @@
                         },
                         "inew": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/include/include.json
+++ b/regression/reference/include/include.json
@@ -54,7 +54,8 @@
                                 },
                                 "comm": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_unknown_scalar"
                                 }
@@ -68,7 +69,8 @@
                                 },
                                 "comm": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_unknown_scalar"
                                 }
@@ -81,7 +83,8 @@
                                 },
                                 "comm": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -579,7 +582,8 @@
                                         },
                                         "arg1": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "c_in_native_scalar"
                                         }
@@ -593,7 +597,8 @@
                                         },
                                         "arg1": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "f_in_native_scalar"
                                         }
@@ -606,7 +611,8 @@
                                         },
                                         "arg1": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     }

--- a/regression/reference/interface/interface.json
+++ b/regression/reference/interface/interface.json
@@ -145,13 +145,15 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -165,13 +167,15 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -184,12 +188,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/names/names.json
+++ b/regression/reference/names/names.json
@@ -852,7 +852,8 @@
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -866,7 +867,8 @@
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -879,7 +881,8 @@
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -891,7 +894,8 @@
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1044,7 +1048,8 @@
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -1058,7 +1063,8 @@
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -1071,7 +1077,8 @@
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1083,7 +1090,8 @@
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1998,12 +2006,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2132,13 +2142,15 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -2152,13 +2164,15 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -2171,12 +2185,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2188,12 +2204,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2483,13 +2501,15 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -2503,13 +2523,15 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -2522,12 +2544,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2539,12 +2563,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3428,19 +3454,288 @@
                         },
                         "afree": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "afree  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "func": {
+                                                "name": "afree",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
+                                            },
+                                            "name": "afree",
+                                            "params": [
+                                                {
+                                                    "declarator": {
+                                                        "attrs": {
+                                                            "intent": "inout"
+                                                        },
+                                                        "name": "arr",
+                                                        "pointer": [
+                                                            {
+                                                                "ptr": "*"
+                                                            }
+                                                        ],
+                                                        "typemap_name": "double"
+                                                    },
+                                                    "specifier": [
+                                                        "double"
+                                                    ],
+                                                    "typemap_name": "double"
+                                                }
+                                            ],
+                                            "typemap_name": "void"
+                                        },
+                                        "specifier": [
+                                            "void"
+                                        ],
+                                        "typemap_name": "void"
+                                    },
+                                    "decl": "void ( * afree)(double * arr +intent(inout))",
+                                    "name": "afree",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true
+                                    },
+                                    "zz_bind": {
+                                        "f": {
+                                            "arr": {
+                                                "meta": {
+                                                    "intent": "inout"
+                                                }
+                                            }
+                                        },
+                                        "share": {
+                                            "arr": {
+                                                "meta": {
+                                                    "intent": "inout"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "afree",
+                                        "F_name_api": "afree",
+                                        "function_name": "afree"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_void_scalar"
                         },
                         "alloc": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "alloc  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "func": {
+                                                "name": "alloc",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
+                                            },
+                                            "name": "alloc",
+                                            "params": [
+                                                {
+                                                    "declarator": {
+                                                        "attrs": {
+                                                            "intent": "inout"
+                                                        },
+                                                        "name": "arr",
+                                                        "pointer": [
+                                                            {
+                                                                "ptr": "*"
+                                                            }
+                                                        ],
+                                                        "typemap_name": "double"
+                                                    },
+                                                    "specifier": [
+                                                        "double"
+                                                    ],
+                                                    "typemap_name": "double"
+                                                },
+                                                {
+                                                    "declarator": {
+                                                        "attrs": {
+                                                            "intent": "out"
+                                                        },
+                                                        "name": "err",
+                                                        "pointer": [
+                                                            {
+                                                                "ptr": "*"
+                                                            }
+                                                        ],
+                                                        "typemap_name": "int"
+                                                    },
+                                                    "specifier": [
+                                                        "int"
+                                                    ],
+                                                    "typemap_name": "int"
+                                                }
+                                            ],
+                                            "typemap_name": "void"
+                                        },
+                                        "specifier": [
+                                            "void"
+                                        ],
+                                        "typemap_name": "void"
+                                    },
+                                    "decl": "void ( * alloc)(double * arr +intent(inout), int * err +intent(out))",
+                                    "name": "alloc",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true
+                                    },
+                                    "zz_bind": {
+                                        "f": {
+                                            "arr": {
+                                                "meta": {
+                                                    "intent": "inout"
+                                                }
+                                            },
+                                            "err": {
+                                                "meta": {
+                                                    "intent": "out"
+                                                }
+                                            }
+                                        },
+                                        "share": {
+                                            "arr": {
+                                                "meta": {
+                                                    "intent": "inout"
+                                                }
+                                            },
+                                            "err": {
+                                                "meta": {
+                                                    "intent": "out"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "alloc",
+                                        "F_name_api": "alloc",
+                                        "function_name": "alloc"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_void_scalar"
                         },
                         "assoc": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "assoc  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "func": {
+                                                "name": "assoc",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
+                                            },
+                                            "name": "assoc",
+                                            "params": [
+                                                {
+                                                    "declarator": {
+                                                        "attrs": {
+                                                            "intent": "in"
+                                                        },
+                                                        "name": "arr",
+                                                        "pointer": [
+                                                            {
+                                                                "ptr": "*"
+                                                            }
+                                                        ],
+                                                        "typemap_name": "double"
+                                                    },
+                                                    "specifier": [
+                                                        "double"
+                                                    ],
+                                                    "typemap_name": "double"
+                                                },
+                                                {
+                                                    "declarator": {
+                                                        "attrs": {
+                                                            "intent": "out"
+                                                        },
+                                                        "name": "err",
+                                                        "pointer": [
+                                                            {
+                                                                "ptr": "*"
+                                                            }
+                                                        ],
+                                                        "typemap_name": "int"
+                                                    },
+                                                    "specifier": [
+                                                        "int"
+                                                    ],
+                                                    "typemap_name": "int"
+                                                }
+                                            ],
+                                            "typemap_name": "void"
+                                        },
+                                        "specifier": [
+                                            "void"
+                                        ],
+                                        "typemap_name": "void"
+                                    },
+                                    "decl": "void ( * assoc)(double * arr +intent(in), int * err +intent(out))",
+                                    "name": "assoc",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true
+                                    },
+                                    "zz_bind": {
+                                        "f": {
+                                            "arr": {
+                                                "meta": {
+                                                    "intent": "in"
+                                                }
+                                            },
+                                            "err": {
+                                                "meta": {
+                                                    "intent": "out"
+                                                }
+                                            }
+                                        },
+                                        "share": {
+                                            "arr": {
+                                                "meta": {
+                                                    "intent": "in"
+                                                }
+                                            },
+                                            "err": {
+                                                "meta": {
+                                                    "intent": "out"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "assoc",
+                                        "F_name_api": "assoc",
+                                        "function_name": "assoc"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_void_scalar"
                         },
@@ -3472,19 +3767,288 @@
                         },
                         "afree": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "afree  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "func": {
+                                                "name": "afree",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
+                                            },
+                                            "name": "afree",
+                                            "params": [
+                                                {
+                                                    "declarator": {
+                                                        "attrs": {
+                                                            "intent": "inout"
+                                                        },
+                                                        "name": "arr",
+                                                        "pointer": [
+                                                            {
+                                                                "ptr": "*"
+                                                            }
+                                                        ],
+                                                        "typemap_name": "double"
+                                                    },
+                                                    "specifier": [
+                                                        "double"
+                                                    ],
+                                                    "typemap_name": "double"
+                                                }
+                                            ],
+                                            "typemap_name": "void"
+                                        },
+                                        "specifier": [
+                                            "void"
+                                        ],
+                                        "typemap_name": "void"
+                                    },
+                                    "decl": "void ( * afree)(double * arr +intent(inout))",
+                                    "name": "afree",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true
+                                    },
+                                    "zz_bind": {
+                                        "f": {
+                                            "arr": {
+                                                "meta": {
+                                                    "intent": "inout"
+                                                }
+                                            }
+                                        },
+                                        "share": {
+                                            "arr": {
+                                                "meta": {
+                                                    "intent": "inout"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "afree",
+                                        "F_name_api": "afree",
+                                        "function_name": "afree"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_void_scalar"
                         },
                         "alloc": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "alloc  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "func": {
+                                                "name": "alloc",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
+                                            },
+                                            "name": "alloc",
+                                            "params": [
+                                                {
+                                                    "declarator": {
+                                                        "attrs": {
+                                                            "intent": "inout"
+                                                        },
+                                                        "name": "arr",
+                                                        "pointer": [
+                                                            {
+                                                                "ptr": "*"
+                                                            }
+                                                        ],
+                                                        "typemap_name": "double"
+                                                    },
+                                                    "specifier": [
+                                                        "double"
+                                                    ],
+                                                    "typemap_name": "double"
+                                                },
+                                                {
+                                                    "declarator": {
+                                                        "attrs": {
+                                                            "intent": "out"
+                                                        },
+                                                        "name": "err",
+                                                        "pointer": [
+                                                            {
+                                                                "ptr": "*"
+                                                            }
+                                                        ],
+                                                        "typemap_name": "int"
+                                                    },
+                                                    "specifier": [
+                                                        "int"
+                                                    ],
+                                                    "typemap_name": "int"
+                                                }
+                                            ],
+                                            "typemap_name": "void"
+                                        },
+                                        "specifier": [
+                                            "void"
+                                        ],
+                                        "typemap_name": "void"
+                                    },
+                                    "decl": "void ( * alloc)(double * arr +intent(inout), int * err +intent(out))",
+                                    "name": "alloc",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true
+                                    },
+                                    "zz_bind": {
+                                        "f": {
+                                            "arr": {
+                                                "meta": {
+                                                    "intent": "inout"
+                                                }
+                                            },
+                                            "err": {
+                                                "meta": {
+                                                    "intent": "out"
+                                                }
+                                            }
+                                        },
+                                        "share": {
+                                            "arr": {
+                                                "meta": {
+                                                    "intent": "inout"
+                                                }
+                                            },
+                                            "err": {
+                                                "meta": {
+                                                    "intent": "out"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "alloc",
+                                        "F_name_api": "alloc",
+                                        "function_name": "alloc"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_void_scalar"
                         },
                         "assoc": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "assoc  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "func": {
+                                                "name": "assoc",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
+                                            },
+                                            "name": "assoc",
+                                            "params": [
+                                                {
+                                                    "declarator": {
+                                                        "attrs": {
+                                                            "intent": "in"
+                                                        },
+                                                        "name": "arr",
+                                                        "pointer": [
+                                                            {
+                                                                "ptr": "*"
+                                                            }
+                                                        ],
+                                                        "typemap_name": "double"
+                                                    },
+                                                    "specifier": [
+                                                        "double"
+                                                    ],
+                                                    "typemap_name": "double"
+                                                },
+                                                {
+                                                    "declarator": {
+                                                        "attrs": {
+                                                            "intent": "out"
+                                                        },
+                                                        "name": "err",
+                                                        "pointer": [
+                                                            {
+                                                                "ptr": "*"
+                                                            }
+                                                        ],
+                                                        "typemap_name": "int"
+                                                    },
+                                                    "specifier": [
+                                                        "int"
+                                                    ],
+                                                    "typemap_name": "int"
+                                                }
+                                            ],
+                                            "typemap_name": "void"
+                                        },
+                                        "specifier": [
+                                            "void"
+                                        ],
+                                        "typemap_name": "void"
+                                    },
+                                    "decl": "void ( * assoc)(double * arr +intent(in), int * err +intent(out))",
+                                    "name": "assoc",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true
+                                    },
+                                    "zz_bind": {
+                                        "f": {
+                                            "arr": {
+                                                "meta": {
+                                                    "intent": "in"
+                                                }
+                                            },
+                                            "err": {
+                                                "meta": {
+                                                    "intent": "out"
+                                                }
+                                            }
+                                        },
+                                        "share": {
+                                            "arr": {
+                                                "meta": {
+                                                    "intent": "in"
+                                                }
+                                            },
+                                            "err": {
+                                                "meta": {
+                                                    "intent": "out"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "assoc",
+                                        "F_name_api": "assoc",
+                                        "function_name": "assoc"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_void_scalar"
                         },
@@ -3518,17 +4082,286 @@
                         },
                         "afree": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "afree  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "func": {
+                                                "name": "afree",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
+                                            },
+                                            "name": "afree",
+                                            "params": [
+                                                {
+                                                    "declarator": {
+                                                        "attrs": {
+                                                            "intent": "inout"
+                                                        },
+                                                        "name": "arr",
+                                                        "pointer": [
+                                                            {
+                                                                "ptr": "*"
+                                                            }
+                                                        ],
+                                                        "typemap_name": "double"
+                                                    },
+                                                    "specifier": [
+                                                        "double"
+                                                    ],
+                                                    "typemap_name": "double"
+                                                }
+                                            ],
+                                            "typemap_name": "void"
+                                        },
+                                        "specifier": [
+                                            "void"
+                                        ],
+                                        "typemap_name": "void"
+                                    },
+                                    "decl": "void ( * afree)(double * arr +intent(inout))",
+                                    "name": "afree",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true
+                                    },
+                                    "zz_bind": {
+                                        "f": {
+                                            "arr": {
+                                                "meta": {
+                                                    "intent": "inout"
+                                                }
+                                            }
+                                        },
+                                        "share": {
+                                            "arr": {
+                                                "meta": {
+                                                    "intent": "inout"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "afree",
+                                        "F_name_api": "afree",
+                                        "function_name": "afree"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "alloc": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "alloc  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "func": {
+                                                "name": "alloc",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
+                                            },
+                                            "name": "alloc",
+                                            "params": [
+                                                {
+                                                    "declarator": {
+                                                        "attrs": {
+                                                            "intent": "inout"
+                                                        },
+                                                        "name": "arr",
+                                                        "pointer": [
+                                                            {
+                                                                "ptr": "*"
+                                                            }
+                                                        ],
+                                                        "typemap_name": "double"
+                                                    },
+                                                    "specifier": [
+                                                        "double"
+                                                    ],
+                                                    "typemap_name": "double"
+                                                },
+                                                {
+                                                    "declarator": {
+                                                        "attrs": {
+                                                            "intent": "out"
+                                                        },
+                                                        "name": "err",
+                                                        "pointer": [
+                                                            {
+                                                                "ptr": "*"
+                                                            }
+                                                        ],
+                                                        "typemap_name": "int"
+                                                    },
+                                                    "specifier": [
+                                                        "int"
+                                                    ],
+                                                    "typemap_name": "int"
+                                                }
+                                            ],
+                                            "typemap_name": "void"
+                                        },
+                                        "specifier": [
+                                            "void"
+                                        ],
+                                        "typemap_name": "void"
+                                    },
+                                    "decl": "void ( * alloc)(double * arr +intent(inout), int * err +intent(out))",
+                                    "name": "alloc",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true
+                                    },
+                                    "zz_bind": {
+                                        "f": {
+                                            "arr": {
+                                                "meta": {
+                                                    "intent": "inout"
+                                                }
+                                            },
+                                            "err": {
+                                                "meta": {
+                                                    "intent": "out"
+                                                }
+                                            }
+                                        },
+                                        "share": {
+                                            "arr": {
+                                                "meta": {
+                                                    "intent": "inout"
+                                                }
+                                            },
+                                            "err": {
+                                                "meta": {
+                                                    "intent": "out"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "alloc",
+                                        "F_name_api": "alloc",
+                                        "function_name": "alloc"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "assoc": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "assoc  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "func": {
+                                                "name": "assoc",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "void"
+                                            },
+                                            "name": "assoc",
+                                            "params": [
+                                                {
+                                                    "declarator": {
+                                                        "attrs": {
+                                                            "intent": "in"
+                                                        },
+                                                        "name": "arr",
+                                                        "pointer": [
+                                                            {
+                                                                "ptr": "*"
+                                                            }
+                                                        ],
+                                                        "typemap_name": "double"
+                                                    },
+                                                    "specifier": [
+                                                        "double"
+                                                    ],
+                                                    "typemap_name": "double"
+                                                },
+                                                {
+                                                    "declarator": {
+                                                        "attrs": {
+                                                            "intent": "out"
+                                                        },
+                                                        "name": "err",
+                                                        "pointer": [
+                                                            {
+                                                                "ptr": "*"
+                                                            }
+                                                        ],
+                                                        "typemap_name": "int"
+                                                    },
+                                                    "specifier": [
+                                                        "int"
+                                                    ],
+                                                    "typemap_name": "int"
+                                                }
+                                            ],
+                                            "typemap_name": "void"
+                                        },
+                                        "specifier": [
+                                            "void"
+                                        ],
+                                        "typemap_name": "void"
+                                    },
+                                    "decl": "void ( * assoc)(double * arr +intent(in), int * err +intent(out))",
+                                    "name": "assoc",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true
+                                    },
+                                    "zz_bind": {
+                                        "f": {
+                                            "arr": {
+                                                "meta": {
+                                                    "intent": "in"
+                                                }
+                                            },
+                                            "err": {
+                                                "meta": {
+                                                    "intent": "out"
+                                                }
+                                            }
+                                        },
+                                        "share": {
+                                            "arr": {
+                                                "meta": {
+                                                    "intent": "in"
+                                                }
+                                            },
+                                            "err": {
+                                                "meta": {
+                                                    "intent": "out"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "assoc",
+                                        "F_name_api": "assoc",
+                                        "function_name": "assoc"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "name": {
@@ -3884,7 +4717,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -3902,7 +4736,8 @@
                             "meta": {
                                 "attr": true,
                                 "bar": 2,
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -3921,7 +4756,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/namespace/namespace.json
+++ b/regression/reference/namespace/namespace.json
@@ -446,12 +446,14 @@
                                         },
                                         "dfield": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "ifield": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     },
@@ -463,12 +465,14 @@
                                         },
                                         "dfield": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         },
                                         "ifield": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     }

--- a/regression/reference/ownership/ownership.json
+++ b/regression/reference/ownership/ownership.json
@@ -3902,7 +3902,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -3916,7 +3917,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -3929,7 +3931,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -3941,7 +3944,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -3953,7 +3957,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4286,7 +4291,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -4302,7 +4308,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -4316,7 +4323,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -4329,7 +4337,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -4342,7 +4351,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/pointers-c-c/pointers.json
+++ b/regression/reference/pointers-c-c/pointers.json
@@ -407,7 +407,8 @@
                         },
                         "argin": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
@@ -432,7 +433,8 @@
                         },
                         "argin": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arginout": {
@@ -633,7 +635,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -668,7 +671,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -861,7 +865,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -896,7 +901,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1398,7 +1404,8 @@
                         },
                         "nvar": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
@@ -1423,7 +1430,8 @@
                         },
                         "nvar": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "values": {
@@ -1581,7 +1589,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
@@ -1607,7 +1616,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "result": {
@@ -1895,7 +1905,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -1914,7 +1925,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2045,7 +2057,8 @@
                         },
                         "x_length": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -2064,7 +2077,8 @@
                         },
                         "x_length": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2196,7 +2210,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -2215,7 +2230,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2457,7 +2473,8 @@
                         },
                         "value": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -2470,7 +2487,8 @@
                         },
                         "value": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4534,7 +4552,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -4547,7 +4566,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4651,7 +4671,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -4664,7 +4685,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/pointers-c-f/pointers.json
+++ b/regression/reference/pointers-c-f/pointers.json
@@ -455,7 +455,8 @@
                         },
                         "argin": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -480,7 +481,8 @@
                         },
                         "argin": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arginout": {
@@ -711,7 +713,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -746,7 +749,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -976,7 +980,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -1011,7 +1016,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1602,7 +1608,8 @@
                         },
                         "nvar": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -1627,7 +1634,8 @@
                         },
                         "nvar": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "values": {
@@ -1810,7 +1818,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -1836,7 +1845,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "result": {
@@ -2177,7 +2187,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -2196,7 +2207,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2355,7 +2367,8 @@
                         },
                         "x_length": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -2374,7 +2387,8 @@
                         },
                         "x_length": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2534,7 +2548,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -2553,7 +2568,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2875,7 +2891,8 @@
                         },
                         "value": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -2888,7 +2905,8 @@
                         },
                         "value": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -5428,7 +5446,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -5441,7 +5460,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -5569,7 +5589,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -5582,7 +5603,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/pointers-c/pointers.json
+++ b/regression/reference/pointers-c/pointers.json
@@ -579,7 +579,8 @@
                         },
                         "argin": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
@@ -605,7 +606,8 @@
                         },
                         "argin": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -630,7 +632,8 @@
                         },
                         "argin": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arginout": {
@@ -922,7 +925,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -960,7 +964,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -995,7 +1000,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1288,7 +1294,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -1326,7 +1333,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -1361,7 +1369,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2167,7 +2176,8 @@
                         },
                         "nvar": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
@@ -2193,7 +2203,8 @@
                         },
                         "nvar": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -2218,7 +2229,8 @@
                         },
                         "nvar": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "values": {
@@ -2447,7 +2459,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
@@ -2474,7 +2487,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -2500,7 +2514,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "result": {
@@ -2951,7 +2966,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -2972,7 +2988,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -2991,7 +3008,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3194,7 +3212,8 @@
                         },
                         "x_length": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -3215,7 +3234,8 @@
                         },
                         "x_length": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -3234,7 +3254,8 @@
                         },
                         "x_length": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3438,7 +3459,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -3459,7 +3481,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -3478,7 +3501,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3931,7 +3955,8 @@
                         },
                         "value": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -3945,7 +3970,8 @@
                         },
                         "value": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -3958,7 +3984,8 @@
                         },
                         "value": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -7377,7 +7404,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -7391,7 +7419,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -7404,7 +7433,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -7572,7 +7602,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -7586,7 +7617,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -7599,7 +7631,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/pointers-cfi/pointers.json
+++ b/regression/reference/pointers-cfi/pointers.json
@@ -579,7 +579,8 @@
                         },
                         "argin": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
@@ -605,7 +606,8 @@
                         },
                         "argin": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -630,7 +632,8 @@
                         },
                         "argin": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arginout": {
@@ -922,7 +925,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -961,7 +965,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -996,7 +1001,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1318,7 +1324,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -1357,7 +1364,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -1392,7 +1400,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2227,7 +2236,8 @@
                         },
                         "nvar": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
@@ -2253,7 +2263,8 @@
                         },
                         "nvar": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -2278,7 +2289,8 @@
                         },
                         "nvar": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "values": {
@@ -2507,7 +2519,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
@@ -2534,7 +2547,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -2561,7 +2575,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "result": {
@@ -3039,7 +3054,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -3061,7 +3077,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -3080,7 +3097,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3304,7 +3322,8 @@
                         },
                         "x_length": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -3326,7 +3345,8 @@
                         },
                         "x_length": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -3345,7 +3365,8 @@
                         },
                         "x_length": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3570,7 +3591,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -3592,7 +3614,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -3611,7 +3634,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4094,7 +4118,8 @@
                         },
                         "value": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -4108,7 +4133,8 @@
                         },
                         "value": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -4121,7 +4147,8 @@
                         },
                         "value": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -7530,7 +7557,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -7544,7 +7572,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -7557,7 +7586,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -7725,7 +7755,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -7739,7 +7770,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -7752,7 +7784,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/pointers-cxx-c/pointers.json
+++ b/regression/reference/pointers-cxx-c/pointers.json
@@ -407,7 +407,8 @@
                         },
                         "argin": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
@@ -432,7 +433,8 @@
                         },
                         "argin": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arginout": {
@@ -633,7 +635,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -668,7 +671,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -861,7 +865,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -896,7 +901,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1398,7 +1404,8 @@
                         },
                         "nvar": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
@@ -1423,7 +1430,8 @@
                         },
                         "nvar": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "values": {
@@ -1581,7 +1589,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
@@ -1607,7 +1616,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "result": {
@@ -1895,7 +1905,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -1914,7 +1925,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2045,7 +2057,8 @@
                         },
                         "x_length": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -2064,7 +2077,8 @@
                         },
                         "x_length": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2196,7 +2210,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -2215,7 +2230,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2457,7 +2473,8 @@
                         },
                         "value": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -2470,7 +2487,8 @@
                         },
                         "value": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4534,7 +4552,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -4547,7 +4566,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4651,7 +4671,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -4664,7 +4685,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/pointers-cxx-f/pointers.json
+++ b/regression/reference/pointers-cxx-f/pointers.json
@@ -458,7 +458,8 @@
                         },
                         "argin": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -483,7 +484,8 @@
                         },
                         "argin": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arginout": {
@@ -715,7 +717,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -750,7 +753,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -981,7 +985,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -1016,7 +1021,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1610,7 +1616,8 @@
                         },
                         "nvar": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -1635,7 +1642,8 @@
                         },
                         "nvar": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "values": {
@@ -1819,7 +1827,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -1845,7 +1854,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "result": {
@@ -2188,7 +2198,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -2207,7 +2218,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2367,7 +2379,8 @@
                         },
                         "x_length": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -2386,7 +2399,8 @@
                         },
                         "x_length": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2547,7 +2561,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -2566,7 +2581,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2889,7 +2905,8 @@
                         },
                         "value": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -2902,7 +2919,8 @@
                         },
                         "value": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -5451,7 +5469,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -5464,7 +5483,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -5593,7 +5613,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -5606,7 +5627,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/pointers-cxx/pointers.json
+++ b/regression/reference/pointers-cxx/pointers.json
@@ -579,7 +579,8 @@
                         },
                         "argin": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
@@ -605,7 +606,8 @@
                         },
                         "argin": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -630,7 +632,8 @@
                         },
                         "argin": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arginout": {
@@ -922,7 +925,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -960,7 +964,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -995,7 +1000,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1288,7 +1294,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -1326,7 +1333,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -1361,7 +1369,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2167,7 +2176,8 @@
                         },
                         "nvar": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
@@ -2193,7 +2203,8 @@
                         },
                         "nvar": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -2218,7 +2229,8 @@
                         },
                         "nvar": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "values": {
@@ -2447,7 +2459,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
@@ -2474,7 +2487,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -2500,7 +2514,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "result": {
@@ -2951,7 +2966,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -2972,7 +2988,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -2991,7 +3008,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3194,7 +3212,8 @@
                         },
                         "x_length": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -3215,7 +3234,8 @@
                         },
                         "x_length": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -3234,7 +3254,8 @@
                         },
                         "x_length": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3438,7 +3459,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -3459,7 +3481,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -3478,7 +3501,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3931,7 +3955,8 @@
                         },
                         "value": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -3945,7 +3970,8 @@
                         },
                         "value": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -3958,7 +3984,8 @@
                         },
                         "value": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -7377,7 +7404,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -7391,7 +7419,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -7404,7 +7433,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -7572,7 +7602,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -7586,7 +7617,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -7599,7 +7631,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/pointers-list-c/pointers.json
+++ b/regression/reference/pointers-list-c/pointers.json
@@ -376,7 +376,8 @@
                         },
                         "argin": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arginout": {
@@ -398,7 +399,8 @@
                         },
                         "argin": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arginout": {
@@ -591,7 +593,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -625,7 +628,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -816,7 +820,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -850,7 +855,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1346,7 +1352,8 @@
                         },
                         "nvar": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "values": {
@@ -1369,7 +1376,8 @@
                         },
                         "nvar": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "values": {
@@ -1523,7 +1531,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "result": {
@@ -1546,7 +1555,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "result": {
@@ -1823,7 +1833,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1841,7 +1852,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1966,7 +1978,8 @@
                         },
                         "x_length": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1984,7 +1997,8 @@
                         },
                         "x_length": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2110,7 +2124,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2128,7 +2143,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2366,7 +2382,8 @@
                         },
                         "value": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2378,7 +2395,8 @@
                         },
                         "value": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3967,7 +3985,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -3979,7 +3998,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4079,7 +4099,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -4091,7 +4112,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/pointers-list-cxx/pointers.json
+++ b/regression/reference/pointers-list-cxx/pointers.json
@@ -376,7 +376,8 @@
                         },
                         "argin": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arginout": {
@@ -398,7 +399,8 @@
                         },
                         "argin": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arginout": {
@@ -591,7 +593,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -625,7 +628,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -816,7 +820,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -850,7 +855,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1346,7 +1352,8 @@
                         },
                         "nvar": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "values": {
@@ -1369,7 +1376,8 @@
                         },
                         "nvar": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "values": {
@@ -1523,7 +1531,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "result": {
@@ -1546,7 +1555,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "result": {
@@ -1823,7 +1833,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1841,7 +1852,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1966,7 +1978,8 @@
                         },
                         "x_length": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1984,7 +1997,8 @@
                         },
                         "x_length": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2110,7 +2124,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2128,7 +2143,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2366,7 +2382,8 @@
                         },
                         "value": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2378,7 +2395,8 @@
                         },
                         "value": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3967,7 +3985,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -3979,7 +3998,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4079,7 +4099,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -4091,7 +4112,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/pointers-numpy-c/pointers.json
+++ b/regression/reference/pointers-numpy-c/pointers.json
@@ -376,7 +376,8 @@
                         },
                         "argin": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arginout": {
@@ -398,7 +399,8 @@
                         },
                         "argin": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arginout": {
@@ -591,7 +593,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -625,7 +628,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -814,7 +818,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -848,7 +853,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1339,7 +1345,8 @@
                         },
                         "nvar": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "values": {
@@ -1362,7 +1369,8 @@
                         },
                         "nvar": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "values": {
@@ -1515,7 +1523,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "result": {
@@ -1538,7 +1547,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "result": {
@@ -1813,7 +1823,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1831,7 +1842,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1954,7 +1966,8 @@
                         },
                         "x_length": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1972,7 +1985,8 @@
                         },
                         "x_length": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2096,7 +2110,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2114,7 +2129,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2351,7 +2367,8 @@
                         },
                         "value": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2363,7 +2380,8 @@
                         },
                         "value": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3947,7 +3965,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -3959,7 +3978,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4059,7 +4079,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -4071,7 +4092,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/pointers-numpy-cxx/pointers.json
+++ b/regression/reference/pointers-numpy-cxx/pointers.json
@@ -376,7 +376,8 @@
                         },
                         "argin": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arginout": {
@@ -398,7 +399,8 @@
                         },
                         "argin": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arginout": {
@@ -591,7 +593,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -625,7 +628,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -814,7 +818,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -848,7 +853,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1339,7 +1345,8 @@
                         },
                         "nvar": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "values": {
@@ -1362,7 +1369,8 @@
                         },
                         "nvar": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "values": {
@@ -1515,7 +1523,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "result": {
@@ -1538,7 +1547,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "result": {
@@ -1813,7 +1823,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1831,7 +1842,8 @@
                         },
                         "sizein": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1954,7 +1966,8 @@
                         },
                         "x_length": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1972,7 +1985,8 @@
                         },
                         "x_length": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2096,7 +2110,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2114,7 +2129,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2351,7 +2367,8 @@
                         },
                         "value": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2363,7 +2380,8 @@
                         },
                         "value": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3947,7 +3965,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -3959,7 +3978,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4059,7 +4079,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -4071,7 +4092,8 @@
                         },
                         "flag": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/preprocess/preprocess.json
+++ b/regression/reference/preprocess/preprocess.json
@@ -343,7 +343,8 @@
                                 },
                                 "i": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_native_scalar"
                                 }
@@ -357,7 +358,8 @@
                                 },
                                 "i": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 }
@@ -370,7 +372,8 @@
                                 },
                                 "i": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             },
@@ -382,7 +385,8 @@
                                 },
                                 "i": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -675,7 +679,8 @@
                                 },
                                 "flag": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_native_scalar"
                                 }
@@ -689,7 +694,8 @@
                                 },
                                 "flag": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 }
@@ -702,7 +708,8 @@
                                 },
                                 "flag": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             },
@@ -714,7 +721,8 @@
                                 },
                                 "flag": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }

--- a/regression/reference/python-only/tutorial.json
+++ b/regression/reference/python-only/tutorial.json
@@ -170,12 +170,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -187,12 +189,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -486,12 +490,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -503,12 +509,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -725,7 +733,8 @@
                         },
                         "indx": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -737,7 +746,8 @@
                         },
                         "indx": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -844,7 +854,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -929,7 +940,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -941,7 +953,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1055,7 +1068,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1067,7 +1081,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1493,7 +1508,8 @@
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "name": {
@@ -1510,7 +1526,8 @@
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "name": {
@@ -1640,17 +1657,20 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1662,17 +1682,20 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1840,22 +1863,26 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1867,22 +1894,26 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2036,7 +2067,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2048,7 +2080,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2140,7 +2173,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2152,7 +2186,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2246,7 +2281,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2258,7 +2294,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2493,9 +2530,6 @@
                                     "params": [
                                         {
                                             "declarator": {
-                                                "attrs": {
-                                                    "value": true
-                                                },
                                                 "typemap_name": "int"
                                             },
                                             "specifier": [
@@ -2540,12 +2574,65 @@
                         },
                         "in": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "incr": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "incr  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "func": {
+                                                "name": "incr",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            "name": "incr",
+                                            "params": [
+                                                {
+                                                    "declarator": {
+                                                        "typemap_name": "int"
+                                                    },
+                                                    "specifier": [
+                                                        "int"
+                                                    ],
+                                                    "typemap_name": "int"
+                                                }
+                                            ],
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    },
+                                    "decl": "int ( * incr)(int)",
+                                    "name": "incr",
+                                    "options": {},
+                                    "wrap": {},
+                                    "zz_bind": {
+                                        "share": {
+                                            "arg1": {
+                                                "meta": {
+                                                    "value": true
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "incr",
+                                        "F_name_api": "incr",
+                                        "function_name": "incr"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/strings-cfi/strings.json
+++ b/regression/reference/strings-cfi/strings.json
@@ -142,7 +142,8 @@
                         },
                         "status": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_char_scalar"
                         }
@@ -156,7 +157,8 @@
                         },
                         "status": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_char_scalar"
                         }
@@ -169,7 +171,8 @@
                         },
                         "status": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -302,7 +305,8 @@
                         },
                         "status": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_char_scalar"
                         }
@@ -316,7 +320,8 @@
                         },
                         "status": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_char_scalar"
                         }
@@ -329,7 +334,8 @@
                         },
                         "status": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -5457,7 +5463,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_string_scalar"
                         }
@@ -5472,7 +5479,8 @@
                         "arg1": {
                             "meta": {
                                 "api": "cfi",
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_string_scalar_cfi"
                         }
@@ -5485,7 +5493,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -7096,7 +7105,8 @@
                         },
                         "status": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_char_scalar"
                         }
@@ -7110,7 +7120,8 @@
                         },
                         "status": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_char_scalar"
                         }
@@ -7123,7 +7134,8 @@
                         },
                         "status": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -8470,7 +8482,8 @@
                         },
                         "addr": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_void_*"
                         },
@@ -8490,7 +8503,8 @@
                         },
                         "addr": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_void_*"
                         },
@@ -8510,7 +8524,8 @@
                         },
                         "addr": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "src": {

--- a/regression/reference/strings/strings.json
+++ b/regression/reference/strings/strings.json
@@ -152,7 +152,8 @@
                         },
                         "status": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_char_scalar"
                         }
@@ -166,7 +167,8 @@
                         },
                         "status": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_char_scalar"
                         }
@@ -179,7 +181,8 @@
                         },
                         "status": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -191,7 +194,8 @@
                         },
                         "status": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -344,7 +348,8 @@
                         },
                         "status": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_char_scalar"
                         }
@@ -358,7 +363,8 @@
                         },
                         "status": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_char_scalar"
                         }
@@ -371,7 +377,8 @@
                         },
                         "status": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -6535,7 +6542,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_string_scalar"
                         }
@@ -6550,7 +6558,8 @@
                         "arg1": {
                             "meta": {
                                 "api": "buf",
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_string_scalar_buf"
                         }
@@ -6563,7 +6572,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -6575,7 +6585,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -8365,7 +8376,8 @@
                         },
                         "status": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_char_scalar"
                         }
@@ -8379,7 +8391,8 @@
                         },
                         "status": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_char_scalar"
                         }
@@ -8392,7 +8405,8 @@
                         },
                         "status": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -8404,7 +8418,8 @@
                         },
                         "status": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -9864,7 +9879,8 @@
                         },
                         "addr": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_void_*"
                         },
@@ -9884,7 +9900,8 @@
                         },
                         "addr": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_void_*"
                         },
@@ -9904,7 +9921,8 @@
                         },
                         "addr": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "src": {

--- a/regression/reference/struct-c/struct.json
+++ b/regression/reference/struct-c/struct.json
@@ -855,7 +855,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     },
                                     "stmt": "f_setter_native_scalar"
                                 }
@@ -868,7 +869,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     }
                                 }
                             }
@@ -1093,7 +1095,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     },
                                     "stmt": "f_setter_native_scalar"
                                 }
@@ -1106,7 +1109,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     }
                                 }
                             }
@@ -1433,7 +1437,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     },
                                     "stmt": "f_setter_native_scalar"
                                 }
@@ -1446,7 +1451,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     }
                                 }
                             }
@@ -1671,7 +1677,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     },
                                     "stmt": "f_setter_native_scalar"
                                 }
@@ -1684,7 +1691,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     }
                                 }
                             }
@@ -1909,7 +1917,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     },
                                     "stmt": "f_setter_native_scalar"
                                 }
@@ -1922,7 +1931,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     }
                                 }
                             }
@@ -2239,7 +2249,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_struct_scalar"
                         }
@@ -2253,7 +2264,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_struct_scalar"
                         }
@@ -2266,7 +2278,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3173,13 +3186,15 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -3199,13 +3214,15 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -3223,12 +3240,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3615,13 +3634,15 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -3635,13 +3656,15 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -3654,12 +3677,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3888,13 +3913,15 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -3910,13 +3937,15 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -3929,12 +3958,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4214,13 +4245,15 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
@@ -4242,13 +4275,15 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -4268,12 +4303,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "outbuf": {
@@ -5043,13 +5080,15 @@
                         },
                         "x": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "y": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -5064,13 +5103,15 @@
                         },
                         "x": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "y": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -5083,12 +5124,14 @@
                         },
                         "x": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "y": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -5530,19 +5573,22 @@
                         },
                         "x": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "y": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "z": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -5557,19 +5603,22 @@
                         },
                         "x": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "y": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "z": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -5582,17 +5631,20 @@
                         },
                         "x": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "y": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "z": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/struct-class-c/struct.json
+++ b/regression/reference/struct-class-c/struct.json
@@ -78,12 +78,14 @@
                                 },
                                 "dfield": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "ifield": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             },
@@ -95,12 +97,14 @@
                                 },
                                 "dfield": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "ifield": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -752,7 +756,8 @@
                                 },
                                 "nitems": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "svalue": {
@@ -809,7 +814,8 @@
                                 },
                                 "nitems": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "svalue": {
@@ -1331,7 +1337,8 @@
                                 },
                                 "nitems": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             },
@@ -1365,7 +1372,8 @@
                                 },
                                 "nitems": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -1739,12 +1747,14 @@
                                 },
                                 "count": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "name": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             },
@@ -1756,12 +1766,14 @@
                                 },
                                 "count": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "name": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -2287,7 +2299,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2299,7 +2312,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2838,12 +2852,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2860,12 +2876,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3094,12 +3112,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -3111,12 +3131,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3254,12 +3276,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -3271,12 +3295,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3431,12 +3457,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "outbuf": {
@@ -3453,12 +3481,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "outbuf": {
@@ -3829,12 +3859,14 @@
                         },
                         "x": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "y": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3976,17 +4008,20 @@
                         },
                         "x": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "y": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "z": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/struct-class-cxx/struct.json
+++ b/regression/reference/struct-class-cxx/struct.json
@@ -78,12 +78,14 @@
                                 },
                                 "dfield": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "ifield": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             },
@@ -95,12 +97,14 @@
                                 },
                                 "dfield": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "ifield": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -752,7 +756,8 @@
                                 },
                                 "nitems": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "svalue": {
@@ -809,7 +814,8 @@
                                 },
                                 "nitems": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "svalue": {
@@ -1331,7 +1337,8 @@
                                 },
                                 "nitems": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             },
@@ -1365,7 +1372,8 @@
                                 },
                                 "nitems": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -1739,12 +1747,14 @@
                                 },
                                 "count": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "name": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             },
@@ -1756,12 +1766,14 @@
                                 },
                                 "count": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "name": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -2287,7 +2299,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2299,7 +2312,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2838,12 +2852,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2860,12 +2876,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3094,12 +3112,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -3111,12 +3131,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3254,12 +3276,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -3271,12 +3295,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3431,12 +3457,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "outbuf": {
@@ -3453,12 +3481,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "outbuf": {
@@ -3829,12 +3859,14 @@
                         },
                         "x": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "y": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3976,17 +4008,20 @@
                         },
                         "x": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "y": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "z": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/struct-cxx/struct.json
+++ b/regression/reference/struct-cxx/struct.json
@@ -855,7 +855,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     },
                                     "stmt": "f_setter_native_scalar"
                                 }
@@ -868,7 +869,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     }
                                 }
                             }
@@ -1093,7 +1095,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     },
                                     "stmt": "f_setter_native_scalar"
                                 }
@@ -1106,7 +1109,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     }
                                 }
                             }
@@ -1433,7 +1437,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     },
                                     "stmt": "f_setter_native_scalar"
                                 }
@@ -1446,7 +1451,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     }
                                 }
                             }
@@ -1671,7 +1677,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     },
                                     "stmt": "f_setter_native_scalar"
                                 }
@@ -1684,7 +1691,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     }
                                 }
                             }
@@ -1909,7 +1917,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     },
                                     "stmt": "f_setter_native_scalar"
                                 }
@@ -1922,7 +1931,8 @@
                                 },
                                 "val": {
                                     "meta": {
-                                        "intent": "setter"
+                                        "intent": "setter",
+                                        "value": true
                                     }
                                 }
                             }
@@ -2239,7 +2249,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_struct_scalar"
                         }
@@ -2253,7 +2264,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_struct_scalar"
                         }
@@ -2266,7 +2278,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3173,13 +3186,15 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -3199,13 +3214,15 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -3223,12 +3240,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3615,13 +3634,15 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -3635,13 +3656,15 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -3654,12 +3677,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3888,13 +3913,15 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -3910,13 +3937,15 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -3929,12 +3958,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4214,13 +4245,15 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
@@ -4242,13 +4275,15 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -4268,12 +4303,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "outbuf": {
@@ -5043,13 +5080,15 @@
                         },
                         "x": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "y": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -5064,13 +5103,15 @@
                         },
                         "x": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "y": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -5083,12 +5124,14 @@
                         },
                         "x": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "y": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -5530,19 +5573,22 @@
                         },
                         "x": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "y": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "z": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -5557,19 +5603,22 @@
                         },
                         "x": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "y": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "z": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -5582,17 +5631,20 @@
                         },
                         "x": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "y": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "z": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/struct-list-cxx/struct.json
+++ b/regression/reference/struct-list-cxx/struct.json
@@ -1016,7 +1016,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1028,7 +1029,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1567,12 +1569,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1589,12 +1593,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1827,12 +1833,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1844,12 +1852,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1986,12 +1996,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2003,12 +2015,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2165,12 +2179,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "outbuf": {
@@ -2187,12 +2203,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "outbuf": {
@@ -2569,12 +2587,14 @@
                         },
                         "x": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "y": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2716,17 +2736,20 @@
                         },
                         "x": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "y": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "z": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/struct-numpy-c/struct.json
+++ b/regression/reference/struct-numpy-c/struct.json
@@ -1016,7 +1016,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1028,7 +1029,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1567,12 +1569,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1589,12 +1593,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1823,12 +1829,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1840,12 +1848,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1983,12 +1993,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2000,12 +2012,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2160,12 +2174,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "outbuf": {
@@ -2182,12 +2198,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "outbuf": {
@@ -2558,12 +2576,14 @@
                         },
                         "x": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "y": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2705,17 +2725,20 @@
                         },
                         "x": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "y": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "z": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/struct-numpy-cxx/struct.json
+++ b/regression/reference/struct-numpy-cxx/struct.json
@@ -1016,7 +1016,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1028,7 +1029,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1567,12 +1569,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1589,12 +1593,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1823,12 +1829,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1840,12 +1848,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1983,12 +1993,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2000,12 +2012,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2160,12 +2174,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "outbuf": {
@@ -2182,12 +2198,14 @@
                         },
                         "d": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "outbuf": {
@@ -2558,12 +2576,14 @@
                         },
                         "x": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "y": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2705,17 +2725,20 @@
                         },
                         "x": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "y": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "z": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/struct-py-c/struct-py.json
+++ b/regression/reference/struct-py-c/struct-py.json
@@ -72,12 +72,14 @@
                                 },
                                 "x1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "y1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             },
@@ -89,12 +91,14 @@
                                 },
                                 "x1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "y1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }

--- a/regression/reference/struct-py-cxx/struct-py.json
+++ b/regression/reference/struct-py-cxx/struct-py.json
@@ -72,12 +72,14 @@
                                 },
                                 "x1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "y1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             },
@@ -89,12 +91,14 @@
                                 },
                                 "x1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "y1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }

--- a/regression/reference/structlist/structlist.json
+++ b/regression/reference/structlist/structlist.json
@@ -81,12 +81,14 @@
                                 },
                                 "count": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "name": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             },
@@ -98,12 +100,14 @@
                                 },
                                 "count": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "name": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }

--- a/regression/reference/templates/templates.json
+++ b/regression/reference/templates/templates.json
@@ -125,12 +125,14 @@
                                 },
                                 "arg1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "arg2": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -220,13 +222,15 @@
                                 },
                                 "arg1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_native_scalar"
                                 },
                                 "arg2": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_native_scalar"
                                 }
@@ -240,13 +244,15 @@
                                 },
                                 "arg1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 },
                                 "arg2": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 }
@@ -259,12 +265,14 @@
                                 },
                                 "arg1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "arg2": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             },
@@ -276,12 +284,14 @@
                                 },
                                 "arg1": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 },
                                 "arg2": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -680,7 +690,8 @@
                                 },
                                 "n": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_native_scalar"
                                 }
@@ -694,7 +705,8 @@
                                 },
                                 "n": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 }
@@ -707,7 +719,8 @@
                                 },
                                 "n": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -956,7 +969,8 @@
                                 },
                                 "v": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -1015,7 +1029,8 @@
                                 },
                                 "v": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_native_scalar"
                                 }
@@ -1029,7 +1044,8 @@
                                 },
                                 "v": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 }
@@ -1042,7 +1058,8 @@
                                 },
                                 "v": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -1530,7 +1547,8 @@
                                 },
                                 "n": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_native_scalar"
                                 }
@@ -1544,7 +1562,8 @@
                                 },
                                 "n": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 }
@@ -1557,7 +1576,8 @@
                                 },
                                 "n": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -1806,7 +1826,8 @@
                                 },
                                 "v": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -1865,7 +1886,8 @@
                                 },
                                 "v": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "c_in_native_scalar"
                                 }
@@ -1879,7 +1901,8 @@
                                 },
                                 "v": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     },
                                     "stmt": "f_in_native_scalar"
                                 }
@@ -1892,7 +1915,8 @@
                                 },
                                 "v": {
                                     "meta": {
-                                        "intent": "in"
+                                        "intent": "in",
+                                        "value": true
                                     }
                                 }
                             }
@@ -2452,12 +2476,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2571,13 +2597,15 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -2591,13 +2619,15 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -2610,12 +2640,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2627,12 +2659,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2908,13 +2942,15 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -2928,13 +2964,15 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -2947,12 +2985,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2964,12 +3004,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4151,7 +4193,8 @@
                                         },
                                         "n": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     }
@@ -4218,7 +4261,8 @@
                                         },
                                         "n": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "c_in_native_scalar"
                                         }
@@ -4233,7 +4277,8 @@
                                         },
                                         "n": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "f_in_native_scalar"
                                         }
@@ -4246,7 +4291,8 @@
                                         },
                                         "n": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     },
@@ -4258,7 +4304,8 @@
                                         },
                                         "n": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     }
@@ -5091,7 +5138,8 @@
                                         },
                                         "n": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     }
@@ -5158,7 +5206,8 @@
                                         },
                                         "n": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "c_in_native_scalar"
                                         }
@@ -5173,7 +5222,8 @@
                                         },
                                         "n": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             },
                                             "stmt": "f_in_native_scalar"
                                         }
@@ -5186,7 +5236,8 @@
                                         },
                                         "n": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     },
@@ -5198,7 +5249,8 @@
                                         },
                                         "n": {
                                             "meta": {
-                                                "intent": "in"
+                                                "intent": "in",
+                                                "value": true
                                             }
                                         }
                                     }

--- a/regression/reference/tutorial/tutorial.json
+++ b/regression/reference/tutorial/tutorial.json
@@ -238,13 +238,15 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -258,13 +260,15 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -277,12 +281,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -294,12 +300,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -311,12 +319,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1220,7 +1230,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -1234,7 +1245,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -1247,7 +1259,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1441,13 +1454,15 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_bool_scalar"
                         }
@@ -1461,13 +1476,15 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_bool_scalar"
                         }
@@ -1480,12 +1497,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1497,12 +1516,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1514,12 +1535,14 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2075,7 +2098,8 @@
                         },
                         "indx": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -2089,7 +2113,8 @@
                         },
                         "indx": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -2102,7 +2127,8 @@
                         },
                         "indx": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2114,7 +2140,8 @@
                         },
                         "indx": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2126,7 +2153,8 @@
                         },
                         "indx": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2319,7 +2347,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2408,7 +2437,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -2422,7 +2452,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -2435,7 +2466,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2447,7 +2479,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2459,7 +2492,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2666,7 +2700,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -2680,7 +2715,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -2693,7 +2729,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2705,7 +2742,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2717,7 +2755,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3461,7 +3500,8 @@
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
@@ -3480,7 +3520,8 @@
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "name": {
@@ -3497,7 +3538,8 @@
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "name": {
@@ -3514,7 +3556,8 @@
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "name": {
@@ -3735,7 +3778,8 @@
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -3755,7 +3799,8 @@
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "name": {
@@ -3923,7 +3968,8 @@
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -3943,7 +3989,8 @@
                         },
                         "arg2": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "name": {
@@ -4092,7 +4139,8 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -4106,7 +4154,8 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -4119,7 +4168,8 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4304,13 +4354,15 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -4324,13 +4376,15 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -4343,12 +4397,14 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4593,19 +4649,22 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -4619,19 +4678,22 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -4644,17 +4706,20 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -4666,17 +4731,20 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -4688,17 +4756,20 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -5086,13 +5157,15 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -5106,13 +5179,15 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -5125,12 +5200,14 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -5363,19 +5440,22 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -5389,19 +5469,22 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -5414,17 +5497,20 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -5717,25 +5803,29 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -5749,25 +5839,29 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -5780,22 +5874,26 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -5807,22 +5905,26 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -5834,22 +5936,26 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "offset": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "stride": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "type": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -6294,7 +6400,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -6308,7 +6415,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -6321,7 +6429,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -6333,7 +6442,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -6345,7 +6455,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -6569,7 +6680,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -6583,7 +6695,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -6596,7 +6709,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -6608,7 +6722,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -6620,7 +6735,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -6854,7 +6970,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -6868,7 +6985,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -6881,7 +6999,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -6893,7 +7012,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -6905,7 +7025,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -7446,9 +7567,6 @@
                                     "params": [
                                         {
                                             "declarator": {
-                                                "attrs": {
-                                                    "value": true
-                                                },
                                                 "typemap_name": "int"
                                             },
                                             "specifier": [
@@ -7497,13 +7615,76 @@
                         },
                         "in": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
                         "incr": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "incr  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "func": {
+                                                "name": "incr",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            "name": "incr",
+                                            "params": [
+                                                {
+                                                    "declarator": {
+                                                        "typemap_name": "int"
+                                                    },
+                                                    "specifier": [
+                                                        "int"
+                                                    ],
+                                                    "typemap_name": "int"
+                                                }
+                                            ],
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    },
+                                    "decl": "int ( * incr)(int)",
+                                    "name": "incr",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true
+                                    },
+                                    "zz_bind": {
+                                        "f": {
+                                            "arg1": {
+                                                "meta": {
+                                                    "value": true
+                                                }
+                                            }
+                                        },
+                                        "share": {
+                                            "arg1": {
+                                                "meta": {
+                                                    "value": true
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "incr",
+                                        "F_name_api": "incr",
+                                        "function_name": "incr"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -7517,13 +7698,76 @@
                         },
                         "in": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
                         "incr": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "incr  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "func": {
+                                                "name": "incr",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            "name": "incr",
+                                            "params": [
+                                                {
+                                                    "declarator": {
+                                                        "typemap_name": "int"
+                                                    },
+                                                    "specifier": [
+                                                        "int"
+                                                    ],
+                                                    "typemap_name": "int"
+                                                }
+                                            ],
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    },
+                                    "decl": "int ( * incr)(int)",
+                                    "name": "incr",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true
+                                    },
+                                    "zz_bind": {
+                                        "f": {
+                                            "arg1": {
+                                                "meta": {
+                                                    "value": true
+                                                }
+                                            }
+                                        },
+                                        "share": {
+                                            "arg1": {
+                                                "meta": {
+                                                    "value": true
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "incr",
+                                        "F_name_api": "incr",
+                                        "function_name": "incr"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -7536,12 +7780,75 @@
                         },
                         "in": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "incr": {
                             "meta": {
-                                "intent": "in"
+                                "fptr": {
+                                    "<FUNCTION>": "incr  None ****************************************",
+                                    "ast": {
+                                        "declarator": {
+                                            "func": {
+                                                "name": "incr",
+                                                "pointer": [
+                                                    {
+                                                        "ptr": "*"
+                                                    }
+                                                ],
+                                                "typemap_name": "int"
+                                            },
+                                            "name": "incr",
+                                            "params": [
+                                                {
+                                                    "declarator": {
+                                                        "typemap_name": "int"
+                                                    },
+                                                    "specifier": [
+                                                        "int"
+                                                    ],
+                                                    "typemap_name": "int"
+                                                }
+                                            ],
+                                            "typemap_name": "int"
+                                        },
+                                        "specifier": [
+                                            "int"
+                                        ],
+                                        "typemap_name": "int"
+                                    },
+                                    "decl": "int ( * incr)(int)",
+                                    "name": "incr",
+                                    "options": {},
+                                    "wrap": {
+                                        "c": true,
+                                        "fortran": true
+                                    },
+                                    "zz_bind": {
+                                        "f": {
+                                            "arg1": {
+                                                "meta": {
+                                                    "value": true
+                                                }
+                                            }
+                                        },
+                                        "share": {
+                                            "arg1": {
+                                                "meta": {
+                                                    "value": true
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "zz_fmtdict": {
+                                        "C_name_api": "incr",
+                                        "F_name_api": "incr",
+                                        "function_name": "incr"
+                                    }
+                                },
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/tutorial/wrapTutorial.cpp
+++ b/regression/reference/tutorial/wrapTutorial.cpp
@@ -572,7 +572,7 @@ void TUT_getMinMax(int * min, int * max)
 // Argument:  int in
 // Statement: c_in_native_scalar
 // ----------------------------------------
-// Argument:  int ( * incr)(int +value)
+// Argument:  int ( * incr)(int)
 // Statement: c_in_native_scalar
 // start TUT_callback1
 int TUT_callback1(int in, int ( * incr)(int))

--- a/regression/reference/tutorial/wrapftutorial.f
+++ b/regression/reference/tutorial/wrapftutorial.f
@@ -648,7 +648,7 @@ module tutorial_mod
     ! Argument:  int in
     ! Statement: f_in_native_scalar
     ! ----------------------------------------
-    ! Argument:  int ( * incr)(int +value)
+    ! Argument:  int ( * incr)(int)
     ! Statement: f_in_native_scalar
     ! start callback1
     interface

--- a/regression/reference/typedefs-c/typedefs.json
+++ b/regression/reference/typedefs-c/typedefs.json
@@ -161,7 +161,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -175,7 +176,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -188,7 +190,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -200,7 +203,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -595,7 +599,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -609,7 +614,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -622,7 +628,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/typedefs-cxx/typedefs.json
+++ b/regression/reference/typedefs-cxx/typedefs.json
@@ -161,7 +161,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -175,7 +176,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -188,7 +190,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -200,7 +203,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -595,7 +599,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -609,7 +614,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -622,7 +628,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/typemap/typemap.json
+++ b/regression/reference/typemap/typemap.json
@@ -143,7 +143,8 @@
                         },
                         "i1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         },
@@ -162,7 +163,8 @@
                         },
                         "i1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i2": {
@@ -329,7 +331,8 @@
                         },
                         "i1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -348,7 +351,8 @@
                         },
                         "i1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i2": {
@@ -528,7 +532,8 @@
                         },
                         "i1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         },
@@ -547,7 +552,8 @@
                         },
                         "i1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         },
                         "i2": {
@@ -737,7 +743,8 @@
                         },
                         "i1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -750,7 +757,8 @@
                         },
                         "i1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -849,7 +857,8 @@
                         },
                         "i1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -862,7 +871,8 @@
                         },
                         "i1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -967,7 +977,8 @@
                         },
                         "i1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -980,7 +991,8 @@
                         },
                         "i1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1113,7 +1125,8 @@
                         },
                         "f1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -1126,7 +1139,8 @@
                         },
                         "f1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1225,7 +1239,8 @@
                         },
                         "f1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -1238,7 +1253,8 @@
                         },
                         "f1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1343,7 +1359,8 @@
                         },
                         "f1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -1356,7 +1373,8 @@
                         },
                         "f1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/types/types.json
+++ b/regression/reference/types/types.json
@@ -56,7 +56,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -70,7 +71,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -83,7 +85,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -95,7 +98,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -293,7 +297,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -307,7 +312,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -320,7 +326,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -332,7 +339,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -530,7 +538,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -544,7 +553,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -557,7 +567,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -569,7 +580,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -769,7 +781,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -783,7 +796,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -796,7 +810,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -808,7 +823,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1010,7 +1026,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -1024,7 +1041,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -1037,7 +1055,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1049,7 +1068,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1249,7 +1269,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -1263,7 +1284,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -1276,7 +1298,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1288,7 +1311,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1490,7 +1514,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -1504,7 +1529,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -1517,7 +1543,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1529,7 +1556,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1729,7 +1757,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -1743,7 +1772,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -1756,7 +1786,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1768,7 +1799,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1968,7 +2000,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -1982,7 +2015,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -1995,7 +2029,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2007,7 +2042,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2207,7 +2243,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -2221,7 +2258,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -2234,7 +2272,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2246,7 +2285,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2446,7 +2486,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -2460,7 +2501,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -2473,7 +2515,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2485,7 +2528,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2687,7 +2731,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -2701,7 +2746,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -2714,7 +2760,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2726,7 +2773,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -2930,7 +2978,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -2944,7 +2993,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -2957,7 +3007,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -2969,7 +3020,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3167,7 +3219,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -3181,7 +3234,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -3194,7 +3248,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -3206,7 +3261,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3404,7 +3460,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -3418,7 +3475,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -3431,7 +3489,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -3443,7 +3502,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3641,7 +3701,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -3655,7 +3716,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -3668,7 +3730,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -3680,7 +3743,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3878,7 +3942,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -3892,7 +3957,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -3905,7 +3971,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -3917,7 +3984,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4115,7 +4183,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -4129,7 +4198,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -4142,7 +4212,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -4154,7 +4225,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4352,7 +4424,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -4366,7 +4439,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -4379,7 +4453,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -4391,7 +4466,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4589,7 +4665,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -4603,7 +4680,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -4616,7 +4694,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -4628,7 +4707,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -4826,7 +4906,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -4840,7 +4921,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -4853,7 +4935,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -4865,7 +4948,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -5063,7 +5147,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -5077,7 +5162,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -5090,7 +5176,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -5102,7 +5189,8 @@
                         },
                         "arg1": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -5300,7 +5388,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_bool_scalar"
                         }
@@ -5314,7 +5403,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_bool_scalar"
                         }
@@ -5327,7 +5417,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -5339,7 +5430,8 @@
                         },
                         "arg": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/vectors-list/vectors.json
+++ b/regression/reference/vectors-list/vectors.json
@@ -904,7 +904,8 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1350,7 +1351,8 @@
                         },
                         "n": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1363,7 +1365,8 @@
                         },
                         "n": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1489,7 +1492,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1507,7 +1511,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/vectors-numpy/vectors.json
+++ b/regression/reference/vectors-numpy/vectors.json
@@ -907,7 +907,8 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1353,7 +1354,8 @@
                         },
                         "n": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1366,7 +1368,8 @@
                         },
                         "n": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -1495,7 +1498,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     },
@@ -1513,7 +1517,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/regression/reference/vectors/vectors.json
+++ b/regression/reference/vectors/vectors.json
@@ -1965,7 +1965,8 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -1987,7 +1988,8 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -2006,7 +2008,8 @@
                         },
                         "num": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3252,7 +3255,8 @@
                         },
                         "n": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -3269,7 +3273,8 @@
                         },
                         "n": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -3283,7 +3288,8 @@
                         },
                         "n": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }
@@ -3507,7 +3513,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "c_in_native_scalar"
                         }
@@ -3528,7 +3535,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             },
                             "stmt": "f_in_native_scalar"
                         }
@@ -3547,7 +3555,8 @@
                         },
                         "len": {
                             "meta": {
-                                "intent": "in"
+                                "intent": "in",
+                                "value": true
                             }
                         }
                     }

--- a/shroud/ast.py
+++ b/shroud/ast.py
@@ -1494,7 +1494,7 @@ class FunctionNode(AstNode):
         self._nargs = None
         self._overloaded = False
         self._gen_fortran_generic = False # An argument is assumed-rank.
-        self._bind = {}
+        self._bind = {}                   # Access with get_func_bind or get_arg_bind
         self.splicer = {}
         self.fstatements = {}
         self.struct_parent = None         # Function is a getter/setter for a struct

--- a/shroud/declast.py
+++ b/shroud/declast.py
@@ -369,6 +369,7 @@ class Parser(ExprParser):
         while self.token.typ != "RPAREN":
             node = self.declaration()
             params.append(node)
+            node.declarator.arg_name = "arg" + str(len(params))
             if self.have("COMMA"):
                 if self.have("VARARG"):
                     raise NotImplementedError("varargs")
@@ -1291,6 +1292,7 @@ class Declarator(Node):
         
         self.ctor_dtor_name = False
         self.default_name = None
+        self.arg_name = None         # default abstract-declarator name - arg%n
 
         self.params = None  # None=No parameters, []=empty parameters list
         self.array = []

--- a/shroud/metaattrs.py
+++ b/shroud/metaattrs.py
@@ -159,7 +159,7 @@ class FillMeta(object):
         else:
             meta["value"] = value
         
-    def set_arg_intent(self, node, arg, meta, is_fptr=False):
+    def set_arg_intent(self, arg, meta, is_fptr=False):
         """Set default intent meta-attribute.
 
         Intent is only valid on arguments.
@@ -488,7 +488,7 @@ class FillMeta(object):
             meta["deref"] = "arg"
             meta["api"] = "buf"
 
-    def set_arg_api_c(self, node, arg, meta):
+    def set_arg_api_c(self, arg, meta):
         declarator = arg.declarator
         ntypemap = arg.typemap
         attrs = declarator.attrs
@@ -645,16 +645,15 @@ class FillMetaShare(FillMeta):
         # --- Loop over function parameters
         for arg in node.ast.declarator.params:
             func_cursor.arg = arg
-            declarator = arg.declarator
 
             a_bind = statements.fetch_arg_bind(node, arg, wlang)
             meta = a_bind.meta
 
             self.check_arg_attrs(node, arg, meta)
-            self.set_arg_intent(node, arg, meta, is_fptr)
+            self.set_arg_intent(arg, meta, is_fptr)
             self.check_value(arg, meta)
 
-            if declarator.is_function_pointer():
+            if arg.declarator.is_function_pointer():
                 fptr = FunctionNode(arg.gen_decl(), parent=node, ast=arg)
                 meta["fptr"] = fptr
                 self.meta_function_params(fptr, is_fptr=True)
@@ -881,15 +880,12 @@ class FillMetaC(FillMeta):
         # --- Loop over function parameters
         for arg in ast.declarator.params:
             func_cursor.arg = arg
-            declarator = arg.declarator
-            arg_name = declarator.user_name
-
             a_bind = statements.fetch_arg_bind(node, arg, wlang)
             meta = a_bind.meta
 
             self.set_arg_share(node, arg, meta)
             self.set_arg_deref_c(arg, meta)
-            self.set_arg_api_c(node, arg, meta)
+            self.set_arg_api_c(arg, meta)
         # --- End loop over function parameters
         func_cursor.arg = None
 
@@ -948,8 +944,6 @@ class FillMetaFortran(FillMeta):
         func_cursor = self.cursor.current
         for arg in node.ast.declarator.params:
             func_cursor.arg = arg
-            declarator = arg.declarator
-            arg_name = declarator.user_name
 
             a_bind = statements.fetch_arg_bind(node, arg, wlang)
             meta = a_bind.meta
@@ -960,7 +954,7 @@ class FillMetaFortran(FillMeta):
             self.set_arg_api_fortran(node, arg, meta)
             self.set_arg_hidden(arg, meta)
 
-            if declarator.is_function_pointer():
+            if arg.declarator.is_function_pointer():
                 self.meta_function_params(meta["fptr"])
         func_cursor.arg = None
         
@@ -1036,8 +1030,6 @@ class FillMetaPython(FillMeta):
         # --- Loop over function parameters
         for arg in ast.declarator.params:
             func_cursor.arg = arg
-            declarator = arg.declarator
-            arg_name = declarator.user_name
 
             a_bind = statements.fetch_arg_bind(node, arg, wlang)
             meta = a_bind.meta
@@ -1113,8 +1105,6 @@ class FillMetaLua(FillMeta):
         # --- Loop over function parameters
         for arg in ast.declarator.params:
             func_cursor.arg = arg
-            declarator = arg.declarator
-            arg_name = declarator.user_name
 
             a_bind = statements.fetch_arg_bind(node, arg, wlang)
             meta = a_bind.meta

--- a/shroud/metaattrs.py
+++ b/shroud/metaattrs.py
@@ -31,9 +31,12 @@ Fortran:
 
 """
 
+from . import ast
 from . import declast
 from . import error
 from . import statements
+
+FunctionNode = ast.FunctionNode
 
 # Unique, non-None default.
 missing = object()
@@ -139,21 +142,24 @@ class FillMeta(object):
                 self.cursor.generate("Only pointer arguments may have intent of 'out' or 'inout'")
         return intent
 
-    def check_value(self, arg):
-        attrs = arg.declarator.attrs
-        if "value" not in attrs:
+    def check_value(self, arg, meta):
+        value = arg.declarator.attrs.get("value", missing)
+        if value is missing:
+            attrs = arg.declarator.attrs
             if arg.declarator.is_indirect():
                 if arg.typemap.name == "void":
                     # This causes Fortran to dereference the C_PTR
                     # Otherwise a void * argument becomes void **
                     if len(arg.declarator.pointer) == 1:
-                        attrs["value"] = True  # void *
+                        meta["value"] = True  # void *
 #                    else:
-#                        attrs["value"] = None # void **  XXX intent(out)?
+#                        meta["value"] = None # void **  XXX intent(out)?
             else:
-                attrs["value"] = True
+                meta["value"] = True
+        else:
+            meta["value"] = value
         
-    def set_arg_intent(self, node, arg, meta):
+    def set_arg_intent(self, node, arg, meta, is_fptr=False):
         """Set default intent meta-attribute.
 
         Intent is only valid on arguments.
@@ -165,7 +171,11 @@ class FillMeta(object):
         intent = self.check_intent(arg)
 
         if intent is None:
-            if declarator.is_function_pointer():
+            if is_fptr:
+                # intent is not defaulted for function pointer arguments
+                # for historical reasons.
+                pass
+            elif declarator.is_function_pointer():
                 intent = "in"
             elif not declarator.is_indirect():
                 intent = "in"
@@ -582,7 +592,8 @@ class FillMeta(object):
         for attr in [
                 "assumedtype",
                 "dimension", "dim_ast",
-                "free_pattern", "hidden", "owner", "rank"]:
+                "free_pattern", "hidden", "owner", "rank",
+        ]:
             meta[attr] = share_meta[attr]
 
     def set_arg_share(self, node, arg, meta):
@@ -594,7 +605,9 @@ class FillMeta(object):
         for attr in [
                 "assumedtype",
                 "dimension", "dim_ast",
-                "free_pattern", "hidden", "owner", "rank"]:
+                "free_pattern", "hidden", "owner", "rank",
+                "fptr", "value",
+        ]:
             meta[attr] = share_meta[attr]
         
 ######################################################################
@@ -607,8 +620,9 @@ class FillMetaShare(FillMeta):
         bind = statements.fetch_var_bind(node, wlang)
 
         self.check_var_attrs(node, bind.meta)
-        
+
     def meta_function(self, cls, node):
+        # node - ast.FunctionNode
         wlang = self.wlang
         func_cursor = self.cursor.current
         #####
@@ -617,28 +631,33 @@ class FillMetaShare(FillMeta):
 
         r_bind = statements.fetch_func_bind(node, wlang)
         r_meta = r_bind.meta
-
+        
         self.check_func_attrs(node, r_meta)
         self.set_func_intent(node, r_meta)
+        self.meta_function_params(node)
 
+    def meta_function_params(self, node, is_fptr=False):
+        """Set function argument meta attributes.
+        Also used with function pointers arguments.
+        """
+        wlang = self.wlang
+        func_cursor = self.cursor.current
         # --- Loop over function parameters
-        for arg in ast.declarator.params:
+        for arg in node.ast.declarator.params:
             func_cursor.arg = arg
             declarator = arg.declarator
-            arg_name = declarator.user_name
 
             a_bind = statements.fetch_arg_bind(node, arg, wlang)
             meta = a_bind.meta
 
             self.check_arg_attrs(node, arg, meta)
-            self.set_arg_intent(node, arg, meta)
+            self.set_arg_intent(node, arg, meta, is_fptr)
+            self.check_value(arg, meta)
 
             if declarator.is_function_pointer():
-                for arg1 in declarator.params:
-                    attrs = arg1.declarator.attrs
-                    attrs["intent"] = self.check_intent(arg1)
-                    self.check_value(arg1)
-            
+                fptr = FunctionNode(arg.gen_decl(), parent=node, ast=arg)
+                meta["fptr"] = fptr
+                self.meta_function_params(fptr, is_fptr=True)
         # --- End loop over function parameters
         func_cursor.arg = None
 
@@ -910,22 +929,7 @@ class FillMetaFortran(FillMeta):
         self.set_func_deref_fortran(node, r_meta)
         self.set_func_api_fortran(node, r_meta)
         
-        # --- Loop over function parameters
-        for arg in ast.declarator.params:
-            func_cursor.arg = arg
-            declarator = arg.declarator
-            arg_name = declarator.user_name
-
-            a_bind = statements.fetch_arg_bind(node, arg, wlang)
-            meta = a_bind.meta
-
-            self.set_arg_share(node, arg, meta)
-            self.set_arg_fortran(node, arg, meta)
-            self.set_arg_deref_fortran(arg, meta)
-            self.set_arg_api_fortran(node, arg, meta)
-            self.set_arg_hidden(arg, meta)
-        # --- End loop over function parameters
-        func_cursor.arg = None
+        self.meta_function_params(node)
 
         # Lookup statements if there are no meta attribute errors
         if node.wrap.fortran:
@@ -939,6 +943,27 @@ class FillMetaFortran(FillMeta):
                 a_bind = statements.get_arg_bind(node, arg, wlang)
                 a_bind.stmt = arg_stmt
 
+    def meta_function_params(self, node):
+        wlang = self.wlang
+        func_cursor = self.cursor.current
+        for arg in node.ast.declarator.params:
+            func_cursor.arg = arg
+            declarator = arg.declarator
+            arg_name = declarator.user_name
+
+            a_bind = statements.fetch_arg_bind(node, arg, wlang)
+            meta = a_bind.meta
+
+            self.set_arg_share(node, arg, meta)
+            self.set_arg_fortran(node, arg, meta)
+            self.set_arg_deref_fortran(arg, meta)
+            self.set_arg_api_fortran(node, arg, meta)
+            self.set_arg_hidden(arg, meta)
+
+            if declarator.is_function_pointer():
+                self.meta_function_params(meta["fptr"])
+        func_cursor.arg = None
+        
     def set_arg_fortran(self, node, arg, meta):
         """
         Deal with Fortran specific attributes.

--- a/shroud/statements.py
+++ b/shroud/statements.py
@@ -67,7 +67,7 @@ def fetch_func_bind(node, wlang):
 def fetch_arg_bind(node, arg, wlang):
     bind = node._bind.setdefault(wlang, {})
     # XXX - better to turn off wrapping when 'Argument must have name'
-    name = arg.declarator.user_name or "no-name"
+    name = arg.declarator.user_name or arg.declarator.arg_name
     bindarg = bind.setdefault(name, BindArg())
     if bindarg.meta is None:
         bindarg.meta = collections.defaultdict(lambda: None)
@@ -90,7 +90,8 @@ def get_func_metaattrs(node, wlang):
     return node._bind[wlang]["+result"].meta
 
 def get_arg_metaattrs(node, arg, wlang):
-    return node._bind[wlang][arg.declarator.user_name].meta
+    name = arg.declarator.user_name or arg.declarator.arg_name
+    return node._bind[wlang][name].meta
 
 def get_var_bind(node, wlang):
     return node._bind[wlang]
@@ -99,7 +100,8 @@ def get_func_bind(node, wlang):
     return node._bind[wlang]["+result"]
 
 def get_arg_bind(node, arg, wlang):
-    return node._bind[wlang][arg.declarator.user_name]
+    name = arg.declarator.user_name or arg.declarator.arg_name
+    return node._bind[wlang][name]
 
 ######################################################################
 

--- a/shroud/todict.py
+++ b/shroud/todict.py
@@ -553,6 +553,8 @@ class ToDict(visitor.Visitor):
                          for (key, value) in node.meta.items()
                          if value is not None}
             if metaattrs:
+                if "fptr" in metaattrs:
+                    metaattrs["fptr"] = self.visit(metaattrs["fptr"])
                 if "dim_ast" in metaattrs:
                     metaattrs["dim_ast"] = self.visit(metaattrs["dim_ast"])
                 d["meta"] = metaattrs

--- a/shroud/wrapf.py
+++ b/shroud/wrapf.py
@@ -947,7 +947,8 @@ rv = .false.
         )
         entry = fileinfo.f_abstract_interface.get(name)
         if entry is None:
-            fileinfo.f_abstract_interface[name] = (node, fmt, arg)
+            meta = get_arg_bind(node, arg, "f").meta
+            fileinfo.f_abstract_interface[name] = (node, fmt, arg, meta["fptr"])
         return name
 
     def dump_abstract_interfaces(self, fileinfo):
@@ -965,7 +966,7 @@ rv = .false.
                 iface.append(1)
 
             for key in sorted(fileinfo.f_abstract_interface.keys()):
-                node, fmt, arg = fileinfo.f_abstract_interface[key]
+                node, fmt, arg, fptr = fileinfo.f_abstract_interface[key]
                 options = node.options
                 ast = node.ast
                 subprogram = arg.declarator.get_subprogram()
@@ -973,9 +974,10 @@ rv = .false.
                 arg_f_names = []
                 arg_c_decl = []
                 modules = {}  # indexed as [module][variable]
-                for i, param in enumerate(arg.declarator.params):
+                for i, param in enumerate(fptr.ast.declarator.params):
                     name = param.declarator.user_name
-                    intent = param.declarator.attrs["intent"]
+                    meta = get_arg_bind(fptr, param, "f").meta
+                    intent = meta["intent"]
                     if name is None:
                         fmt.index = str(i)
                         name = wformat(

--- a/tests/test_declast.py
+++ b/tests/test_declast.py
@@ -321,12 +321,6 @@ class CheckParse(unittest.TestCase):
         s = r.gen_arg_as_fortran(local=True)
         self.assertEqual("character(len=30) :: var1", s)
 
-        r = declast.check_decl("char *var1 +allocatable", symtab)
-        s = r.gen_decl()
-        self.assertEqual("char * var1 +allocatable", s)
-        s = r.gen_arg_as_fortran()
-        self.assertEqual("character(len=:), allocatable :: var1", s)
-
         r = declast.check_decl("char *var1 +deref(allocatable)", symtab)
         s = r.gen_decl()
         self.assertEqual("char * var1 +deref(allocatable)", s)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -14,12 +14,10 @@ import unittest
 
 ShroudParseError = error.ShroudParseError
 
-class Cursor(object):
+class Cursor(error.Cursor):
     """Mock class for error.Cursor
     Record last error message.
     """
-    def __init__(self):
-        self.message = None
     def push_phase(self, name):
         pass
     def pop_phase(self, name):

--- a/tests/test_statements.py
+++ b/tests/test_statements.py
@@ -38,14 +38,20 @@ class Statements(unittest.TestCase):
         cf_dict = {}
         stmts = [
             dict(
-                name="c_a",
+                name="c_mixin_a",
                 field1="field1_from_c_a",
                 field2="field2_from_c_a",
             ),
             dict(
+                name="c_a",
+                mixin=[
+                    "c_mixin_a",
+                ],
+            ),
+            dict(
                 name="c_b",
                 mixin=[
-                    "c_a",
+                    "c_mixin_a",
                 ],
                 field2="field2_from_c_b",
             ),

--- a/tests/test_wrapp.py
+++ b/tests/test_wrapp.py
@@ -8,6 +8,7 @@ from __future__ import print_function
 
 from shroud import ast
 from shroud import declast
+from shroud import metaattrs
 from shroud import statements
 from shroud import util
 from shroud import wrapp
@@ -57,6 +58,8 @@ struct Cstruct_list {
     char **svalue   +dimension(nitems);
 };
 """)
+        metaattrs.process_metaattrs(self.library, "share")
+        metaattrs.process_metaattrs(self.library, "py")
 
     def test_dimension(self):
         self.struct.create_node_map()


### PR DESCRIPTION
Add metaattribute *fptr* for a function pointer argument which contains a `FunctionNode` that uses the `_bind` field for its arguments.
    
Add `Declarator.arg_name` to set default name for abstract declarators. `_bind` is indexed by the argument name so it needs something.
    
Set `meta["value"]` instead of `attr["value"]`. This changes some comments in wrappers.
    
Do not default *intent* meta attribute for function pointer arguments. This preserves the existing wrappers. But may want to reconsider this later.
