### PR TITLE
Use statements for implied attribute

### DIFF
--- a/regression/reference/arrayclass/arrayclass.json
+++ b/regression/reference/arrayclass/arrayclass.json
@@ -103,6 +103,7 @@
                                         "f_derived_type": "ArrayWrapper",
                                         "f_intent": "OUT",
                                         "f_intent_attr": ", intent(OUT)",
+                                        "f_kind": "ArrayWrapper",
                                         "f_local_ptr": "SHT_prv",
                                         "f_type": "type(ArrayWrapper)",
                                         "f_var": "SHT_rv",
@@ -4419,6 +4420,7 @@
             "f_capsule_data_type": "ARR_SHROUD_capsule_data",
             "f_class": "class(ArrayWrapper)",
             "f_derived_type": "ArrayWrapper",
+            "f_kind": "ArrayWrapper",
             "f_module": {
                 "arrayclass_mod": [
                     "ArrayWrapper"

--- a/regression/reference/classes/classes.json
+++ b/regression/reference/classes/classes.json
@@ -195,6 +195,7 @@
                                         "f_derived_type": "class1",
                                         "f_intent": "OUT",
                                         "f_intent_attr": ", intent(OUT)",
+                                        "f_kind": "class1",
                                         "f_local_ptr": "SHT_prv",
                                         "f_type": "type(class1)",
                                         "f_var": "SHT_rv",
@@ -444,6 +445,7 @@
                                         "f_derived_type": "class1",
                                         "f_intent": "OUT",
                                         "f_intent_attr": ", intent(OUT)",
+                                        "f_kind": "class1",
                                         "f_local_ptr": "SHT_prv",
                                         "f_type": "type(class1)",
                                         "f_var": "SHT_rv",
@@ -1116,6 +1118,7 @@
                                         "f_derived_type": "class1",
                                         "f_intent": "IN",
                                         "f_intent_attr": ", intent(IN)",
+                                        "f_kind": "class1",
                                         "f_type": "type(class1)",
                                         "f_var": "obj2",
                                         "fc_var": "obj2",
@@ -1340,6 +1343,7 @@
                                         "f_derived_type": "class1",
                                         "f_intent": "OUT",
                                         "f_intent_attr": ", intent(OUT)",
+                                        "f_kind": "class1",
                                         "f_type": "type(class1)",
                                         "f_var": "SHT_rv",
                                         "i_type": "type(CLA_SHROUD_capsule_data)",
@@ -1474,6 +1478,7 @@
                                         "f_derived_type": "class1",
                                         "f_intent": "OUT",
                                         "f_intent_attr": ", intent(OUT)",
+                                        "f_kind": "class1",
                                         "f_local_ptr": "SHT_prv",
                                         "f_type": "type(class1)",
                                         "f_var": "SHT_rv",
@@ -1597,6 +1602,7 @@
                                         "f_derived_type": "class1",
                                         "f_intent": "OUT",
                                         "f_intent_attr": ", intent(OUT)",
+                                        "f_kind": "class1",
                                         "f_local_ptr": "SHT_prv",
                                         "f_type": "type(class1)",
                                         "f_var": "SHT_rv",
@@ -1827,6 +1833,7 @@
                                         "f_derived_type": "class1",
                                         "f_intent": "OUT",
                                         "f_intent_attr": ", intent(OUT)",
+                                        "f_kind": "class1",
                                         "f_local_ptr": "SHT_prv",
                                         "f_type": "type(class1)",
                                         "f_var": "SHT_rv",
@@ -3919,6 +3926,7 @@
                                         "f_derived_type": "singleton",
                                         "f_intent": "OUT",
                                         "f_intent_attr": ", intent(OUT)",
+                                        "f_kind": "singleton",
                                         "f_local_ptr": "SHT_prv",
                                         "f_type": "type(singleton)",
                                         "f_var": "SHT_rv",
@@ -4156,6 +4164,7 @@
                                         "f_derived_type": "shape",
                                         "f_intent": "OUT",
                                         "f_intent_attr": ", intent(OUT)",
+                                        "f_kind": "shape",
                                         "f_local_ptr": "SHT_prv",
                                         "f_type": "type(shape)",
                                         "f_var": "SHT_rv",
@@ -4599,6 +4608,7 @@
                                         "f_derived_type": "circle",
                                         "f_intent": "OUT",
                                         "f_intent_attr": ", intent(OUT)",
+                                        "f_kind": "circle",
                                         "f_local_ptr": "SHT_prv",
                                         "f_type": "type(circle)",
                                         "f_var": "SHT_rv",
@@ -5099,6 +5109,7 @@
                                         "f_derived_type": "data",
                                         "f_intent": "OUT",
                                         "f_intent_attr": ", intent(OUT)",
+                                        "f_kind": "data",
                                         "f_local_ptr": "SHT_prv",
                                         "f_type": "type(data)",
                                         "f_var": "SHT_rv",
@@ -6356,6 +6367,7 @@
                                 "f_derived_type": "class1",
                                 "f_intent": "IN",
                                 "f_intent_attr": ", intent(IN)",
+                                "f_kind": "class1",
                                 "f_type": "type(class1)",
                                 "f_value_attr": ", value",
                                 "f_var": "arg",
@@ -6631,6 +6643,7 @@
                                 "f_derived_type": "class1",
                                 "f_intent": "IN",
                                 "f_intent_attr": ", intent(IN)",
+                                "f_kind": "class1",
                                 "f_type": "type(class1)",
                                 "f_var": "arg",
                                 "fc_var": "arg",
@@ -6853,6 +6866,7 @@
                                 "f_derived_type": "class1",
                                 "f_intent": "OUT",
                                 "f_intent_attr": ", intent(OUT)",
+                                "f_kind": "class1",
                                 "f_local_ptr": "SHT_prv",
                                 "f_type": "type(class1)",
                                 "f_var": "SHT_rv",
@@ -6990,6 +7004,7 @@
                                 "f_derived_type": "class1",
                                 "f_intent": "OUT",
                                 "f_intent_attr": ", intent(OUT)",
+                                "f_kind": "class1",
                                 "f_local_ptr": "SHT_prv",
                                 "f_type": "type(class1)",
                                 "f_var": "SHT_rv",
@@ -7173,6 +7188,7 @@
                                 "f_derived_type": "class1",
                                 "f_intent": "OUT",
                                 "f_intent_attr": ", intent(OUT)",
+                                "f_kind": "class1",
                                 "f_type": "type(class1)",
                                 "f_var": "SHT_rv",
                                 "fc_var": "SHT_rv",
@@ -7305,6 +7321,7 @@
                                 "f_derived_type": "class1",
                                 "f_intent": "OUT",
                                 "f_intent_attr": ", intent(OUT)",
+                                "f_kind": "class1",
                                 "f_type": "type(class1)",
                                 "f_var": "SHT_rv",
                                 "fc_var": "SHT_rv",
@@ -7438,6 +7455,7 @@
                                 "f_derived_type": "class1",
                                 "f_intent": "OUT",
                                 "f_intent_attr": ", intent(OUT)",
+                                "f_kind": "class1",
                                 "f_local_ptr": "SHT_prv",
                                 "f_type": "type(class1)",
                                 "f_var": "SHT_rv",
@@ -7572,6 +7590,7 @@
                                 "f_derived_type": "class1",
                                 "f_intent": "OUT",
                                 "f_intent_attr": ", intent(OUT)",
+                                "f_kind": "class1",
                                 "f_local_ptr": "SHT_prv",
                                 "f_type": "type(class1)",
                                 "f_var": "SHT_rv",
@@ -7794,6 +7813,7 @@
                                 "f_derived_type": "class1",
                                 "f_intent": "OUT",
                                 "f_intent_attr": ", intent(OUT)",
+                                "f_kind": "class1",
                                 "f_local_ptr": "SHC_rv_ptr",
                                 "f_type": "type(class1)",
                                 "f_var": "SHT_rv",
@@ -8560,6 +8580,7 @@
             "f_capsule_data_type": "CLA_SHROUD_capsule_data",
             "f_class": "class(circle)",
             "f_derived_type": "circle",
+            "f_kind": "circle",
             "f_module": {
                 "classes_mod": [
                     "circle"
@@ -8600,6 +8621,7 @@
             "f_capsule_data_type": "CLA_SHROUD_capsule_data",
             "f_class": "class(class1)",
             "f_derived_type": "class1",
+            "f_kind": "class1",
             "f_module": {
                 "classes_mod": [
                     "class1"
@@ -8676,6 +8698,7 @@
             "f_capsule_data_type": "CLA_SHROUD_capsule_data",
             "f_class": "class(class2)",
             "f_derived_type": "class2",
+            "f_kind": "class2",
             "f_module": {
                 "classes_mod": [
                     "class2"
@@ -8710,6 +8733,7 @@
             "f_capsule_data_type": "CLA_SHROUD_capsule_data",
             "f_class": "class(data)",
             "f_derived_type": "data",
+            "f_kind": "data",
             "f_module": {
                 "classes_mod": [
                     "data"
@@ -8750,6 +8774,7 @@
             "f_capsule_data_type": "CLA_SHROUD_capsule_data",
             "f_class": "class(shape)",
             "f_derived_type": "shape",
+            "f_kind": "shape",
             "f_module": {
                 "classes_mod": [
                     "shape"
@@ -8790,6 +8815,7 @@
             "f_capsule_data_type": "CLA_SHROUD_capsule_data",
             "f_class": "class(singleton)",
             "f_derived_type": "singleton",
+            "f_kind": "singleton",
             "f_module": {
                 "classes_mod": [
                     "singleton"

--- a/regression/reference/clibrary/wrapfclibrary.f
+++ b/regression/reference/clibrary/wrapfclibrary.f
@@ -627,6 +627,12 @@ contains
     ! ----------------------------------------
     ! Function:  char *Function4a +len(30)
     ! Statement: f_function_char*_buf_copy
+    ! ----------------------------------------
+    ! Argument:  const char *arg1
+    ! Statement: f_in_char*
+    ! ----------------------------------------
+    ! Argument:  const char *arg2
+    ! Statement: f_in_char*
     function function4a(arg1, arg2) &
             result(SHT_rv)
         use iso_c_binding, only : C_INT, C_NULL_CHAR
@@ -644,6 +650,9 @@ contains
     ! ----------------------------------------
     ! Function:  void acceptName
     ! Statement: f_subroutine
+    ! ----------------------------------------
+    ! Argument:  const char *name
+    ! Statement: f_in_char*
     ! start accept_name
     subroutine accept_name(name)
         use iso_c_binding, only : C_NULL_CHAR

--- a/regression/reference/clibrary/wrapfclibrary.f
+++ b/regression/reference/clibrary/wrapfclibrary.f
@@ -767,6 +767,9 @@ contains
     ! ----------------------------------------
     ! Argument:  char *text +charlen(MAXNAME)+intent(out)
     ! Statement: f_out_char*_buf
+    ! ----------------------------------------
+    ! Argument:  int ltext +implied(len(text))
+    ! Statement: c_default
     !>
     !! \brief Fill text, at most ltext characters.
     !!
@@ -791,6 +794,12 @@ contains
     ! ----------------------------------------
     ! Argument:  const char *text +api(capi)
     ! Statement: f_in_char*_capi
+    ! ----------------------------------------
+    ! Argument:  int ltext +implied(len(text))
+    ! Statement: c_default
+    ! ----------------------------------------
+    ! Argument:  bool flag +implied(false)
+    ! Statement: c_default
     !>
     !! \brief Return the implied argument - text length
     !!
@@ -817,6 +826,12 @@ contains
     ! ----------------------------------------
     ! Argument:  const char *text +api(capi)
     ! Statement: f_in_char*_capi
+    ! ----------------------------------------
+    ! Argument:  int ltext +implied(len_trim(text))
+    ! Statement: c_default
+    ! ----------------------------------------
+    ! Argument:  bool flag +implied(true)
+    ! Statement: c_default
     !>
     !! \brief Return the implied argument - text length
     !!
@@ -840,6 +855,9 @@ contains
     ! ----------------------------------------
     ! Function:  bool ImpliedBoolTrue
     ! Statement: f_function_bool
+    ! ----------------------------------------
+    ! Argument:  bool flag +implied(true)
+    ! Statement: c_default
     !>
     !! \brief Single, implied bool argument
     !!
@@ -858,6 +876,9 @@ contains
     ! ----------------------------------------
     ! Function:  bool ImpliedBoolFalse
     ! Statement: f_function_bool
+    ! ----------------------------------------
+    ! Argument:  bool flag +implied(false)
+    ! Statement: c_default
     !>
     !! \brief Single, implied bool argument
     !!

--- a/regression/reference/cxxlibrary/cxxlibrary.json
+++ b/regression/reference/cxxlibrary/cxxlibrary.json
@@ -629,6 +629,7 @@
                                         "f_derived_type": "class1",
                                         "f_intent": "OUT",
                                         "f_intent_attr": ", intent(OUT)",
+                                        "f_kind": "class1",
                                         "f_local_ptr": "SHT_prv",
                                         "f_type": "type(class1)",
                                         "f_var": "SHT_rv",
@@ -1429,6 +1430,7 @@
                                         "f_derived_type": "class1",
                                         "f_intent": "OUT",
                                         "f_intent_attr": ", intent(OUT)",
+                                        "f_kind": "class1",
                                         "f_type": "type(class1)",
                                         "f_var": "SHT_rv",
                                         "i_type": "type(CXX_SHROUD_capsule_data)",
@@ -1651,6 +1653,7 @@
                                         "f_derived_type": "class1",
                                         "f_intent": "OUT",
                                         "f_intent_attr": ", intent(OUT)",
+                                        "f_kind": "class1",
                                         "f_type": "type(class1)",
                                         "f_var": "SHT_rv",
                                         "i_type": "type(CXX_SHROUD_capsule_data)",
@@ -7077,6 +7080,7 @@
             "f_capsule_data_type": "CXX_SHROUD_capsule_data",
             "f_class": "class(class1)",
             "f_derived_type": "class1",
+            "f_kind": "class1",
             "f_module": {
                 "cxxlibrary_mod": [
                     "class1"

--- a/regression/reference/defaultarg/defaultarg.json
+++ b/regression/reference/defaultarg/defaultarg.json
@@ -156,6 +156,7 @@
                                         "f_derived_type": "class1",
                                         "f_intent": "OUT",
                                         "f_intent_attr": ", intent(OUT)",
+                                        "f_kind": "class1",
                                         "f_local_ptr": "SHT_prv",
                                         "f_type": "type(class1)",
                                         "f_var": "SHT_rv",
@@ -422,6 +423,7 @@
                                         "f_derived_type": "class1",
                                         "f_intent": "OUT",
                                         "f_intent_attr": ", intent(OUT)",
+                                        "f_kind": "class1",
                                         "f_local_ptr": "SHT_prv",
                                         "f_type": "type(class1)",
                                         "f_var": "SHT_rv",
@@ -775,6 +777,7 @@
                                         "f_derived_type": "class1",
                                         "f_intent": "OUT",
                                         "f_intent_attr": ", intent(OUT)",
+                                        "f_kind": "class1",
                                         "f_local_ptr": "SHT_prv",
                                         "f_type": "type(class1)",
                                         "f_var": "SHT_rv",
@@ -5719,6 +5722,7 @@
             "f_capsule_data_type": "DEF_SHROUD_capsule_data",
             "f_class": "class(class1)",
             "f_derived_type": "class1",
+            "f_kind": "class1",
             "f_module": {
                 "defaultarg_mod": [
                     "class1"

--- a/regression/reference/error-generate/wrapferror.f
+++ b/regression/reference/error-generate/wrapferror.f
@@ -96,7 +96,7 @@ contains
             result(SHT_rv)
         use iso_c_binding, only : C_INT
         type(struct1), intent(IN) :: SH_this
-        integer(C_INT) :: SHT_rv(narg2)
+        ===>f_arg_decl<===
         ! splicer begin function.struct1_get_arg2
         SHT_rv = c_struct1_get_arg2(SH_this, SHT_rv)
         ! splicer end function.struct1_get_arg2

--- a/regression/reference/error-generate/wrapferror.f
+++ b/regression/reference/error-generate/wrapferror.f
@@ -94,7 +94,6 @@ contains
     ! Statement: f_in_struct*
     function struct1_get_arg2(SH_this) &
             result(SHT_rv)
-        use iso_c_binding, only : C_INT
         type(struct1), intent(IN) :: SH_this
         ===>f_arg_decl<===
         ! splicer begin function.struct1_get_arg2

--- a/regression/reference/error/error.json
+++ b/regression/reference/error/error.json
@@ -1734,6 +1734,7 @@
             "f_capsule_data_type": "ERR_SHROUD_capsule_data",
             "f_class": "class(cstruct_as_subclass)",
             "f_derived_type": "cstruct_as_subclass",
+            "f_kind": "cstruct_as_subclass",
             "f_module": {
                 "error_mod": [
                     "cstruct_as_subclass"

--- a/regression/reference/example/example.json
+++ b/regression/reference/example/example.json
@@ -124,6 +124,7 @@
                                                         "f_derived_type": "ex_class1",
                                                         "f_intent": "OUT",
                                                         "f_intent_attr": ", intent(OUT)",
+                                                        "f_kind": "ex_class1",
                                                         "f_local_ptr": "SHT_prv",
                                                         "f_type": "type(ex_class1)",
                                                         "f_var": "SHT_rv",
@@ -317,6 +318,7 @@
                                                         "f_derived_type": "ex_class1",
                                                         "f_intent": "OUT",
                                                         "f_intent_attr": ", intent(OUT)",
+                                                        "f_kind": "ex_class1",
                                                         "f_local_ptr": "SHT_prv",
                                                         "f_type": "type(ex_class1)",
                                                         "f_var": "SHT_rv",
@@ -403,6 +405,7 @@
                                                         "f_derived_type": "ex_class1",
                                                         "f_intent": "OUT",
                                                         "f_intent_attr": ", intent(OUT)",
+                                                        "f_kind": "ex_class1",
                                                         "f_local_ptr": "SHT_prv",
                                                         "f_type": "type(ex_class1)",
                                                         "f_var": "SHT_rv",
@@ -2749,6 +2752,7 @@
                                                         "f_derived_type": "ex_class2",
                                                         "f_intent": "OUT",
                                                         "f_intent_attr": ", intent(OUT)",
+                                                        "f_kind": "ex_class2",
                                                         "f_local_ptr": "SHT_prv",
                                                         "f_type": "type(ex_class2)",
                                                         "f_var": "SHT_rv",
@@ -2835,6 +2839,7 @@
                                                         "f_derived_type": "ex_class2",
                                                         "f_intent": "OUT",
                                                         "f_intent_attr": ", intent(OUT)",
+                                                        "f_kind": "ex_class2",
                                                         "f_local_ptr": "SHT_prv",
                                                         "f_type": "type(ex_class2)",
                                                         "f_var": "SHT_rv",
@@ -4421,6 +4426,7 @@
                                                         "f_derived_type": "ex_class1",
                                                         "f_intent": "OUT",
                                                         "f_intent_attr": ", intent(OUT)",
+                                                        "f_kind": "ex_class1",
                                                         "f_local_ptr": "SHT_prv",
                                                         "f_type": "type(ex_class1)",
                                                         "f_var": "SHT_rv",
@@ -4460,6 +4466,7 @@
                                                         "f_derived_type": "ex_class1",
                                                         "f_intent": "IN",
                                                         "f_intent_attr": ", intent(IN)",
+                                                        "f_kind": "ex_class1",
                                                         "f_type": "type(ex_class1)",
                                                         "f_var": "in",
                                                         "fc_var": "in",
@@ -17621,6 +17628,7 @@
             "f_capsule_data_type": "AA_SHROUD_capsule_data",
             "f_class": "class(ex_class1)",
             "f_derived_type": "ex_class1",
+            "f_kind": "ex_class1",
             "f_module": {
                 "userlibrary_example_nested_mod": [
                     "ex_class1"
@@ -17661,6 +17669,7 @@
             "f_capsule_data_type": "AA_SHROUD_capsule_data",
             "f_class": "class(ex_class2)",
             "f_derived_type": "ex_class2",
+            "f_kind": "ex_class2",
             "f_module": {
                 "userlibrary_example_nested_mod": [
                     "ex_class2"
@@ -17696,6 +17705,7 @@
             "f_capsule_data_type": "AA_SHROUD_capsule_data",
             "f_class": "class(ex_class2_nested)",
             "f_derived_type": "ex_class2_nested",
+            "f_kind": "ex_class2_nested",
             "f_module": {
                 "userlibrary_example_nested_mod": [
                     "ex_class2_nested"

--- a/regression/reference/example/wrapfUserLibrary_example_nested.f
+++ b/regression/reference/example/wrapfUserLibrary_example_nested.f
@@ -1934,6 +1934,9 @@ contains
     ! ----------------------------------------
     ! Argument:  double *out +dimension(shape(in))+intent(out)
     ! Statement: f_out_native*
+    ! ----------------------------------------
+    ! Argument:  int sizein +implied(size(in))
+    ! Statement: c_default
     !>
     !! \brief Test multidimensional arrays with allocatable
     !!

--- a/regression/reference/forward/forward.json
+++ b/regression/reference/forward/forward.json
@@ -157,6 +157,7 @@
                                         "f_derived_type": "class2",
                                         "f_intent": "OUT",
                                         "f_intent_attr": ", intent(OUT)",
+                                        "f_kind": "class2",
                                         "f_local_ptr": "SHT_prv",
                                         "f_type": "type(class2)",
                                         "f_var": "SHT_rv",
@@ -517,6 +518,7 @@
                                         "f_derived_type": "class1",
                                         "f_intent": "IN",
                                         "f_intent_attr": ", intent(IN)",
+                                        "f_kind": "class1",
                                         "f_type": "type(class1)",
                                         "f_var": "arg",
                                         "fc_var": "arg",
@@ -782,6 +784,7 @@
                                         "f_derived_type": "class3",
                                         "f_intent": "IN",
                                         "f_intent_attr": ", intent(IN)",
+                                        "f_kind": "class3",
                                         "f_type": "type(class3)",
                                         "f_var": "arg",
                                         "fc_var": "arg",
@@ -1241,6 +1244,7 @@
             "f_capsule_data_type": "FOR_SHROUD_capsule_data",
             "f_class": "class(class2)",
             "f_derived_type": "class2",
+            "f_kind": "class2",
             "f_module": {
                 "forward_mod": [
                     "class2"
@@ -1281,6 +1285,7 @@
             "f_capsule_data_type": "FOR_SHROUD_capsule_data",
             "f_class": "class(class3)",
             "f_derived_type": "class3",
+            "f_kind": "class3",
             "f_module": {
                 "forward_mod": [
                     "class3"
@@ -1318,6 +1323,7 @@
             "f_capsule_data_type": "SHROUD_class1_capsule",
             "f_class": "class(class1)",
             "f_derived_type": "class1",
+            "f_kind": "class1",
             "f_module": {
                 "tutorial_mod": [
                     "class1"
@@ -1349,6 +1355,7 @@
             "f_capsule_data_type": "CLA_SHROUD_capsule_data",
             "f_class": "class(class2)",
             "f_derived_type": "class2",
+            "f_kind": "class2",
             "f_module": {
                 "classes_mod": [
                     "class2"

--- a/regression/reference/funptr-c/wrapffunptr.f
+++ b/regression/reference/funptr-c/wrapffunptr.f
@@ -471,6 +471,9 @@ contains
     ! Argument:  int *ilow +intent(in)+rank(1)
     ! Statement: f_in_native*
     ! ----------------------------------------
+    ! Argument:  int nargs +implied(size(ilow))
+    ! Statement: c_default
+    ! ----------------------------------------
     ! Argument:  int (*actor)(int *ilow +intent(in)+rank(1), int nargs +intent(in))
     ! Statement: f_in_procedure
     !>

--- a/regression/reference/funptr-c/wrapffunptr.f
+++ b/regression/reference/funptr-c/wrapffunptr.f
@@ -368,6 +368,9 @@ contains
     ! Function:  void callback2
     ! Statement: f_subroutine
     ! ----------------------------------------
+    ! Argument:  const char *name
+    ! Statement: f_in_char*
+    ! ----------------------------------------
     ! Argument:  int ival
     ! Statement: f_in_native
     ! ----------------------------------------
@@ -391,6 +394,9 @@ contains
     ! Function:  void callback2_external
     ! Statement: f_subroutine
     ! ----------------------------------------
+    ! Argument:  const char *name
+    ! Statement: f_in_char*
+    ! ----------------------------------------
     ! Argument:  int ival
     ! Statement: f_in_native
     ! ----------------------------------------
@@ -413,6 +419,9 @@ contains
     ! ----------------------------------------
     ! Function:  void callback2_funptr
     ! Statement: f_subroutine
+    ! ----------------------------------------
+    ! Argument:  const char *name
+    ! Statement: f_in_char*
     ! ----------------------------------------
     ! Argument:  int ival
     ! Statement: f_in_native

--- a/regression/reference/funptr-cxx/wrapffunptr.f
+++ b/regression/reference/funptr-cxx/wrapffunptr.f
@@ -471,6 +471,9 @@ contains
     ! Argument:  int *ilow +intent(in)+rank(1)
     ! Statement: f_in_native*
     ! ----------------------------------------
+    ! Argument:  int nargs +implied(size(ilow))
+    ! Statement: c_default
+    ! ----------------------------------------
     ! Argument:  int (*actor)(int *ilow +intent(in)+rank(1), int nargs +intent(in))
     ! Statement: f_in_procedure
     !>

--- a/regression/reference/funptr-cxx/wrapffunptr.f
+++ b/regression/reference/funptr-cxx/wrapffunptr.f
@@ -368,6 +368,9 @@ contains
     ! Function:  void callback2
     ! Statement: f_subroutine
     ! ----------------------------------------
+    ! Argument:  const char *name
+    ! Statement: f_in_char*
+    ! ----------------------------------------
     ! Argument:  int ival
     ! Statement: f_in_native
     ! ----------------------------------------
@@ -391,6 +394,9 @@ contains
     ! Function:  void callback2_external
     ! Statement: f_subroutine
     ! ----------------------------------------
+    ! Argument:  const char *name
+    ! Statement: f_in_char*
+    ! ----------------------------------------
     ! Argument:  int ival
     ! Statement: f_in_native
     ! ----------------------------------------
@@ -413,6 +419,9 @@ contains
     ! ----------------------------------------
     ! Function:  void callback2_funptr
     ! Statement: f_subroutine
+    ! ----------------------------------------
+    ! Argument:  const char *name
+    ! Statement: f_in_char*
     ! ----------------------------------------
     ! Argument:  int ival
     ! Statement: f_in_native

--- a/regression/reference/generic-cfi/generic.json
+++ b/regression/reference/generic-cfi/generic.json
@@ -5425,6 +5425,7 @@
                                 "f_derived_type": "struct_as_class",
                                 "f_intent": "OUT",
                                 "f_intent_attr": ", intent(OUT)",
+                                "f_kind": "struct_as_class",
                                 "f_local_ptr": "SHT_prv",
                                 "f_type": "type(struct_as_class)",
                                 "f_var": "SHT_rv",
@@ -5719,6 +5720,7 @@
                                 "f_derived_type": "struct_as_class",
                                 "f_intent": "INOUT",
                                 "f_intent_attr": ", intent(INOUT)",
+                                "f_kind": "struct_as_class",
                                 "f_type": "type(struct_as_class)",
                                 "f_var": "arg",
                                 "fc_var": "arg",
@@ -5924,6 +5926,7 @@
                                 "f_derived_type": "struct_as_class",
                                 "f_intent": "INOUT",
                                 "f_intent_attr": ", intent(INOUT)",
+                                "f_kind": "struct_as_class",
                                 "f_type": "type(struct_as_class)",
                                 "f_var": "arg",
                                 "fc_var": "arg",
@@ -6032,6 +6035,7 @@
             "f_capsule_data_type": "GEN_SHROUD_capsule_data",
             "f_class": "class(struct_as_class)",
             "f_derived_type": "struct_as_class",
+            "f_kind": "struct_as_class",
             "f_module": {
                 "generic_mod": [
                     "struct_as_class"

--- a/regression/reference/generic-cfi/wrapfgeneric.f
+++ b/regression/reference/generic-cfi/wrapfgeneric.f
@@ -845,6 +845,12 @@ contains
     ! ----------------------------------------
     ! Argument:  float *addr +intent(in)+rank(1)
     ! Statement: f_in_native*_cfi
+    ! ----------------------------------------
+    ! Argument:  int type +implied(T_FLOAT)
+    ! Statement: c_default
+    ! ----------------------------------------
+    ! Argument:  size_t size +implied(size(addr))
+    ! Statement: c_default
     subroutine save_pointer_float1d(addr)
         use iso_c_binding, only : C_FLOAT, C_INT, C_SIZE_T
         real(C_FLOAT), intent(IN) :: addr(:)
@@ -866,6 +872,12 @@ contains
     ! ----------------------------------------
     ! Argument:  float *addr +intent(in)+rank(2)
     ! Statement: f_in_native*_cfi
+    ! ----------------------------------------
+    ! Argument:  int type +implied(T_FLOAT)
+    ! Statement: c_default
+    ! ----------------------------------------
+    ! Argument:  size_t size +implied(size(addr))
+    ! Statement: c_default
     subroutine save_pointer_float2d(addr)
         use iso_c_binding, only : C_FLOAT, C_INT, C_SIZE_T
         real(C_FLOAT), intent(IN) :: addr(:,:)
@@ -886,6 +898,12 @@ contains
     ! ----------------------------------------
     ! Argument:  float *addr +intent(in)+rank(1)
     ! Statement: f_in_native*_cfi
+    ! ----------------------------------------
+    ! Argument:  int type +implied(type(addr))
+    ! Statement: c_default
+    ! ----------------------------------------
+    ! Argument:  size_t size +implied(size(addr))
+    ! Statement: c_default
     subroutine save_pointer2_float1d(addr)
         use iso_c_binding, only : C_FLOAT, C_INT, C_SIZE_T
         real(C_FLOAT), intent(IN) :: addr(:)
@@ -905,6 +923,12 @@ contains
     ! ----------------------------------------
     ! Argument:  float *addr +intent(in)+rank(2)
     ! Statement: f_in_native*_cfi
+    ! ----------------------------------------
+    ! Argument:  int type +implied(type(addr))
+    ! Statement: c_default
+    ! ----------------------------------------
+    ! Argument:  size_t size +implied(size(addr))
+    ! Statement: c_default
     subroutine save_pointer2_float2d(addr)
         use iso_c_binding, only : C_FLOAT, C_INT, C_SIZE_T
         real(C_FLOAT), intent(IN) :: addr(:,:)

--- a/regression/reference/generic/generic.json
+++ b/regression/reference/generic/generic.json
@@ -6013,6 +6013,7 @@
                                 "f_derived_type": "struct_as_class",
                                 "f_intent": "OUT",
                                 "f_intent_attr": ", intent(OUT)",
+                                "f_kind": "struct_as_class",
                                 "f_local_ptr": "SHT_prv",
                                 "f_type": "type(struct_as_class)",
                                 "f_var": "SHT_rv",
@@ -6307,6 +6308,7 @@
                                 "f_derived_type": "struct_as_class",
                                 "f_intent": "INOUT",
                                 "f_intent_attr": ", intent(INOUT)",
+                                "f_kind": "struct_as_class",
                                 "f_type": "type(struct_as_class)",
                                 "f_var": "arg",
                                 "fc_var": "arg",
@@ -6512,6 +6514,7 @@
                                 "f_derived_type": "struct_as_class",
                                 "f_intent": "INOUT",
                                 "f_intent_attr": ", intent(INOUT)",
+                                "f_kind": "struct_as_class",
                                 "f_type": "type(struct_as_class)",
                                 "f_var": "arg",
                                 "fc_var": "arg",
@@ -6620,6 +6623,7 @@
             "f_capsule_data_type": "GEN_SHROUD_capsule_data",
             "f_class": "class(struct_as_class)",
             "f_derived_type": "struct_as_class",
+            "f_kind": "struct_as_class",
             "f_module": {
                 "generic_mod": [
                     "struct_as_class"

--- a/regression/reference/generic/wrapfgeneric.f
+++ b/regression/reference/generic/wrapfgeneric.f
@@ -964,6 +964,12 @@ contains
     ! ----------------------------------------
     ! Argument:  float *addr +intent(in)+rank(1)
     ! Statement: f_in_native*
+    ! ----------------------------------------
+    ! Argument:  int type +implied(T_FLOAT)
+    ! Statement: c_default
+    ! ----------------------------------------
+    ! Argument:  size_t size +implied(size(addr))
+    ! Statement: c_default
     subroutine save_pointer_float1d(addr)
         use iso_c_binding, only : C_FLOAT, C_INT, C_SIZE_T
         real(C_FLOAT), intent(IN) :: addr(:)
@@ -985,6 +991,12 @@ contains
     ! ----------------------------------------
     ! Argument:  float *addr +intent(in)+rank(2)
     ! Statement: f_in_native*
+    ! ----------------------------------------
+    ! Argument:  int type +implied(T_FLOAT)
+    ! Statement: c_default
+    ! ----------------------------------------
+    ! Argument:  size_t size +implied(size(addr))
+    ! Statement: c_default
     subroutine save_pointer_float2d(addr)
         use iso_c_binding, only : C_FLOAT, C_INT, C_SIZE_T
         real(C_FLOAT), intent(IN) :: addr(:,:)
@@ -1005,6 +1017,12 @@ contains
     ! ----------------------------------------
     ! Argument:  float *addr +intent(in)+rank(1)
     ! Statement: f_in_native*
+    ! ----------------------------------------
+    ! Argument:  int type +implied(type(addr))
+    ! Statement: c_default
+    ! ----------------------------------------
+    ! Argument:  size_t size +implied(size(addr))
+    ! Statement: c_default
     subroutine save_pointer2_float1d(addr)
         use iso_c_binding, only : C_FLOAT, C_INT, C_SIZE_T
         real(C_FLOAT), intent(IN) :: addr(:)
@@ -1024,6 +1042,12 @@ contains
     ! ----------------------------------------
     ! Argument:  float *addr +intent(in)+rank(2)
     ! Statement: f_in_native*
+    ! ----------------------------------------
+    ! Argument:  int type +implied(type(addr))
+    ! Statement: c_default
+    ! ----------------------------------------
+    ! Argument:  size_t size +implied(size(addr))
+    ! Statement: c_default
     subroutine save_pointer2_float2d(addr)
         use iso_c_binding, only : C_FLOAT, C_INT, C_SIZE_T
         real(C_FLOAT), intent(IN) :: addr(:,:)

--- a/regression/reference/include/include.json
+++ b/regression/reference/include/include.json
@@ -313,6 +313,7 @@
                                         "f_derived_type": "class1",
                                         "f_intent": "INOUT",
                                         "f_intent_attr": ", intent(INOUT)",
+                                        "f_kind": "class1",
                                         "f_type": "type(class1)",
                                         "f_var": "c2",
                                         "fc_var": "c2",
@@ -1324,6 +1325,7 @@
             "f_capsule_data_type": "LIB_SHROUD_capsule_data",
             "f_class": "class(class2)",
             "f_derived_type": "class2",
+            "f_kind": "class2",
             "f_module": {
                 "library_mod": [
                     "class2"
@@ -1399,6 +1401,7 @@
             "f_capsule_data_type": "LIB_SHROUD_capsule_data",
             "f_class": "class(class0)",
             "f_derived_type": "class0",
+            "f_kind": "class0",
             "f_module": {
                 "library_outer1_mod": [
                     "class0"
@@ -1433,6 +1436,7 @@
             "f_capsule_data_type": "LIB_SHROUD_capsule_data",
             "f_class": "class(class0)",
             "f_derived_type": "class0",
+            "f_kind": "class0",
             "f_module": {
                 "library_outer2_mod": [
                     "class0"
@@ -1468,6 +1472,7 @@
             "f_capsule_data_type": "LIB_SHROUD_capsule_data",
             "f_class": "class(class1)",
             "f_derived_type": "class1",
+            "f_kind": "class1",
             "f_module": {
                 "library_three_mod": [
                     "class1"

--- a/regression/reference/names/names.json
+++ b/regression/reference/names/names.json
@@ -3362,6 +3362,7 @@
                                 "f_derived_type": "Fstruct_as_class",
                                 "f_intent": "IN",
                                 "f_intent_attr": ", intent(IN)",
+                                "f_kind": "Fstruct_as_class",
                                 "f_type": "type(Fstruct_as_class)",
                                 "f_var": "point",
                                 "fc_var": "point",
@@ -5493,6 +5494,7 @@
                                                 "f_derived_type": "FNames",
                                                 "f_intent": "OUT",
                                                 "f_intent_attr": ", intent(OUT)",
+                                                "f_kind": "FNames",
                                                 "f_local_ptr": "SHT_prv",
                                                 "f_type": "type(FNames)",
                                                 "f_var": "SHT_rv",
@@ -7027,6 +7029,7 @@
             "f_capsule_data_type": "TES_SHROUD_capsule_data",
             "f_class": "class(class1)",
             "f_derived_type": "class1",
+            "f_kind": "class1",
             "f_module": {
                 "testnames_capi_mod": [
                     "class1"
@@ -7100,6 +7103,7 @@
             "f_capsule_data_type": "TES_SHROUD_capsule_data",
             "f_class": "class(Fstruct_as_class)",
             "f_derived_type": "Fstruct_as_class",
+            "f_kind": "Fstruct_as_class",
             "f_module": {
                 "top_module": [
                     "Fstruct_as_class"
@@ -7137,6 +7141,7 @@
             "f_capsule_data_type": "TES_SHROUD_capsule_data",
             "f_class": "class(Fstruct_as_subclass)",
             "f_derived_type": "Fstruct_as_subclass",
+            "f_kind": "Fstruct_as_subclass",
             "f_module": {
                 "top_module": [
                     "Fstruct_as_subclass"
@@ -7174,6 +7179,7 @@
             "f_capsule_data_type": "TES_SHROUD_capsule_data",
             "f_class": "class(names2)",
             "f_derived_type": "names2",
+            "f_kind": "names2",
             "f_module": {
                 "top_module": [
                     "names2"
@@ -7206,6 +7212,7 @@
             "f_capsule_data_type": "TES_SHROUD_capsule_data",
             "f_class": "class(impl_worker1)",
             "f_derived_type": "impl_worker1",
+            "f_kind": "impl_worker1",
             "f_module": {
                 "testnames_internal_mod": [
                     "impl_worker1"
@@ -7244,6 +7251,7 @@
             "f_capsule_data_type": "TES_SHROUD_capsule_data",
             "f_class": "class(FNames)",
             "f_derived_type": "FNames",
+            "f_kind": "FNames",
             "f_module": {
                 "name_module": [
                     "FNames"
@@ -7318,6 +7326,7 @@
             "f_capsule_data_type": "TES_SHROUD_capsule_data",
             "f_class": "class(FFvvv1)",
             "f_derived_type": "FFvvv1",
+            "f_kind": "FFvvv1",
             "f_module": {
                 "testnames_std_mod": [
                     "FFvvv1"
@@ -7358,6 +7367,7 @@
             "f_capsule_data_type": "TES_SHROUD_capsule_data",
             "f_class": "class(vector)",
             "f_derived_type": "vector",
+            "f_kind": "vector",
             "f_module": {
                 "testnames_std_mod": [
                     "vector"
@@ -7397,6 +7407,7 @@
             "f_capsule_data_type": "TES_SHROUD_capsule_data",
             "f_class": "class(vector_double)",
             "f_derived_type": "vector_double",
+            "f_kind": "vector_double",
             "f_module": {
                 "testnames_std_mod": [
                     "vector_double"
@@ -7436,6 +7447,7 @@
             "f_capsule_data_type": "TES_SHROUD_capsule_data",
             "f_class": "class(vector_instantiation3)",
             "f_derived_type": "vector_instantiation3",
+            "f_kind": "vector_instantiation3",
             "f_module": {
                 "testnames_std_mod": [
                     "vector_instantiation3"
@@ -7475,6 +7487,7 @@
             "f_capsule_data_type": "TES_SHROUD_capsule_data",
             "f_class": "class(vector_instantiation5)",
             "f_derived_type": "vector_instantiation5",
+            "f_kind": "vector_instantiation5",
             "f_module": {
                 "testnames_std_mod": [
                     "vector_instantiation5"
@@ -7513,6 +7526,7 @@
             "f_capsule_data_type": "TES_SHROUD_capsule_data",
             "f_class": "class(two_ts)",
             "f_derived_type": "two_ts",
+            "f_kind": "two_ts",
             "f_module": {
                 "top_module": [
                     "two_ts"
@@ -7550,6 +7564,7 @@
             "f_capsule_data_type": "TES_SHROUD_capsule_data",
             "f_class": "class(two_ts_0)",
             "f_derived_type": "two_ts_0",
+            "f_kind": "two_ts_0",
             "f_module": {
                 "top_module": [
                     "two_ts_0"
@@ -7587,6 +7602,7 @@
             "f_capsule_data_type": "TES_SHROUD_capsule_data",
             "f_class": "class(two_ts_instantiation4)",
             "f_derived_type": "two_ts_instantiation4",
+            "f_kind": "two_ts_instantiation4",
             "f_module": {
                 "top_module": [
                     "two_ts_instantiation4"

--- a/regression/reference/names/top.f
+++ b/regression/reference/names/top.f
@@ -734,6 +734,15 @@ contains
     ! Function:  void external_funcs
     ! Statement: f_subroutine
     ! ----------------------------------------
+    ! Argument:  const char *rdbase
+    ! Statement: f_in_char*
+    ! ----------------------------------------
+    ! Argument:  const char *pkg
+    ! Statement: f_in_char*
+    ! ----------------------------------------
+    ! Argument:  const char *name
+    ! Statement: f_in_char*
+    ! ----------------------------------------
     ! Argument:  void (*alloc)(double *arr +intent(inout), int *err +intent(out))
     ! Statement: f_in_procedure
     ! ----------------------------------------

--- a/regression/reference/namespace/namespace.json
+++ b/regression/reference/namespace/namespace.json
@@ -945,6 +945,7 @@
             "f_capsule_data_type": "NS_SHROUD_capsule_data",
             "f_class": "class(class_work)",
             "f_derived_type": "class_work",
+            "f_kind": "class_work",
             "f_module": {
                 "ns_nswork_mod": [
                     "class_work"

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -507,6 +507,8 @@ root
           pointer -- f_mixin_char_cdesc_pointer
       declare-fortran-arg -- f_mixin_declare-fortran-arg
       declare-fortran-arg-no-module -- f_mixin_declare-fortran-arg-no-module
+      declare-fortran-result -- f_mixin_declare-fortran-result
+      declare-fortran-result-no-module -- f_mixin_declare-fortran-result-no-module
       declare-interface-arg -- f_mixin_declare-interface-arg
       function -- f_mixin_function
         c-ptr -- f_mixin_function_c-ptr
@@ -4690,8 +4692,13 @@ f_function_bool:
   comments:
   - Call a function.
   intent: function
+  f_arg_decl:
+  - '{f_type}{f_deref_attr} :: {f_var}{f_dimension}'
   f_call:
   - '{F_result} = {F_C_call}({F_arg_c_call})'
+  f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
   f_need_wrapper: true
   owner: library
 f_function_char:
@@ -4880,6 +4887,8 @@ f_function_char*_buf_copy:
   - Copy result into caller's buffer.
   - XXX - maybe fmtdict to rename c_local_cxx as output
   intent: function
+  f_arg_decl:
+  - '{f_type}{f_deref_attr} :: {f_var}{f_dimension}'
   f_declare:
   - integer(C_INT) {f_var_len}
   f_pre_call:
@@ -5099,6 +5108,8 @@ f_function_char*_cfi_copy:
   comments:
   - Copy result into caller's buffer.
   intent: function
+  f_arg_decl:
+  - '{f_type}{f_deref_attr} :: {f_var}{f_dimension}'
   f_arg_call:
   - '{f_var}'
   f_call:
@@ -5402,8 +5413,13 @@ f_function_enum:
   comments:
   - Return as the Fortran bind(C) type.
   intent: function
+  f_arg_decl:
+  - '{f_type}{f_deref_attr} :: {f_var}{f_dimension}'
   f_call:
   - '{F_result} = {F_C_call}({F_arg_c_call})'
+  f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
   c_post_call:
   - "{ci_type} {c_var} =\t {cast_static}{ci_type}{cast1}{cxx_var}{cast2};"
   owner: library
@@ -5412,8 +5428,13 @@ f_function_native:
   comments:
   - Call a function.
   intent: function
+  f_arg_decl:
+  - '{f_type}{f_deref_attr} :: {f_var}{f_dimension}'
   f_call:
   - '{F_result} = {F_C_call}({F_arg_c_call})'
+  f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
   owner: library
 f_function_native&:
   name: f_function_native&
@@ -5847,8 +5868,13 @@ f_function_native*_scalar:
   comments:
   - Return a scalar to avoid doing the deref in Fortran.
   intent: function
+  f_arg_decl:
+  - '{f_type}{f_deref_attr} :: {f_var}{f_dimension}'
   f_call:
   - '{F_result} = {F_C_call}({F_arg_c_call})'
+  f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
   c_return:
   - return *{cxx_var};
   c_return_type: '{c_type}'
@@ -7015,6 +7041,8 @@ f_function_string&_cfi_copy:
   - Make the argument a CFI_desc_t.
   - Local character argument passed as CFI_desc_t.
   intent: function
+  f_arg_decl:
+  - '{f_type}{f_deref_attr} :: {f_var}{f_dimension}'
   f_arg_call:
   - '{f_var}'
   f_call:
@@ -7718,6 +7746,8 @@ f_function_string*_cfi_copy:
   - Make the argument a CFI_desc_t.
   - Local character argument passed as CFI_desc_t.
   intent: function
+  f_arg_decl:
+  - '{f_type}{f_deref_attr} :: {f_var}{f_dimension}'
   f_arg_call:
   - '{f_var}'
   f_call:
@@ -8428,6 +8458,8 @@ f_function_string_cfi_copy:
   - Make the argument a CFI_desc_t.
   - Local character argument passed as CFI_desc_t.
   intent: function
+  f_arg_decl:
+  - '{f_type}{f_deref_attr} :: {f_var}{f_dimension}'
   f_arg_call:
   - '{f_var}'
   f_call:
@@ -8616,10 +8648,15 @@ f_function_struct:
   comments:
   - Call the C wrapper as a subroutine.
   intent: function
+  f_arg_decl:
+  - '{f_type}{f_deref_attr} :: {f_var}{f_dimension}'
   f_arg_call:
   - '{f_var}'
   f_call:
   - call {F_C_call}({F_arg_c_call})
+  f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -8802,6 +8839,11 @@ f_function_void*:
 f_getter_bool:
   name: f_getter_bool
   intent: getter
+  f_arg_decl:
+  - '{f_type}{f_deref_attr} :: {f_var}{f_dimension}'
+  f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
   c_call:
   - // skip call c_getter
   c_return:
@@ -8810,6 +8852,11 @@ f_getter_bool:
 f_getter_native:
   name: f_getter_native
   intent: getter
+  f_arg_decl:
+  - '{f_type}{f_deref_attr} :: {f_var}{f_dimension}'
+  f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
   c_call:
   - // skip call c_getter
   c_return:
@@ -8869,6 +8916,11 @@ f_getter_native*_cdesc_pointer:
 f_getter_native*_pointer:
   name: f_getter_native*_pointer
   intent: getter
+  f_arg_decl:
+  - '{f_type}{f_deref_attr} :: {f_var}{f_dimension}'
+  f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
   c_call:
   - // skip call c_getter
   c_return:
@@ -11633,6 +11685,25 @@ f_mixin_declare-fortran-arg-no-module:
   c_arg_call:
   - '{cxx_var}'
   owner: library
+f_mixin_declare-fortran-result:
+  name: f_mixin_declare-fortran-result
+  intent: mixin
+  f_arg_decl:
+  - '{f_type}{f_deref_attr} :: {f_var}{f_dimension}'
+  f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
+  c_arg_call:
+  - '{cxx_var}'
+  owner: library
+f_mixin_declare-fortran-result-no-module:
+  name: f_mixin_declare-fortran-result-no-module
+  intent: mixin
+  f_arg_decl:
+  - '{f_type}{f_deref_attr} :: {f_var}{f_dimension}'
+  c_arg_call:
+  - '{cxx_var}'
+  owner: library
 f_mixin_declare-interface-arg:
   name: f_mixin_declare-interface-arg
   intent: mixin
@@ -12281,6 +12352,8 @@ f_mixin_unknown:
   comments:
   - Default returned by lookup_fc_stmts when group is not found.
   intent: mixin
+  f_arg_decl:
+  - ===>f_arg_decl<===
   i_arg_names:
   - ===>i_arg_names<===
   i_arg_decl:

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -5453,6 +5453,8 @@ f_function_native&:
   f_post_call:
   - call c_f_pointer({f_local_ptr}, {F_result})
   f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
     iso_c_binding:
     - C_PTR
     - c_f_pointer
@@ -5482,6 +5484,8 @@ f_function_native&_pointer:
   f_post_call:
   - call c_f_pointer({f_local_ptr}, {F_result})
   f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
     iso_c_binding:
     - C_PTR
     - c_f_pointer
@@ -5538,6 +5542,8 @@ f_function_native*_cdesc_allocatable:
     \ kind=C_SIZE_T))"
   - call {f_helper_capsule_dtor}({f_var_capsule})
   f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
     iso_c_binding:
     - C_LOC
     - C_SIZE_T
@@ -5597,6 +5603,8 @@ f_function_native*_cdesc_pointer:
   f_post_call:
   - "call c_f_pointer(\t{f_var_cdesc}%base_addr,\t {F_result}{f_array_shape})"
   f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
     iso_c_binding:
     - c_f_pointer
   f_temps:
@@ -5653,6 +5661,8 @@ f_function_native*_cdesc_pointer_caller:
   f_post_call:
   - "call c_f_pointer(\t{f_var_cdesc}%base_addr,\t {F_result}{f_array_shape})"
   f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
     iso_c_binding:
     - c_f_pointer
   f_temps:
@@ -5705,6 +5715,9 @@ f_function_native*_cfi_allocatable:
   - '{f_var}'
   f_call:
   - call {F_C_call}({F_arg_c_call})
+  f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -5751,6 +5764,9 @@ f_function_native*_cfi_pointer:
   - '{f_var}'
   f_call:
   - call {F_C_call}({F_arg_c_call})
+  f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -5806,6 +5822,8 @@ f_function_native*_pointer:
   f_post_call:
   - call c_f_pointer({f_local_ptr}, {F_result})
   f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
     iso_c_binding:
     - C_PTR
     - c_f_pointer
@@ -5835,6 +5853,8 @@ f_function_native*_pointer_caller:
   f_post_call:
   - call c_f_pointer({f_local_ptr}, {F_result})
   f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
     iso_c_binding:
     - C_PTR
     - c_f_pointer
@@ -8689,6 +8709,8 @@ f_function_struct*_cdesc_pointer:
   f_post_call:
   - "call c_f_pointer(\t{f_var_cdesc}%base_addr,\t {F_result}{f_array_shape})"
   f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
     iso_c_binding:
     - c_f_pointer
   f_temps:
@@ -8730,6 +8752,8 @@ f_function_struct*_pointer:
   f_post_call:
   - call c_f_pointer({f_local_ptr}, {F_result})
   f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
     iso_c_binding:
     - C_PTR
     - c_f_pointer
@@ -8884,6 +8908,8 @@ f_getter_native*_cdesc_pointer:
   f_post_call:
   - "call c_f_pointer(\t{f_var_cdesc}%base_addr,\t {F_result}{f_array_shape})"
   f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
     iso_c_binding:
     - c_f_pointer
   f_temps:
@@ -9040,6 +9066,8 @@ f_getter_struct*_cdesc_pointer:
   f_post_call:
   - "call c_f_pointer(\t{f_var_cdesc}%base_addr,\t {F_result}{f_array_shape})"
   f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
     iso_c_binding:
     - c_f_pointer
   f_temps:
@@ -11748,6 +11776,8 @@ f_mixin_function_c-ptr:
   f_post_call:
   - call c_f_pointer({f_local_ptr}, {F_result})
   f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
     iso_c_binding:
     - C_PTR
     - c_f_pointer
@@ -12077,6 +12107,8 @@ f_mixin_native_cdesc_allocate:
   - "call {f_helper_copy_array}(\t{f_var_cdesc},\t C_LOC({f_var}),\t size({f_var},\t\
     \ kind=C_SIZE_T))"
   f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
     iso_c_binding:
     - C_LOC
     - C_SIZE_T
@@ -12097,6 +12129,8 @@ f_mixin_native_cdesc_pointer:
   f_post_call:
   - "call c_f_pointer(\t{f_var_cdesc}%base_addr,\t {F_result}{f_array_shape})"
   f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
     iso_c_binding:
     - c_f_pointer
   c_arg_call:

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -9428,6 +9428,9 @@ f_in_native:
   - '{f_var}'
   f_arg_decl:
   - '{f_type}{f_value_attr}{f_intent_attr}{f_optional_attr} :: {f_var}{f_dimension}'
+  f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -9469,6 +9472,9 @@ f_in_native*:
   - '{f_var}'
   f_arg_decl:
   - '{f_type}{f_value_attr}{f_intent_attr}{f_optional_attr} :: {f_var}{f_dimension}'
+  f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -9491,6 +9497,9 @@ f_in_native**:
   - '{f_var}'
   f_arg_decl:
   - '{f_type}{f_value_attr}{f_intent_attr}{f_optional_attr} :: {f_var}{f_dimension}'
+  f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -9661,6 +9670,9 @@ f_in_shadow:
   - '{f_type}{f_intent_attr} :: {f_var}'
   f_arg_call:
   - '{f_var}%{F_derived_member}'
+  f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
   f_need_wrapper: true
   i_arg_names:
   - '{i_var}'
@@ -9689,6 +9701,9 @@ f_in_shadow&:
   - '{f_type}{f_intent_attr} :: {f_var}'
   f_arg_call:
   - '{f_var}%{F_derived_member}'
+  f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
   f_need_wrapper: true
   i_arg_names:
   - '{i_var}'
@@ -9717,6 +9732,9 @@ f_in_shadow*:
   - '{f_type}{f_intent_attr} :: {f_var}'
   f_arg_call:
   - '{f_var}%{F_derived_member}'
+  f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
   f_need_wrapper: true
   i_arg_names:
   - '{i_var}'
@@ -10482,6 +10500,9 @@ f_in_void:
   - '{f_var}'
   f_arg_decl:
   - '{f_type}{f_value_attr}{f_intent_attr}{f_optional_attr} :: {f_var}{f_dimension}'
+  f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10834,6 +10855,9 @@ f_inout_native*:
   - '{f_var}'
   f_arg_decl:
   - '{f_type}{f_value_attr}{f_intent_attr}{f_optional_attr} :: {f_var}{f_dimension}'
+  f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -10947,6 +10971,9 @@ f_inout_shadow&:
   - '{f_type}{f_intent_attr} :: {f_var}'
   f_arg_call:
   - '{f_var}%{F_derived_member}'
+  f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
   f_need_wrapper: true
   i_arg_names:
   - '{i_var}'
@@ -10975,6 +11002,9 @@ f_inout_shadow*:
   - '{f_type}{f_intent_attr} :: {f_var}'
   f_arg_call:
   - '{f_var}%{F_derived_member}'
+  f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
   f_need_wrapper: true
   i_arg_names:
   - '{i_var}'
@@ -12353,6 +12383,9 @@ f_mixin_shadow-arg:
   - '{f_type}{f_intent_attr} :: {f_var}'
   f_arg_call:
   - '{f_var}%{F_derived_member}'
+  f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
   f_need_wrapper: true
   c_arg_call:
   - '{cxx_var}'
@@ -12441,6 +12474,9 @@ f_none_native:
   - '{f_var}'
   f_arg_decl:
   - '{f_type}{f_value_attr}{f_intent_attr}{f_optional_attr} :: {f_var}{f_dimension}'
+  f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
@@ -12663,6 +12699,9 @@ f_out_native*:
   - '{f_var}'
   f_arg_decl:
   - '{f_type}{f_value_attr}{f_intent_attr}{f_optional_attr} :: {f_var}{f_dimension}'
+  f_module:
+    '{typemap.f_module_name}':
+    - '{typemap.f_kind}'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:

--- a/regression/reference/ownership/ownership.json
+++ b/regression/reference/ownership/ownership.json
@@ -4351,6 +4351,7 @@
                                 "f_derived_type": "class1",
                                 "f_intent": "OUT",
                                 "f_intent_attr": ", intent(OUT)",
+                                "f_kind": "class1",
                                 "f_local_ptr": "SHT_prv",
                                 "f_type": "type(class1)",
                                 "f_var": "SHT_rv",
@@ -4587,6 +4588,7 @@
                                 "f_derived_type": "class1",
                                 "f_intent": "OUT",
                                 "f_intent_attr": ", intent(OUT)",
+                                "f_kind": "class1",
                                 "f_local_ptr": "SHT_prv",
                                 "f_type": "type(class1)",
                                 "f_var": "SHT_rv",
@@ -4784,6 +4786,7 @@
             "f_capsule_data_type": "OWN_SHROUD_capsule_data",
             "f_class": "class(class1)",
             "f_derived_type": "class1",
+            "f_kind": "class1",
             "f_module": {
                 "ownership_mod": [
                     "class1"

--- a/regression/reference/pointers-c-f/wrapfpointers.f
+++ b/regression/reference/pointers-c-f/wrapfpointers.f
@@ -1863,7 +1863,7 @@ contains
     ! start return_int_raw
     function return_int_raw() &
             result(SHT_rv)
-        use iso_c_binding, only : C_INT, C_PTR
+        use iso_c_binding, only : C_PTR
         type(C_PTR) :: SHT_rv
         ! splicer begin function.return_int_raw
         SHT_rv = c_return_int_raw()
@@ -1882,7 +1882,7 @@ contains
     ! start return_int_raw_with_args
     function return_int_raw_with_args(name) &
             result(SHT_rv)
-        use iso_c_binding, only : C_INT, C_NULL_CHAR, C_PTR
+        use iso_c_binding, only : C_NULL_CHAR, C_PTR
         character(len=*), intent(IN) :: name
         type(C_PTR) :: SHT_rv
         ! splicer begin function.return_int_raw_with_args

--- a/regression/reference/pointers-c-f/wrapfpointers.f
+++ b/regression/reference/pointers-c-f/wrapfpointers.f
@@ -1046,6 +1046,9 @@ contains
     ! ----------------------------------------
     ! Argument:  double *out +dimension(size(in))+intent(out)
     ! Statement: f_out_native*
+    ! ----------------------------------------
+    ! Argument:  int sizein +implied(size(in))
+    ! Statement: c_default
     !>
     !! \brief compute cos of IN and save in OUT
     !!
@@ -1073,6 +1076,9 @@ contains
     ! ----------------------------------------
     ! Argument:  int *out +dimension(size(in))+intent(out)
     ! Statement: f_out_native*
+    ! ----------------------------------------
+    ! Argument:  int sizein +implied(size(in))
+    ! Statement: c_default
     !>
     !! \brief truncate IN argument and save in OUT
     !!
@@ -1179,6 +1185,9 @@ contains
     ! Function:  void Sum
     ! Statement: f_subroutine
     ! ----------------------------------------
+    ! Argument:  int len +implied(size(values))
+    ! Statement: c_default
+    ! ----------------------------------------
     ! Argument:  const int *values +rank(1)
     ! Statement: f_in_native*
     ! ----------------------------------------
@@ -1225,6 +1234,9 @@ contains
     ! ----------------------------------------
     ! Argument:  int *array +intent(inout)+rank(1)
     ! Statement: f_inout_native*
+    ! ----------------------------------------
+    ! Argument:  int sizein +implied(size(array))
+    ! Statement: c_default
     !>
     !! Increment array in place using intent(INOUT).
     !<
@@ -1246,6 +1258,9 @@ contains
     ! ----------------------------------------
     ! Argument:  double *x +rank(1)
     ! Statement: f_inout_native*
+    ! ----------------------------------------
+    ! Argument:  int x_length +implied(size(x))
+    ! Statement: c_default
     ! start fill_with_zeros
     subroutine fill_with_zeros(x)
         use iso_c_binding, only : C_DOUBLE, C_INT
@@ -1264,6 +1279,9 @@ contains
     ! ----------------------------------------
     ! Argument:  const int *arr +rank(1)
     ! Statement: f_in_native*
+    ! ----------------------------------------
+    ! Argument:  size_t len +implied(size(arr))
+    ! Statement: c_default
     ! start accumulate
     function accumulate(arr) &
             result(SHT_rv)

--- a/regression/reference/pointers-c-f/wrapfpointers.f
+++ b/regression/reference/pointers-c-f/wrapfpointers.f
@@ -1875,6 +1875,9 @@ contains
     ! ----------------------------------------
     ! Function:  int *returnIntRawWithArgs +deref(raw)
     ! Statement: f_function_native*_raw
+    ! ----------------------------------------
+    ! Argument:  const char *name
+    ! Statement: f_in_char*
     !>
     !! Like returnIntRaw but with another argument to force a wrapper.
     !! Uses fc_statements f_function_native_*_raw.

--- a/regression/reference/pointers-c/wrapfpointers.f
+++ b/regression/reference/pointers-c/wrapfpointers.f
@@ -1863,7 +1863,7 @@ contains
     ! start return_int_raw
     function return_int_raw() &
             result(SHT_rv)
-        use iso_c_binding, only : C_INT, C_PTR
+        use iso_c_binding, only : C_PTR
         type(C_PTR) :: SHT_rv
         ! splicer begin function.return_int_raw
         SHT_rv = c_return_int_raw()
@@ -1882,7 +1882,7 @@ contains
     ! start return_int_raw_with_args
     function return_int_raw_with_args(name) &
             result(SHT_rv)
-        use iso_c_binding, only : C_INT, C_NULL_CHAR, C_PTR
+        use iso_c_binding, only : C_NULL_CHAR, C_PTR
         character(len=*), intent(IN) :: name
         type(C_PTR) :: SHT_rv
         ! splicer begin function.return_int_raw_with_args

--- a/regression/reference/pointers-c/wrapfpointers.f
+++ b/regression/reference/pointers-c/wrapfpointers.f
@@ -1046,6 +1046,9 @@ contains
     ! ----------------------------------------
     ! Argument:  double *out +dimension(size(in))+intent(out)
     ! Statement: f_out_native*
+    ! ----------------------------------------
+    ! Argument:  int sizein +implied(size(in))
+    ! Statement: c_default
     !>
     !! \brief compute cos of IN and save in OUT
     !!
@@ -1073,6 +1076,9 @@ contains
     ! ----------------------------------------
     ! Argument:  int *out +dimension(size(in))+intent(out)
     ! Statement: f_out_native*
+    ! ----------------------------------------
+    ! Argument:  int sizein +implied(size(in))
+    ! Statement: c_default
     !>
     !! \brief truncate IN argument and save in OUT
     !!
@@ -1179,6 +1185,9 @@ contains
     ! Function:  void Sum
     ! Statement: f_subroutine
     ! ----------------------------------------
+    ! Argument:  int len +implied(size(values))
+    ! Statement: c_default
+    ! ----------------------------------------
     ! Argument:  const int *values +rank(1)
     ! Statement: f_in_native*
     ! ----------------------------------------
@@ -1225,6 +1234,9 @@ contains
     ! ----------------------------------------
     ! Argument:  int *array +intent(inout)+rank(1)
     ! Statement: f_inout_native*
+    ! ----------------------------------------
+    ! Argument:  int sizein +implied(size(array))
+    ! Statement: c_default
     !>
     !! Increment array in place using intent(INOUT).
     !<
@@ -1246,6 +1258,9 @@ contains
     ! ----------------------------------------
     ! Argument:  double *x +rank(1)
     ! Statement: f_inout_native*
+    ! ----------------------------------------
+    ! Argument:  int x_length +implied(size(x))
+    ! Statement: c_default
     ! start fill_with_zeros
     subroutine fill_with_zeros(x)
         use iso_c_binding, only : C_DOUBLE, C_INT
@@ -1264,6 +1279,9 @@ contains
     ! ----------------------------------------
     ! Argument:  const int *arr +rank(1)
     ! Statement: f_in_native*
+    ! ----------------------------------------
+    ! Argument:  size_t len +implied(size(arr))
+    ! Statement: c_default
     ! start accumulate
     function accumulate(arr) &
             result(SHT_rv)

--- a/regression/reference/pointers-c/wrapfpointers.f
+++ b/regression/reference/pointers-c/wrapfpointers.f
@@ -1875,6 +1875,9 @@ contains
     ! ----------------------------------------
     ! Function:  int *returnIntRawWithArgs +deref(raw)
     ! Statement: f_function_native*_raw
+    ! ----------------------------------------
+    ! Argument:  const char *name
+    ! Statement: f_in_char*
     !>
     !! Like returnIntRaw but with another argument to force a wrapper.
     !! Uses fc_statements f_function_native_*_raw.

--- a/regression/reference/pointers-cfi/wrapfpointers.f
+++ b/regression/reference/pointers-cfi/wrapfpointers.f
@@ -1362,6 +1362,9 @@ contains
     ! ----------------------------------------
     ! Argument:  double *out +dimension(size(in))+intent(out)
     ! Statement: f_out_native*
+    ! ----------------------------------------
+    ! Argument:  int sizein +implied(size(in))
+    ! Statement: c_default
     !>
     !! \brief compute cos of IN and save in OUT
     !!
@@ -1389,6 +1392,9 @@ contains
     ! ----------------------------------------
     ! Argument:  int *out +dimension(size(in))+intent(out)
     ! Statement: f_out_native*
+    ! ----------------------------------------
+    ! Argument:  int sizein +implied(size(in))
+    ! Statement: c_default
     !>
     !! \brief truncate IN argument and save in OUT
     !!
@@ -1495,6 +1501,9 @@ contains
     ! Function:  void Sum
     ! Statement: f_subroutine
     ! ----------------------------------------
+    ! Argument:  int len +implied(size(values))
+    ! Statement: c_default
+    ! ----------------------------------------
     ! Argument:  const int *values +rank(1)
     ! Statement: f_in_native*_cfi
     ! ----------------------------------------
@@ -1541,6 +1550,9 @@ contains
     ! ----------------------------------------
     ! Argument:  int *array +intent(inout)+rank(1)
     ! Statement: f_inout_native*_cfi
+    ! ----------------------------------------
+    ! Argument:  int sizein +implied(size(array))
+    ! Statement: c_default
     !>
     !! Increment array in place using intent(INOUT).
     !<
@@ -1562,6 +1574,9 @@ contains
     ! ----------------------------------------
     ! Argument:  double *x +rank(1)
     ! Statement: f_inout_native*_cfi
+    ! ----------------------------------------
+    ! Argument:  int x_length +implied(size(x))
+    ! Statement: c_default
     ! start fill_with_zeros
     subroutine fill_with_zeros(x)
         use iso_c_binding, only : C_DOUBLE, C_INT
@@ -1580,6 +1595,9 @@ contains
     ! ----------------------------------------
     ! Argument:  const int *arr +rank(1)
     ! Statement: f_in_native*_cfi
+    ! ----------------------------------------
+    ! Argument:  size_t len +implied(size(arr))
+    ! Statement: c_default
     ! start accumulate
     function accumulate(arr) &
             result(SHT_rv)

--- a/regression/reference/pointers-cfi/wrapfpointers.f
+++ b/regression/reference/pointers-cfi/wrapfpointers.f
@@ -2173,7 +2173,7 @@ contains
     ! start return_int_raw
     function return_int_raw() &
             result(SHT_rv)
-        use iso_c_binding, only : C_INT, C_PTR
+        use iso_c_binding, only : C_PTR
         type(C_PTR) :: SHT_rv
         ! splicer begin function.return_int_raw
         SHT_rv = c_return_int_raw()
@@ -2197,7 +2197,7 @@ contains
     ! start return_int_raw_with_args
     function return_int_raw_with_args(name) &
             result(SHT_rv)
-        use iso_c_binding, only : C_INT, C_PTR
+        use iso_c_binding, only : C_PTR
         character(len=*), intent(IN) :: name
         type(C_PTR) :: SHT_rv
         ! splicer begin function.return_int_raw_with_args

--- a/regression/reference/pointers-cxx-f/wrapfpointers.f
+++ b/regression/reference/pointers-cxx-f/wrapfpointers.f
@@ -1863,7 +1863,7 @@ contains
     ! start return_int_raw
     function return_int_raw() &
             result(SHT_rv)
-        use iso_c_binding, only : C_INT, C_PTR
+        use iso_c_binding, only : C_PTR
         type(C_PTR) :: SHT_rv
         ! splicer begin function.return_int_raw
         SHT_rv = c_return_int_raw_bufferify()
@@ -1882,7 +1882,7 @@ contains
     ! start return_int_raw_with_args
     function return_int_raw_with_args(name) &
             result(SHT_rv)
-        use iso_c_binding, only : C_INT, C_NULL_CHAR, C_PTR
+        use iso_c_binding, only : C_NULL_CHAR, C_PTR
         character(len=*), intent(IN) :: name
         type(C_PTR) :: SHT_rv
         ! splicer begin function.return_int_raw_with_args

--- a/regression/reference/pointers-cxx-f/wrapfpointers.f
+++ b/regression/reference/pointers-cxx-f/wrapfpointers.f
@@ -1046,6 +1046,9 @@ contains
     ! ----------------------------------------
     ! Argument:  double *out +dimension(size(in))+intent(out)
     ! Statement: f_out_native*
+    ! ----------------------------------------
+    ! Argument:  int sizein +implied(size(in))
+    ! Statement: c_default
     !>
     !! \brief compute cos of IN and save in OUT
     !!
@@ -1073,6 +1076,9 @@ contains
     ! ----------------------------------------
     ! Argument:  int *out +dimension(size(in))+intent(out)
     ! Statement: f_out_native*
+    ! ----------------------------------------
+    ! Argument:  int sizein +implied(size(in))
+    ! Statement: c_default
     !>
     !! \brief truncate IN argument and save in OUT
     !!
@@ -1179,6 +1185,9 @@ contains
     ! Function:  void Sum
     ! Statement: f_subroutine
     ! ----------------------------------------
+    ! Argument:  int len +implied(size(values))
+    ! Statement: c_default
+    ! ----------------------------------------
     ! Argument:  const int *values +rank(1)
     ! Statement: f_in_native*
     ! ----------------------------------------
@@ -1225,6 +1234,9 @@ contains
     ! ----------------------------------------
     ! Argument:  int *array +intent(inout)+rank(1)
     ! Statement: f_inout_native*
+    ! ----------------------------------------
+    ! Argument:  int sizein +implied(size(array))
+    ! Statement: c_default
     !>
     !! Increment array in place using intent(INOUT).
     !<
@@ -1246,6 +1258,9 @@ contains
     ! ----------------------------------------
     ! Argument:  double *x +rank(1)
     ! Statement: f_inout_native*
+    ! ----------------------------------------
+    ! Argument:  int x_length +implied(size(x))
+    ! Statement: c_default
     ! start fill_with_zeros
     subroutine fill_with_zeros(x)
         use iso_c_binding, only : C_DOUBLE, C_INT
@@ -1264,6 +1279,9 @@ contains
     ! ----------------------------------------
     ! Argument:  const int *arr +rank(1)
     ! Statement: f_in_native*
+    ! ----------------------------------------
+    ! Argument:  size_t len +implied(size(arr))
+    ! Statement: c_default
     ! start accumulate
     function accumulate(arr) &
             result(SHT_rv)

--- a/regression/reference/pointers-cxx-f/wrapfpointers.f
+++ b/regression/reference/pointers-cxx-f/wrapfpointers.f
@@ -1875,6 +1875,9 @@ contains
     ! ----------------------------------------
     ! Function:  int *returnIntRawWithArgs +deref(raw)
     ! Statement: f_function_native*_raw
+    ! ----------------------------------------
+    ! Argument:  const char *name
+    ! Statement: f_in_char*
     !>
     !! Like returnIntRaw but with another argument to force a wrapper.
     !! Uses fc_statements f_function_native_*_raw.

--- a/regression/reference/pointers-cxx/wrapfpointers.f
+++ b/regression/reference/pointers-cxx/wrapfpointers.f
@@ -2128,6 +2128,9 @@ contains
     ! ----------------------------------------
     ! Function:  int *returnIntRawWithArgs +deref(raw)
     ! Statement: f_function_native*_raw
+    ! ----------------------------------------
+    ! Argument:  const char *name
+    ! Statement: f_in_char*
     !>
     !! Like returnIntRaw but with another argument to force a wrapper.
     !! Uses fc_statements f_function_native_*_raw.

--- a/regression/reference/pointers-cxx/wrapfpointers.f
+++ b/regression/reference/pointers-cxx/wrapfpointers.f
@@ -1299,6 +1299,9 @@ contains
     ! ----------------------------------------
     ! Argument:  double *out +dimension(size(in))+intent(out)
     ! Statement: f_out_native*
+    ! ----------------------------------------
+    ! Argument:  int sizein +implied(size(in))
+    ! Statement: c_default
     !>
     !! \brief compute cos of IN and save in OUT
     !!
@@ -1326,6 +1329,9 @@ contains
     ! ----------------------------------------
     ! Argument:  int *out +dimension(size(in))+intent(out)
     ! Statement: f_out_native*
+    ! ----------------------------------------
+    ! Argument:  int sizein +implied(size(in))
+    ! Statement: c_default
     !>
     !! \brief truncate IN argument and save in OUT
     !!
@@ -1432,6 +1438,9 @@ contains
     ! Function:  void Sum
     ! Statement: f_subroutine
     ! ----------------------------------------
+    ! Argument:  int len +implied(size(values))
+    ! Statement: c_default
+    ! ----------------------------------------
     ! Argument:  const int *values +rank(1)
     ! Statement: f_in_native*
     ! ----------------------------------------
@@ -1478,6 +1487,9 @@ contains
     ! ----------------------------------------
     ! Argument:  int *array +intent(inout)+rank(1)
     ! Statement: f_inout_native*
+    ! ----------------------------------------
+    ! Argument:  int sizein +implied(size(array))
+    ! Statement: c_default
     !>
     !! Increment array in place using intent(INOUT).
     !<
@@ -1499,6 +1511,9 @@ contains
     ! ----------------------------------------
     ! Argument:  double *x +rank(1)
     ! Statement: f_inout_native*
+    ! ----------------------------------------
+    ! Argument:  int x_length +implied(size(x))
+    ! Statement: c_default
     ! start fill_with_zeros
     subroutine fill_with_zeros(x)
         use iso_c_binding, only : C_DOUBLE, C_INT
@@ -1517,6 +1532,9 @@ contains
     ! ----------------------------------------
     ! Argument:  const int *arr +rank(1)
     ! Statement: f_in_native*
+    ! ----------------------------------------
+    ! Argument:  size_t len +implied(size(arr))
+    ! Statement: c_default
     ! start accumulate
     function accumulate(arr) &
             result(SHT_rv)

--- a/regression/reference/pointers-cxx/wrapfpointers.f
+++ b/regression/reference/pointers-cxx/wrapfpointers.f
@@ -2116,7 +2116,7 @@ contains
     ! start return_int_raw
     function return_int_raw() &
             result(SHT_rv)
-        use iso_c_binding, only : C_INT, C_PTR
+        use iso_c_binding, only : C_PTR
         type(C_PTR) :: SHT_rv
         ! splicer begin function.return_int_raw
         SHT_rv = c_return_int_raw()
@@ -2135,7 +2135,7 @@ contains
     ! start return_int_raw_with_args
     function return_int_raw_with_args(name) &
             result(SHT_rv)
-        use iso_c_binding, only : C_INT, C_NULL_CHAR, C_PTR
+        use iso_c_binding, only : C_NULL_CHAR, C_PTR
         character(len=*), intent(IN) :: name
         type(C_PTR) :: SHT_rv
         ! splicer begin function.return_int_raw_with_args

--- a/regression/reference/preprocess/preprocess.json
+++ b/regression/reference/preprocess/preprocess.json
@@ -981,6 +981,7 @@
             "f_capsule_data_type": "PRE_SHROUD_capsule_data",
             "f_class": "class(user1)",
             "f_derived_type": "user1",
+            "f_kind": "user1",
             "f_module": {
                 "preprocess_mod": [
                     "user1"
@@ -1020,6 +1021,7 @@
             "f_capsule_data_type": "PRE_SHROUD_capsule_data",
             "f_class": "class(user2)",
             "f_derived_type": "user2",
+            "f_kind": "user2",
             "f_module": {
                 "preprocess_mod": [
                     "user2"

--- a/regression/reference/scope/scope.json
+++ b/regression/reference/scope/scope.json
@@ -2186,6 +2186,7 @@
             "f_capsule_data_type": "SCO_SHROUD_capsule_data",
             "f_class": "class(class1)",
             "f_derived_type": "class1",
+            "f_kind": "class1",
             "f_module": {
                 "scope_mod": [
                     "class1"
@@ -2254,6 +2255,7 @@
             "f_capsule_data_type": "SCO_SHROUD_capsule_data",
             "f_class": "class(class2)",
             "f_derived_type": "class2",
+            "f_kind": "class2",
             "f_module": {
                 "scope_mod": [
                     "class2"

--- a/regression/reference/strings/wrapfstrings.f
+++ b/regression/reference/strings/wrapfstrings.f
@@ -1536,6 +1536,9 @@ contains
     ! ----------------------------------------
     ! Argument:  char *dest +charlen(40)+intent(out)
     ! Statement: f_out_char*_buf
+    ! ----------------------------------------
+    ! Argument:  const char *src
+    ! Statement: f_in_char*
     !>
     !! \brief strcpy like behavior
     !!
@@ -2255,6 +2258,9 @@ contains
     ! ----------------------------------------
     ! Function:  void explicit1
     ! Statement: f_subroutine
+    ! ----------------------------------------
+    ! Argument:  char *name +intent(in)+len_trim(AAlen)
+    ! Statement: f_in_char*
     subroutine explicit1(name)
         use iso_c_binding, only : C_NULL_CHAR
         character(len=*), intent(IN) :: name
@@ -2458,6 +2464,9 @@ contains
     ! ----------------------------------------
     ! Function:  int CpassCharPtrCAPI2
     ! Statement: f_function_native
+    ! ----------------------------------------
+    ! Argument:  const char *in
+    ! Statement: f_in_char*
     ! ----------------------------------------
     ! Argument:  const char *src +api(capi)
     ! Statement: f_in_char*_capi

--- a/regression/reference/struct-c/struct.json
+++ b/regression/reference/struct-c/struct.json
@@ -4149,6 +4149,7 @@
                                 "f_derived_type": "cstruct_as_class",
                                 "f_intent": "OUT",
                                 "f_intent_attr": ", intent(OUT)",
+                                "f_kind": "cstruct_as_class",
                                 "f_local_ptr": "SHT_prv",
                                 "f_type": "type(cstruct_as_class)",
                                 "f_var": "SHT_rv",
@@ -4272,6 +4273,7 @@
                                 "f_derived_type": "cstruct_as_class",
                                 "f_intent": "OUT",
                                 "f_intent_attr": ", intent(OUT)",
+                                "f_kind": "cstruct_as_class",
                                 "f_local_ptr": "SHT_prv",
                                 "f_type": "type(cstruct_as_class)",
                                 "f_var": "SHT_rv",
@@ -4454,6 +4456,7 @@
                                 "f_derived_type": "cstruct_as_class",
                                 "f_intent": "OUT",
                                 "f_intent_attr": ", intent(OUT)",
+                                "f_kind": "cstruct_as_class",
                                 "f_type": "type(cstruct_as_class)",
                                 "f_var": "SHT_rv",
                                 "fc_var": "SHT_rv",
@@ -4572,6 +4575,7 @@
                                 "f_derived_type": "cstruct_as_class",
                                 "f_intent": "OUT",
                                 "f_intent_attr": ", intent(OUT)",
+                                "f_kind": "cstruct_as_class",
                                 "f_type": "type(cstruct_as_class)",
                                 "f_var": "SHT_rv",
                                 "fc_var": "SHT_rv",
@@ -4805,6 +4809,7 @@
                                 "f_derived_type": "cstruct_as_class",
                                 "f_intent": "IN",
                                 "f_intent_attr": ", intent(IN)",
+                                "f_kind": "cstruct_as_class",
                                 "f_type": "type(cstruct_as_class)",
                                 "f_var": "point",
                                 "fc_var": "point",
@@ -4941,6 +4946,7 @@
                                 "f_derived_type": "cstruct_as_subclass",
                                 "f_intent": "OUT",
                                 "f_intent_attr": ", intent(OUT)",
+                                "f_kind": "cstruct_as_subclass",
                                 "f_local_ptr": "SHT_prv",
                                 "f_type": "type(cstruct_as_subclass)",
                                 "f_var": "SHT_rv",
@@ -5197,6 +5203,7 @@
                                 "f_derived_type": "cstruct_as_subclass",
                                 "f_intent": "OUT",
                                 "f_intent_attr": ", intent(OUT)",
+                                "f_kind": "cstruct_as_subclass",
                                 "f_type": "type(cstruct_as_subclass)",
                                 "f_var": "SHT_rv",
                                 "fc_var": "SHT_rv",
@@ -6642,6 +6649,7 @@
             "f_capsule_data_type": "STR_SHROUD_capsule_data",
             "f_class": "class(cstruct_as_class)",
             "f_derived_type": "cstruct_as_class",
+            "f_kind": "cstruct_as_class",
             "f_module": {
                 "struct_mod": [
                     "cstruct_as_class"
@@ -6676,6 +6684,7 @@
             "f_capsule_data_type": "STR_SHROUD_capsule_data",
             "f_class": "class(cstruct_as_subclass)",
             "f_derived_type": "cstruct_as_subclass",
+            "f_kind": "cstruct_as_subclass",
             "f_module": {
                 "struct_mod": [
                     "cstruct_as_subclass"

--- a/regression/reference/struct-class-c/struct.json
+++ b/regression/reference/struct-class-c/struct.json
@@ -4508,6 +4508,7 @@
             "f_capsule_data_type": "STR_SHROUD_capsule_data",
             "f_class": "class(cstruct_as_class)",
             "f_derived_type": "cstruct_as_class",
+            "f_kind": "cstruct_as_class",
             "f_module": {
                 "struct_mod": [
                     "cstruct_as_class"
@@ -4542,6 +4543,7 @@
             "f_capsule_data_type": "STR_SHROUD_capsule_data",
             "f_class": "class(cstruct_as_subclass)",
             "f_derived_type": "cstruct_as_subclass",
+            "f_kind": "cstruct_as_subclass",
             "f_module": {
                 "struct_mod": [
                     "cstruct_as_subclass"

--- a/regression/reference/struct-class-cxx/struct.json
+++ b/regression/reference/struct-class-cxx/struct.json
@@ -4502,6 +4502,7 @@
             "f_capsule_data_type": "STR_SHROUD_capsule_data",
             "f_class": "class(cstruct_as_class)",
             "f_derived_type": "cstruct_as_class",
+            "f_kind": "cstruct_as_class",
             "f_module": {
                 "struct_mod": [
                     "cstruct_as_class"
@@ -4536,6 +4537,7 @@
             "f_capsule_data_type": "STR_SHROUD_capsule_data",
             "f_class": "class(cstruct_as_subclass)",
             "f_derived_type": "cstruct_as_subclass",
+            "f_kind": "cstruct_as_subclass",
             "f_module": {
                 "struct_mod": [
                     "cstruct_as_subclass"

--- a/regression/reference/struct-cxx/struct.json
+++ b/regression/reference/struct-cxx/struct.json
@@ -5098,6 +5098,7 @@
                                 "f_derived_type": "cstruct_as_class",
                                 "f_intent": "OUT",
                                 "f_intent_attr": ", intent(OUT)",
+                                "f_kind": "cstruct_as_class",
                                 "f_local_ptr": "SHT_prv",
                                 "f_type": "type(cstruct_as_class)",
                                 "f_var": "SHT_rv",
@@ -5316,6 +5317,7 @@
                                 "f_derived_type": "cstruct_as_class",
                                 "f_intent": "OUT",
                                 "f_intent_attr": ", intent(OUT)",
+                                "f_kind": "cstruct_as_class",
                                 "f_local_ptr": "SHT_prv",
                                 "f_type": "type(cstruct_as_class)",
                                 "f_var": "SHT_rv",
@@ -5530,6 +5532,7 @@
                                 "f_derived_type": "cstruct_as_class",
                                 "f_intent": "OUT",
                                 "f_intent_attr": ", intent(OUT)",
+                                "f_kind": "cstruct_as_class",
                                 "f_type": "type(cstruct_as_class)",
                                 "f_var": "SHT_rv",
                                 "fc_var": "SHT_rv",
@@ -5741,6 +5744,7 @@
                                 "f_derived_type": "cstruct_as_class",
                                 "f_intent": "OUT",
                                 "f_intent_attr": ", intent(OUT)",
+                                "f_kind": "cstruct_as_class",
                                 "f_type": "type(cstruct_as_class)",
                                 "f_var": "SHT_rv",
                                 "fc_var": "SHT_rv",
@@ -6034,6 +6038,7 @@
                                 "f_derived_type": "cstruct_as_class",
                                 "f_intent": "IN",
                                 "f_intent_attr": ", intent(IN)",
+                                "f_kind": "cstruct_as_class",
                                 "f_type": "type(cstruct_as_class)",
                                 "f_var": "point",
                                 "fc_var": "point",
@@ -6295,6 +6300,7 @@
                                 "f_derived_type": "cstruct_as_subclass",
                                 "f_intent": "OUT",
                                 "f_intent_attr": ", intent(OUT)",
+                                "f_kind": "cstruct_as_subclass",
                                 "f_local_ptr": "SHT_prv",
                                 "f_type": "type(cstruct_as_subclass)",
                                 "f_var": "SHT_rv",
@@ -6674,6 +6680,7 @@
                                 "f_derived_type": "cstruct_as_subclass",
                                 "f_intent": "OUT",
                                 "f_intent_attr": ", intent(OUT)",
+                                "f_kind": "cstruct_as_subclass",
                                 "f_type": "type(cstruct_as_subclass)",
                                 "f_var": "SHT_rv",
                                 "fc_var": "SHT_rv",
@@ -8114,6 +8121,7 @@
             "f_capsule_data_type": "STR_SHROUD_capsule_data",
             "f_class": "class(cstruct_as_class)",
             "f_derived_type": "cstruct_as_class",
+            "f_kind": "cstruct_as_class",
             "f_module": {
                 "struct_mod": [
                     "cstruct_as_class"
@@ -8148,6 +8156,7 @@
             "f_capsule_data_type": "STR_SHROUD_capsule_data",
             "f_class": "class(cstruct_as_subclass)",
             "f_derived_type": "cstruct_as_subclass",
+            "f_kind": "cstruct_as_subclass",
             "f_module": {
                 "struct_mod": [
                     "cstruct_as_subclass"

--- a/regression/reference/struct-list-cxx/struct.json
+++ b/regression/reference/struct-list-cxx/struct.json
@@ -3186,6 +3186,7 @@
             "f_capsule_data_type": "STR_SHROUD_capsule_data",
             "f_class": "class(cstruct_as_class)",
             "f_derived_type": "cstruct_as_class",
+            "f_kind": "cstruct_as_class",
             "f_module": {
                 "struct_mod": [
                     "cstruct_as_class"
@@ -3220,6 +3221,7 @@
             "f_capsule_data_type": "STR_SHROUD_capsule_data",
             "f_class": "class(cstruct_as_subclass)",
             "f_derived_type": "cstruct_as_subclass",
+            "f_kind": "cstruct_as_subclass",
             "f_module": {
                 "struct_mod": [
                     "cstruct_as_subclass"

--- a/regression/reference/struct-numpy-c/struct.json
+++ b/regression/reference/struct-numpy-c/struct.json
@@ -3181,6 +3181,7 @@
             "f_capsule_data_type": "STR_SHROUD_capsule_data",
             "f_class": "class(cstruct_as_class)",
             "f_derived_type": "cstruct_as_class",
+            "f_kind": "cstruct_as_class",
             "f_module": {
                 "struct_mod": [
                     "cstruct_as_class"
@@ -3215,6 +3216,7 @@
             "f_capsule_data_type": "STR_SHROUD_capsule_data",
             "f_class": "class(cstruct_as_subclass)",
             "f_derived_type": "cstruct_as_subclass",
+            "f_kind": "cstruct_as_subclass",
             "f_module": {
                 "struct_mod": [
                     "cstruct_as_subclass"

--- a/regression/reference/struct-numpy-cxx/struct.json
+++ b/regression/reference/struct-numpy-cxx/struct.json
@@ -3175,6 +3175,7 @@
             "f_capsule_data_type": "STR_SHROUD_capsule_data",
             "f_class": "class(cstruct_as_class)",
             "f_derived_type": "cstruct_as_class",
+            "f_kind": "cstruct_as_class",
             "f_module": {
                 "struct_mod": [
                     "cstruct_as_class"
@@ -3209,6 +3210,7 @@
             "f_capsule_data_type": "STR_SHROUD_capsule_data",
             "f_class": "class(cstruct_as_subclass)",
             "f_derived_type": "cstruct_as_subclass",
+            "f_kind": "cstruct_as_subclass",
             "f_module": {
                 "struct_mod": [
                     "cstruct_as_subclass"

--- a/regression/reference/templates/templates.json
+++ b/regression/reference/templates/templates.json
@@ -651,6 +651,7 @@
                                         "f_derived_type": "struct_as_class_int",
                                         "f_intent": "OUT",
                                         "f_intent_attr": ", intent(OUT)",
+                                        "f_kind": "struct_as_class_int",
                                         "f_local_ptr": "SHT_prv",
                                         "f_type": "type(struct_as_class_int)",
                                         "f_var": "SHT_rv",
@@ -1527,6 +1528,7 @@
                                         "f_derived_type": "struct_as_class_double",
                                         "f_intent": "OUT",
                                         "f_intent_attr": ", intent(OUT)",
+                                        "f_kind": "struct_as_class_double",
                                         "f_local_ptr": "SHT_prv",
                                         "f_type": "type(struct_as_class_double)",
                                         "f_var": "SHT_rv",
@@ -2428,6 +2430,7 @@
                                 "f_derived_type": "user_int",
                                 "f_intent": "OUT",
                                 "f_intent_attr": ", intent(OUT)",
+                                "f_kind": "user_int",
                                 "f_local_ptr": "SHC_rv_ptr",
                                 "f_type": "type(user_int)",
                                 "f_var": "SHT_rv",
@@ -3905,6 +3908,7 @@
                                                 "f_derived_type": "vector_int",
                                                 "f_intent": "OUT",
                                                 "f_intent_attr": ", intent(OUT)",
+                                                "f_kind": "vector_int",
                                                 "f_local_ptr": "SHT_prv",
                                                 "f_type": "type(vector_int)",
                                                 "f_var": "SHT_rv",
@@ -4923,6 +4927,7 @@
                                                 "f_derived_type": "vector_double",
                                                 "f_intent": "OUT",
                                                 "f_intent_attr": ", intent(OUT)",
+                                                "f_kind": "vector_double",
                                                 "f_local_ptr": "SHT_prv",
                                                 "f_type": "type(vector_double)",
                                                 "f_var": "SHT_rv",
@@ -6031,6 +6036,7 @@
             "f_capsule_data_type": "TEM_SHROUD_capsule_data",
             "f_class": "class(worker)",
             "f_derived_type": "worker",
+            "f_kind": "worker",
             "f_module": {
                 "templates_mod": [
                     "worker"
@@ -6070,6 +6076,7 @@
             "f_capsule_data_type": "TEM_SHROUD_capsule_data",
             "f_class": "class(impl_worker1)",
             "f_derived_type": "impl_worker1",
+            "f_kind": "impl_worker1",
             "f_module": {
                 "templates_internal_mod": [
                     "impl_worker1"
@@ -6109,6 +6116,7 @@
             "f_capsule_data_type": "TEM_SHROUD_capsule_data",
             "f_class": "class(impl_worker2)",
             "f_derived_type": "impl_worker2",
+            "f_kind": "impl_worker2",
             "f_module": {
                 "templates_internal_mod": [
                     "impl_worker2"
@@ -6147,6 +6155,7 @@
             "f_capsule_data_type": "TEM_SHROUD_capsule_data",
             "f_class": "class(vector)",
             "f_derived_type": "vector",
+            "f_kind": "vector",
             "f_module": {
                 "templates_std_mod": [
                     "vector"
@@ -6300,6 +6309,7 @@
             "f_capsule_data_type": "TEM_SHROUD_capsule_data",
             "f_class": "class(vector_double)",
             "f_derived_type": "vector_double",
+            "f_kind": "vector_double",
             "f_module": {
                 "templates_std_mod": [
                     "vector_double"
@@ -6340,6 +6350,7 @@
             "f_capsule_data_type": "TEM_SHROUD_capsule_data",
             "f_class": "class(vector_int)",
             "f_derived_type": "vector_int",
+            "f_kind": "vector_int",
             "f_module": {
                 "templates_std_mod": [
                     "vector_int"
@@ -6379,6 +6390,7 @@
             "f_capsule_data_type": "TEM_SHROUD_capsule_data",
             "f_class": "class(struct_as_class)",
             "f_derived_type": "struct_as_class",
+            "f_kind": "struct_as_class",
             "f_module": {
                 "templates_mod": [
                     "struct_as_class"
@@ -6414,6 +6426,7 @@
             "f_capsule_data_type": "TEM_SHROUD_capsule_data",
             "f_class": "class(struct_as_class_double)",
             "f_derived_type": "struct_as_class_double",
+            "f_kind": "struct_as_class_double",
             "f_module": {
                 "templates_mod": [
                     "struct_as_class_double"
@@ -6449,6 +6462,7 @@
             "f_capsule_data_type": "TEM_SHROUD_capsule_data",
             "f_class": "class(struct_as_class_int)",
             "f_derived_type": "struct_as_class_int",
+            "f_kind": "struct_as_class_int",
             "f_module": {
                 "templates_mod": [
                     "struct_as_class_int"
@@ -6487,6 +6501,7 @@
             "f_capsule_data_type": "TEM_SHROUD_capsule_data",
             "f_class": "class(user)",
             "f_derived_type": "user",
+            "f_kind": "user",
             "f_module": {
                 "templates_mod": [
                     "user"
@@ -6526,6 +6541,7 @@
             "f_capsule_data_type": "TEM_SHROUD_capsule_data",
             "f_class": "class(user_int)",
             "f_derived_type": "user_int",
+            "f_kind": "user_int",
             "f_module": {
                 "templates_mod": [
                     "user_int"

--- a/regression/reference/vectors/wrapfvectors.f
+++ b/regression/reference/vectors/wrapfvectors.f
@@ -651,7 +651,7 @@ contains
     ! start vector_iota_out_with_num
     function vector_iota_out_with_num(arg) &
             result(num)
-        use iso_c_binding, only : C_INT, C_LOC, C_LONG, C_PTR, C_SIZE_T
+        use iso_c_binding, only : C_INT, C_LOC, C_LONG, C_SIZE_T
         integer(C_INT), intent(OUT), target :: arg(:)
         integer(C_LONG) :: num
         ! splicer begin function.vector_iota_out_with_num
@@ -679,7 +679,7 @@ contains
     ! start vector_iota_out_with_num2
     function vector_iota_out_with_num2(arg) &
             result(num)
-        use iso_c_binding, only : C_INT, C_LOC, C_LONG, C_PTR, C_SIZE_T
+        use iso_c_binding, only : C_INT, C_LOC, C_LONG, C_SIZE_T
         integer(C_INT), intent(OUT), target :: arg(:)
         integer(C_LONG) :: num
         ! splicer begin function.vector_iota_out_with_num2

--- a/regression/reference/vectors/wrapfvectors.f
+++ b/regression/reference/vectors/wrapfvectors.f
@@ -929,6 +929,9 @@ contains
     ! ----------------------------------------
     ! Argument:  int *arg +intent(in)+rank(2)
     ! Statement: f_in_native*
+    ! ----------------------------------------
+    ! Argument:  int len +implied(size(arg,2))
+    ! Statement: c_default
     function return_dim2(arg) &
             result(SHT_rv)
         use iso_c_binding, only : C_INT

--- a/regression/reference/wrap-c/wrap.json
+++ b/regression/reference/wrap-c/wrap.json
@@ -162,6 +162,7 @@
             "f_capsule_data_type": "WRA_SHROUD_capsule_data",
             "f_class": "class(class1)",
             "f_derived_type": "class1",
+            "f_kind": "class1",
             "f_module": {
                 "wrap_mod": [
                     "class1"

--- a/regression/reference/wrap-cxx/wrap.json
+++ b/regression/reference/wrap-cxx/wrap.json
@@ -162,6 +162,7 @@
             "f_capsule_data_type": "WRA_SHROUD_capsule_data",
             "f_class": "class(class1)",
             "f_derived_type": "class1",
+            "f_kind": "class1",
             "f_module": {
                 "wrap_mod": [
                     "class1"

--- a/shroud/fc-statements.json
+++ b/shroud/fc-statements.json
@@ -247,6 +247,9 @@
         ],
         "c_need_wrapper": true,
         "f_module": {
+            "{typemap.f_module_name}": [
+                "{typemap.f_kind}"
+            ],
             "iso_c_binding": [
                 "C_PTR",
                 "c_f_pointer"
@@ -417,6 +420,9 @@
             "copy_array"
         ],
         "f_module": {
+            "{typemap.f_module_name}": [
+                "{typemap.f_kind}"
+            ],
             "iso_c_binding": [
                 "C_LOC",
                 "C_SIZE_T"
@@ -465,6 +471,9 @@
             "Set Fortran pointer to native array."
         ],
         "f_module": {
+            "{typemap.f_module_name}": [
+                "{typemap.f_kind}"
+            ],
             "iso_c_binding": [
                 "c_f_pointer"
             ]
@@ -4823,6 +4832,11 @@
             "c_mixin_arg_native_cfi",
             "c_mixin_native_cfi_allocatable"
         ],
+        "f_module": {
+            "{typemap.f_module_name}": [
+                "{typemap.f_kind}"
+            ]
+        },
         "f_arg_decl": [
             "{f_type}, allocatable :: {f_var}{f_assumed_shape}"
         ],
@@ -4848,6 +4862,11 @@
             "c_mixin_arg_native_cfi",
             "c_mixin_native_cfi_pointer"
         ],
+        "f_module": {
+            "{typemap.f_module_name}": [
+                "{typemap.f_kind}"
+            ]
+        },
         "f_arg_decl": [
             "{f_type}, pointer :: {f_var}{f_assumed_shape}"
         ],

--- a/shroud/fc-statements.json
+++ b/shroud/fc-statements.json
@@ -189,6 +189,30 @@
         "c_return_type": "void"
     },
     {
+        "name": "f_mixin_declare-fortran-result",
+        "notes": [
+            "Fortran function result."
+        ],
+        "f_module": {
+            "{typemap.f_module_name}": [
+                "{typemap.f_kind}"
+            ]
+        },
+        "f_arg_decl": [
+            "{f_type}{f_deref_attr} :: {f_var}{f_dimension}"
+        ]
+    },
+    {
+        "name": "f_mixin_declare-fortran-result-no-module",
+        "notes": [
+            "Fortran function result.",
+            "Used with CHARACTER which does not use a module"
+        ],
+        "f_arg_decl": [
+            "{f_type}{f_deref_attr} :: {f_var}{f_dimension}"
+        ]
+    },
+    {
         "name": "f_mixin_function_ptr",
         "comments": [
             "Return a C pointer directly as type(C_PTR)."
@@ -1068,7 +1092,8 @@
             "c_function_native"
         ],
         "mixin": [
-            "f_mixin_function"
+            "f_mixin_function",
+            "f_mixin_declare-fortran-result"
         ]
     },
     {
@@ -1077,7 +1102,8 @@
             "Return a scalar to avoid doing the deref in Fortran."
         ],
         "mixin": [
-            "f_mixin_function"
+            "f_mixin_function",
+            "f_mixin_declare-fortran-result"
         ],
         "c_return_type": "{c_type}",
         "c_return": [
@@ -1533,7 +1559,8 @@
             "c_function_bool"
         ],
         "mixin": [
-            "f_mixin_function"
+            "f_mixin_function",
+            "f_mixin_declare-fortran-result"
         ],
         "f_need_wrapper": true
     },
@@ -1709,7 +1736,8 @@
             "Return as the Fortran bind(C) type."
         ],
         "mixin": [
-            "f_mixin_function"
+            "f_mixin_function",
+            "f_mixin_declare-fortran-result"
         ],
         "c_post_call": [
             "{ci_type} {c_var} =\t {cast_static}{ci_type}{cast1}{cxx_var}{cast2};"
@@ -1948,6 +1976,7 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
+            "f_mixin_declare-fortran-result-no-module",
             "f_mixin_pass_character_buf",
             "c_mixin_in_character_buf"
         ],
@@ -3769,7 +3798,8 @@
             "c_function_struct"
         ],
         "mixin": [
-            "f_mixin_function-to-subroutine"
+            "f_mixin_function-to-subroutine",
+            "f_mixin_declare-fortran-result"
         ],
         "f_arg_call": [
             "{f_var}"
@@ -3871,7 +3901,8 @@
     {
         "name": "f_getter_bool",
         "mixin": [
-            "c_mixin_noargs"
+            "c_mixin_noargs",
+            "f_mixin_declare-fortran-result"
         ],
         "f_arg_call": [],
         "c_call": [
@@ -3904,7 +3935,8 @@
             "c_getter_native*"
         ],
         "mixin": [
-            "c_mixin_noargs"
+            "c_mixin_noargs",
+            "f_mixin_declare-fortran-result"
         ],
         "f_arg_call": [],
         "c_call": [
@@ -4297,6 +4329,7 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
+            "f_mixin_declare-fortran-result-no-module",
             "c_mixin_arg_character_cfi"
         ],
         "f_arg_call": [
@@ -4479,6 +4512,7 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
+            "f_mixin_declare-fortran-result-no-module",
             "c_mixin_arg_character_cfi"
         ],
         "f_need_wrapper": true,
@@ -4915,6 +4949,9 @@
         "name": "f_mixin_unknown",
         "comments": [
             "Default returned by lookup_fc_stmts when group is not found."
+        ],
+        "f_arg_decl": [
+            "===>f_arg_decl<==="
         ],
         "i_arg_names": [
             "===>i_arg_names<==="

--- a/shroud/fc-statements.json
+++ b/shroud/fc-statements.json
@@ -32,6 +32,11 @@
         "f_arg_decl": [
             "{f_type}{f_value_attr}{f_intent_attr}{f_optional_attr} :: {f_var}{f_dimension}"
         ],
+        "f_module": {
+            "{typemap.f_module_name}": [
+                "{typemap.f_kind}"
+            ]
+        },
         "i_arg_names": [
             "{i_var}"
         ],
@@ -3509,6 +3514,11 @@
         "f_arg_call": [
             "{f_var}%{F_derived_member}"
         ],
+        "f_module": {
+            "{typemap.f_module_name}": [
+                "{typemap.f_kind}"
+            ]
+        },
         "f_need_wrapper": true
     },
     {

--- a/shroud/typemap.py
+++ b/shroud/typemap.py
@@ -1126,7 +1126,7 @@ def create_class_typemap_from_fields(cxx_name, fields, library):
         base="shadow", sgroup="shadow",
         cxx_type=cxx_name,
         f_capsule_data_type="missing-f_capsule_data_type",
-        f_derived_type=cxx_name,
+        f_kind=fields["f_derived_type"],
 
         cxx_to_c="static_cast<{c_const}void *>(\t{cxx_addr}{cxx_var})",
         c_to_cxx="static_cast<{c_const}%s *>\t({c_var}->addr)" % cxx_name,
@@ -1190,6 +1190,7 @@ def fill_class_typemap(node, fields={}):
         c_type=c_name,
         f_module_name=fmt_class.F_module_name,
         f_derived_type=fmt_class.F_derived_name,
+        f_kind=fmt_class.F_derived_name,
         f_capsule_data_type=fmt_class.F_capsule_data_type,
         # #- f_to_c='{f_var}%%%s()' % fmt_class.F_name_instance_get, # XXX - develop test
         sh_type="SH_TYPE_OTHER",

--- a/shroud/wrapf.py
+++ b/shroud/wrapf.py
@@ -743,18 +743,13 @@ rv = .false.
 
     def add_stmt_declaration(self, stmts, arg_f_decl, arg_f_names, fmt):
         """Add declarations from fc_statements.
-
-        Return True if f_arg_decl found.
         """
-        found = False
         if stmts.f_arg_decl:
-            found = True
             for line in stmts.f_arg_decl:
                 append_format(arg_f_decl, line, fmt)
         if stmts.f_arg_name:
             for aname in stmts.f_arg_name:
                 append_format(arg_f_names, aname, fmt)
-        return found
 
     def add_stmt_var(self, group, lst, fmt):
         """Add a variable fc_statements to lst.
@@ -1616,23 +1611,15 @@ rv = .false.
             arg_c_call,
             need_wrapper,
         )
-        found_arg_decl_ret = self.add_stmt_declaration(
+        self.add_stmt_declaration(
             result_stmt, arg_f_decl, arg_f_names, fmt_result)
 
         # Declare function return value after arguments
         # since arguments may be used to compute return value
         # (for example, string lengths).
-        # Unless explicitly set by FStmts.f_arg_decl
         if subprogram == "function":
             # if func_is_const:
             #     fmt_result.F_pure_clause = 'pure '
-            if not found_arg_decl_ret:
-                # result_as_arg or None
-                # local=True will add any character len attributes
-                # e.g.  CHARACTER(LEN=30)
-                arg_f_decl.append(
-                    gen_arg_as_fortran(ast, name=fmt_result.F_result, local=True)
-                )
 
             if ast.declarator.is_indirect() < 2:
                 # If more than one level of indirection, will return

--- a/shroud/wrapf.py
+++ b/shroud/wrapf.py
@@ -1491,16 +1491,10 @@ rv = .false.
 
             if arg_typemap.base == "procedure":
                 # typedef function pointer
-                do_use = False
                 fmt_arg.f_abstract_interface = arg_typemap.f_kind
             elif f_declarator.is_function_pointer():
-                do_use = False
                 if "funptr" not in f_attrs:
                     absiface = self.add_abstract_interface(node, f_arg, fileinfo, fmt_arg)
-            elif arg_stmt.f_module:
-                do_use = False
-            else:
-                do_use = True
 
             if arg_meta["ftrim_char_in"]:
                 # Pass NULL terminated string to C.
@@ -1547,11 +1541,6 @@ rv = .false.
                 c_decl = gen_decl(c_arg)
                 if f_decl != c_decl:
                     stmts_comments.append("! Argument:  " + c_decl)
-
-            if do_use:
-                # XXX - function pointers confuse this code
-                # XXX - it adds a USE for the function pointers's return type.
-                self.update_f_module(modules, arg_typemap.f_module, fmt_arg)
 
             # Now C function arguments
             # May have different types, like generic

--- a/shroud/wrapf.py
+++ b/shroud/wrapf.py
@@ -1611,21 +1611,12 @@ rv = .false.
             arg_c_call,
             need_wrapper,
         )
-        self.add_stmt_declaration(
-            result_stmt, arg_f_decl, arg_f_names, fmt_result)
-
         # Declare function return value after arguments
         # since arguments may be used to compute return value
         # (for example, string lengths).
-        if subprogram == "function":
-            # if func_is_const:
-            #     fmt_result.F_pure_clause = 'pure '
-
-            if ast.declarator.is_indirect() < 2:
-                # If more than one level of indirection, will return
-                # a type(C_PTR).  i.e. int ** same as void *.
-                # So do not add type's f_module.
-                self.update_f_module(modules, result_typemap.f_module, fmt_result)
+        self.add_stmt_declaration(
+            result_stmt, arg_f_decl, arg_f_names, fmt_result)
+        self.add_f_module_from_stmts(result_stmt, modules, fmt_result)
 
         if node.options.class_ctor:
             # Generic constructor for C "class" (wrap_struct_as=class).

--- a/shroud/wrapf.py
+++ b/shroud/wrapf.py
@@ -1504,14 +1504,12 @@ rv = .false.
 
             if arg_meta["ftrim_char_in"]:
                 # Pass NULL terminated string to C.
-                arg_f_decl.append(
-                    "character(len=*), intent(IN) :: {}".format(fmt_arg.f_var)
-                )
-                arg_f_names.append(fmt_arg.f_var)
-                arg_c_call.append("trim({})//C_NULL_CHAR".format(fmt_arg.f_var))
+                arg_stmt = util.Scope(arg_stmt)
+                arg_stmt.f_arg_call = [
+                    "trim({})//C_NULL_CHAR".format(fmt_arg.f_var)
+                ]
                 self.set_f_module(modules, "iso_c_binding", "C_NULL_CHAR")
                 need_wrapper = True
-                continue
             elif implied:
                 # implied is computed then passed to C++.
                 fmt_arg.pre_call_intent, intermediate, f_helper = ftn_implied(


### PR DESCRIPTION
Change attributes *implied* and *ftrim_char_in* to use the same code generation as other argumnets. They are now added to the debug code in the generated wrapper.

Use `stmt.f_module` instead of defaulting to `typemap.f_module`. This allows better control of the `USE` via `fc-statements.json`.

Define `typemap.f_kind` for derived types the same as `typemap.f_derived_type`. To be used with `statements.f_module`.