### PR TITLE
Allow name and alias to be merged in statements

### DIFF
--- a/docs/statements.rst
+++ b/docs/statements.rst
@@ -30,7 +30,7 @@ Statement names which start with a `!` are ignored.
           Useful to define a group that varies slightly
           such as pointer vs reference argument.
 
-.. mixin - list of single names, no alternative allowed such as allocatable/pointer
+.. mixin - list of names
            must not contain 'alias', 'append' or 'base'
            List fields from the mixin group will be appended to the group
            being defined.

--- a/docs/statements.rst
+++ b/docs/statements.rst
@@ -31,11 +31,13 @@ Statement names which start with a `!` are ignored.
           such as pointer vs reference argument.
 
 .. mixin - list of names
-           must not contain 'alias', 'append' or 'base'
            List fields from the mixin group will be appended to the group
            being defined.
            Non-lists are assigned.
            Dictionaries are recursively appended (f_module).
+
+           A mixin group is created when the intent in the name is 'mixin'.
+           Must not contain 'alias', 'append' or 'base'
 
 .. append - applied after mixins as a sort of one-off mixin to append to fields.
       f_post_call is defined by the mixins but need to add one more line.
@@ -59,6 +61,7 @@ Statement names which start with a `!` are ignored.
            copy_allocate: "call {f_helper_array_string_allocatable}({f_var_alloc}, {f_var_cdesc})"
 
 .. alias
+     An alias field can be used with or without the name field.
 
 .. fmtdict - A dictionary to replace default values
 

--- a/docs/statements.rst
+++ b/docs/statements.rst
@@ -16,7 +16,7 @@ Combinations of language, type and attributes are used to select
 a statement entry.
 
 
-Statement names which start with a `!` are ignored.
+Statement names or alias which start with a `#` are ignored.
 
 .. name
 

--- a/docs/statements.rst
+++ b/docs/statements.rst
@@ -63,6 +63,9 @@ Statement names or alias which start with a `#` are ignored.
 .. alias
      An alias field can be used with or without the name field.
 
+     If there are C and Fortran group, make the first alias a Fortran name.
+     C is a subset of Fortran and the first alias determines the defaults.
+
 .. fmtdict - A dictionary to replace default values
 
         name: f_function_char_*_cfi_arg

--- a/regression/input/error-stmt.yaml
+++ b/regression/input/error-stmt.yaml
@@ -38,9 +38,6 @@ statements:
     - name: f_mixin_good1
 
     - name: f_mixin_good2
-    - name: f_mixin_good2/good3
-
-    - name: f/c_in_foo3
 
     - name: f_in_foo4
       base: nonexistent
@@ -51,7 +48,6 @@ statements:
       - f_in_foo5a
 
     - name: f_badintent_foo6
-    - name: f_in/outer_foo6
 
 # statements.post_mixin_check_statement
 

--- a/regression/input/error-stmt.yaml
+++ b/regression/input/error-stmt.yaml
@@ -25,6 +25,12 @@ statements:
       alias: ["nonexistent"]
     - name: f_mixin_with-append
       append: nonexistent
+    - name: f_mixin_with-alias
+      alias:
+      - f_in_no-alias-in-mixin-group
+
+    - alias:
+      - f_mixin_one_alias
 
     - name: f_in_foo1
       mixin:
@@ -46,6 +52,8 @@ statements:
       alias:
       - f_in_foo5a
       - f_in_foo5a
+      - f_badintent_foo5ain
+      - f_mixin_not-here
 
     - name: f_badintent_foo6
 

--- a/regression/reference/error-stmt/output
+++ b/regression/reference/error-stmt/output
@@ -9,6 +9,10 @@ statement line 19
 Statement: short
 Statement name is too short, must include language and intent.
 --------------------
+statement line 20
+Statement: java_mixin
+Statement does not start with a known language code: 'java'
+--------------------
 statement line 22
 Statement: f_mixin_with-base
 Intent mixin group should not have 'base' field.
@@ -33,6 +37,14 @@ statement line 38
 Statement: f_mixin_good1
 Statement name 'f_mixin_good1' already exists.
 --------------------
+statement line 42
+Statement: f_in_foo4
+Base 'nonexistent' not found.
+--------------------
+statement line 45
+Statement: f_in_foo5
+Alias 'f_in_foo5a' already exists.
+--------------------
 statement line 50
 Statement: f_badintent_foo6
 Invalid intent 'badintent'.
@@ -49,18 +61,6 @@ Missing i_arg_decl, i_arg_names.
 statement line 56
 Statement: f_in_foo8
 c_arg_decl, i_arg_decl and i_arg_names must all be same length. Used 1, 1, 2.
---------------------
-statement line 20
-Statement: java_mixin
-Statement does not start with a known language code: 'java'
---------------------
-statement line 42
-Statement: f_in_foo4
-Base 'nonexistent' not found.
---------------------
-statement line 45
-Statement: f_in_foo5
-Alias 'f_in_foo5a' already exists.
 Wrote wrapferror.f
 Wrote utilerror.cpp
 Wrote typeserror.h

--- a/regression/reference/error-stmt/output
+++ b/regression/reference/error-stmt/output
@@ -33,32 +33,20 @@ statement line 38
 Statement: f_mixin_good1
 Statement name 'f_mixin_good1' already exists.
 --------------------
-statement line 41
-Statement: f_mixin_good2/good3
-Statement name 'f_mixin_good2' already exists.
---------------------
-statement line 43
-Statement: f/c_in_foo3
-Only one language per group. Used f, c
---------------------
-statement line 53
+statement line 50
 Statement: f_badintent_foo6
 Invalid intent 'badintent'.
 --------------------
 statement line 54
-Statement: f_in/outer_foo6
-Invalid intent 'outer'.
---------------------
-statement line 58
 Statement: f_in_foo7
 c_arg_decl must be a list.
 --------------------
-statement line 58
+statement line 54
 Statement: f_in_foo7
 c_arg_decl, i_arg_decl and i_arg_names must all exist together.
 Missing i_arg_decl, i_arg_names.
 --------------------
-statement line 60
+statement line 56
 Statement: f_in_foo8
 c_arg_decl, i_arg_decl and i_arg_names must all be same length. Used 1, 1, 2.
 --------------------
@@ -66,11 +54,11 @@ statement line 20
 Statement: java_mixin
 Statement does not start with a known language code: 'java'
 --------------------
-statement line 45
+statement line 42
 Statement: f_in_foo4
 Base 'nonexistent' not found.
 --------------------
-statement line 48
+statement line 45
 Statement: f_in_foo5
 Alias 'f_in_foo5a' already exists.
 Wrote wrapferror.f

--- a/regression/reference/error-stmt/output
+++ b/regression/reference/error-stmt/output
@@ -3,7 +3,7 @@
 Phase: Check statements
 ----------------------------------------
 statement line 18
-Missing name in statement
+Statement must have name or alias
 --------------------
 statement line 19
 Statement: short
@@ -25,40 +25,55 @@ statement line 26
 Statement: f_mixin_with-append
 Intent mixin group should not have 'append' field.
 --------------------
-statement line 29
+statement line 28
+Statement: f_mixin_with-alias
+Intent mixin group should not have 'alias' field.
+--------------------
+statement line 32
+Intent mixin only allowed in name, not alias.
+--------------------
+statement line 35
 Statement: f_in_foo1
 Mixin 'f_in_foo1mixin' must have intent 'mixin'.
 --------------------
-statement line 32
+statement line 38
 Statement: f_in_foo2
 Mixin 'f_mixin_nonexistent' not found.
 --------------------
-statement line 38
+statement line 44
 Statement: f_mixin_good1
 Statement name 'f_mixin_good1' already exists.
 --------------------
-statement line 42
+statement line 48
 Statement: f_in_foo4
 Base 'nonexistent' not found.
 --------------------
-statement line 45
+statement line 51
 Statement: f_in_foo5
 Alias 'f_in_foo5a' already exists.
 --------------------
-statement line 50
+statement line 51
+Statement: f_in_foo5
+Invalid intent 'badintent' in alias 'f_badintent_foo5ain'.
+--------------------
+statement line 51
+Statement: f_in_foo5
+Mixin not allowed in alias 'f_mixin_not-here'.
+--------------------
+statement line 58
 Statement: f_badintent_foo6
 Invalid intent 'badintent'.
 --------------------
-statement line 54
+statement line 62
 Statement: f_in_foo7
 c_arg_decl must be a list.
 --------------------
-statement line 54
+statement line 62
 Statement: f_in_foo7
 c_arg_decl, i_arg_decl and i_arg_names must all exist together.
 Missing i_arg_decl, i_arg_names.
 --------------------
-statement line 56
+statement line 64
 Statement: f_in_foo8
 c_arg_decl, i_arg_decl and i_arg_names must all be same length. Used 1, 1, 2.
 Wrote wrapferror.f

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -248,9 +248,6 @@ root
           buf -- c_setter_string_scalar_buf
     subroutine -- c_subroutine
   f
-    XXXin
-      string
-        scalar -- f_XXXin_string_scalar
     ctor
       shadow
         capptr -- f_ctor_shadow_capptr
@@ -3874,29 +3871,6 @@ c_subroutine:
   - No arguments to a function.
   intent: subroutine
   name: c_subroutine
-  owner: library
-f_XXXin_string_scalar:
-  comments:
-  - Pass CHARACTER and LEN to C wrapper.
-  f_arg_call:
-  - '{f_var}'
-  - '{f_var_len}'
-  f_arg_decl:
-  - 'character(len=*), intent(IN) :: {f_var}'
-  f_declare:
-  - integer(C_INT) {f_var_len}
-  f_module:
-    iso_c_binding:
-    - C_INT
-  f_need_wrapper: true
-  f_pre_call:
-  - '{f_var_len} = len({f_var}, kind=C_INT)'
-  f_temps:
-  - len
-  intent: XXXin
-  name: f_XXXin_string_scalar
-  notes:
-  - Do not use arg_decl here since it does not understand +len(30) on functions.
   owner: library
 f_ctor_shadow_capptr:
   c_arg_decl:

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -3,141 +3,141 @@ root
   c
     ctor
       shadow
-        capptr -- f_ctor_shadow_capptr
+        capptr -- c_ctor_shadow_capptr
     defaulttmp -- c_defaulttmp
-    dtor -- f_dtor
+    dtor -- c_dtor
     function -- c_function
-      bool -- f_function_bool
-      char -- f_function_char
-      char* -- f_function_char*
-        arg -- f_function_char*_arg
+      bool -- c_function_bool
+      char -- c_function_char
+      char* -- c_function_char*
+        arg -- c_function_char*_arg
         buf
-          arg -- f_function_char*_arg
-          copy -- f_function_char*_buf_copy
-      enum -- f_function_native
-      native -- f_function_native
-      native& -- f_function_native*_raw
-      native* -- f_function_native*_raw
-        caller -- f_function_native*_raw
+          arg -- c_function_char*_buf_arg
+          copy -- c_function_char*_buf_copy
+      enum -- c_function_enum
+      native -- c_function_native
+      native& -- c_function_native&
+      native* -- c_function_native*
+        caller -- c_function_native*_caller
         scalar -- c_function_native*_scalar
-      native** -- f_function_native*_raw
+      native** -- c_function_native**
       shadow
-        capptr -- f_function_shadow_capptr
+        capptr -- c_function_shadow_capptr
       shadow&
-        capptr -- f_function_shadow*_capptr
-          caller -- f_function_shadow*_capptr
-          library -- f_function_shadow*_capptr
+        capptr -- c_function_shadow&_capptr
+          caller -- c_function_shadow&_capptr_caller
+          library -- c_function_shadow&_capptr_library
       shadow*
-        capptr -- f_function_shadow*_capptr
-          caller -- f_function_shadow*_capptr
-          library -- f_function_shadow*_capptr
-        capsule -- f_function_shadow*_capsule
-        this -- f_function_shadow*_this
+        capptr -- c_function_shadow*_capptr
+          caller -- c_function_shadow*_capptr_caller
+          library -- c_function_shadow*_capptr_library
+        capsule -- c_function_shadow*_capsule
+        this -- c_function_shadow*_this
       shadow<native>
-        capptr -- f_function_shadow_capptr
+        capptr -- c_function_shadow<native>_capptr
       string -- c_function_string
         buf
-          arg -- f_function_string_buf_arg
-          copy -- f_function_string_buf
-      string& -- f_shared_function_string_scalar
+          arg -- c_function_string_buf_arg
+          copy -- c_function_string_buf_copy
+      string& -- c_function_string&
         buf
-          arg -- f_function_string_buf_arg
-          copy -- f_function_string_buf
-        copy -- f_shared_function_string_scalar
-      string* -- f_shared_function_string_scalar
+          arg -- c_function_string&_buf_arg
+          copy -- c_function_string&_buf_copy
+        copy -- c_function_string&_copy
+      string* -- c_function_string*
         buf
-          copy -- f_function_string_buf
-        caller -- f_shared_function_string_scalar
-        copy -- f_shared_function_string_scalar
-        library -- f_shared_function_string_scalar
-      struct -- f_function_struct
-      struct* -- f_function_struct*_pointer
+          copy -- c_function_string*_buf_copy
+        caller -- c_function_string*_caller
+        copy -- c_function_string*_copy
+        library -- c_function_string*_library
+      struct -- c_function_struct
+      struct* -- c_function_struct*
       vector<native> -- c_function_vector<native>
         malloc -- c_function_vector<native>_malloc
-      void* -- f_function_void*
+      void* -- c_function_void*
     getter
-      native -- f_getter_native
-      native* -- f_getter_native
+      native -- c_getter_native
+      native* -- c_getter_native*
     in
-      bool -- f_in_bool
-      char -- f_in_char
-      char* -- f_shared_native
-        buf -- f_in_char*_buf
-      char** -- f_in_char**
-        buf -- f_in_char**_buf
-      enum -- f_shared_native
-      native -- f_shared_native
-      native& -- f_shared_native
-      native* -- f_shared_native
-        cdesc -- f_in_native*_cdesc
-      native** -- f_in_native**
-      procedure -- f_in_procedure
-      shadow -- f_in_shadow
-      shadow& -- f_in_shadow&
-      shadow* -- f_in_shadow*
-      string -- f_in_string
-        buf -- f_in_string_buf
-      string& -- f_in_string*
-        buf -- f_in_string*_buf
-      string* -- f_in_string*
-        buf -- f_in_string*_buf
-      struct -- f_shared_struct
-      struct& -- f_shared_struct
-      struct* -- f_shared_struct
-      unknown -- f_shared_native
-      vector<native*>& -- c_shared_vector_argument
-        buf -- f_in_vector<native*>&_buf
+      bool -- c_in_bool
+      char -- c_in_char
+      char* -- c_in_char*
+        buf -- c_in_char*_buf
+      char** -- c_in_char**
+        buf -- c_in_char**_buf
+      enum -- c_in_enum
+      native -- c_in_native
+      native& -- c_in_native&
+      native* -- c_in_native*
+        cdesc -- c_in_native*_cdesc
+      native** -- c_in_native**
+      procedure -- c_in_procedure
+      shadow -- c_in_shadow
+      shadow& -- c_in_shadow&
+      shadow* -- c_in_shadow*
+      string -- c_in_string
+        buf -- c_in_string_buf
+      string& -- c_in_string&
+        buf -- c_in_string&_buf
+      string* -- c_in_string*
+        buf -- c_in_string*_buf
+      struct -- c_in_struct
+      struct& -- c_in_struct&
+      struct* -- c_in_struct*
+      unknown -- c_in_unknown
+      vector<native*>& -- c_in_vector<native*>&
+        buf -- c_in_vector<native*>&_buf
       vector<native>
-        buf -- f_in_vector<native>_buf
-      vector<native>& -- c_shared_vector_argument
-        buf -- f_in_vector<native>_buf
+        buf -- c_in_vector<native>_buf
+      vector<native>& -- c_in_vector<native>&
+        buf -- c_in_vector<native>&_buf
       vector<native>*
-        buf -- f_in_vector<native>_buf
+        buf -- c_in_vector<native>*_buf
       vector<string>
-        buf -- f_in_vector<string>_buf
-      vector<string>& -- c_shared_vector_argument
-        buf -- f_in_vector<string>_buf
+        buf -- c_in_vector<string>_buf
+      vector<string>& -- c_in_vector<string>&
+        buf -- c_in_vector<string>&_buf
       vector<string>*
-        buf -- f_in_vector<string>_buf
-      void -- f_shared_native
-      void* -- f_in_void*
-        cdesc -- f_in_native*_cdesc
-      void** -- f_in_void**
+        buf -- c_in_vector<string>*_buf
+      void -- c_in_void
+      void* -- c_in_void*
+        cdesc -- c_in_void*_cdesc
+      void** -- c_in_void**
     inout
       bool
-        * -- f_inout_bool*
-      char* -- f_shared_native
-        buf -- f_inout_char*_buf
-      enum* -- f_inout_enum*
-      native& -- f_shared_native
-        hidden -- f_out_native&_hidden
-      native* -- f_shared_native
-        cdesc -- f_in_native*_cdesc
-        hidden -- f_out_native*_hidden
-      shadow& -- f_in_shadow*
-      shadow* -- f_in_shadow*
-      string& -- f_inout_string*
-        buf -- f_inout_string*_buf
-      string* -- f_inout_string*
-        buf -- f_inout_string*_buf
-      struct& -- f_shared_struct
-      struct* -- f_shared_struct
+        * -- c_inout_bool_*
+      char* -- c_inout_char*
+        buf -- c_inout_char*_buf
+      enum* -- c_inout_enum*
+      native& -- c_inout_native&
+        hidden -- c_inout_native&_hidden
+      native* -- c_inout_native*
+        cdesc -- c_inout_native*_cdesc
+        hidden -- c_inout_native*_hidden
+      shadow& -- c_inout_shadow&
+      shadow* -- c_inout_shadow*
+      string& -- c_inout_string&
+        buf -- c_inout_string&_buf
+      string* -- c_inout_string*
+        buf -- c_inout_string*_buf
+      struct& -- c_inout_struct&
+      struct* -- c_inout_struct*
       vector<native>
         buf
           copy -- c_inout_vector<native>_buf_copy
           malloc -- c_inout_vector<native>_buf_malloc
       vector<native>&
         buf
-          copy -- c_inout_vector<native>_buf_copy
-          malloc -- c_inout_vector<native>_buf_malloc
+          copy -- c_inout_vector<native>&_buf_copy
+          malloc -- c_inout_vector<native>&_buf_malloc
       vector<native>*
         buf
-          copy -- c_inout_vector<native>_buf_copy
-          malloc -- c_inout_vector<native>_buf_malloc
-      vector<scalar>& -- c_shared_vector_argument
+          copy -- c_inout_vector<native>*_buf_copy
+          malloc -- c_inout_vector<native>*_buf_malloc
+      vector<scalar>& -- c_inout_vector<scalar>&
       void*
-        cdesc -- f_in_native*_cdesc
-      void** -- f_in_void**
+        cdesc -- c_inout_void*_cdesc
+      void** -- c_inout_void**
     mixin
       arg
         cfi -- c_mixin_arg_cfi
@@ -186,71 +186,71 @@ root
           fill-cdesc -- c_mixin_vector_cdesc_fill-cdesc
     out
       bool
-        * -- f_out_bool*
+        * -- c_out_bool_*
       char
         *
-          buf -- f_out_char*_buf
-      char* -- f_shared_native
-      enum* -- f_out_enum*
+          buf -- c_out_char_*_buf
+      char* -- c_out_char*
+      enum* -- c_out_enum*
       native
-        &* -- c_defaulttmp
-      native& -- f_shared_native
-        hidden -- f_out_native&_hidden
-      native* -- f_out_native*
-        cdesc -- f_in_native*_cdesc
-        hidden -- f_out_native*_hidden
-      native*& -- f_shared_native
-      native** -- f_out_native**_raw
-        raw -- f_out_native**_raw
-      native*** -- f_shared_native
-      string& -- f_out_string*
-        buf -- f_out_string*_buf
-      string* -- f_out_string*
-        buf -- f_out_string*_buf
-      string** -- f_out_string**_copy
+        &* -- c_out_native_&*
+      native& -- c_out_native&
+        hidden -- c_out_native&_hidden
+      native* -- c_out_native*
+        cdesc -- c_out_native*_cdesc
+        hidden -- c_out_native*_hidden
+      native*& -- c_out_native*&
+      native** -- c_out_native**
+        raw -- c_out_native**_raw
+      native*** -- c_out_native***
+      string& -- c_out_string&
+        buf -- c_out_string&_buf
+      string* -- c_out_string*
+        buf -- c_out_string*_buf
+      string** -- c_out_string**
         cdesc
-          copy -- f_out_string**_cdesc_copy
-      struct& -- f_shared_struct
-      struct* -- f_shared_struct
+          copy -- c_out_string**_cdesc_copy
+      struct& -- c_out_struct&
+      struct* -- c_out_struct*
       vector<native>
         buf
           copy -- c_out_vector<native>_buf_copy
           malloc -- c_out_vector<native>_buf_malloc
-      vector<native>& -- c_shared_vector_argument
+      vector<native>& -- c_out_vector<native>&
         buf
-          copy -- c_out_vector<native>_buf_copy
-          malloc -- c_out_vector<native>_buf_malloc
-        cdesc -- f_out_vector<native>*_cdesc
+          copy -- c_out_vector<native>&_buf_copy
+          malloc -- c_out_vector<native>&_buf_malloc
+        cdesc -- c_out_vector<native>&_cdesc
       vector<native>*
         buf
-          copy -- c_out_vector<native>_buf_copy
-          malloc -- c_out_vector<native>_buf_malloc
-        cdesc -- f_out_vector<native>*_cdesc
+          copy -- c_out_vector<native>*_buf_copy
+          malloc -- c_out_vector<native>*_buf_malloc
+        cdesc -- c_out_vector<native>*_cdesc
       vector<string>
         buf
           copy -- c_out_vector<string>_buf_copy
-      vector<string>& -- c_shared_vector_argument
+      vector<string>& -- c_out_vector<string>&
         buf
-          copy -- c_out_vector<string>_buf_copy
-        cdesc -- f_out_vector<string>&_cdesc
-          allocatable -- f_out_vector<string>&_cdesc_allocatable
+          copy -- c_out_vector<string>&_buf_copy
+        cdesc -- c_out_vector<string>&_cdesc
+          allocatable -- c_out_vector<string>&_cdesc_allocatable
       vector<string>*
         buf
-          copy -- c_out_vector<string>_buf_copy
+          copy -- c_out_vector<string>*_buf_copy
       void*
-        cdesc -- f_in_native*_cdesc
-      void*& -- f_shared_native
-      void** -- f_in_void**
-    setter -- f_setter
-      native -- f_setter_native
-      native* -- f_setter_native
+        cdesc -- c_out_void*_cdesc
+      void*& -- c_out_void*&
+      void** -- c_out_void**
+    setter -- c_setter
+      native -- c_setter_native
+      native* -- c_setter_native*
       string
         scalar
-          buf -- f_setter_string_buf
+          buf -- c_setter_string_scalar_buf
     shared
       vector
         argument -- c_shared_vector_argument
-    subroutine -- f_subroutine
+    subroutine -- c_subroutine
   f
     XXXin
       string
@@ -267,29 +267,29 @@ root
           allocatable -- f_function_char_cdesc_allocatable
           pointer -- f_function_char_cdesc_pointer
         cfi
-          allocatable -- f_function_char*_cfi_allocatable
+          allocatable -- f_function_char_cfi_allocatable
           pointer -- f_function_char_cfi_pointer
       char* -- f_function_char*
-        allocatable -- f_function_char*
+        allocatable -- f_function_char*_allocatable
         arg -- f_function_char*_arg
         buf
-          arg -- f_function_char*_arg
+          arg -- f_function_char*_buf_arg
           copy -- f_function_char*_buf_copy
         cdesc
-          allocatable -- f_function_char_cdesc_allocatable
-          pointer -- f_function_char_cdesc_pointer
+          allocatable -- f_function_char*_cdesc_allocatable
+          pointer -- f_function_char*_cdesc_pointer
         cfi
           allocatable -- f_function_char*_cfi_allocatable
           arg -- f_function_char*_cfi_arg
           copy -- f_function_char*_cfi_copy
-          pointer -- f_function_char_cfi_pointer
-        copy -- f_function_char*
-        pointer -- f_function_char*
-        raw -- f_function_char*
-      enum -- f_function_native
+          pointer -- f_function_char*_cfi_pointer
+        copy -- f_function_char*_copy
+        pointer -- f_function_char*_pointer
+        raw -- f_function_char*_raw
+      enum -- f_function_enum
       native -- f_function_native
       native& -- f_function_native&
-        pointer -- f_function_native&
+        pointer -- f_function_native&_pointer
       native*
         cdesc
           allocatable -- f_function_native*_cdesc_allocatable
@@ -298,86 +298,86 @@ root
         cfi
           allocatable -- f_function_native*_cfi_allocatable
           pointer -- f_function_native*_cfi_pointer
-        pointer -- f_function_native&
-          caller -- f_function_native&
+        pointer -- f_function_native*_pointer
+          caller -- f_function_native*_pointer_caller
         raw -- f_function_native*_raw
         scalar -- f_function_native*_scalar
-      native** -- f_function_native*_raw
+      native** -- f_function_native**
       shadow
         capptr -- f_function_shadow_capptr
-          caller -- f_function_shadow_capptr
-          library -- f_function_shadow_capptr
+          caller -- f_function_shadow_capptr_caller
+          library -- f_function_shadow_capptr_library
       shadow&
-        capptr -- f_function_shadow*_capptr
-          caller -- f_function_shadow*_capptr
-          library -- f_function_shadow*_capptr
+        capptr -- f_function_shadow&_capptr
+          caller -- f_function_shadow&_capptr_caller
+          library -- f_function_shadow&_capptr_library
       shadow*
         capptr -- f_function_shadow*_capptr
-          caller -- f_function_shadow*_capptr
-          library -- f_function_shadow*_capptr
+          caller -- f_function_shadow*_capptr_caller
+          library -- f_function_shadow*_capptr_library
         capsule -- f_function_shadow*_capsule
         this -- f_function_shadow*_this
       shadow<native>
-        capptr -- f_function_shadow_capptr
+        capptr -- f_function_shadow<native>_capptr
       string
         buf -- f_function_string_buf
           arg -- f_function_string_buf_arg
-          copy -- f_function_string_buf
+          copy -- f_function_string_buf_copy
         cdesc
           allocatable -- f_function_string_cdesc_allocatable
-            caller -- f_function_string_cdesc_allocatable
-            library -- f_function_string_cdesc_allocatable
+            caller -- f_function_string_cdesc_allocatable_caller
+            library -- f_function_string_cdesc_allocatable_library
         cfi
           allocatable -- f_function_string_cfi_allocatable
-            caller -- f_function_string*_cfi_allocatable
-            library -- f_function_string*_cfi_allocatable
+            caller -- f_function_string_cfi_allocatable_caller
+            library -- f_function_string_cfi_allocatable_library
           arg -- f_function_string_cfi_arg
           copy -- f_function_string_cfi_copy
-          pointer -- f_shared_function_string*_cfi_pointer
-            caller -- f_shared_function_string*_cfi_pointer
-            library -- f_shared_function_string*_cfi_pointer
+          pointer -- f_function_string_cfi_pointer
+            caller -- f_function_string_cfi_pointer_caller
+            library -- f_function_string_cfi_pointer_library
       string&
-        buf -- f_function_string_buf
-          arg -- f_function_string_buf_arg
-          copy -- f_function_string_buf
+        buf -- f_function_string&_buf
+          arg -- f_function_string&_buf_arg
+          copy -- f_function_string&_buf_copy
         cdesc
-          allocatable -- f_function_string*_cdesc_allocatable
-            caller -- f_function_string*_cdesc_allocatable
-            library -- f_function_string*_cdesc_allocatable
-          pointer -- f_function_string*_cdesc_pointer
-            caller -- f_function_string*_cdesc_pointer
-            library -- f_function_string*_cdesc_pointer
+          allocatable -- f_function_string&_cdesc_allocatable
+            caller -- f_function_string&_cdesc_allocatable_caller
+            library -- f_function_string&_cdesc_allocatable_library
+          pointer -- f_function_string&_cdesc_pointer
+            caller -- f_function_string&_cdesc_pointer_caller
+            library -- f_function_string&_cdesc_pointer_library
         cfi
-          allocatable -- f_function_string*_cfi_allocatable
-            caller -- f_function_string*_cfi_allocatable
-            library -- f_function_string*_cfi_allocatable
-          arg -- f_function_string_cfi_arg
-          copy -- f_function_string_cfi_copy
-          pointer -- f_shared_function_string*_cfi_pointer
-            caller -- f_shared_function_string*_cfi_pointer
-            library -- f_shared_function_string*_cfi_pointer
+          allocatable -- f_function_string&_cfi_allocatable
+            caller -- f_function_string&_cfi_allocatable_caller
+            library -- f_function_string&_cfi_allocatable_library
+          arg -- f_function_string&_cfi_arg
+          copy -- f_function_string&_cfi_copy
+          pointer -- f_function_string&_cfi_pointer
+            caller -- f_function_string&_cfi_pointer_caller
+            library -- f_function_string&_cfi_pointer_library
       string*
-        buf -- f_function_string_buf
-          copy -- f_function_string_buf
+        buf -- f_function_string*_buf
+          copy -- f_function_string*_buf_copy
         cdesc
           allocatable -- f_function_string*_cdesc_allocatable
-            caller -- f_function_string*_cdesc_allocatable
-            library -- f_function_string*_cdesc_allocatable
+            caller -- f_function_string*_cdesc_allocatable_caller
+            library -- f_function_string*_cdesc_allocatable_library
           pointer -- f_function_string*_cdesc_pointer
-            caller -- f_function_string*_cdesc_pointer
-            library -- f_function_string*_cdesc_pointer
+            caller -- f_function_string*_cdesc_pointer_caller
+            library -- f_function_string*_cdesc_pointer_library
         cfi
           allocatable -- f_function_string*_cfi_allocatable
-            caller -- f_function_string*_cfi_allocatable
-            library -- f_function_string*_cfi_allocatable
-          copy -- f_function_string_cfi_copy
-          pointer -- f_shared_function_string*_cfi_pointer
-            caller -- f_shared_function_string*_cfi_pointer
-            library -- f_shared_function_string*_cfi_pointer
+            caller -- f_function_string*_cfi_allocatable_caller
+            library -- f_function_string*_cfi_allocatable_library
+          copy -- f_function_string*_cfi_copy
+          pointer -- f_function_string*_cfi_pointer
+            caller -- f_function_string*_cfi_pointer_caller
+            library -- f_function_string*_cfi_pointer_library
       struct -- f_function_struct
       struct*
         cdesc
-          pointer -- f_function_native*_cdesc_pointer
+          pointer -- f_function_struct*_cdesc_pointer
         pointer -- f_function_struct*_pointer
       vector
         scalar
@@ -392,13 +392,13 @@ root
       native*
         cdesc
           pointer -- f_getter_native*_cdesc_pointer
-        pointer -- f_getter_native
+        pointer -- f_getter_native*_pointer
       string
         cdesc
           allocatable -- f_getter_string_cdesc_allocatable
       struct*
         cdesc
-          pointer -- f_getter_native*_cdesc_pointer
+          pointer -- f_getter_struct*_cdesc_pointer
         fapi
           pointer -- f_getter_struct*_fapi_pointer
       struct**
@@ -407,17 +407,17 @@ root
     in
       bool -- f_in_bool
       char -- f_in_char
-      char* -- f_shared_native
+      char* -- f_in_char*
         buf -- f_in_char*_buf
-        capi -- f_shared_native
+        capi -- f_in_char*_capi
         cfi -- f_in_char*_cfi
       char** -- f_in_char**
         buf -- f_in_char**_buf
         cfi -- f_in_char**_cfi
-      enum -- f_shared_native
-      native -- f_shared_native
-      native& -- f_shared_native
-      native* -- f_shared_native
+      enum -- f_in_enum
+      native -- f_in_native
+      native& -- f_in_native&
+      native* -- f_in_native*
         cdesc -- f_in_native*_cdesc
         cfi -- f_in_native*_cfi
       native** -- f_in_native**
@@ -428,64 +428,64 @@ root
       string -- f_in_string
         buf -- f_in_string_buf
         cfi -- f_in_string_cfi
-      string& -- f_in_string*
-        buf -- f_in_string*_buf
-        cfi -- f_in_string_cfi
+      string& -- f_in_string&
+        buf -- f_in_string&_buf
+        cfi -- f_in_string&_cfi
       string* -- f_in_string*
         buf -- f_in_string*_buf
-        cfi -- f_in_string_cfi
-      struct -- f_shared_struct
-      struct& -- f_shared_struct
-      struct* -- f_shared_struct
-      unknown -- f_shared_native
+        cfi -- f_in_string*_cfi
+      struct -- f_in_struct
+      struct& -- f_in_struct&
+      struct* -- f_in_struct*
+      unknown -- f_in_unknown
       vector
         &
           cdesc
             targ
               native
-                scalar -- f_defaulttmp
+                scalar -- f_in_vector_&_cdesc_targ_native_scalar
       vector<native*>&
         buf -- f_in_vector<native*>&_buf
       vector<native>
         buf -- f_in_vector<native>_buf
       vector<native>&
-        buf -- f_in_vector<native>_buf
+        buf -- f_in_vector<native>&_buf
       vector<native>*
-        buf -- f_in_vector<native>_buf
+        buf -- f_in_vector<native>*_buf
       vector<string>
         buf -- f_in_vector<string>_buf
       vector<string>&
-        buf -- f_in_vector<string>_buf
+        buf -- f_in_vector<string>&_buf
       vector<string>*
-        buf -- f_in_vector<string>_buf
-      void -- f_shared_native
+        buf -- f_in_vector<string>*_buf
+      void -- f_in_void
       void* -- f_in_void*
-        cdesc -- f_in_native*_cdesc
+        cdesc -- f_in_void*_cdesc
       void** -- f_in_void**
-        cfi -- f_in_void**
+        cfi -- f_in_void**_cfi
     inout
       bool* -- f_inout_bool*
-      char* -- f_shared_native
+      char* -- f_inout_char*
         buf -- f_inout_char*_buf
-        capi -- f_shared_native
+        capi -- f_inout_char*_capi
         cfi -- f_inout_char*_cfi
       enum* -- f_inout_enum*
-      native& -- f_shared_native
-        hidden -- f_out_native&_hidden
-      native* -- f_shared_native
-        cdesc -- f_in_native*_cdesc
-        cfi -- f_in_native*_cfi
-        hidden -- f_out_native*_hidden
-      shadow& -- f_in_shadow*
-      shadow* -- f_in_shadow*
-      string& -- f_inout_string*
-        buf -- f_inout_string*_buf
-        cfi -- f_inout_string*_cfi
+      native& -- f_inout_native&
+        hidden -- f_inout_native&_hidden
+      native* -- f_inout_native*
+        cdesc -- f_inout_native*_cdesc
+        cfi -- f_inout_native*_cfi
+        hidden -- f_inout_native*_hidden
+      shadow& -- f_inout_shadow&
+      shadow* -- f_inout_shadow*
+      string& -- f_inout_string&
+        buf -- f_inout_string&_buf
+        cfi -- f_inout_string&_cfi
       string* -- f_inout_string*
         buf -- f_inout_string*_buf
         cfi -- f_inout_string*_cfi
-      struct& -- f_shared_struct
-      struct* -- f_shared_struct
+      struct& -- f_inout_struct&
+      struct* -- f_inout_struct*
       vector
         buf
           targ
@@ -495,8 +495,8 @@ root
         cdesc -- f_inout_vector<native>&_cdesc
           allocatable -- f_inout_vector<native>&_cdesc_allocatable
       void*
-        cdesc -- f_in_native*_cdesc
-      void** -- f_in_void**
+        cdesc -- f_inout_void*_cdesc
+      void** -- f_inout_void**
     mixin
       arg
         capsule -- f_mixin_arg_capsule
@@ -571,21 +571,21 @@ root
         capsule -- f_mixin_use_capsule
     out
       bool* -- f_out_bool*
-      char* -- f_shared_native
+      char* -- f_out_char*
         buf -- f_out_char*_buf
-        capi -- f_shared_native
+        capi -- f_out_char*_capi
         cfi -- f_out_char*_cfi
       enum* -- f_out_enum*
-      native& -- f_shared_native
+      native& -- f_out_native&
         hidden -- f_out_native&_hidden
       native* -- f_out_native*
-        cdesc -- f_in_native*_cdesc
+        cdesc -- f_out_native*_cdesc
         cfi
           allocatable -- f_out_native*_cfi_allocatable
         hidden -- f_out_native*_hidden
       native*&
         cdesc -- f_out_native*&_cdesc
-          pointer -- f_out_native*&_cdesc
+          pointer -- f_out_native*&_cdesc_pointer
       native**
         cdesc
           allocatable -- f_out_native**_cdesc_allocatable
@@ -594,10 +594,10 @@ root
           allocatable -- f_out_native**_cfi_allocatable
           pointer -- f_out_native**_cfi_pointer
         raw -- f_out_native**_raw
-      native*** -- f_shared_native
-      string& -- f_out_string*
-        buf -- f_out_string*_buf
-        cfi -- f_out_string*_cfi
+      native*** -- f_out_native***
+      string& -- f_out_string&
+        buf -- f_out_string&_buf
+        cfi -- f_out_string&_cfi
       string* -- f_out_string*
         buf -- f_out_string*_buf
         cfi -- f_out_string*_cfi
@@ -609,16 +609,16 @@ root
           allocatable -- f_out_string**_cfi_allocatable
           copy -- f_out_string**_cfi_copy
         copy -- f_out_string**_copy
-      struct& -- f_shared_struct
-      struct* -- f_shared_struct
+      struct& -- f_out_struct&
+      struct* -- f_out_struct*
       vector
         buf
           targ
             string
               scalar -- f_out_vector_buf_targ_string_scalar
       vector<native>&
-        cdesc -- f_out_vector<native>*_cdesc
-          allocatable -- f_out_vector<native>*_cdesc_allocatable
+        cdesc -- f_out_vector<native>&_cdesc
+          allocatable -- f_out_vector<native>&_cdesc_allocatable
       vector<native>*
         cdesc -- f_out_vector<native>*_cdesc
           allocatable -- f_out_vector<native>*_cdesc_allocatable
@@ -626,16 +626,16 @@ root
         cdesc -- f_out_vector<string>&_cdesc
           allocatable -- f_out_vector<string>&_cdesc_allocatable
       void*
-        cdesc -- f_in_native*_cdesc
-      void*& -- f_shared_native
-      void** -- f_in_void**
+        cdesc -- f_out_void*_cdesc
+      void*& -- f_out_void*&
+      void** -- f_out_void**
     setter -- f_setter
       bool -- f_setter_bool
       native -- f_setter_native
-      native* -- f_setter_native
+      native* -- f_setter_native*
       string
         buf -- f_setter_string_buf
-      struct* -- f_setter_struct*_pointer
+      struct* -- f_setter_struct*
         pointer -- f_setter_struct*_pointer
       struct** -- f_setter_struct**
     shared
@@ -12199,33 +12199,33 @@ root
           fill -- py_base_ctor_array_fill
     ctor
       char* -- py_ctor_char*
-        numpy -- py_ctor_char*
+        numpy -- py_ctor_char*_numpy
       char** -- py_ctor_char**
-        list -- py_ctor_char**
+        list -- py_ctor_char**_list
       char[] -- py_ctor_char[]
-        list -- py_ctor_char[]
-        numpy -- py_ctor_char[]
+        list -- py_ctor_char[]_list
+        numpy -- py_ctor_char[]_numpy
       native -- py_ctor_native
-        list -- py_ctor_native
-        numpy -- py_ctor_native
+        list -- py_ctor_native_list
+        numpy -- py_ctor_native_numpy
       native* -- py_ctor_native*
-        list -- py_ctor_native*
-        numpy -- py_ctor_native*
+        list -- py_ctor_native*_list
+        numpy -- py_ctor_native*_numpy
       native[] -- py_ctor_native[]
-        list -- py_ctor_native[]
-        numpy -- py_ctor_native[]
+        list -- py_ctor_native[]_list
+        numpy -- py_ctor_native[]_numpy
     defaulttmp -- py_defaulttmp
     descr
       bool
         scalar -- py_descr_bool_scalar
       char
         * -- py_descr_char_*
-          numpy -- py_descr_char_*
+          numpy -- py_descr_char_*_numpy
         **
           list -- py_descr_char_**_list
         [] -- py_descr_char_[]
-          list -- py_descr_char_[]
-          numpy -- py_descr_char_[]
+          list -- py_descr_char_[]_list
+          numpy -- py_descr_char_[]_numpy
       native
         *
           list -- py_descr_native_*_list
@@ -12238,42 +12238,42 @@ root
       bool -- py_function_bool
       char -- py_function_char
       char* -- py_function_char*
-      enum -- py_defaulttmp
-      native -- py_defaulttmp
+      enum -- py_function_enum
+      native -- py_function_native
       native&
-        numpy -- py_function_native*_numpy
+        numpy -- py_function_native&_numpy
       native*
         list -- py_function_native*_list
         numpy -- py_function_native*_numpy
-        scalar -- py_defaulttmp
-      shadow -- py_out_struct*_class
-      shadow& -- py_function_shadow*
+        scalar -- py_function_native*_scalar
+      shadow -- py_function_shadow
+      shadow& -- py_function_shadow&
       shadow* -- py_function_shadow*
       string -- py_function_string
-      string& -- py_function_string*
+      string& -- py_function_string&
       string* -- py_function_string*
       struct
         class -- py_function_struct_class
-        list -- py_defaulttmp
+        list -- py_function_struct_list
         numpy -- py_function_struct_numpy
       struct*
-        class -- py_function_struct_class
-        list -- py_defaulttmp
-        numpy -- py_function_struct_numpy
+        class -- py_function_struct*_class
+        list -- py_function_struct*_list
+        numpy -- py_function_struct*_numpy
       vector
         list -- py_function_vector_list
         numpy -- py_function_vector_numpy
       vector<native>
-        list -- py_function_vector_list
-        numpy -- py_function_vector_numpy
+        list -- py_function_vector<native>_list
+        numpy -- py_function_vector<native>_numpy
       void* -- py_function_void*
     in
       bool -- py_in_bool
       char -- py_in_char
       char* -- py_in_char*
       char** -- py_in_char**
-      enum -- py_defaulttmp
-      native -- py_defaulttmp
+      enum -- py_in_enum
+      native -- py_in_native
       native& -- py_in_native&
       native* -- py_in_native*
         list -- py_in_native*_list
@@ -12282,7 +12282,7 @@ root
       shadow& -- py_in_shadow&
       shadow* -- py_in_shadow*
       string -- py_in_string
-      string& -- py_in_string
+      string& -- py_in_string&
       string* -- py_in_string*
       struct
         class -- py_in_struct_class
@@ -12295,7 +12295,7 @@ root
         class -- py_in_struct*_class
         list -- py_in_struct*_list
         numpy -- py_in_struct*_numpy
-      unknown -- py_defaulttmp
+      unknown -- py_in_unknown
       vector<native>&
         list -- py_in_vector<native>&_list
         numpy -- py_in_vector<native>&_numpy
@@ -12311,7 +12311,7 @@ root
       shadow
         * -- py_inout_shadow_*
       string -- py_inout_string
-      string& -- py_inout_string
+      string& -- py_inout_string&
       string* -- py_inout_string*
       struct
         list -- py_inout_struct_list
@@ -12343,7 +12343,7 @@ root
       shadow
         * -- py_out_shadow_*
       string -- py_out_string
-      string& -- py_out_string
+      string& -- py_out_string&
       string* -- py_out_string*
       struct
         list -- py_out_struct_list
@@ -14267,7 +14267,7 @@ root
     dtor -- lua_dtor
     function
       bool -- lua_function_bool
-      enum -- lua_function_native
+      enum -- lua_function_enum
       native -- lua_function_native
       shadow* -- lua_function_shadow*
       string -- lua_function_string
@@ -14275,14 +14275,14 @@ root
       void* -- lua_function_void*
     in
       bool -- lua_in_bool
-      enum -- lua_in_native
+      enum -- lua_in_enum
       native -- lua_in_native
-      native* -- lua_defaulttmp
+      native* -- lua_in_native*
       shadow* -- lua_in_shadow*
-      string& -- lua_in_string*
+      string& -- lua_in_string&
       string* -- lua_in_string*
-      unknown -- lua_defaulttmp
-      void -- lua_defaulttmp
+      unknown -- lua_in_unknown
+      void -- lua_in_void
     inout
       native* -- lua_inout_native*
     mixin
@@ -14290,7 +14290,7 @@ root
       push -- lua_mixin_push
       unknown -- lua_mixin_unknown
     out
-      native* -- lua_defaulttmp
+      native* -- lua_out_native*
     subroutine -- lua_subroutine
 lua_ctor:
   call:

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -12084,7 +12084,6 @@ root
       native[] -- py_ctor_native[]
         list -- py_ctor_native[]_list
         numpy -- py_ctor_native[]_numpy
-    defaulttmp -- py_defaulttmp
     descr
       bool
         scalar -- py_descr_bool_scalar
@@ -12479,9 +12478,6 @@ py_ctor_native_numpy:
   name: py_ctor_native_numpy
   post_call:
   - SH_obj->{field_name} = {field_name};
-py_defaulttmp:
-  intent: defaulttmp
-  name: py_defaulttmp
 py_descr_bool_scalar:
   getter:
   - return PyBool_FromLong({c_var});
@@ -14133,7 +14129,6 @@ py_out_void**:
 root
   lua
     ctor -- lua_ctor
-    defaulttmp -- lua_defaulttmp
     dtor -- lua_dtor
     function
       bool -- lua_function_bool
@@ -14173,9 +14168,6 @@ lua_ctor:
   - lua_setmetatable(L, -2);
   intent: ctor
   name: lua_ctor
-lua_defaulttmp:
-  intent: defaulttmp
-  name: lua_defaulttmp
 lua_dtor:
   call:
   - delete {LUA_userdata_var}->{LUA_userdata_member};

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -69,7 +69,7 @@ root
       native -- f_shared_native
       native& -- f_shared_native
       native* -- f_shared_native
-        cdesc -- f_in/out/inout_native*_cdesc
+        cdesc -- f_in_native*_cdesc
       native** -- f_in_native**
       procedure -- f_in_procedure
       shadow -- f_in_shadow
@@ -101,8 +101,8 @@ root
         buf -- f_in_vector<string>_buf
       void -- f_shared_native
       void* -- f_in_void*
-        cdesc -- f_in/out/inout_native*_cdesc
-      void** -- f_in/out/inout_void**
+        cdesc -- f_in_native*_cdesc
+      void** -- f_in_void**
     inout
       bool
         * -- f_inout_bool*
@@ -110,10 +110,10 @@ root
         buf -- f_inout_char*_buf
       enum* -- f_inout_enum*
       native& -- f_shared_native
-        hidden -- f_out/inout_native&_hidden
+        hidden -- f_out_native&_hidden
       native* -- f_shared_native
-        cdesc -- f_in/out/inout_native*_cdesc
-        hidden -- f_out/inout_native*_hidden
+        cdesc -- f_in_native*_cdesc
+        hidden -- f_out_native*_hidden
       shadow& -- f_in_shadow*
       shadow* -- f_in_shadow*
       string& -- f_inout_string*
@@ -136,8 +136,8 @@ root
           malloc -- c_inout_vector<native>_buf_malloc
       vector<scalar>& -- c_shared_vector_argument
       void*
-        cdesc -- f_in/out/inout_native*_cdesc
-      void** -- f_in/out/inout_void**
+        cdesc -- f_in_native*_cdesc
+      void** -- f_in_void**
     mixin
       arg
         cfi -- c_mixin_arg_cfi
@@ -195,10 +195,10 @@ root
       native
         &* -- c_defaulttmp
       native& -- f_shared_native
-        hidden -- f_out/inout_native&_hidden
+        hidden -- f_out_native&_hidden
       native* -- f_out_native*
-        cdesc -- f_in/out/inout_native*_cdesc
-        hidden -- f_out/inout_native*_hidden
+        cdesc -- f_in_native*_cdesc
+        hidden -- f_out_native*_hidden
       native*& -- f_shared_native
       native** -- f_out_native**_raw
         raw -- f_out_native**_raw
@@ -238,9 +238,9 @@ root
         buf
           copy -- c_out_vector<string>_buf_copy
       void*
-        cdesc -- f_in/out/inout_native*_cdesc
+        cdesc -- f_in_native*_cdesc
       void*& -- f_shared_native
-      void** -- f_in/out/inout_void**
+      void** -- f_in_void**
     setter -- f_setter
       native -- f_setter_native
       native* -- f_setter_native
@@ -418,8 +418,8 @@ root
       native -- f_shared_native
       native& -- f_shared_native
       native* -- f_shared_native
-        cdesc -- f_in/out/inout_native*_cdesc
-        cfi -- f_in/inout_native*_cfi
+        cdesc -- f_in_native*_cdesc
+        cfi -- f_in_native*_cfi
       native** -- f_in_native**
       procedure -- f_in_procedure
       shadow -- f_in_shadow
@@ -460,9 +460,9 @@ root
         buf -- f_in_vector<string>_buf
       void -- f_shared_native
       void* -- f_in_void*
-        cdesc -- f_in/out/inout_native*_cdesc
-      void** -- f_in/out/inout_void**
-        cfi -- f_in/out/inout_void**
+        cdesc -- f_in_native*_cdesc
+      void** -- f_in_void**
+        cfi -- f_in_void**
     inout
       bool* -- f_inout_bool*
       char* -- f_shared_native
@@ -471,11 +471,11 @@ root
         cfi -- f_inout_char*_cfi
       enum* -- f_inout_enum*
       native& -- f_shared_native
-        hidden -- f_out/inout_native&_hidden
+        hidden -- f_out_native&_hidden
       native* -- f_shared_native
-        cdesc -- f_in/out/inout_native*_cdesc
-        cfi -- f_in/inout_native*_cfi
-        hidden -- f_out/inout_native*_hidden
+        cdesc -- f_in_native*_cdesc
+        cfi -- f_in_native*_cfi
+        hidden -- f_out_native*_hidden
       shadow& -- f_in_shadow*
       shadow* -- f_in_shadow*
       string& -- f_inout_string*
@@ -495,8 +495,8 @@ root
         cdesc -- f_inout_vector<native>&_cdesc
           allocatable -- f_inout_vector<native>&_cdesc_allocatable
       void*
-        cdesc -- f_in/out/inout_native*_cdesc
-      void** -- f_in/out/inout_void**
+        cdesc -- f_in_native*_cdesc
+      void** -- f_in_void**
     mixin
       arg
         capsule -- f_mixin_arg_capsule
@@ -577,12 +577,12 @@ root
         cfi -- f_out_char*_cfi
       enum* -- f_out_enum*
       native& -- f_shared_native
-        hidden -- f_out/inout_native&_hidden
+        hidden -- f_out_native&_hidden
       native* -- f_out_native*
-        cdesc -- f_in/out/inout_native*_cdesc
+        cdesc -- f_in_native*_cdesc
         cfi
           allocatable -- f_out_native*_cfi_allocatable
-        hidden -- f_out/inout_native*_hidden
+        hidden -- f_out_native*_hidden
       native*&
         cdesc -- f_out_native*&_cdesc
           pointer -- f_out_native*&_cdesc
@@ -626,9 +626,9 @@ root
         cdesc -- f_out_vector<string>&_cdesc
           allocatable -- f_out_vector<string>&_cdesc_allocatable
       void*
-        cdesc -- f_in/out/inout_native*_cdesc
+        cdesc -- f_in_native*_cdesc
       void*& -- f_shared_native
-      void** -- f_in/out/inout_void**
+      void** -- f_in_void**
     setter -- f_setter
       bool -- f_setter_bool
       native -- f_setter_native

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -4,7 +4,6 @@ root
     ctor
       shadow
         capptr -- c_ctor_shadow_capptr
-    defaulttmp -- c_defaulttmp
     dtor -- c_dtor
     function -- c_function
       bool -- c_function_bool
@@ -258,7 +257,6 @@ root
     ctor
       shadow
         capptr -- f_ctor_shadow_capptr
-    defaulttmp -- f_defaulttmp
     dtor -- f_dtor
     function
       bool -- f_function_bool
@@ -675,10 +673,6 @@ c_ctor_shadow_capptr:
   intent: ctor
   name: c_ctor_shadow_capptr
   owner: caller
-c_defaulttmp:
-  intent: defaulttmp
-  name: c_defaulttmp
-  owner: library
 c_dtor:
   c_call:
   - delete {CXX_this};
@@ -3963,10 +3957,6 @@ f_ctor_shadow_capptr:
   intent: ctor
   name: f_ctor_shadow_capptr
   owner: caller
-f_defaulttmp:
-  intent: defaulttmp
-  name: f_defaulttmp
-  owner: library
 f_dtor:
   c_call:
   - delete {CXX_this};

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -246,9 +246,6 @@ root
       string
         scalar
           buf -- c_setter_string_scalar_buf
-    shared
-      vector
-        argument -- c_shared_vector_argument
     subroutine -- c_subroutine
   f
     XXXin
@@ -636,15 +633,6 @@ root
       struct* -- f_setter_struct*
         pointer -- f_setter_struct*_pointer
       struct** -- f_setter_struct**
-    shared
-      function
-        string
-          scalar -- f_shared_function_string_scalar
-        string*
-          cfi
-            pointer -- f_shared_function_string*_cfi_pointer
-      native -- f_shared_native
-      struct -- f_shared_struct
     subroutine -- f_subroutine
 c_ctor_shadow_capptr:
   c_arg_decl:
@@ -3880,13 +3868,6 @@ c_setter_string_scalar_buf:
   - Used with function which pass in character argument.
   - Used with function which return a char *.
   - C wrapper will fill argument.
-  owner: library
-c_shared_vector_argument:
-  comments:
-  - Need to know the length of the vector from C
-  intent: shared
-  name: c_shared_vector_argument
-  notimplemented: true
   owner: library
 c_subroutine:
   comments:
@@ -12096,81 +12077,6 @@ f_setter_struct*_pointer:
   - '{i_var}'
   intent: setter
   name: f_setter_struct*_pointer
-  owner: library
-f_shared_function_string*_cfi_pointer:
-  c_arg_decl:
-  - CFI_cdesc_t *{c_var_cfi}
-  c_local:
-  - cptr
-  - fptr
-  - cdesc
-  - len
-  - err
-  c_post_call:
-  - int {c_local_err};
-  - if ({cxx_var} == {nullptr}) {{+
-  - "{c_local_err} = CFI_setpointer(\t{c_var_cfi},\t {nullptr},\t {nullptr});"
-  - -}} else {{+
-  - CFI_CDESC_T(0) {c_local_fptr};
-  - CFI_cdesc_t *{c_local_cdesc} = {cast_reinterpret}CFI_cdesc_t *{cast1}&{c_local_fptr}{cast2};
-  - void *{c_local_cptr} = const_cast<char *>({cxx_var}{cxx_member}data());
-  - size_t {c_local_len} = {cxx_var}{cxx_member}length();
-  - "{c_local_err} = CFI_establish({c_local_cdesc},\t {c_local_cptr},\t CFI_attribute_pointer,\t\
-    \ CFI_type_char,\t {c_local_len},\t 0,\t {nullptr});"
-  - if ({c_local_err} == CFI_SUCCESS) {{+
-  - '{c_var_cfi}->elem_len = {c_local_cdesc}->elem_len;'
-  - "{c_local_err} = CFI_setpointer(\t{c_var_cfi},\t {c_local_cdesc},\t {nullptr});"
-  - -}}
-  - -}}
-  c_return_type: void
-  c_temps:
-  - cfi
-  comments:
-  - Call the C wrapper as a subroutine.
-  - Make the argument a CFI_desc_t.
-  f_arg_call:
-  - '{f_var}'
-  f_arg_decl:
-  - 'character(len=:), pointer :: {f_var}'
-  f_call:
-  - call {F_C_call}({F_arg_c_call})
-  f_need_wrapper: true
-  i_arg_decl:
-  - 'character(len=:), intent({f_intent}), pointer :: {i_var}'
-  i_arg_names:
-  - '{i_var}'
-  iface_header:
-  - ISO_Fortran_binding.h
-  intent: shared
-  name: f_shared_function_string*_cfi_pointer
-  notes:
-  - XXX - consolidate with c_function*_cfi_pointer?
-  - XXX - via a helper to get address and length of string
-  owner: library
-f_shared_function_string_scalar:
-  c_return:
-  - return {c_var};
-  i_module:
-    iso_c_binding:
-    - C_PTR
-  i_result_decl:
-  - type(C_PTR) {i_var}
-  intent: shared
-  name: f_shared_function_string_scalar
-  notes:
-  - Fortran calling a C function without
-  - any api argument - is this useful?
-  owner: library
-f_shared_native:
-  intent: shared
-  name: f_shared_native
-  owner: library
-f_shared_struct:
-  intent: shared
-  name: f_shared_struct
-  notes:
-  - Used with in, out, inout.
-  - C pointer -> void pointer -> C++ pointer
   owner: library
 f_subroutine:
   comments:

--- a/shroud/fc-statements.json
+++ b/shroud/fc-statements.json
@@ -9,12 +9,12 @@
         "i_arg_names": []
     },
     {
-        "name": "f_subroutine",
+        "alias": [
+            "f_subroutine",
+            "c_subroutine"
+        ],
         "mixin": [
             "c_mixin_noargs"
-        ],
-        "alias": [
-            "c_subroutine"
         ],
         "f_arg_call": [],
         "f_call": [
@@ -903,13 +903,11 @@
         ]
     },
     {
-        "name": "f_defaulttmp",
         "alias": [
             "f_in_vector_&_cdesc_targ_native_scalar"
         ]
     },
     {
-        "name": "c_defaulttmp",
         "alias": [
             "c_out_native_&*"
         ]

--- a/shroud/fc-statements.json
+++ b/shroud/fc-statements.json
@@ -35,11 +35,11 @@
         ]
     },
     {
-        "name": "f_function_native",
         "alias": [
+            "f_function_native",
+            "c_function_native",
             "f_function_enum",
-            "c_function_enum",
-            "c_function_native"
+            "c_function_enum"
         ]
     },
     {
@@ -913,7 +913,6 @@
         ]
     },
     {
-        "name": "f_shared_native",
         "alias": [
             "f_in_native",
             "c_in_native",
@@ -962,36 +961,36 @@
         ]
     },
     {
-        "name": "f_in_bool",
-        "mixin": [
-            "f_mixin_local-logical-var"
-        ],
         "alias": [
+            "f_in_bool",
             "c_in_bool"
         ],
+        "mixin": [
+            "f_mixin_local-logical-var"
+        ],
         "f_pre_call": [
             "{f_var_cxx} = {f_var}  ! coerce to C_BOOL"
         ]
     },
     {
-        "name": "f_out_bool*",
-        "mixin": [
-            "f_mixin_local-logical-var"
-        ],
         "alias": [
+            "f_out_bool*",
             "c_out_bool_*"
         ],
+        "mixin": [
+            "f_mixin_local-logical-var"
+        ],
         "f_post_call": [
             "{f_var} = {f_var_cxx}  ! coerce to logical"
         ]
     },
     {
-        "name": "f_inout_bool*",
+        "alias": [
+            "f_inout_bool*",
+            "c_inout_bool_*"
+        ],
         "mixin": [
             "f_mixin_local-logical-var"
-        ],
-        "alias": [
-            "c_inout_bool_*"
         ],
         "f_pre_call": [
             "{f_var_cxx} = {f_var}  ! coerce to C_BOOL"
@@ -1001,15 +1000,15 @@
         ]
     },
     {
-        "name": "f_function_bool",
         "alias": [
+            "f_function_bool",
             "c_function_bool"
         ],
         "f_need_wrapper": true
     },
     {
-        "name": "f_out_native*",
         "alias": [
+            "f_out_native*",
             "c_out_native*"
         ],
         "f_arg_decl": [
@@ -1017,13 +1016,13 @@
         ]
     },
     {
-        "name": "f_in_native**",
+        "alias": [
+            "f_in_native**",
+            "c_in_native**"
+        ],
         "notes": [
             "Any array of pointers.  Assumed to be non-contiguous memory.",
             "All Fortran can do is treat as a type(C_PTR)."
-        ],
-        "alias": [
-            "c_in_native**"
         ],
         "c_arg_decl": [
             "{cxx_type} **{cxx_var}"
@@ -1053,14 +1052,14 @@
         ]
     },
     {
-        "name": "f_out_native*&_cdesc",
+        "alias": [
+            "f_out_native*&_cdesc",
+            "f_out_native*&_cdesc_pointer"
+        ],
         "mixin": [
             "f_mixin_pass_cdesc",
             "c_mixin_native_cdesc_fill-cdesc",
             "f_mixin_out_native_cdesc_pointer"
-        ],
-        "alias": [
-            "f_out_native*&_cdesc_pointer"
         ],
         "c_pre_call": [
             "{c_const}{cxx_type} *{cxx_var};"
@@ -1099,13 +1098,13 @@
         ]
     },
     {
-        "name": "f_out_native**_raw",
-        "notes": [
-            "Make argument type(C_PTR) from 'int ** +intent(out)+deref(raw)'"
-        ],
         "alias": [
+            "f_out_native**_raw",
             "c_out_native**_raw",
             "c_out_native**"
+        ],
+        "notes": [
+            "Make argument type(C_PTR) from 'int ** +intent(out)+deref(raw)'"
         ],
         "f_arg_decl": [
             "type(C_PTR), intent({f_intent}) :: {f_var}"
@@ -1117,8 +1116,8 @@
         }
     },
     {
-        "name": "f_in_native*_cdesc",
         "alias": [
+            "f_in_native*_cdesc",
             "f_out_native*_cdesc",
             "f_inout_native*_cdesc",
             "c_in_native*_cdesc",
@@ -1165,8 +1164,8 @@
         }
     },
     {
-        "name": "f_out_native*_hidden",
         "alias": [
+            "f_out_native*_hidden",
             "f_inout_native*_hidden",
             "c_out_native*_hidden",
             "c_inout_native*_hidden"
@@ -1182,8 +1181,8 @@
         ]
     },
     {
-        "name": "f_out_native&_hidden",
         "alias": [
+            "f_out_native&_hidden",
             "f_inout_native&_hidden",
             "c_out_native&_hidden",
             "c_inout_native&_hidden"
@@ -1199,8 +1198,8 @@
         ]
     },
     {
-        "name": "f_in_void*",
         "alias": [
+            "f_in_void*",
             "c_in_void*"
         ],
         "f_module": {
@@ -1213,8 +1212,8 @@
         ]
     },
     {
-        "name": "f_function_void*",
         "alias": [
+            "f_function_void*",
             "c_function_void*"
         ],
         "f_module": {
@@ -1227,8 +1226,8 @@
         ]
     },
     {
-        "name": "f_in_void**",
         "alias": [
+            "f_in_void**",
             "f_out_void**",
             "f_inout_void**",
             "c_in_void**",
@@ -1284,30 +1283,30 @@
         ]
     },
     {
-        "name": "f_function_native&",
+        "alias": [
+            "f_function_native&",
+            "f_function_native*_pointer",
+            "f_function_native*_pointer_caller",
+            "f_function_native&_pointer"
+        ],
         "notes": [
             "Pointer to scalar.",
             "type(C_PTR) is returned instead of a cdesc argument."
         ],
         "mixin": [
             "f_mixin_function_c-ptr"
-        ],
-        "alias": [
-            "f_function_native*_pointer",
-            "f_function_native*_pointer_caller",
-            "f_function_native&_pointer"
         ]
     },
     {
-        "name": "f_function_native*_cdesc_pointer",
+        "alias": [
+            "f_function_native*_cdesc_pointer",
+            "f_function_struct*_cdesc_pointer"
+        ],
         "mixin": [
             "f_mixin_function-to-subroutine",
             "f_mixin_pass_cdesc",
             "c_mixin_native_cdesc_fill-cdesc",
             "f_mixin_native_cdesc_pointer"
-        ],
-        "alias": [
-            "f_function_struct*_cdesc_pointer"
         ]
     },
     {
@@ -1326,21 +1325,21 @@
         ]
     },
     {
-        "name": "f_function_native*_raw",
-        "mixin": [
-            "f_mixin_function_ptr"
-        ],
         "alias": [
+            "f_function_native*_raw",
             "c_function_native*",
             "c_function_native&",
             "c_function_native*_caller",
             "c_function_native**",
             "f_function_native**"
+        ],
+        "mixin": [
+            "f_mixin_function_ptr"
         ]
     },
     {
-        "name": "f_in_char",
         "alias": [
+            "f_in_char",
             "c_in_char"
         ],
         "f_arg_decl": [
@@ -1362,12 +1361,12 @@
         }
     },
     {
-        "name": "f_function_char",
+        "alias": [
+            "f_function_char",
+            "c_function_char"
+        ],
         "mixin": [
             "f_mixin_function-to-subroutine"
-        ],
-        "alias": [
-            "c_function_char"
         ],
         "f_arg_call": [
             "{f_var}"
@@ -1391,8 +1390,8 @@
         }
     },
     {
-        "name": "f_function_char*",
         "alias": [
+            "f_function_char*",
             "c_function_char*",
             "f_function_char*_allocatable",
             "f_function_char*_copy",
@@ -1412,13 +1411,13 @@
         }
     },
     {
-        "name": "f_in_char*_buf",
+        "alias": [
+            "f_in_char*_buf",
+            "c_in_char*_buf"
+        ],
         "mixin": [
             "f_mixin_in_character_buf",
             "c_mixin_in_character_buf"
-        ],
-        "alias": [
-            "c_in_char*_buf"
         ],
         "c_temps": [
             "len",
@@ -1439,13 +1438,13 @@
         ]
     },
     {
-        "name": "f_out_char*_buf",
+        "alias": [
+            "f_out_char*_buf",
+            "c_out_char_*_buf"
+        ],
         "mixin": [
             "f_mixin_in_character_buf",
             "c_mixin_in_character_buf"
-        ],
-        "alias": [
-            "c_out_char_*_buf"
         ],
         "c_helper": [
             "char_blank_fill"
@@ -1455,13 +1454,13 @@
         ]
     },
     {
-        "name": "f_inout_char*_buf",
+        "alias": [
+            "f_inout_char*_buf",
+            "c_inout_char*_buf"
+        ],
         "mixin": [
             "f_mixin_in_character_buf",
             "c_mixin_in_character_buf"
-        ],
-        "alias": [
-            "c_inout_char*_buf"
         ],
         "c_temps": [
             "len",
@@ -1484,7 +1483,10 @@
         ]
     },
     {
-        "name": "f_function_char*_buf_copy",
+        "alias": [
+            "f_function_char*_buf_copy",
+            "c_function_char*_buf_copy"
+        ],
         "notes": [
             "char *getname() +len(30)",
             "Copy result into caller's buffer."
@@ -1493,9 +1495,6 @@
             "f_mixin_function-to-subroutine",
             "f_mixin_in_character_buf",
             "c_mixin_in_character_buf"
-        ],
-        "alias": [
-            "c_function_char*_buf_copy"
         ],
         "cxx_local_var": "result",
         "c_helper": [
@@ -1506,17 +1505,17 @@
         ]
     },
     {
-        "name": "f_function_char*_arg",
+        "alias": [
+            "f_function_char*_arg",
+            "c_function_char*_arg",
+            "f_function_char*_buf_arg",
+            "c_function_char*_buf_arg"
+        ],
         "notes": [
             "Change function result into an argument",
             "Use F_string_result_as_arg as the argument name."
         ],
         "base": "f_function_char*_buf_copy",
-        "alias": [
-            "c_function_char*_arg",
-            "f_function_char*_buf_arg",
-            "c_function_char*_buf_arg"
-        ],
         "fmtdict": {
             "f_var": "{F_string_result_as_arg}",
             "i_var": "{F_string_result_as_arg}",
@@ -1534,12 +1533,12 @@
         ]
     },
     {
-        "name": "f_in_char**",
+        "alias": [
+            "f_in_char**",
+            "c_in_char**"
+        ],
         "notes": [
             "Treat as an assumed length array in Fortran interface."
-        ],
-        "alias": [
-            "c_in_char**"
         ],
         "c_arg_decl": [
             "char **{c_var}"
@@ -1557,12 +1556,12 @@
         }
     },
     {
-        "name": "f_in_char**_buf",
+        "alias": [
+            "f_in_char**_buf",
+            "c_in_char**_buf"
+        ],
         "mixin": [
             "f_mixin_in_string_array_buf"
-        ],
-        "alias": [
-            "c_in_char**_buf"
         ],
         "c_helper": [
             "char_array_alloc",
@@ -1577,32 +1576,32 @@
         ]
     },
     {
-        "name": "f_function_char_cdesc_allocatable",
+        "alias": [
+            "f_function_char_cdesc_allocatable",
+            "f_function_char*_cdesc_allocatable"
+        ],
         "mixin": [
             "f_mixin_function-to-subroutine",
             "f_mixin_pass_cdesc",
             "f_mixin_char_cdesc_allocate",
             "c_mixin_function_char*_cdesc"
-        ],
-        "alias": [
-            "f_function_char*_cdesc_allocatable"
         ]
     },
     {
-        "name": "f_function_char_cdesc_pointer",
+        "alias": [
+            "f_function_char_cdesc_pointer",
+            "f_function_char*_cdesc_pointer"
+        ],
         "mixin": [
             "f_mixin_function-to-subroutine",
             "f_mixin_pass_cdesc",
             "c_mixin_function_char*_cdesc",
             "f_mixin_char_cdesc_pointer"
-        ],
-        "alias": [
-            "f_function_char*_cdesc_pointer"
         ]
     },
     {
-        "name": "f_function_string*_cdesc_pointer",
         "alias": [
+            "f_function_string*_cdesc_pointer",
             "f_function_string&_cdesc_pointer",
             "f_function_string*_cdesc_pointer_caller",
             "f_function_string*_cdesc_pointer_library",
@@ -1617,8 +1616,8 @@
         ]
     },
     {
-        "name": "f_in_string*",
         "alias": [
+            "f_in_string*",
             "f_in_string&",
             "c_in_string*",
             "c_in_string&"
@@ -1629,8 +1628,8 @@
         ]
     },
     {
-        "name": "f_out_string*",
         "alias": [
+            "f_out_string*",
             "f_out_string&",
             "c_out_string*",
             "c_out_string&"
@@ -1649,14 +1648,14 @@
         ]
     },
     {
-        "name": "f_inout_string*",
-        "mixin": [
-            "f_mixin_in_character_buf"
-        ],
         "alias": [
+            "f_inout_string*",
             "f_inout_string&",
             "c_inout_string*",
             "c_inout_string&"
+        ],
+        "mixin": [
+            "f_mixin_in_character_buf"
         ],
         "lang_cxx": {
             "impl_header": [
@@ -1672,15 +1671,15 @@
         ]
     },
     {
-        "name": "f_in_string*_buf",
-        "mixin": [
-            "f_mixin_in_character_buf",
-            "c_mixin_in_character_buf"
-        ],
         "alias": [
+            "f_in_string*_buf",
             "f_in_string&_buf",
             "c_in_string*_buf",
             "c_in_string&_buf"
+        ],
+        "mixin": [
+            "f_mixin_in_character_buf",
+            "c_mixin_in_character_buf"
         ],
         "c_helper": [
             "char_len_trim"
@@ -1691,8 +1690,8 @@
         ]
     },
     {
-        "name": "f_out_string*_buf",
         "alias": [
+            "f_out_string*_buf",
             "f_out_string&_buf",
             "c_out_string*_buf",
             "c_out_string&_buf"
@@ -1713,8 +1712,8 @@
         ]
     },
     {
-        "name": "f_inout_string*_buf",
         "alias": [
+            "f_inout_string*_buf",
             "f_inout_string&_buf",
             "c_inout_string*_buf",
             "c_inout_string&_buf"
@@ -1736,7 +1735,6 @@
         ]
     },
     {
-        "name": "f_shared_function_string_scalar",
         "alias": [
             "c_function_string*",
             "c_function_string&",
@@ -1779,8 +1777,8 @@
         ]
     },
     {
-        "name": "f_in_string",
         "alias": [
+            "f_in_string",
             "c_in_string"
         ],
         "c_arg_decl": [
@@ -1799,13 +1797,13 @@
         }
     },
     {
-        "name": "f_in_string_buf",
+        "alias": [
+            "f_in_string_buf",
+            "c_in_string_buf"
+        ],
         "mixin": [
             "f_mixin_in_character_buf",
             "c_mixin_in_character_buf"
-        ],
-        "alias": [
-            "c_in_string_buf"
         ],
         "f_arg_decl": [
             "character(len=*), intent({f_intent}) :: {f_var}"
@@ -1826,8 +1824,8 @@
         ]
     },
     {
-        "name": "f_function_string*_cdesc_allocatable",
         "alias": [
+            "f_function_string*_cdesc_allocatable",
             "f_function_string&_cdesc_allocatable",
             "f_function_string*_cdesc_allocatable_caller",
             "f_function_string*_cdesc_allocatable_library",
@@ -1845,13 +1843,8 @@
         ]
     },
     {
-        "name": "f_function_string_buf",
-        "mixin": [
-            "f_mixin_function-to-subroutine",
-            "f_mixin_in_character_buf",
-            "c_mixin_in_character_buf"
-        ],
         "alias": [
+            "f_function_string_buf",
             "f_function_string*_buf",
             "f_function_string&_buf",
             "f_function_string_buf_copy",
@@ -1860,6 +1853,11 @@
             "c_function_string_buf_copy",
             "c_function_string*_buf_copy",
             "c_function_string&_buf_copy"
+        ],
+        "mixin": [
+            "f_mixin_function-to-subroutine",
+            "f_mixin_in_character_buf",
+            "c_mixin_in_character_buf"
         ],
         "c_helper": [
             "char_copy"
@@ -1873,17 +1871,17 @@
         ]
     },
     {
-        "name": "f_function_string_buf_arg",
+        "alias": [
+            "f_function_string_buf_arg",
+            "c_function_string_buf_arg",
+            "f_function_string&_buf_arg",
+            "c_function_string&_buf_arg"
+        ],
         "comments": [
             "Change function result into an argument.",
             "Use F_string_result_as_arg as the argument name."
         ],
         "base": "f_function_string_buf",
-        "alias": [
-            "c_function_string_buf_arg",
-            "f_function_string&_buf_arg",
-            "c_function_string&_buf_arg"
-        ],
         "fmtdict": {
             "f_var": "{F_string_result_as_arg}",
             "i_var": "{F_string_result_as_arg}",
@@ -1901,8 +1899,8 @@
         ]
     },
     {
-        "name": "f_function_string_cdesc_allocatable",
         "alias": [
+            "f_function_string_cdesc_allocatable",
             "f_function_string_cdesc_allocatable_caller",
             "f_function_string_cdesc_allocatable_library"
         ],
@@ -1920,8 +1918,8 @@
         ]
     },
     {
-        "name": "f_out_enum*",
         "alias": [
+            "f_out_enum*",
             "c_out_enum*"
         ],
         "cxx_local_var": "scalar",
@@ -1940,11 +1938,11 @@
         }
     },
     {
-        "name": "f_inout_enum*",
-        "base": "f_out_enum*",
         "alias": [
+            "f_inout_enum*",
             "c_inout_enum*"
         ],
+        "base": "f_out_enum*",
         "lang_c": {
             "c_pre_call": [
                 "{cxx_type} {cxx_var} = ({cxx_type}) *{c_var};"
@@ -1964,11 +1962,6 @@
         ]
     },
     {
-        "name": "c_shared_vector_argument",
-        "notimplemented": true,
-        "comments": [
-            "Need to know the length of the vector from C"
-        ],
         "alias": [
             "c_in_vector<native>&",
             "c_out_vector<native>&",
@@ -1976,11 +1969,15 @@
             "c_in_vector<native*>&",
             "c_in_vector<string>&",
             "c_out_vector<string>&"
+        ],
+        "notimplemented": true,
+        "comments": [
+            "Need to know the length of the vector from C"
         ]
     },
     {
-        "name": "f_in_vector<native>_buf",
         "alias": [
+            "f_in_vector<native>_buf",
             "f_in_vector<native>*_buf",
             "f_in_vector<native>&_buf",
             "c_in_vector<native>_buf",
@@ -1996,8 +1993,8 @@
         ]
     },
     {
-        "name": "c_out_vector<native>_buf_copy",
         "alias": [
+            "c_out_vector<native>_buf_copy",
             "c_out_vector<native>*_buf_copy",
             "c_out_vector<native>&_buf_copy"
         ],
@@ -2021,8 +2018,8 @@
         ]
     },
     {
-        "name": "c_inout_vector<native>_buf_copy",
         "alias": [
+            "c_inout_vector<native>_buf_copy",
             "c_inout_vector<native>*_buf_copy",
             "c_inout_vector<native>&_buf_copy"
         ],
@@ -2039,14 +2036,14 @@
         "notimplemented": true
     },
     {
-        "name": "c_out_vector<native>_buf_malloc",
+        "alias": [
+            "c_out_vector<native>_buf_malloc",
+            "c_out_vector<native>*_buf_malloc",
+            "c_out_vector<native>&_buf_malloc"
+        ],
         "comments": [
             "Create empty local vector then copy result to",
             "malloc allocated array."
-        ],
-        "alias": [
-            "c_out_vector<native>*_buf_malloc",
-            "c_out_vector<native>&_buf_malloc"
         ],
         "mixin": [
             "c_mixin_out_vector_buf_malloc"
@@ -2070,14 +2067,14 @@
         ]
     },
     {
-        "name": "c_inout_vector<native>_buf_malloc",
+        "alias": [
+            "c_inout_vector<native>_buf_malloc",
+            "c_inout_vector<native>*_buf_malloc",
+            "c_inout_vector<native>&_buf_malloc"
+        ],
         "comments": [
             "Create local vector from arguments then copy result to",
             "malloc allocated array."
-        ],
-        "alias": [
-            "c_inout_vector<native>*_buf_malloc",
-            "c_inout_vector<native>&_buf_malloc"
         ],
         "mixin": [
             "c_mixin_out_vector_buf_malloc"
@@ -2130,8 +2127,8 @@
         ]
     },
     {
-        "name": "f_out_vector<native>*_cdesc",
         "alias": [
+            "f_out_vector<native>*_cdesc",
             "f_out_vector<native>&_cdesc",
             "c_out_vector<native>*_cdesc",
             "c_out_vector<native>&_cdesc"
@@ -2257,8 +2254,8 @@
         ]
     },
     {
-        "name": "f_in_vector<native*>&_buf",
         "alias": [
+            "f_in_vector<native*>&_buf",
             "c_in_vector<native*>&_buf"
         ],
         "comments": [
@@ -2279,8 +2276,8 @@
         ]
     },
     {
-        "name": "f_in_vector<string>_buf",
         "alias": [
+            "f_in_vector<string>_buf",
             "f_in_vector<string>*_buf",
             "f_in_vector<string>&_buf",
             "c_in_vector<string>_buf",
@@ -2314,8 +2311,8 @@
         ]
     },
     {
-        "name": "c_out_vector<string>_buf_copy",
         "alias": [
+            "c_out_vector<string>_buf_copy",
             "c_out_vector<string>*_buf_copy",
             "c_out_vector<string>&_buf_copy"
         ],
@@ -2452,7 +2449,10 @@
         ]
     },
     {
-        "name": "f_out_vector<string>&_cdesc",
+        "alias": [
+            "f_out_vector<string>&_cdesc",
+            "c_out_vector<string>&_cdesc"
+        ],
         "notes": [
             "f_arg_decl replaces values from f_mixin_str_array",
             "This one needs to use targs."
@@ -2460,9 +2460,6 @@
         "mixin": [
             "f_mixin_str_array",
             "f_mixin_pass_cdesc"
-        ],
-        "alias": [
-            "c_out_vector<string>&_cdesc"
         ],
         "f_helper": [
             "type_defines",
@@ -2517,8 +2514,8 @@
         ]
     },
     {
-        "name": "f_out_vector<string>&_cdesc_allocatable",
         "alias": [
+            "f_out_vector<string>&_cdesc_allocatable",
             "c_out_vector<string>&_cdesc_allocatable"
         ],
         "mixin": [
@@ -2572,8 +2569,8 @@
         ]
     },
     {
-        "name": "f_out_vector<native>*_cdesc_allocatable",
         "alias": [
+            "f_out_vector<native>*_cdesc_allocatable",
             "f_out_vector<native>&_cdesc_allocatable"
         ],
         "notes": [
@@ -2657,13 +2654,13 @@
         }
     },
     {
-        "name": "f_in_shadow",
+        "alias": [
+            "f_in_shadow",
+            "c_in_shadow"
+        ],
         "mixin": [
             "f_mixin_shadow-arg",
             "c_mixin_shadow"
-        ],
-        "alias": [
-            "c_in_shadow"
         ],
         "c_arg_decl": [
             "{c_type} {c_var}"
@@ -2677,17 +2674,17 @@
         ]
     },
     {
-        "name": "f_in_shadow*",
-        "mixin": [
-            "f_mixin_shadow-arg",
-            "c_mixin_shadow"
-        ],
         "alias": [
+            "f_in_shadow*",
             "c_in_shadow*",
             "f_inout_shadow*",
             "c_inout_shadow*",
             "f_inout_shadow&",
             "c_inout_shadow&"
+        ],
+        "mixin": [
+            "f_mixin_shadow-arg",
+            "c_mixin_shadow"
         ],
         "cxx_local_var": "pointer",
         "c_pre_call": [
@@ -2695,7 +2692,10 @@
         ]
     },
     {
-        "name": "f_function_shadow*_capsule",
+        "alias": [
+            "f_function_shadow*_capsule",
+            "c_function_shadow*_capsule"
+        ],
         "comments": [
             "Return a C_capsule_data_type."
         ],
@@ -2704,9 +2704,6 @@
             "f_mixin_function_shadow_capsule",
             "c_mixin_shadow"
         ],
-        "alias": [
-            "c_function_shadow*_capsule"
-        ],
         "cxx_local_var": "result",
         "c_post_call": [
             "{c_var}->addr = {cxx_nonconst_ptr};",
@@ -2714,7 +2711,10 @@
         ]
     },
     {
-        "name": "f_function_shadow*_this",
+        "alias": [
+            "f_function_shadow*_this",
+            "c_function_shadow*_this"
+        ],
         "notes": [
             "Input set return_this.",
             "Do not return anything."
@@ -2722,21 +2722,18 @@
         "mixin": [
             "f_mixin_function-to-subroutine"
         ],
-        "alias": [
-            "c_function_shadow*_this"
-        ],
         "f_result": "subroutine",
         "c_call": [
             "{CXX_this_call}{function_name}{CXX_template}({C_call_list});"
         ]
     },
     {
-        "name": "f_in_shadow&",
+        "alias": [
+            "f_in_shadow&",
+            "c_in_shadow&"
+        ],
         "mixin": [
             "c_mixin_shadow"
-        ],
-        "alias": [
-            "c_in_shadow&"
         ],
         "f_arg_decl": [
             "{f_type}, intent({f_intent}) :: {f_var}"
@@ -2751,8 +2748,8 @@
         ]
     },
     {
-        "name": "f_function_shadow*_capptr",
         "alias": [
+            "f_function_shadow*_capptr",
             "f_function_shadow&_capptr",
             "c_function_shadow*_capptr",
             "c_function_shadow&_capptr",
@@ -2783,8 +2780,8 @@
         ]
     },
     {
-        "name": "f_function_shadow_capptr",
         "alias": [
+            "f_function_shadow_capptr",
             "c_function_shadow_capptr",
             "f_function_shadow<native>_capptr",
             "c_function_shadow<native>_capptr",
@@ -2818,13 +2815,13 @@
         ]
     },
     {
-        "name": "f_ctor_shadow_capptr",
+        "alias": [
+            "f_ctor_shadow_capptr",
+            "c_ctor_shadow_capptr"
+        ],
         "mixin": [
             "f_mixin_function_shadow_capptr",
             "c_mixin_shadow"
-        ],
-        "alias": [
-            "c_ctor_shadow_capptr"
         ],
         "c_call": [
             "{cxx_type} *{cxx_var} =\t new {cxx_type}({C_call_list});",
@@ -2834,13 +2831,13 @@
         "owner": "caller"
     },
     {
-        "name": "f_dtor",
+        "alias": [
+            "f_dtor",
+            "c_dtor"
+        ],
         "mixin": [
             "c_mixin_noargs",
             "f_mixin_function-to-subroutine"
-        ],
-        "alias": [
-            "c_dtor"
         ],
         "lang_c": {
             "impl_header": [
@@ -2859,11 +2856,6 @@
         ]
     },
     {
-        "name": "f_shared_struct",
-        "notes": [
-            "Used with in, out, inout.",
-            "C pointer -> void pointer -> C++ pointer"
-        ],
         "alias": [
             "f_in_struct",
             "f_in_struct*",
@@ -2879,16 +2871,20 @@
             "c_out_struct&",
             "c_inout_struct*",
             "c_inout_struct&"
+        ],
+        "notes": [
+            "Used with in, out, inout.",
+            "C pointer -> void pointer -> C++ pointer"
         ]
     },
     {
         "start-after": "start function_struct_scalar",
-        "name": "f_function_struct",
+        "alias": [
+            "f_function_struct",
+            "c_function_struct"
+        ],
         "mixin": [
             "f_mixin_function-to-subroutine"
-        ],
-        "alias": [
-            "c_function_struct"
         ],
         "f_arg_call": [
             "{f_var}"
@@ -2913,15 +2909,15 @@
         "end-before": "end function_struct_scalar"
     },
     {
-        "name": "f_function_struct*_pointer",
+        "alias": [
+            "f_function_struct*_pointer",
+            "c_function_struct*"
+        ],
         "comments": [
             "C++ pointer -> void pointer -> C pointer"
         ],
         "mixin": [
             "f_mixin_function_c-ptr"
-        ],
-        "alias": [
-            "c_function_struct*"
         ]
     },
     {
@@ -2945,8 +2941,8 @@
         "f_need_wrapper": true
     },
     {
-        "name": "f_setter_struct*_pointer",
         "alias": [
+            "f_setter_struct*_pointer",
             "f_setter_struct*"
         ],
         "i_arg_names": [
@@ -3002,14 +2998,14 @@
         ]
     },
     {
-        "name": "f_getter_native",
-        "mixin": [
-            "c_mixin_noargs"
-        ],
         "alias": [
+            "f_getter_native",
             "c_getter_native",
             "f_getter_native*_pointer",
             "c_getter_native*"
+        ],
+        "mixin": [
+            "c_mixin_noargs"
         ],
         "f_arg_call": [],
         "c_call": [
@@ -3020,12 +3016,12 @@
         ]
     },
     {
-        "name": "f_setter",
+        "alias": [
+            "f_setter",
+            "c_setter"
+        ],
         "mixin": [
             "c_mixin_noargs"
-        ],
-        "alias": [
-            "c_setter"
         ],
         "f_arg_call": [],
         "f_call": [
@@ -3036,8 +3032,8 @@
         ]
     },
     {
-        "name": "f_setter_native",
         "alias": [
+            "f_setter_native",
             "f_setter_native*",
             "c_setter_native",
             "c_setter_native*"
@@ -3068,7 +3064,10 @@
         ]
     },
     {
-        "name": "f_getter_native*_cdesc_pointer",
+        "alias": [
+            "f_getter_native*_cdesc_pointer",
+            "f_getter_struct*_cdesc_pointer"
+        ],
         "notes": [
             "Similar to calling a function, but save field pointer instead."
         ],
@@ -3077,9 +3076,6 @@
             "f_mixin_pass_cdesc",
             "f_mixin_native_cdesc_pointer",
             "f_mixin_getter_cdesc"
-        ],
-        "alias": [
-            "f_getter_struct*_cdesc_pointer"
         ]
     },
     {
@@ -3109,7 +3105,10 @@
         ]
     },
     {
-        "name": "f_setter_string_buf",
+        "alias": [
+            "f_setter_string_buf",
+            "c_setter_string_scalar_buf"
+        ],
         "comments": [
             "Extract meta data and pass to C.",
             "Create std::string from Fortran meta data."
@@ -3117,9 +3116,6 @@
         "mixin": [
             "f_mixin_in_character_buf",
             "c_mixin_in_character_buf"
-        ],
-        "alias": [
-            "c_setter_string_scalar_buf"
         ],
         "f_arg_decl": [
             "character(len=*), intent({f_intent}) :: {f_var}"
@@ -3144,16 +3140,16 @@
         ]
     },
     {
-        "name": "f_function_char*_cfi_allocatable",
+        "alias": [
+            "f_function_char*_cfi_allocatable",
+            "f_function_char_cfi_allocatable"
+        ],
         "notes": [
             "Add allocatable attribute to declaration."
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
             "c_mixin_arg_cfi"
-        ],
-        "alias": [
-            "f_function_char_cfi_allocatable"
         ],
         "f_need_wrapper": true,
         "f_arg_decl": [
@@ -3180,13 +3176,13 @@
         ]
     },
     {
-        "name": "f_function_char_cfi_pointer",
+        "alias": [
+            "f_function_char_cfi_pointer",
+            "f_function_char*_cfi_pointer"
+        ],
         "mixin": [
             "f_mixin_function-to-subroutine",
             "c_mixin_arg_cfi"
-        ],
-        "alias": [
-            "f_function_char*_cfi_pointer"
         ],
         "f_need_wrapper": true,
         "f_arg_decl": [
@@ -3313,8 +3309,8 @@
         ]
     },
     {
-        "name": "f_in_native*_cfi",
         "alias": [
+            "f_in_native*_cfi",
             "f_inout_native*_cfi"
         ],
         "mixin": [
@@ -3447,8 +3443,8 @@
         ]
     },
     {
-        "name": "f_in_string_cfi",
         "alias": [
+            "f_in_string_cfi",
             "f_in_string*_cfi",
             "f_in_string&_cfi"
         ],
@@ -3469,8 +3465,8 @@
         ]
     },
     {
-        "name": "f_out_string*_cfi",
         "alias": [
+            "f_out_string*_cfi",
             "f_out_string&_cfi"
         ],
         "mixin": [
@@ -3489,8 +3485,8 @@
         ]
     },
     {
-        "name": "f_inout_string*_cfi",
         "alias": [
+            "f_inout_string*_cfi",
             "f_inout_string&_cfi"
         ],
         "mixin": [
@@ -3514,14 +3510,14 @@
         ]
     },
     {
-        "name": "f_function_string_cfi_copy",
+        "alias": [
+            "f_function_string_cfi_copy",
+            "f_function_string*_cfi_copy",
+            "f_function_string&_cfi_copy"
+        ],
         "mixin": [
             "f_mixin_function-to-subroutine",
             "c_mixin_arg_character_cfi"
-        ],
-        "alias": [
-            "f_function_string*_cfi_copy",
-            "f_function_string&_cfi_copy"
         ],
         "f_need_wrapper": true,
         "f_arg_call": [
@@ -3542,15 +3538,15 @@
         ]
     },
     {
-        "name": "f_function_string_cfi_arg",
+        "alias": [
+            "f_function_string_cfi_arg",
+            "f_function_string&_cfi_arg"
+        ],
         "comments": [
             "Change function result into an argument.",
             "Use F_string_result_as_arg as the argument name."
         ],
         "base": "f_function_string_cfi_copy",
-        "alias": [
-            "f_function_string&_cfi_arg"
-        ],
         "fmtdict": {
             "f_var": "{F_string_result_as_arg}",
             "i_var": "{F_string_result_as_arg}",
@@ -3565,7 +3561,6 @@
         ]
     },
     {
-        "name": "f_shared_function_string*_cfi_pointer",
         "alias": [
             "f_function_string_cfi_pointer",
             "f_function_string*_cfi_pointer",
@@ -3638,8 +3633,8 @@
         ]
     },
     {
-        "name": "f_function_string*_cfi_allocatable",
         "alias": [
+            "f_function_string*_cfi_allocatable",
             "f_function_string&_cfi_allocatable",
             "f_function_string_cfi_allocatable_caller",
             "f_function_string_cfi_allocatable_library",
@@ -3750,7 +3745,10 @@
         ]
     },
     {
-        "name": "f_out_string**_cdesc_copy",
+        "alias": [
+            "f_out_string**_cdesc_copy",
+            "c_out_string**_cdesc_copy"
+        ],
         "notes": [
             "Pass a cdesc down to describe the memory and a capsule to hold the",
             "C++ array. Copy into Fortran argument.",
@@ -3759,9 +3757,6 @@
         "mixin": [
             "f_mixin_str_array",
             "f_mixin_pass_cdesc"
-        ],
-        "alias": [
-            "c_out_string**_cdesc_copy"
         ],
         "f_helper": [
             "type_defines",
@@ -3781,14 +3776,14 @@
         ]
     },
     {
-        "name": "f_out_string**_copy",
+        "alias": [
+            "f_out_string**_copy",
+            "c_out_string**"
+        ],
         "notes": [
             "std::string **arg+intent(out)+dimension(size)",
             "Returning a pointer to a string*. However, this needs additional",
             "mapping for the C interface.  Fortran calls the +api(cdesc) variant."
-        ],
-        "alias": [
-            "c_out_string**"
         ],
         "notimplemented": true
     },
@@ -3932,8 +3927,8 @@
         "cxx_local_var": "result"
     },
     {
-        "name": "f_in_procedure",
         "alias": [
+            "f_in_procedure",
             "c_in_procedure"
         ],
         "f_arg_decl": [

--- a/shroud/fc-statements.json
+++ b/shroud/fc-statements.json
@@ -1767,7 +1767,7 @@
         ]
     },
     {
-        "name": "f_XXXin_string_scalar",
+        "name": "#f_in_string_scalar",
         "f_need_wrapper": true,
         "mixin": [
             "f_mixin_in_character_buf"

--- a/shroud/fc-statements.json
+++ b/shroud/fc-statements.json
@@ -1119,11 +1119,10 @@
         }
     },
     {
-        "name": "f_in/out/inout_native*_cdesc",
-        "mixin": [
-            "f_mixin_pass_cdesc"
-        ],
+        "name": "f_in_native*_cdesc",
         "alias": [
+            "f_out_native*_cdesc",
+            "f_inout_native*_cdesc",
             "c_in_native*_cdesc",
             "c_out_native*_cdesc",
             "c_inout_native*_cdesc",
@@ -1133,6 +1132,9 @@
             "f_in_void*_cdesc",
             "f_out_void*_cdesc",
             "f_inout_void*_cdesc"
+        ],
+        "mixin": [
+            "f_mixin_pass_cdesc"
         ],
         "f_arg_decl": [
             "{f_type}, intent({f_intent}), target :: {f_var}{f_assumed_shape}"
@@ -1165,12 +1167,14 @@
         }
     },
     {
-        "name": "f_out/inout_native*_hidden",
+        "name": "f_out_native*_hidden",
+        "alias": [
+            "f_inout_native*_hidden",
+            "c_out_native*_hidden",
+            "c_inout_native*_hidden"
+        ],
         "comments": [
             "Declare a local variable and pass to C."
-        ],
-        "alias": [
-            "c_out/inout_native*_hidden"
         ],
         "c_pre_call": [
             "{cxx_type} {cxx_var};"
@@ -1180,12 +1184,14 @@
         ]
     },
     {
-        "name": "f_out/inout_native&_hidden",
+        "name": "f_out_native&_hidden",
+        "alias": [
+            "f_inout_native&_hidden",
+            "c_out_native&_hidden",
+            "c_inout_native&_hidden"
+        ],
         "comments": [
             "Declare a local variable and pass to C."
-        ],
-        "alias": [
-            "c_out/inout_native&_hidden"
         ],
         "c_pre_call": [
             "{cxx_type} {cxx_var};"
@@ -1223,13 +1229,17 @@
         ]
     },
     {
-        "name": "f_in/out/inout_void**",
+        "name": "f_in_void**",
+        "alias": [
+            "f_out_void**",
+            "f_inout_void**",
+            "c_in_void**",
+            "c_out_void**",
+            "c_inout_void**",
+            "f_in_void**_cfi"
+        ],
         "notes": [
             "Treat as an assumed length array in Fortran interface."
-        ],
-        "alias": [
-            "c_in/out/inout_void**",
-            "f_in_void**_cfi"
         ],
         "f_module": {
             "iso_c_binding": [
@@ -1386,7 +1396,10 @@
         "name": "f_function_char*",
         "alias": [
             "c_function_char*",
-            "f_function_char*_allocatable/copy/pointer/raw"
+            "f_function_char*_allocatable",
+            "f_function_char*_copy",
+            "f_function_char*_pointer",
+            "f_function_char*_raw"
         ],
         "f_arg_decl": [
             "type(C_PTR) :: {f_var}"
@@ -1591,16 +1604,18 @@
     },
     {
         "name": "f_function_string*_cdesc_pointer",
+        "alias": [
+            "f_function_string&_cdesc_pointer",
+            "f_function_string*_cdesc_pointer_caller",
+            "f_function_string*_cdesc_pointer_library",
+            "f_function_string&_cdesc_pointer_caller",
+            "f_function_string&_cdesc_pointer_library"
+        ],
         "mixin": [
             "f_mixin_function-to-subroutine",
             "f_mixin_pass_cdesc",
             "c_mixin_function_string_cdesc",
             "f_mixin_char_cdesc_pointer"
-        ],
-        "alias": [
-            "f_function_string&_cdesc_pointer",
-            "f_function_string*_cdesc_pointer_caller/library",
-            "f_function_string&_cdesc_pointer_caller/library"
         ]
     },
     {
@@ -1724,16 +1739,17 @@
     },
     {
         "name": "f_shared_function_string_scalar",
-        "notes": [
-            "Fortran calling a C function without",
-            "any api argument - is this useful?"
-        ],
         "alias": [
             "c_function_string*",
             "c_function_string&",
-            "c_function_string*_caller/library",
+            "c_function_string*_caller",
+            "c_function_string*_library",
             "c_function_string*_copy",
             "c_function_string&_copy"
+        ],
+        "notes": [
+            "Fortran calling a C function without",
+            "any api argument - is this useful?"
         ],
         "c_return": [
             "return {c_var};"
@@ -1813,6 +1829,13 @@
     },
     {
         "name": "f_function_string*_cdesc_allocatable",
+        "alias": [
+            "f_function_string&_cdesc_allocatable",
+            "f_function_string*_cdesc_allocatable_caller",
+            "f_function_string*_cdesc_allocatable_library",
+            "f_function_string&_cdesc_allocatable_caller",
+            "f_function_string&_cdesc_allocatable_library"
+        ],
         "mixin": [
             "f_mixin_function-to-subroutine",
             "f_mixin_pass_cdesc",
@@ -1821,11 +1844,6 @@
             "c_mixin_native_capsule_fill",
             "f_mixin_char_cdesc_allocate",
             "f_mixin_capsule_dtor"
-        ],
-        "alias": [
-            "f_function_string&_cdesc_allocatable",
-            "f_function_string*_cdesc_allocatable_caller/library",
-            "f_function_string&_cdesc_allocatable_caller/library"
         ]
     },
     {
@@ -1886,6 +1904,10 @@
     },
     {
         "name": "f_function_string_cdesc_allocatable",
+        "alias": [
+            "f_function_string_cdesc_allocatable_caller",
+            "f_function_string_cdesc_allocatable_library"
+        ],
         "mixin": [
             "f_mixin_function-to-subroutine",
             "f_mixin_pass_cdesc",
@@ -1893,9 +1915,6 @@
             "c_mixin_function_string_cdesc",
             "f_mixin_char_cdesc_allocate",
             "f_mixin_use_capsule"
-        ],
-        "alias": [
-            "f_function_string_cdesc_allocatable_caller/library"
         ],
         "cxx_local_var": "pointer",
         "c_pre_call": [
@@ -2735,21 +2754,25 @@
     },
     {
         "name": "f_function_shadow*_capptr",
+        "alias": [
+            "f_function_shadow&_capptr",
+            "c_function_shadow*_capptr",
+            "c_function_shadow&_capptr",
+            "f_function_shadow*_capptr_caller",
+            "f_function_shadow*_capptr_library",
+            "f_function_shadow&_capptr_caller",
+            "f_function_shadow&_capptr_library",
+            "c_function_shadow*_capptr_caller",
+            "c_function_shadow*_capptr_library",
+            "c_function_shadow&_capptr_caller",
+            "c_function_shadow&_capptr_library"
+        ],
         "comments": [
             "Return a C_capsule_data_type."
         ],
         "mixin": [
             "f_mixin_function_shadow_capptr",
             "c_mixin_shadow"
-        ],
-        "alias": [
-            "f_function_shadow&_capptr",
-            "c_function_shadow*_capptr",
-            "c_function_shadow&_capptr",
-            "f_function_shadow*_capptr_caller/library",
-            "f_function_shadow&_capptr_caller/library",
-            "c_function_shadow*_capptr_caller/library",
-            "c_function_shadow&_capptr_caller/library"
         ],
         "cxx_local_var": "result",
         "c_post_call": [
@@ -2763,6 +2786,13 @@
     },
     {
         "name": "f_function_shadow_capptr",
+        "alias": [
+            "c_function_shadow_capptr",
+            "f_function_shadow<native>_capptr",
+            "c_function_shadow<native>_capptr",
+            "f_function_shadow_capptr_caller",
+            "f_function_shadow_capptr_library"
+        ],
         "comments": [
             "Return a instance by value."
         ],
@@ -2774,12 +2804,6 @@
         "mixin": [
             "f_mixin_function_shadow_capptr",
             "c_mixin_shadow"
-        ],
-        "alias": [
-            "c_function_shadow_capptr",
-            "f_function_shadow<native>_capptr",
-            "c_function_shadow<native>_capptr",
-            "f_function_shadow_capptr_caller/library"
         ],
         "cxx_local_var": "pointer",
         "owner": "caller",
@@ -3291,7 +3315,10 @@
         ]
     },
     {
-        "name": "f_in/inout_native*_cfi",
+        "name": "f_in_native*_cfi",
+        "alias": [
+            "f_inout_native*_cfi"
+        ],
         "mixin": [
             "c_mixin_arg_native_cfi"
         ],
@@ -3541,6 +3568,17 @@
     },
     {
         "name": "f_shared_function_string*_cfi_pointer",
+        "alias": [
+            "f_function_string_cfi_pointer",
+            "f_function_string*_cfi_pointer",
+            "f_function_string&_cfi_pointer",
+            "f_function_string_cfi_pointer_caller",
+            "f_function_string_cfi_pointer_library",
+            "f_function_string*_cfi_pointer_caller",
+            "f_function_string*_cfi_pointer_library",
+            "f_function_string&_cfi_pointer_caller",
+            "f_function_string&_cfi_pointer_library"
+        ],
         "notes": [
             "XXX - consolidate with c_function*_cfi_pointer?",
             "XXX - via a helper to get address and length of string"
@@ -3548,14 +3586,6 @@
         "mixin": [
             "f_mixin_function-to-subroutine",
             "c_mixin_arg_cfi"
-        ],
-        "alias": [
-            "f_function_string_cfi_pointer",
-            "f_function_string*_cfi_pointer",
-            "f_function_string&_cfi_pointer",
-            "f_function_string_cfi_pointer_caller/library",
-            "f_function_string*_cfi_pointer_caller/library",
-            "f_function_string&_cfi_pointer_caller/library"
         ],
         "f_need_wrapper": true,
         "f_arg_decl": [
@@ -3611,16 +3641,19 @@
     },
     {
         "name": "f_function_string*_cfi_allocatable",
+        "alias": [
+            "f_function_string&_cfi_allocatable",
+            "f_function_string_cfi_allocatable_caller",
+            "f_function_string_cfi_allocatable_library",
+            "f_function_string*_cfi_allocatable_caller",
+            "f_function_string*_cfi_allocatable_library",
+            "f_function_string&_cfi_allocatable_caller",
+            "f_function_string&_cfi_allocatable_library"
+        ],
         "mixin": [
             "f_mixin_function-to-subroutine",
             "f_mixin_function_string_cfi_allocatable",
             "c_mixin_arg_cfi"
-        ],
-        "alias": [
-            "f_function_string&_cfi_allocatable",
-            "f_function_string_cfi_allocatable_caller/library",
-            "f_function_string*_cfi_allocatable_caller/library",
-            "f_function_string&_cfi_allocatable_caller/library"
         ],
         "i_arg_decl": [
             "character(len=:), intent({f_intent}), allocatable :: {i_var}"

--- a/shroud/statements.py
+++ b/shroud/statements.py
@@ -472,7 +472,6 @@ def process_mixin(stmts, defaults, stmtdict):
                 append_mixin(node, stmt["append"])
             node.update(stmt)
         post_mixin_check_statement(name, node)
-        node["orig"] = name
         node["index"] = str(index)
         index += 1
         node["name"] = name
@@ -650,7 +649,7 @@ def print_tree_index(tree, lines, indent=""):
     parts = tree.get('_key', 'root').split('_')
     if "_node" in tree:
         #        final = '' # + tree["_node"]["scope"].name + '-'
-        origname = tree["_node"]["orig"]
+        origname = tree["_node"]["name"]
         lines.append("{}{} -- {}\n".format(indent, parts[-1], origname))
     else:
         lines.append("{}{}\n".format(indent, parts[-1]))

--- a/shroud/statements.py
+++ b/shroud/statements.py
@@ -407,7 +407,7 @@ valid_intents = [
     "getter", "setter",
     "ctor", "dtor",
     "base", "descr",
-    "defaulttmp", "XXXin", "test",
+    "defaulttmp",
 ]
 
 def process_mixin(stmts, defaults, stmtdict):
@@ -451,7 +451,7 @@ def process_mixin(stmts, defaults, stmtdict):
         if "name" in stmt:
             name = stmt["name"]
             tmp_name = name
-            if tmp_name[0] == "!":
+            if tmp_name[0] == "#":
                 continue
         if not tmp_name:
             cursor.warning("Statement must have name or alias")
@@ -532,6 +532,8 @@ def process_mixin(stmts, defaults, stmtdict):
         if aliases:
             # Install with alias name.
             for alias in aliases:
+                if alias[0] == "#":
+                    continue
                 apart = alias.split("_", 2)
                 intent = apart[1]
                 anode = util.Scope(node)

--- a/shroud/statements.py
+++ b/shroud/statements.py
@@ -407,7 +407,7 @@ valid_intents = [
     "getter", "setter",
     "ctor", "dtor",
     "base", "descr",
-    "defaulttmp", "XXXin", "test", "shared",
+    "defaulttmp", "XXXin", "test",
 ]
 
 def process_mixin(stmts, defaults, stmtdict):

--- a/shroud/statements.py
+++ b/shroud/statements.py
@@ -402,12 +402,12 @@ def append_mixin(stmt, mixin):
             stmt[key] = value
 
 valid_intents = [
-    "in", "out", "inout", "mixin",
+    "in", "out", "inout",
+    "mixin",
     "function", "subroutine",
     "getter", "setter",
     "ctor", "dtor",
     "base", "descr",
-    "defaulttmp",
 ]
 
 def process_mixin(stmts, defaults, stmtdict):

--- a/shroud/wrapl.py
+++ b/shroud/wrapl.py
@@ -1089,8 +1089,8 @@ lua_statements = [
     #####
     # native
     dict(
-        name="lua_in_native",
         alias=[
+            "lua_in_native",
             "lua_in_enum",
         ],
         pre_call=[
@@ -1104,20 +1104,20 @@ lua_statements = [
         ],
     ),
     dict(
-        name="lua_function_native",
+        alias=[
+            "lua_function_native",
+            "lua_function_enum",
+        ],
         mixin=[
             "lua_mixin_callfunction",
             "lua_mixin_push"
-        ],
-        alias=[
-            "lua_function_enum",
         ],
     ),
     #####
     # string
     dict(
-        name="lua_in_string*",
         alias=[
+            "lua_in_string*",
             "lua_in_string&",
         ],
         pre_call=[

--- a/shroud/wrapl.py
+++ b/shroud/wrapl.py
@@ -1024,7 +1024,6 @@ lua_statements = [
     ),
     
     dict(
-        name="lua_defaulttmp",
         alias=[
             "lua_in_unknown",
             "lua_in_void",

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -4026,8 +4026,8 @@ py_statements = [
         goto_fail=True,
     ),
     dict(
-        name="py_function_native*_numpy",
         alias=[
+            "py_function_native*_numpy",
             "py_function_native&_numpy",
         ],
         need_numpy=True,
@@ -4293,8 +4293,8 @@ py_statements = [
 # string
 # ctor_expr is arguments to PyString_FromStringAndSize.
     dict(
-        name="py_in_string",
         alias=[
+            "py_in_string",
             "py_in_string&",
         ],
         cxx_local_var="scalar",
@@ -4308,8 +4308,8 @@ py_statements = [
         ),
     ),
     dict(
-        name="py_inout_string",
         alias=[
+            "py_inout_string",
             "py_inout_string&",
         ],
         cxx_local_var="scalar",
@@ -4322,8 +4322,8 @@ py_statements = [
         ),
     ),
     dict(
-        name="py_out_string",
         alias=[
+            "py_out_string",
             "py_out_string&",
         ],
         arg_declare=[],
@@ -4340,8 +4340,8 @@ py_statements = [
         ),
     ),
     dict(
-        name="py_function_string*",
         alias=[
+            "py_function_string*",
             "py_function_string&",
         ],
         fmtdict=dict(
@@ -4534,8 +4534,8 @@ py_statements = [
         goto_fail=True,
     ),
     dict(
-        name="py_function_struct_numpy",
         alias=[
+            "py_function_struct_numpy",
             "py_function_struct*_numpy",
         ],
         # XXX - expand to array of struct
@@ -4611,8 +4611,8 @@ py_statements = [
         incref_on_return=True,
     ),
     dict(
-        name="py_out_struct*_class",
         alias=[
+            "py_out_struct*_class",
             "py_function_shadow",
         ],
 #        allocate_local_var=True,  # needed to release memory
@@ -4651,8 +4651,8 @@ py_statements = [
         goto_fail=True,
     ),
     dict(
-        name="py_function_struct_class",
         alias=[
+            "py_function_struct_class",
             "py_function_struct*_class",
         ],
         cxx_local_var="pointer",
@@ -4742,8 +4742,8 @@ py_statements = [
         goto_fail=True,
     ),
     dict(
-        name="py_function_shadow*",
         alias=[
+            "py_function_shadow*",
             "py_function_shadow&",
         ],
 #            declare=[
@@ -4827,8 +4827,8 @@ py_statements = [
     ),
     # XXX - must release after copying result.
     dict(
-        name="py_function_vector_list",
         alias=[
+            "py_function_vector_list",
             "py_function_vector<native>_list",
         ],
         declare=[
@@ -4911,8 +4911,8 @@ py_statements = [
         fail_capsule=fail_capsule,
     ),
     dict(
-        name="py_function_vector_numpy",
         alias=[
+            "py_function_vector_numpy",
             "py_function_vector<native>_numpy",
         ],
         need_numpy=True,
@@ -4981,8 +4981,8 @@ py_statements = [
     ),
     
     dict(
-        name="py_ctor_native",
         alias=[
+            "py_ctor_native",
             "py_ctor_native_list",
             "py_ctor_native_numpy",
         ],
@@ -4995,47 +4995,47 @@ py_statements = [
         ],
     ),
     dict(
-        name="py_ctor_native[]",
-        base="py_base_ctor_array_fill",
         alias=[
+            "py_ctor_native[]",
             "py_ctor_native[]_list",
             "py_ctor_native[]_numpy",
         ],
+        base="py_base_ctor_array_fill",
         c_helper="fill_from_PyObject_{c_type}_{PY_array_arg}",
     ),
     dict(
-        name="py_ctor_native*",
-        base="py_base_ctor_array",
         alias=[
+            "py_ctor_native*",
             "py_ctor_native*_list",
             "py_ctor_native*_numpy",
         ],
+        base="py_base_ctor_array",
         c_helper="get_from_object_{c_type}_{PY_array_arg}",
     ),
     
     dict(
-        name="py_ctor_char[]",
-        base="py_base_ctor_array_fill",
         alias=[
+            "py_ctor_char[]",
             "py_ctor_char[]_list",
             "py_ctor_char[]_numpy",
         ],
+        base="py_base_ctor_array_fill",
         c_helper="fill_from_PyObject_char",
     ),
     dict(
-        name="py_ctor_char*",
-        base="py_base_ctor_array",
         alias=[
+            "py_ctor_char*",
             "py_ctor_char*_numpy",
         ],
+        base="py_base_ctor_array",
         c_helper="get_from_object_char",
     ),
     dict(
-        name="py_ctor_char**",
-        base="py_base_ctor_array",
         alias=[
+            "py_ctor_char**",
             "py_ctor_char**_list",
         ],
+        base="py_base_ctor_array",
         c_helper="get_from_object_charptr",
         # Need explicit post_call to change cast to char **.
         post_call=[
@@ -5105,8 +5105,8 @@ py_statements = [
         ],
     ),
     dict(
-        name="py_descr_char_*",
         alias=[
+            "py_descr_char_*",
             "py_descr_char_*_numpy",
         ],
         setter_helper="get_from_object_{c_type}_list",
@@ -5244,8 +5244,8 @@ py_statements = [
     ),
 
     dict(
-        name="py_descr_char_[]",
         alias=[
+            "py_descr_char_[]",
             "py_descr_char_[]_list",
             "py_descr_char_[]_numpy",
         ],

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -3744,7 +3744,6 @@ py_statements = [
         ],
     ),
     dict(
-        name="py_defaulttmp",
         alias=[
             "py_function_native",
             "py_in_native",


### PR DESCRIPTION
* Make the *name* field optional if *alias* is provided. This makes it possible to format all names/alias together to look
for possible errors by noticing patterns.

* Removes several intents (defaulttmp, shared) that were added for the same reason (to group all names together)

* Remove the permutation option in names ( f_in/out ) This made it harder to find names in `fc-statements.json` with grep/search. I had been adding comments in Python for all the expanded permutations, but JSON does not support comments.