### PR TITLE
Use format fields for struct members

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1549,8 +1549,16 @@ i_dimension
    dimension of ``(*)``.
 
 i_kind
+  The bind(C) interface of the argument.
+  Derived from the ``typemap.i_type`` for the argument.
+  If it is not set, then use ``typemap.f_type``.
 
 i_module_name
+  The bind(C) interface of the argument.
+  Derived from the ``typemap.i_module_name`` for the argument.
+  If it is not set, then use ``typemap.f_type`` if it is set.
+  This makes it possible to define ``f_module_name`` as ``iso_c_binding``
+  and have it used with the interface as well.
 
 i_result_clause
     Added at the end of a function declaration to

--- a/regression/reference/classes/classes.json
+++ b/regression/reference/classes/classes.json
@@ -3444,9 +3444,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "m_flag",
-                            "variable_lower": "m_flag",
-                            "variable_name": "m_flag",
-                            "variable_upper": "M_FLAG"
+                            "variable_name": "m_flag"
                         }
                     },
                     {
@@ -3482,9 +3480,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "m_test",
-                            "variable_lower": "test",
-                            "variable_name": "test",
-                            "variable_upper": "TEST"
+                            "variable_name": "test"
                         }
                     },
                     {
@@ -3517,9 +3513,7 @@
                             "c_type": "bool",
                             "cxx_type": "bool",
                             "field_name": "m_bool",
-                            "variable_lower": "m_bool",
-                            "variable_name": "m_bool",
-                            "variable_upper": "M_BOOL"
+                            "variable_name": "m_bool"
                         }
                     },
                     {
@@ -3550,9 +3544,7 @@
                             "c_type": "char",
                             "cxx_type": "std::string",
                             "field_name": "m_name",
-                            "variable_lower": "m_name",
-                            "variable_name": "m_name",
-                            "variable_upper": "M_NAME"
+                            "variable_name": "m_name"
                         }
                     }
                 ],
@@ -5884,9 +5876,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "nitems",
-                            "variable_lower": "nitems",
-                            "variable_name": "nitems",
-                            "variable_upper": "NITEMS"
+                            "variable_name": "nitems"
                         }
                     },
                     {
@@ -5931,9 +5921,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "items",
-                            "variable_lower": "items",
-                            "variable_name": "items",
-                            "variable_upper": "ITEMS"
+                            "variable_name": "items"
                         }
                     }
                 ],

--- a/regression/reference/clibrary/clibrary.json
+++ b/regression/reference/clibrary/clibrary.json
@@ -36,7 +36,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_INT",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "integer(C_INT)",
+                                    "i_kind": "C_INT",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "integer(C_INT)",
+                                    "sh_type": "SH_TYPE_INT"
+                                }
                             },
                             "share": {}
                         },

--- a/regression/reference/clibrary/clibrary.json
+++ b/regression/reference/clibrary/clibrary.json
@@ -35,6 +35,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {}
                         },
                         "zz_fmtdict": {

--- a/regression/reference/clibrary/clibrary.json
+++ b/regression/reference/clibrary/clibrary.json
@@ -39,7 +39,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)"
+                                    "i_type": "integer(C_INT)",
+                                    "i_var": "tc"
                                 }
                             },
                             "share": {}

--- a/regression/reference/clibrary/clibrary.json
+++ b/regression/reference/clibrary/clibrary.json
@@ -37,13 +37,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_INT",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "integer(C_INT)",
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)",
-                                    "sh_type": "SH_TYPE_INT"
+                                    "i_type": "integer(C_INT)"
                                 }
                             },
                             "share": {}

--- a/regression/reference/clibrary/clibrary.json
+++ b/regression/reference/clibrary/clibrary.json
@@ -49,9 +49,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "tc",
-                            "variable_lower": "tc",
-                            "variable_name": "tc",
-                            "variable_upper": "TC"
+                            "variable_name": "tc"
                         }
                     }
                 ],

--- a/regression/reference/cxxlibrary/cxxlibrary.json
+++ b/regression/reference/cxxlibrary/cxxlibrary.json
@@ -327,7 +327,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_INT",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "integer(C_INT)",
+                                    "i_kind": "C_INT",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "integer(C_INT)",
+                                    "sh_type": "SH_TYPE_INT"
+                                }
                             },
                             "share": {}
                         },
@@ -361,7 +369,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_INT",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "integer(C_INT)",
+                                    "i_kind": "C_INT",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "integer(C_INT)",
+                                    "sh_type": "SH_TYPE_INT"
+                                }
                             },
                             "share": {}
                         },
@@ -400,7 +416,16 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_derived_type": "nested",
+                                    "f_kind": "nested",
+                                    "f_module_name": "cxxlibrary_mod",
+                                    "f_type": "type(nested)",
+                                    "i_kind": "nested",
+                                    "i_module_name": "cxxlibrary_mod",
+                                    "i_type": "type(nested)",
+                                    "sh_type": "SH_TYPE_STRUCT"
+                                }
                             },
                             "share": {}
                         },
@@ -445,7 +470,16 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_derived_type": "nested",
+                                    "f_kind": "nested",
+                                    "f_module_name": "cxxlibrary_mod",
+                                    "f_type": "type(nested)",
+                                    "i_kind": "nested",
+                                    "i_module_name": "cxxlibrary_mod",
+                                    "i_type": "type(nested)",
+                                    "sh_type": "SH_TYPE_STRUCT"
+                                }
                             },
                             "share": {
                                 "meta": {
@@ -496,7 +530,16 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_derived_type": "nested",
+                                    "f_kind": "nested",
+                                    "f_module_name": "cxxlibrary_mod",
+                                    "f_type": "type(nested)",
+                                    "i_kind": "nested",
+                                    "i_module_name": "cxxlibrary_mod",
+                                    "i_type": "type(nested)",
+                                    "sh_type": "SH_TYPE_STRUCT"
+                                }
                             },
                             "share": {
                                 "meta": {
@@ -6045,7 +6088,15 @@
                                 },
                                 "zz_bind": {
                                     "f": {
-                                        "fmtdict": {}
+                                        "fmtdict": {
+                                            "f_kind": "C_INT",
+                                            "f_module_name": "iso_c_binding",
+                                            "f_type": "integer(C_INT)",
+                                            "i_kind": "C_INT",
+                                            "i_module_name": "iso_c_binding",
+                                            "i_type": "integer(C_INT)",
+                                            "sh_type": "SH_TYPE_INT"
+                                        }
                                     },
                                     "share": {}
                                 },
@@ -6079,7 +6130,15 @@
                                 },
                                 "zz_bind": {
                                     "f": {
-                                        "fmtdict": {}
+                                        "fmtdict": {
+                                            "f_kind": "C_DOUBLE",
+                                            "f_module_name": "iso_c_binding",
+                                            "f_type": "real(C_DOUBLE)",
+                                            "i_kind": "C_DOUBLE",
+                                            "i_module_name": "iso_c_binding",
+                                            "i_type": "real(C_DOUBLE)",
+                                            "sh_type": "SH_TYPE_DOUBLE"
+                                        }
                                     },
                                     "share": {}
                                 },

--- a/regression/reference/cxxlibrary/cxxlibrary.json
+++ b/regression/reference/cxxlibrary/cxxlibrary.json
@@ -326,6 +326,9 @@
                             "python": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {}
                         },
                         "zz_fmtdict": {
@@ -357,6 +360,9 @@
                             "python": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {}
                         },
                         "zz_fmtdict": {
@@ -393,6 +399,9 @@
                             "python": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {}
                         },
                         "zz_fmtdict": {
@@ -435,6 +444,9 @@
                             "python": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {
                                 "meta": {
                                     "dim_ast": [
@@ -483,6 +495,9 @@
                             "python": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {
                                 "meta": {
                                     "dim_ast": [
@@ -6029,6 +6044,9 @@
                                     "python": true
                                 },
                                 "zz_bind": {
+                                    "f": {
+                                        "fmtdict": {}
+                                    },
                                     "share": {}
                                 },
                                 "zz_fmtdict": {
@@ -6060,6 +6078,9 @@
                                     "python": true
                                 },
                                 "zz_bind": {
+                                    "f": {
+                                        "fmtdict": {}
+                                    },
                                     "share": {}
                                 },
                                 "zz_fmtdict": {

--- a/regression/reference/cxxlibrary/cxxlibrary.json
+++ b/regression/reference/cxxlibrary/cxxlibrary.json
@@ -330,7 +330,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)"
+                                    "i_type": "integer(C_INT)",
+                                    "i_var": "index"
                                 }
                             },
                             "share": {}
@@ -368,7 +369,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)"
+                                    "i_type": "integer(C_INT)",
+                                    "i_var": "sublevels"
                                 }
                             },
                             "share": {}
@@ -411,7 +413,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "type(C_PTR)"
+                                    "i_type": "type(C_PTR)",
+                                    "i_var": "parent"
                                 }
                             },
                             "share": {}
@@ -460,7 +463,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "type(C_PTR)"
+                                    "i_type": "type(C_PTR)",
+                                    "i_var": "child"
                                 }
                             },
                             "share": {
@@ -515,7 +519,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "type(C_PTR)"
+                                    "i_type": "type(C_PTR)",
+                                    "i_var": "array"
                                 }
                             },
                             "share": {
@@ -6068,7 +6073,8 @@
                                         "fmtdict": {
                                             "i_kind": "C_INT",
                                             "i_module_name": "iso_c_binding",
-                                            "i_type": "integer(C_INT)"
+                                            "i_type": "integer(C_INT)",
+                                            "i_var": "ifield"
                                         }
                                     },
                                     "share": {}
@@ -6106,7 +6112,8 @@
                                         "fmtdict": {
                                             "i_kind": "C_DOUBLE",
                                             "i_module_name": "iso_c_binding",
-                                            "i_type": "real(C_DOUBLE)"
+                                            "i_type": "real(C_DOUBLE)",
+                                            "i_var": "dfield"
                                         }
                                     },
                                     "share": {}

--- a/regression/reference/cxxlibrary/cxxlibrary.json
+++ b/regression/reference/cxxlibrary/cxxlibrary.json
@@ -328,13 +328,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_INT",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "integer(C_INT)",
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)",
-                                    "sh_type": "SH_TYPE_INT"
+                                    "i_type": "integer(C_INT)"
                                 }
                             },
                             "share": {}
@@ -370,13 +366,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_INT",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "integer(C_INT)",
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)",
-                                    "sh_type": "SH_TYPE_INT"
+                                    "i_type": "integer(C_INT)"
                                 }
                             },
                             "share": {}
@@ -417,14 +409,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_derived_type": "nested",
-                                    "f_kind": "nested",
-                                    "f_module_name": "cxxlibrary_mod",
-                                    "f_type": "type(nested)",
-                                    "i_kind": "nested",
-                                    "i_module_name": "cxxlibrary_mod",
-                                    "i_type": "type(nested)",
-                                    "sh_type": "SH_TYPE_STRUCT"
+                                    "i_kind": "C_PTR",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "type(C_PTR)"
                                 }
                             },
                             "share": {}
@@ -471,14 +458,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_derived_type": "nested",
-                                    "f_kind": "nested",
-                                    "f_module_name": "cxxlibrary_mod",
-                                    "f_type": "type(nested)",
-                                    "i_kind": "nested",
-                                    "i_module_name": "cxxlibrary_mod",
-                                    "i_type": "type(nested)",
-                                    "sh_type": "SH_TYPE_STRUCT"
+                                    "i_kind": "C_PTR",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "type(C_PTR)"
                                 }
                             },
                             "share": {
@@ -531,14 +513,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_derived_type": "nested",
-                                    "f_kind": "nested",
-                                    "f_module_name": "cxxlibrary_mod",
-                                    "f_type": "type(nested)",
-                                    "i_kind": "nested",
-                                    "i_module_name": "cxxlibrary_mod",
-                                    "i_type": "type(nested)",
-                                    "sh_type": "SH_TYPE_STRUCT"
+                                    "i_kind": "C_PTR",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "type(C_PTR)"
                                 }
                             },
                             "share": {
@@ -6089,13 +6066,9 @@
                                 "zz_bind": {
                                     "f": {
                                         "fmtdict": {
-                                            "f_kind": "C_INT",
-                                            "f_module_name": "iso_c_binding",
-                                            "f_type": "integer(C_INT)",
                                             "i_kind": "C_INT",
                                             "i_module_name": "iso_c_binding",
-                                            "i_type": "integer(C_INT)",
-                                            "sh_type": "SH_TYPE_INT"
+                                            "i_type": "integer(C_INT)"
                                         }
                                     },
                                     "share": {}
@@ -6131,13 +6104,9 @@
                                 "zz_bind": {
                                     "f": {
                                         "fmtdict": {
-                                            "f_kind": "C_DOUBLE",
-                                            "f_module_name": "iso_c_binding",
-                                            "f_type": "real(C_DOUBLE)",
                                             "i_kind": "C_DOUBLE",
                                             "i_module_name": "iso_c_binding",
-                                            "i_type": "real(C_DOUBLE)",
-                                            "sh_type": "SH_TYPE_DOUBLE"
+                                            "i_type": "real(C_DOUBLE)"
                                         }
                                     },
                                     "share": {}

--- a/regression/reference/cxxlibrary/cxxlibrary.json
+++ b/regression/reference/cxxlibrary/cxxlibrary.json
@@ -230,9 +230,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "ifield",
-                            "variable_lower": "ifield",
-                            "variable_name": "ifield",
-                            "variable_upper": "IFIELD"
+                            "variable_name": "ifield"
                         }
                     },
                     {
@@ -262,9 +260,7 @@
                             "c_type": "double",
                             "cxx_type": "double",
                             "field_name": "dfield",
-                            "variable_lower": "dfield",
-                            "variable_name": "dfield",
-                            "variable_upper": "DFIELD"
+                            "variable_name": "dfield"
                         }
                     }
                 ],
@@ -340,9 +336,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "index",
-                            "variable_lower": "index",
-                            "variable_name": "index",
-                            "variable_upper": "INDEX"
+                            "variable_name": "index"
                         }
                     },
                     {
@@ -379,9 +373,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "sublevels",
-                            "variable_lower": "sublevels",
-                            "variable_name": "sublevels",
-                            "variable_upper": "SUBLEVELS"
+                            "variable_name": "sublevels"
                         }
                     },
                     {
@@ -423,9 +415,7 @@
                             "c_type": "CXX_nested",
                             "cxx_type": "nested",
                             "field_name": "parent",
-                            "variable_lower": "parent",
-                            "variable_name": "parent",
-                            "variable_upper": "PARENT"
+                            "variable_name": "parent"
                         }
                     },
                     {
@@ -482,9 +472,7 @@
                             "c_type": "CXX_nested",
                             "cxx_type": "nested",
                             "field_name": "child",
-                            "variable_lower": "child",
-                            "variable_name": "child",
-                            "variable_upper": "CHILD"
+                            "variable_name": "child"
                         }
                     },
                     {
@@ -538,9 +526,7 @@
                             "c_type": "CXX_nested",
                             "cxx_type": "nested",
                             "field_name": "array",
-                            "variable_lower": "array",
-                            "variable_name": "array",
-                            "variable_upper": "ARRAY"
+                            "variable_name": "array"
                         }
                     }
                 ],
@@ -2415,9 +2401,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "m_length",
-                            "variable_lower": "length",
-                            "variable_name": "length",
-                            "variable_upper": "LENGTH"
+                            "variable_name": "length"
                         }
                     }
                 ],
@@ -6083,9 +6067,7 @@
                                     "c_type": "int",
                                     "cxx_type": "int",
                                     "field_name": "ifield",
-                                    "variable_lower": "ifield",
-                                    "variable_name": "ifield",
-                                    "variable_upper": "IFIELD"
+                                    "variable_name": "ifield"
                                 }
                             },
                             {
@@ -6122,9 +6104,7 @@
                                     "c_type": "double",
                                     "cxx_type": "double",
                                     "field_name": "dfield",
-                                    "variable_lower": "dfield",
-                                    "variable_name": "dfield",
-                                    "variable_upper": "DFIELD"
+                                    "variable_name": "dfield"
                                 }
                             }
                         ],

--- a/regression/reference/debugfalse/tutorial.json
+++ b/regression/reference/debugfalse/tutorial.json
@@ -8907,9 +8907,7 @@
                     "c_type": "int",
                     "cxx_type": "int",
                     "field_name": "global_flag",
-                    "variable_lower": "global_flag",
-                    "variable_name": "global_flag",
-                    "variable_upper": "GLOBAL_FLAG"
+                    "variable_name": "global_flag"
                 }
             },
             {
@@ -8939,9 +8937,7 @@
                     "c_type": "int",
                     "cxx_type": "int",
                     "field_name": "tutorial_flag",
-                    "variable_lower": "tutorial_flag",
-                    "variable_name": "tutorial_flag",
-                    "variable_upper": "TUTORIAL_FLAG"
+                    "variable_name": "tutorial_flag"
                 }
             }
         ],

--- a/regression/reference/defaultarg/defaultarg.json
+++ b/regression/reference/defaultarg/defaultarg.json
@@ -2202,9 +2202,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "m_field1",
-                            "variable_lower": "field1",
-                            "variable_name": "field1",
-                            "variable_upper": "FIELD1"
+                            "variable_name": "field1"
                         }
                     },
                     {
@@ -2236,9 +2234,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "m_field2",
-                            "variable_lower": "field2",
-                            "variable_name": "field2",
-                            "variable_upper": "FIELD2"
+                            "variable_name": "field2"
                         }
                     },
                     {
@@ -2270,9 +2266,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "m_field3",
-                            "variable_lower": "field3",
-                            "variable_name": "field3",
-                            "variable_upper": "FIELD3"
+                            "variable_name": "field3"
                         }
                     }
                 ],

--- a/regression/reference/error-generate/error-generate.json
+++ b/regression/reference/error-generate/error-generate.json
@@ -37,13 +37,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_INT",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "integer(C_INT)",
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)",
-                                    "sh_type": "SH_TYPE_INT"
+                                    "i_type": "integer(C_INT)"
                                 }
                             },
                             "share": {
@@ -88,13 +84,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_INT",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "integer(C_INT)",
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)",
-                                    "sh_type": "SH_TYPE_INT"
+                                    "i_type": "integer(C_INT)"
                                 }
                             },
                             "share": {}
@@ -139,13 +131,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_INT",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "integer(C_INT)",
-                                    "i_kind": "C_INT",
+                                    "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)",
-                                    "sh_type": "SH_TYPE_INT"
+                                    "i_type": "type(C_PTR)"
                                 }
                             },
                             "share": {
@@ -258,13 +246,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_INT",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "integer(C_INT)",
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)",
-                                    "sh_type": "SH_TYPE_INT"
+                                    "i_type": "integer(C_INT)"
                                 }
                             },
                             "share": {}

--- a/regression/reference/error-generate/error-generate.json
+++ b/regression/reference/error-generate/error-generate.json
@@ -36,7 +36,15 @@
                         "wrap": {},
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_INT",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "integer(C_INT)",
+                                    "i_kind": "C_INT",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "integer(C_INT)",
+                                    "sh_type": "SH_TYPE_INT"
+                                }
                             },
                             "share": {
                                 "meta": {
@@ -79,7 +87,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_INT",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "integer(C_INT)",
+                                    "i_kind": "C_INT",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "integer(C_INT)",
+                                    "sh_type": "SH_TYPE_INT"
+                                }
                             },
                             "share": {}
                         },
@@ -122,7 +138,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_INT",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "integer(C_INT)",
+                                    "i_kind": "C_INT",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "integer(C_INT)",
+                                    "sh_type": "SH_TYPE_INT"
+                                }
                             },
                             "share": {
                                 "meta": {
@@ -233,7 +257,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_INT",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "integer(C_INT)",
+                                    "i_kind": "C_INT",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "integer(C_INT)",
+                                    "sh_type": "SH_TYPE_INT"
+                                }
                             },
                             "share": {}
                         },

--- a/regression/reference/error-generate/error-generate.json
+++ b/regression/reference/error-generate/error-generate.json
@@ -58,9 +58,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "arg1",
-                            "variable_lower": "arg1",
-                            "variable_name": "arg1",
-                            "variable_upper": "ARG1"
+                            "variable_name": "arg1"
                         }
                     },
                     {
@@ -97,9 +95,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "narg2",
-                            "variable_lower": "narg2",
-                            "variable_name": "narg2",
-                            "variable_upper": "NARG2"
+                            "variable_name": "narg2"
                         }
                     },
                     {
@@ -154,9 +150,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "arg2",
-                            "variable_lower": "arg2",
-                            "variable_name": "arg2",
-                            "variable_upper": "ARG2"
+                            "variable_name": "arg2"
                         }
                     }
                 ],
@@ -261,9 +255,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "sublevels",
-                            "variable_lower": "sublevels",
-                            "variable_name": "sublevels",
-                            "variable_upper": "SUBLEVELS"
+                            "variable_name": "sublevels"
                         }
                     }
                 ],

--- a/regression/reference/error-generate/error-generate.json
+++ b/regression/reference/error-generate/error-generate.json
@@ -39,7 +39,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)"
+                                    "i_type": "integer(C_INT)",
+                                    "i_var": "arg1"
                                 }
                             },
                             "share": {
@@ -86,7 +87,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)"
+                                    "i_type": "integer(C_INT)",
+                                    "i_var": "narg2"
                                 }
                             },
                             "share": {}
@@ -133,7 +135,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "type(C_PTR)"
+                                    "i_type": "type(C_PTR)",
+                                    "i_var": "arg2"
                                 }
                             },
                             "share": {
@@ -248,7 +251,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)"
+                                    "i_type": "integer(C_INT)",
+                                    "i_var": "sublevels"
                                 }
                             },
                             "share": {}

--- a/regression/reference/error-generate/error-generate.json
+++ b/regression/reference/error-generate/error-generate.json
@@ -35,6 +35,9 @@
                         "options": {},
                         "wrap": {},
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {
                                 "meta": {
                                     "dim_ast": [
@@ -75,6 +78,9 @@
                             "python": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {}
                         },
                         "zz_fmtdict": {
@@ -115,6 +121,9 @@
                             "python": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {
                                 "meta": {
                                     "dim_ast": [
@@ -223,6 +232,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {}
                         },
                         "zz_fmtdict": {

--- a/regression/reference/error-generate/wrapferror.f
+++ b/regression/reference/error-generate/wrapferror.f
@@ -28,7 +28,7 @@ module error_mod
 
 
     type, bind(C) :: struct1
-        integer(C_INT) :: arg1(10)
+        integer(C_INT) :: arg1
         integer(C_INT) :: narg2
         type(C_PTR) :: arg2
     end type struct1

--- a/regression/reference/error/error.json
+++ b/regression/reference/error/error.json
@@ -777,9 +777,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "x1",
-                            "variable_lower": "x1",
-                            "variable_name": "x1",
-                            "variable_upper": "X1"
+                            "variable_name": "x1"
                         }
                     },
                     {
@@ -808,9 +806,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "y1",
-                            "variable_lower": "y1",
-                            "variable_name": "y1",
-                            "variable_upper": "Y1"
+                            "variable_name": "y1"
                         }
                     },
                     {
@@ -839,9 +835,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "z1",
-                            "variable_lower": "z1",
-                            "variable_name": "z1",
-                            "variable_upper": "Z1"
+                            "variable_name": "z1"
                         }
                     }
                 ],

--- a/regression/reference/namespace/namespace.json
+++ b/regression/reference/namespace/namespace.json
@@ -622,13 +622,9 @@
                                 "zz_bind": {
                                     "f": {
                                         "fmtdict": {
-                                            "f_kind": "C_INT",
-                                            "f_module_name": "iso_c_binding",
-                                            "f_type": "integer(C_INT)",
                                             "i_kind": "C_INT",
                                             "i_module_name": "iso_c_binding",
-                                            "i_type": "integer(C_INT)",
-                                            "sh_type": "SH_TYPE_INT"
+                                            "i_type": "integer(C_INT)"
                                         }
                                     },
                                     "share": {}
@@ -667,13 +663,9 @@
                                 "zz_bind": {
                                     "f": {
                                         "fmtdict": {
-                                            "f_kind": "C_DOUBLE",
-                                            "f_module_name": "iso_c_binding",
-                                            "f_type": "real(C_DOUBLE)",
                                             "i_kind": "C_DOUBLE",
                                             "i_module_name": "iso_c_binding",
-                                            "i_type": "real(C_DOUBLE)",
-                                            "sh_type": "SH_TYPE_DOUBLE"
+                                            "i_type": "real(C_DOUBLE)"
                                         }
                                     },
                                     "share": {}

--- a/regression/reference/namespace/namespace.json
+++ b/regression/reference/namespace/namespace.json
@@ -621,7 +621,15 @@
                                 },
                                 "zz_bind": {
                                     "f": {
-                                        "fmtdict": {}
+                                        "fmtdict": {
+                                            "f_kind": "C_INT",
+                                            "f_module_name": "iso_c_binding",
+                                            "f_type": "integer(C_INT)",
+                                            "i_kind": "C_INT",
+                                            "i_module_name": "iso_c_binding",
+                                            "i_type": "integer(C_INT)",
+                                            "sh_type": "SH_TYPE_INT"
+                                        }
                                     },
                                     "share": {}
                                 },
@@ -658,7 +666,15 @@
                                 },
                                 "zz_bind": {
                                     "f": {
-                                        "fmtdict": {}
+                                        "fmtdict": {
+                                            "f_kind": "C_DOUBLE",
+                                            "f_module_name": "iso_c_binding",
+                                            "f_type": "real(C_DOUBLE)",
+                                            "i_kind": "C_DOUBLE",
+                                            "i_module_name": "iso_c_binding",
+                                            "i_type": "real(C_DOUBLE)",
+                                            "sh_type": "SH_TYPE_DOUBLE"
+                                        }
                                     },
                                     "share": {}
                                 },

--- a/regression/reference/namespace/namespace.json
+++ b/regression/reference/namespace/namespace.json
@@ -624,7 +624,8 @@
                                         "fmtdict": {
                                             "i_kind": "C_INT",
                                             "i_module_name": "iso_c_binding",
-                                            "i_type": "integer(C_INT)"
+                                            "i_type": "integer(C_INT)",
+                                            "i_var": "ifield"
                                         }
                                     },
                                     "share": {}
@@ -665,7 +666,8 @@
                                         "fmtdict": {
                                             "i_kind": "C_DOUBLE",
                                             "i_module_name": "iso_c_binding",
-                                            "i_type": "real(C_DOUBLE)"
+                                            "i_type": "real(C_DOUBLE)",
+                                            "i_var": "dfield"
                                         }
                                     },
                                     "share": {}

--- a/regression/reference/namespace/namespace.json
+++ b/regression/reference/namespace/namespace.json
@@ -620,6 +620,9 @@
                                     "python": true
                                 },
                                 "zz_bind": {
+                                    "f": {
+                                        "fmtdict": {}
+                                    },
                                     "share": {}
                                 },
                                 "zz_fmtdict": {
@@ -654,6 +657,9 @@
                                     "python": true
                                 },
                                 "zz_bind": {
+                                    "f": {
+                                        "fmtdict": {}
+                                    },
                                     "share": {}
                                 },
                                 "zz_fmtdict": {

--- a/regression/reference/namespace/namespace.json
+++ b/regression/reference/namespace/namespace.json
@@ -637,9 +637,7 @@
                                     "c_type": "int",
                                     "cxx_type": "int",
                                     "field_name": "ifield",
-                                    "variable_lower": "ifield",
-                                    "variable_name": "ifield",
-                                    "variable_upper": "IFIELD"
+                                    "variable_name": "ifield"
                                 }
                             },
                             {
@@ -679,9 +677,7 @@
                                     "c_type": "double",
                                     "cxx_type": "double",
                                     "field_name": "dfield",
-                                    "variable_lower": "dfield",
-                                    "variable_name": "dfield",
-                                    "variable_upper": "DFIELD"
+                                    "variable_name": "dfield"
                                 }
                             }
                         ],

--- a/regression/reference/ownership/ownership.json
+++ b/regression/reference/ownership/ownership.json
@@ -275,9 +275,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "m_flag",
-                            "variable_lower": "flag",
-                            "variable_name": "flag",
-                            "variable_upper": "FLAG"
+                            "variable_name": "flag"
                         }
                     }
                 ],

--- a/regression/reference/python-only/tutorial.json
+++ b/regression/reference/python-only/tutorial.json
@@ -2836,9 +2836,7 @@
                     "c_type": "int",
                     "cxx_type": "int",
                     "field_name": "global_flag",
-                    "variable_lower": "global_flag",
-                    "variable_name": "global_flag",
-                    "variable_upper": "GLOBAL_FLAG"
+                    "variable_name": "global_flag"
                 }
             },
             {
@@ -2865,9 +2863,7 @@
                     "c_type": "int",
                     "cxx_type": "int",
                     "field_name": "tutorial_flag",
-                    "variable_lower": "tutorial_flag",
-                    "variable_name": "tutorial_flag",
-                    "variable_upper": "TUTORIAL_FLAG"
+                    "variable_name": "tutorial_flag"
                 }
             }
         ],

--- a/regression/reference/scope/scope.json
+++ b/regression/reference/scope/scope.json
@@ -38,7 +38,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_INT",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "integer(C_INT)",
+                                    "i_kind": "C_INT",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "integer(C_INT)",
+                                    "sh_type": "SH_TYPE_INT"
+                                }
                             },
                             "share": {}
                         },
@@ -79,7 +87,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_INT",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "integer(C_INT)",
+                                    "i_kind": "C_INT",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "integer(C_INT)",
+                                    "sh_type": "SH_TYPE_INT"
+                                }
                             },
                             "share": {
                                 "meta": {
@@ -970,7 +986,15 @@
                                 },
                                 "zz_bind": {
                                     "f": {
-                                        "fmtdict": {}
+                                        "fmtdict": {
+                                            "f_kind": "C_INT",
+                                            "f_module_name": "iso_c_binding",
+                                            "f_type": "integer(C_INT)",
+                                            "i_kind": "C_INT",
+                                            "i_module_name": "iso_c_binding",
+                                            "i_type": "integer(C_INT)",
+                                            "sh_type": "SH_TYPE_INT"
+                                        }
                                     },
                                     "share": {}
                                 },
@@ -1011,7 +1035,15 @@
                                 },
                                 "zz_bind": {
                                     "f": {
-                                        "fmtdict": {}
+                                        "fmtdict": {
+                                            "f_kind": "C_INT",
+                                            "f_module_name": "iso_c_binding",
+                                            "f_type": "integer(C_INT)",
+                                            "i_kind": "C_INT",
+                                            "i_module_name": "iso_c_binding",
+                                            "i_type": "integer(C_INT)",
+                                            "sh_type": "SH_TYPE_INT"
+                                        }
                                     },
                                     "share": {
                                         "meta": {
@@ -1596,7 +1628,15 @@
                                 },
                                 "zz_bind": {
                                     "f": {
-                                        "fmtdict": {}
+                                        "fmtdict": {
+                                            "f_kind": "C_INT",
+                                            "f_module_name": "iso_c_binding",
+                                            "f_type": "integer(C_INT)",
+                                            "i_kind": "C_INT",
+                                            "i_module_name": "iso_c_binding",
+                                            "i_type": "integer(C_INT)",
+                                            "sh_type": "SH_TYPE_INT"
+                                        }
                                     },
                                     "share": {}
                                 },
@@ -1637,7 +1677,15 @@
                                 },
                                 "zz_bind": {
                                     "f": {
-                                        "fmtdict": {}
+                                        "fmtdict": {
+                                            "f_kind": "C_INT",
+                                            "f_module_name": "iso_c_binding",
+                                            "f_type": "integer(C_INT)",
+                                            "i_kind": "C_INT",
+                                            "i_module_name": "iso_c_binding",
+                                            "i_type": "integer(C_INT)",
+                                            "sh_type": "SH_TYPE_INT"
+                                        }
                                     },
                                     "share": {
                                         "meta": {

--- a/regression/reference/scope/scope.json
+++ b/regression/reference/scope/scope.json
@@ -51,9 +51,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "nitems",
-                            "variable_lower": "nitems",
-                            "variable_name": "nitems",
-                            "variable_upper": "NITEMS"
+                            "variable_name": "nitems"
                         }
                     },
                     {
@@ -106,9 +104,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "items",
-                            "variable_lower": "items",
-                            "variable_name": "items",
-                            "variable_upper": "ITEMS"
+                            "variable_name": "items"
                         }
                     }
                 ],
@@ -993,9 +989,7 @@
                                     "c_type": "int",
                                     "cxx_type": "int",
                                     "field_name": "nitems",
-                                    "variable_lower": "nitems",
-                                    "variable_name": "nitems",
-                                    "variable_upper": "NITEMS"
+                                    "variable_name": "nitems"
                                 }
                             },
                             {
@@ -1048,9 +1042,7 @@
                                     "c_type": "int",
                                     "cxx_type": "int",
                                     "field_name": "items",
-                                    "variable_lower": "items",
-                                    "variable_name": "items",
-                                    "variable_upper": "ITEMS"
+                                    "variable_name": "items"
                                 }
                             }
                         ],
@@ -1629,9 +1621,7 @@
                                     "c_type": "int",
                                     "cxx_type": "int",
                                     "field_name": "nitems",
-                                    "variable_lower": "nitems",
-                                    "variable_name": "nitems",
-                                    "variable_upper": "NITEMS"
+                                    "variable_name": "nitems"
                                 }
                             },
                             {
@@ -1684,9 +1674,7 @@
                                     "c_type": "int",
                                     "cxx_type": "int",
                                     "field_name": "items",
-                                    "variable_lower": "items",
-                                    "variable_name": "items",
-                                    "variable_upper": "ITEMS"
+                                    "variable_name": "items"
                                 }
                             }
                         ],

--- a/regression/reference/scope/scope.json
+++ b/regression/reference/scope/scope.json
@@ -41,7 +41,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)"
+                                    "i_type": "integer(C_INT)",
+                                    "i_var": "nitems"
                                 }
                             },
                             "share": {}
@@ -86,7 +87,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "type(C_PTR)"
+                                    "i_type": "type(C_PTR)",
+                                    "i_var": "items"
                                 }
                             },
                             "share": {
@@ -981,7 +983,8 @@
                                         "fmtdict": {
                                             "i_kind": "C_INT",
                                             "i_module_name": "iso_c_binding",
-                                            "i_type": "integer(C_INT)"
+                                            "i_type": "integer(C_INT)",
+                                            "i_var": "nitems"
                                         }
                                     },
                                     "share": {}
@@ -1026,7 +1029,8 @@
                                         "fmtdict": {
                                             "i_kind": "C_PTR",
                                             "i_module_name": "iso_c_binding",
-                                            "i_type": "type(C_PTR)"
+                                            "i_type": "type(C_PTR)",
+                                            "i_var": "items"
                                         }
                                     },
                                     "share": {
@@ -1615,7 +1619,8 @@
                                         "fmtdict": {
                                             "i_kind": "C_INT",
                                             "i_module_name": "iso_c_binding",
-                                            "i_type": "integer(C_INT)"
+                                            "i_type": "integer(C_INT)",
+                                            "i_var": "nitems"
                                         }
                                     },
                                     "share": {}
@@ -1660,7 +1665,8 @@
                                         "fmtdict": {
                                             "i_kind": "C_PTR",
                                             "i_module_name": "iso_c_binding",
-                                            "i_type": "type(C_PTR)"
+                                            "i_type": "type(C_PTR)",
+                                            "i_var": "items"
                                         }
                                     },
                                     "share": {

--- a/regression/reference/scope/scope.json
+++ b/regression/reference/scope/scope.json
@@ -39,13 +39,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_INT",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "integer(C_INT)",
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)",
-                                    "sh_type": "SH_TYPE_INT"
+                                    "i_type": "integer(C_INT)"
                                 }
                             },
                             "share": {}
@@ -88,13 +84,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_INT",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "integer(C_INT)",
-                                    "i_kind": "C_INT",
+                                    "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)",
-                                    "sh_type": "SH_TYPE_INT"
+                                    "i_type": "type(C_PTR)"
                                 }
                             },
                             "share": {
@@ -987,13 +979,9 @@
                                 "zz_bind": {
                                     "f": {
                                         "fmtdict": {
-                                            "f_kind": "C_INT",
-                                            "f_module_name": "iso_c_binding",
-                                            "f_type": "integer(C_INT)",
                                             "i_kind": "C_INT",
                                             "i_module_name": "iso_c_binding",
-                                            "i_type": "integer(C_INT)",
-                                            "sh_type": "SH_TYPE_INT"
+                                            "i_type": "integer(C_INT)"
                                         }
                                     },
                                     "share": {}
@@ -1036,13 +1024,9 @@
                                 "zz_bind": {
                                     "f": {
                                         "fmtdict": {
-                                            "f_kind": "C_INT",
-                                            "f_module_name": "iso_c_binding",
-                                            "f_type": "integer(C_INT)",
-                                            "i_kind": "C_INT",
+                                            "i_kind": "C_PTR",
                                             "i_module_name": "iso_c_binding",
-                                            "i_type": "integer(C_INT)",
-                                            "sh_type": "SH_TYPE_INT"
+                                            "i_type": "type(C_PTR)"
                                         }
                                     },
                                     "share": {
@@ -1629,13 +1613,9 @@
                                 "zz_bind": {
                                     "f": {
                                         "fmtdict": {
-                                            "f_kind": "C_INT",
-                                            "f_module_name": "iso_c_binding",
-                                            "f_type": "integer(C_INT)",
                                             "i_kind": "C_INT",
                                             "i_module_name": "iso_c_binding",
-                                            "i_type": "integer(C_INT)",
-                                            "sh_type": "SH_TYPE_INT"
+                                            "i_type": "integer(C_INT)"
                                         }
                                     },
                                     "share": {}
@@ -1678,13 +1658,9 @@
                                 "zz_bind": {
                                     "f": {
                                         "fmtdict": {
-                                            "f_kind": "C_INT",
-                                            "f_module_name": "iso_c_binding",
-                                            "f_type": "integer(C_INT)",
-                                            "i_kind": "C_INT",
+                                            "i_kind": "C_PTR",
                                             "i_module_name": "iso_c_binding",
-                                            "i_type": "integer(C_INT)",
-                                            "sh_type": "SH_TYPE_INT"
+                                            "i_type": "type(C_PTR)"
                                         }
                                     },
                                     "share": {

--- a/regression/reference/scope/scope.json
+++ b/regression/reference/scope/scope.json
@@ -37,6 +37,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {}
                         },
                         "zz_fmtdict": {
@@ -75,6 +78,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {
                                 "meta": {
                                     "dim_ast": [
@@ -963,6 +969,9 @@
                                     "fortran": true
                                 },
                                 "zz_bind": {
+                                    "f": {
+                                        "fmtdict": {}
+                                    },
                                     "share": {}
                                 },
                                 "zz_fmtdict": {
@@ -1001,6 +1010,9 @@
                                     "fortran": true
                                 },
                                 "zz_bind": {
+                                    "f": {
+                                        "fmtdict": {}
+                                    },
                                     "share": {
                                         "meta": {
                                             "dim_ast": [
@@ -1583,6 +1595,9 @@
                                     "fortran": true
                                 },
                                 "zz_bind": {
+                                    "f": {
+                                        "fmtdict": {}
+                                    },
                                     "share": {}
                                 },
                                 "zz_fmtdict": {
@@ -1621,6 +1636,9 @@
                                     "fortran": true
                                 },
                                 "zz_bind": {
+                                    "f": {
+                                        "fmtdict": {}
+                                    },
                                     "share": {
                                         "meta": {
                                             "dim_ast": [

--- a/regression/reference/struct-c/struct.json
+++ b/regression/reference/struct-c/struct.json
@@ -41,6 +41,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {}
                         },
                         "zz_fmtdict": {
@@ -70,6 +73,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {}
                         },
                         "zz_fmtdict": {
@@ -135,6 +141,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {}
                         },
                         "zz_fmtdict": {
@@ -170,6 +179,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {}
                         },
                         "zz_fmtdict": {
@@ -232,6 +244,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {}
                         },
                         "zz_fmtdict": {
@@ -269,6 +284,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {
                                 "meta": {
                                     "dim_ast": [
@@ -321,6 +339,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {
                                 "meta": {
                                     "dim_ast": [
@@ -376,6 +397,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {
                                 "meta": {
                                     "dim_ast": [
@@ -448,6 +472,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {}
                         },
                         "zz_fmtdict": {
@@ -485,6 +512,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {
                                 "meta": {
                                     "dim_ast": [
@@ -531,6 +561,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {
                                 "meta": {
                                     "dim_ast": [
@@ -607,6 +640,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {}
                         },
                         "zz_fmtdict": {
@@ -641,6 +677,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {}
                         },
                         "zz_fmtdict": {
@@ -2152,6 +2191,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {}
                         },
                         "zz_fmtdict": {

--- a/regression/reference/struct-c/struct.json
+++ b/regression/reference/struct-c/struct.json
@@ -42,7 +42,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_INT",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "integer(C_INT)",
+                                    "i_kind": "C_INT",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "integer(C_INT)",
+                                    "sh_type": "SH_TYPE_INT"
+                                }
                             },
                             "share": {}
                         },
@@ -74,7 +82,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_DOUBLE",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "real(C_DOUBLE)",
+                                    "i_kind": "C_DOUBLE",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "real(C_DOUBLE)",
+                                    "sh_type": "SH_TYPE_DOUBLE"
+                                }
                             },
                             "share": {}
                         },
@@ -142,7 +158,13 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_type": "character(len=*)",
+                                    "i_kind": "C_CHAR",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "character(kind=C_CHAR)",
+                                    "sh_type": "SH_TYPE_OTHER"
+                                }
                             },
                             "share": {}
                         },
@@ -180,7 +202,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_DOUBLE",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "real(C_DOUBLE)",
+                                    "i_kind": "C_DOUBLE",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "real(C_DOUBLE)",
+                                    "sh_type": "SH_TYPE_DOUBLE"
+                                }
                             },
                             "share": {}
                         },
@@ -245,7 +275,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_INT",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "integer(C_INT)",
+                                    "i_kind": "C_INT",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "integer(C_INT)",
+                                    "sh_type": "SH_TYPE_INT"
+                                }
                             },
                             "share": {}
                         },
@@ -285,7 +323,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_INT",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "integer(C_INT)",
+                                    "i_kind": "C_INT",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "integer(C_INT)",
+                                    "sh_type": "SH_TYPE_INT"
+                                }
                             },
                             "share": {
                                 "meta": {
@@ -340,7 +386,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_DOUBLE",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "real(C_DOUBLE)",
+                                    "i_kind": "C_DOUBLE",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "real(C_DOUBLE)",
+                                    "sh_type": "SH_TYPE_DOUBLE"
+                                }
                             },
                             "share": {
                                 "meta": {
@@ -398,7 +452,13 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_type": "character(len=*)",
+                                    "i_kind": "C_CHAR",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "character(kind=C_CHAR)",
+                                    "sh_type": "SH_TYPE_OTHER"
+                                }
                             },
                             "share": {
                                 "meta": {
@@ -473,7 +533,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_INT",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "integer(C_INT)",
+                                    "i_kind": "C_INT",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "integer(C_INT)",
+                                    "sh_type": "SH_TYPE_INT"
+                                }
                             },
                             "share": {}
                         },
@@ -513,7 +581,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_INT",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "integer(C_INT)",
+                                    "i_kind": "C_INT",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "integer(C_INT)",
+                                    "sh_type": "SH_TYPE_INT"
+                                }
                             },
                             "share": {
                                 "meta": {
@@ -562,7 +638,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_DOUBLE",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "real(C_DOUBLE)",
+                                    "i_kind": "C_DOUBLE",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "real(C_DOUBLE)",
+                                    "sh_type": "SH_TYPE_DOUBLE"
+                                }
                             },
                             "share": {
                                 "meta": {
@@ -641,7 +725,13 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_type": "character(len=*)",
+                                    "i_kind": "C_CHAR",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "character(kind=C_CHAR)",
+                                    "sh_type": "SH_TYPE_OTHER"
+                                }
                             },
                             "share": {}
                         },
@@ -678,7 +768,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_INT",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "integer(C_INT)",
+                                    "i_kind": "C_INT",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "integer(C_INT)",
+                                    "sh_type": "SH_TYPE_INT"
+                                }
                             },
                             "share": {}
                         },
@@ -2192,7 +2290,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_INT",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "integer(C_INT)",
+                                    "i_kind": "C_INT",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "integer(C_INT)",
+                                    "sh_type": "SH_TYPE_INT"
+                                }
                             },
                             "share": {}
                         },

--- a/regression/reference/struct-c/struct.json
+++ b/regression/reference/struct-c/struct.json
@@ -45,7 +45,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)"
+                                    "i_type": "integer(C_INT)",
+                                    "i_var": "ifield"
                                 }
                             },
                             "share": {}
@@ -81,7 +82,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_DOUBLE",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "real(C_DOUBLE)"
+                                    "i_type": "real(C_DOUBLE)",
+                                    "i_var": "dfield"
                                 }
                             },
                             "share": {}
@@ -153,7 +155,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "type(C_PTR)"
+                                    "i_type": "type(C_PTR)",
+                                    "i_var": "cfield"
                                 }
                             },
                             "share": {}
@@ -195,7 +198,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "type(C_PTR)"
+                                    "i_type": "type(C_PTR)",
+                                    "i_var": "const_dvalue"
                                 }
                             },
                             "share": {}
@@ -264,7 +268,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)"
+                                    "i_type": "integer(C_INT)",
+                                    "i_var": "nitems"
                                 }
                             },
                             "share": {}
@@ -308,7 +313,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "type(C_PTR)"
+                                    "i_type": "type(C_PTR)",
+                                    "i_var": "ivalue"
                                 }
                             },
                             "share": {
@@ -367,7 +373,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "type(C_PTR)"
+                                    "i_type": "type(C_PTR)",
+                                    "i_var": "dvalue"
                                 }
                             },
                             "share": {
@@ -429,7 +436,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "type(C_PTR)"
+                                    "i_type": "type(C_PTR)",
+                                    "i_var": "svalue"
                                 }
                             },
                             "share": {
@@ -508,7 +516,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)"
+                                    "i_type": "integer(C_INT)",
+                                    "i_var": "nitems"
                                 }
                             },
                             "share": {}
@@ -552,7 +561,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "type(C_PTR)"
+                                    "i_type": "type(C_PTR)",
+                                    "i_var": "ivalue"
                                 }
                             },
                             "share": {
@@ -605,7 +615,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "type(C_PTR)"
+                                    "i_type": "type(C_PTR)",
+                                    "i_var": "dvalue"
                                 }
                             },
                             "share": {
@@ -689,7 +700,8 @@
                                     "i_dimension": "(20)",
                                     "i_kind": "C_CHAR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "character(kind=C_CHAR)"
+                                    "i_type": "character(kind=C_CHAR)",
+                                    "i_var": "name"
                                 }
                             },
                             "share": {}
@@ -731,7 +743,8 @@
                                     "i_dimension": "(10)",
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)"
+                                    "i_type": "integer(C_INT)",
+                                    "i_var": "count"
                                 }
                             },
                             "share": {}
@@ -2249,7 +2262,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)"
+                                    "i_type": "integer(C_INT)",
+                                    "i_var": "sublevels"
                                 }
                             },
                             "share": {}

--- a/regression/reference/struct-c/struct.json
+++ b/regression/reference/struct-c/struct.json
@@ -43,13 +43,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_INT",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "integer(C_INT)",
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)",
-                                    "sh_type": "SH_TYPE_INT"
+                                    "i_type": "integer(C_INT)"
                                 }
                             },
                             "share": {}
@@ -83,13 +79,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_DOUBLE",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "real(C_DOUBLE)",
                                     "i_kind": "C_DOUBLE",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "real(C_DOUBLE)",
-                                    "sh_type": "SH_TYPE_DOUBLE"
+                                    "i_type": "real(C_DOUBLE)"
                                 }
                             },
                             "share": {}
@@ -159,11 +151,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_type": "character(len=*)",
-                                    "i_kind": "C_CHAR",
+                                    "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "character(kind=C_CHAR)",
-                                    "sh_type": "SH_TYPE_OTHER"
+                                    "i_type": "type(C_PTR)"
                                 }
                             },
                             "share": {}
@@ -203,13 +193,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_DOUBLE",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "real(C_DOUBLE)",
-                                    "i_kind": "C_DOUBLE",
+                                    "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "real(C_DOUBLE)",
-                                    "sh_type": "SH_TYPE_DOUBLE"
+                                    "i_type": "type(C_PTR)"
                                 }
                             },
                             "share": {}
@@ -276,13 +262,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_INT",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "integer(C_INT)",
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)",
-                                    "sh_type": "SH_TYPE_INT"
+                                    "i_type": "integer(C_INT)"
                                 }
                             },
                             "share": {}
@@ -324,13 +306,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_INT",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "integer(C_INT)",
-                                    "i_kind": "C_INT",
+                                    "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)",
-                                    "sh_type": "SH_TYPE_INT"
+                                    "i_type": "type(C_PTR)"
                                 }
                             },
                             "share": {
@@ -387,13 +365,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_DOUBLE",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "real(C_DOUBLE)",
-                                    "i_kind": "C_DOUBLE",
+                                    "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "real(C_DOUBLE)",
-                                    "sh_type": "SH_TYPE_DOUBLE"
+                                    "i_type": "type(C_PTR)"
                                 }
                             },
                             "share": {
@@ -453,11 +427,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_type": "character(len=*)",
-                                    "i_kind": "C_CHAR",
+                                    "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "character(kind=C_CHAR)",
-                                    "sh_type": "SH_TYPE_OTHER"
+                                    "i_type": "type(C_PTR)"
                                 }
                             },
                             "share": {
@@ -534,13 +506,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_INT",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "integer(C_INT)",
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)",
-                                    "sh_type": "SH_TYPE_INT"
+                                    "i_type": "integer(C_INT)"
                                 }
                             },
                             "share": {}
@@ -582,13 +550,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_INT",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "integer(C_INT)",
-                                    "i_kind": "C_INT",
+                                    "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)",
-                                    "sh_type": "SH_TYPE_INT"
+                                    "i_type": "type(C_PTR)"
                                 }
                             },
                             "share": {
@@ -639,13 +603,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_DOUBLE",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "real(C_DOUBLE)",
-                                    "i_kind": "C_DOUBLE",
+                                    "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "real(C_DOUBLE)",
-                                    "sh_type": "SH_TYPE_DOUBLE"
+                                    "i_type": "type(C_PTR)"
                                 }
                             },
                             "share": {
@@ -726,11 +686,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_type": "character(len=*)",
                                     "i_kind": "C_CHAR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "character(kind=C_CHAR)",
-                                    "sh_type": "SH_TYPE_OTHER"
+                                    "i_type": "character(kind=C_CHAR)"
                                 }
                             },
                             "share": {}
@@ -769,13 +727,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_INT",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "integer(C_INT)",
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)",
-                                    "sh_type": "SH_TYPE_INT"
+                                    "i_type": "integer(C_INT)"
                                 }
                             },
                             "share": {}
@@ -2291,13 +2245,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_INT",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "integer(C_INT)",
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)",
-                                    "sh_type": "SH_TYPE_INT"
+                                    "i_type": "integer(C_INT)"
                                 }
                             },
                             "share": {}

--- a/regression/reference/struct-c/struct.json
+++ b/regression/reference/struct-c/struct.json
@@ -55,9 +55,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "ifield",
-                            "variable_lower": "ifield",
-                            "variable_name": "ifield",
-                            "variable_upper": "IFIELD"
+                            "variable_name": "ifield"
                         }
                     },
                     {
@@ -92,9 +90,7 @@
                             "c_type": "double",
                             "cxx_type": "double",
                             "field_name": "dfield",
-                            "variable_lower": "dfield",
-                            "variable_name": "dfield",
-                            "variable_upper": "DFIELD"
+                            "variable_name": "dfield"
                         }
                     }
                 ],
@@ -165,9 +161,7 @@
                             "c_type": "char",
                             "cxx_type": "char",
                             "field_name": "cfield",
-                            "variable_lower": "cfield",
-                            "variable_name": "cfield",
-                            "variable_upper": "CFIELD"
+                            "variable_name": "cfield"
                         }
                     },
                     {
@@ -208,9 +202,7 @@
                             "c_type": "double",
                             "cxx_type": "double",
                             "field_name": "const_dvalue",
-                            "variable_lower": "const_dvalue",
-                            "variable_name": "const_dvalue",
-                            "variable_upper": "CONST_DVALUE"
+                            "variable_name": "const_dvalue"
                         }
                     }
                 ],
@@ -278,9 +270,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "nitems",
-                            "variable_lower": "nitems",
-                            "variable_name": "nitems",
-                            "variable_upper": "NITEMS"
+                            "variable_name": "nitems"
                         }
                     },
                     {
@@ -338,9 +328,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "ivalue",
-                            "variable_lower": "ivalue",
-                            "variable_name": "ivalue",
-                            "variable_upper": "IVALUE"
+                            "variable_name": "ivalue"
                         }
                     },
                     {
@@ -398,9 +386,7 @@
                             "c_type": "double",
                             "cxx_type": "double",
                             "field_name": "dvalue",
-                            "variable_lower": "dvalue",
-                            "variable_name": "dvalue",
-                            "variable_upper": "DVALUE"
+                            "variable_name": "dvalue"
                         }
                     },
                     {
@@ -455,9 +441,7 @@
                             "c_type": "char",
                             "cxx_type": "char",
                             "field_name": "svalue",
-                            "variable_lower": "svalue",
-                            "variable_name": "svalue",
-                            "variable_upper": "SVALUE"
+                            "variable_name": "svalue"
                         }
                     }
                 ],
@@ -526,9 +510,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "nitems",
-                            "variable_lower": "nitems",
-                            "variable_name": "nitems",
-                            "variable_upper": "NITEMS"
+                            "variable_name": "nitems"
                         }
                     },
                     {
@@ -580,9 +562,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "ivalue",
-                            "variable_lower": "ivalue",
-                            "variable_name": "ivalue",
-                            "variable_upper": "IVALUE"
+                            "variable_name": "ivalue"
                         }
                     },
                     {
@@ -634,9 +614,7 @@
                             "c_type": "double",
                             "cxx_type": "double",
                             "field_name": "dvalue",
-                            "variable_lower": "dvalue",
-                            "variable_name": "dvalue",
-                            "variable_upper": "DVALUE"
+                            "variable_name": "dvalue"
                         }
                     }
                 ],
@@ -710,9 +688,7 @@
                             "c_type": "char",
                             "cxx_type": "char",
                             "field_name": "name",
-                            "variable_lower": "name",
-                            "variable_name": "name",
-                            "variable_upper": "NAME"
+                            "variable_name": "name"
                         }
                     },
                     {
@@ -753,9 +729,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "count",
-                            "variable_lower": "count",
-                            "variable_name": "count",
-                            "variable_upper": "COUNT"
+                            "variable_name": "count"
                         }
                     }
                 ],
@@ -1307,9 +1281,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "x1",
-                            "variable_lower": "x1",
-                            "variable_name": "x1",
-                            "variable_upper": "X1"
+                            "variable_name": "x1"
                         }
                     },
                     {
@@ -1336,9 +1308,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "y1",
-                            "variable_lower": "y1",
-                            "variable_name": "y1",
-                            "variable_upper": "Y1"
+                            "variable_name": "y1"
                         }
                     }
                 ],
@@ -2139,9 +2109,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "x1",
-                            "variable_lower": "x1",
-                            "variable_name": "x1",
-                            "variable_upper": "X1"
+                            "variable_name": "x1"
                         }
                     },
                     {
@@ -2168,9 +2136,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "y1",
-                            "variable_lower": "y1",
-                            "variable_name": "y1",
-                            "variable_upper": "Y1"
+                            "variable_name": "y1"
                         }
                     },
                     {
@@ -2197,9 +2163,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "z1",
-                            "variable_lower": "z1",
-                            "variable_name": "z1",
-                            "variable_upper": "Z1"
+                            "variable_name": "z1"
                         }
                     }
                 ],
@@ -2272,9 +2236,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "sublevels",
-                            "variable_lower": "sublevels",
-                            "variable_name": "sublevels",
-                            "variable_upper": "SUBLEVELS"
+                            "variable_name": "sublevels"
                         }
                     }
                 ],

--- a/regression/reference/struct-c/struct.json
+++ b/regression/reference/struct-c/struct.json
@@ -686,6 +686,7 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
+                                    "i_dimension": "(20)",
                                     "i_kind": "C_CHAR",
                                     "i_module_name": "iso_c_binding",
                                     "i_type": "character(kind=C_CHAR)"
@@ -727,6 +728,7 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
+                                    "i_dimension": "(10)",
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
                                     "i_type": "integer(C_INT)"

--- a/regression/reference/struct-class-c/struct.json
+++ b/regression/reference/struct-class-c/struct.json
@@ -234,9 +234,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "ifield",
-                            "variable_lower": "ifield",
-                            "variable_name": "ifield",
-                            "variable_upper": "IFIELD"
+                            "variable_name": "ifield"
                         }
                     },
                     {
@@ -266,9 +264,7 @@
                             "c_type": "double",
                             "cxx_type": "double",
                             "field_name": "dfield",
-                            "variable_lower": "dfield",
-                            "variable_name": "dfield",
-                            "variable_upper": "DFIELD"
+                            "variable_name": "dfield"
                         }
                     }
                 ],
@@ -548,9 +544,7 @@
                             "cxx_type": "char",
                             "field_name": "cfield",
                             "py_var": "SHPy_cfield",
-                            "variable_lower": "cfield",
-                            "variable_name": "cfield",
-                            "variable_upper": "CFIELD"
+                            "variable_name": "cfield"
                         }
                     },
                     {
@@ -589,9 +583,7 @@
                             "cxx_type": "double",
                             "field_name": "const_dvalue",
                             "py_var": "SHPy_const_dvalue",
-                            "variable_lower": "const_dvalue",
-                            "variable_name": "const_dvalue",
-                            "variable_upper": "CONST_DVALUE"
+                            "variable_name": "const_dvalue"
                         }
                     }
                 ],
@@ -1040,9 +1032,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "nitems",
-                            "variable_lower": "nitems",
-                            "variable_name": "nitems",
-                            "variable_upper": "NITEMS"
+                            "variable_name": "nitems"
                         }
                     },
                     {
@@ -1098,9 +1088,7 @@
                             "cxx_type": "int",
                             "field_name": "ivalue",
                             "py_var": "SHPy_ivalue",
-                            "variable_lower": "ivalue",
-                            "variable_name": "ivalue",
-                            "variable_upper": "IVALUE"
+                            "variable_name": "ivalue"
                         }
                     },
                     {
@@ -1156,9 +1144,7 @@
                             "cxx_type": "double",
                             "field_name": "dvalue",
                             "py_var": "SHPy_dvalue",
-                            "variable_lower": "dvalue",
-                            "variable_name": "dvalue",
-                            "variable_upper": "DVALUE"
+                            "variable_name": "dvalue"
                         }
                     },
                     {
@@ -1211,9 +1197,7 @@
                             "cxx_type": "char",
                             "field_name": "svalue",
                             "py_var": "SHPy_svalue",
-                            "variable_lower": "svalue",
-                            "variable_name": "svalue",
-                            "variable_upper": "SVALUE"
+                            "variable_name": "svalue"
                         }
                     }
                 ],
@@ -1566,9 +1550,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "nitems",
-                            "variable_lower": "nitems",
-                            "variable_name": "nitems",
-                            "variable_upper": "NITEMS"
+                            "variable_name": "nitems"
                         }
                     },
                     {
@@ -1618,9 +1600,7 @@
                             "cxx_type": "int",
                             "field_name": "ivalue",
                             "py_var": "SHPy_ivalue",
-                            "variable_lower": "ivalue",
-                            "variable_name": "ivalue",
-                            "variable_upper": "IVALUE"
+                            "variable_name": "ivalue"
                         }
                     },
                     {
@@ -1670,9 +1650,7 @@
                             "cxx_type": "double",
                             "field_name": "dvalue",
                             "py_var": "SHPy_dvalue",
-                            "variable_lower": "dvalue",
-                            "variable_name": "dvalue",
-                            "variable_upper": "DVALUE"
+                            "variable_name": "dvalue"
                         }
                     }
                 ],
@@ -1951,9 +1929,7 @@
                             "cxx_type": "char",
                             "field_name": "name",
                             "py_var": "SHPy_name",
-                            "variable_lower": "name",
-                            "variable_name": "name",
-                            "variable_upper": "NAME"
+                            "variable_name": "name"
                         }
                     },
                     {
@@ -1991,9 +1967,7 @@
                             "cxx_type": "int",
                             "field_name": "count",
                             "py_var": "SHPy_count",
-                            "variable_lower": "count",
-                            "variable_name": "count",
-                            "variable_upper": "COUNT"
+                            "variable_name": "count"
                         }
                     }
                 ],
@@ -2061,9 +2035,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "x1",
-                            "variable_lower": "x1",
-                            "variable_name": "x1",
-                            "variable_upper": "X1"
+                            "variable_name": "x1"
                         }
                     },
                     {
@@ -2088,9 +2060,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "y1",
-                            "variable_lower": "y1",
-                            "variable_name": "y1",
-                            "variable_upper": "Y1"
+                            "variable_name": "y1"
                         }
                     }
                 ],
@@ -2150,9 +2120,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "x1",
-                            "variable_lower": "x1",
-                            "variable_name": "x1",
-                            "variable_upper": "X1"
+                            "variable_name": "x1"
                         }
                     },
                     {
@@ -2177,9 +2145,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "y1",
-                            "variable_lower": "y1",
-                            "variable_name": "y1",
-                            "variable_upper": "Y1"
+                            "variable_name": "y1"
                         }
                     },
                     {
@@ -2204,9 +2170,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "z1",
-                            "variable_lower": "z1",
-                            "variable_name": "z1",
-                            "variable_upper": "Z1"
+                            "variable_name": "z1"
                         }
                     }
                 ],
@@ -2263,9 +2227,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "sublevels",
-                            "variable_lower": "sublevels",
-                            "variable_name": "sublevels",
-                            "variable_upper": "SUBLEVELS"
+                            "variable_name": "sublevels"
                         }
                     }
                 ],

--- a/regression/reference/struct-class-cxx/struct.json
+++ b/regression/reference/struct-class-cxx/struct.json
@@ -234,9 +234,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "ifield",
-                            "variable_lower": "ifield",
-                            "variable_name": "ifield",
-                            "variable_upper": "IFIELD"
+                            "variable_name": "ifield"
                         }
                     },
                     {
@@ -266,9 +264,7 @@
                             "c_type": "double",
                             "cxx_type": "double",
                             "field_name": "dfield",
-                            "variable_lower": "dfield",
-                            "variable_name": "dfield",
-                            "variable_upper": "DFIELD"
+                            "variable_name": "dfield"
                         }
                     }
                 ],
@@ -548,9 +544,7 @@
                             "cxx_type": "char",
                             "field_name": "cfield",
                             "py_var": "SHPy_cfield",
-                            "variable_lower": "cfield",
-                            "variable_name": "cfield",
-                            "variable_upper": "CFIELD"
+                            "variable_name": "cfield"
                         }
                     },
                     {
@@ -589,9 +583,7 @@
                             "cxx_type": "double",
                             "field_name": "const_dvalue",
                             "py_var": "SHPy_const_dvalue",
-                            "variable_lower": "const_dvalue",
-                            "variable_name": "const_dvalue",
-                            "variable_upper": "CONST_DVALUE"
+                            "variable_name": "const_dvalue"
                         }
                     }
                 ],
@@ -1040,9 +1032,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "nitems",
-                            "variable_lower": "nitems",
-                            "variable_name": "nitems",
-                            "variable_upper": "NITEMS"
+                            "variable_name": "nitems"
                         }
                     },
                     {
@@ -1098,9 +1088,7 @@
                             "cxx_type": "int",
                             "field_name": "ivalue",
                             "py_var": "SHPy_ivalue",
-                            "variable_lower": "ivalue",
-                            "variable_name": "ivalue",
-                            "variable_upper": "IVALUE"
+                            "variable_name": "ivalue"
                         }
                     },
                     {
@@ -1156,9 +1144,7 @@
                             "cxx_type": "double",
                             "field_name": "dvalue",
                             "py_var": "SHPy_dvalue",
-                            "variable_lower": "dvalue",
-                            "variable_name": "dvalue",
-                            "variable_upper": "DVALUE"
+                            "variable_name": "dvalue"
                         }
                     },
                     {
@@ -1211,9 +1197,7 @@
                             "cxx_type": "char",
                             "field_name": "svalue",
                             "py_var": "SHPy_svalue",
-                            "variable_lower": "svalue",
-                            "variable_name": "svalue",
-                            "variable_upper": "SVALUE"
+                            "variable_name": "svalue"
                         }
                     }
                 ],
@@ -1566,9 +1550,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "nitems",
-                            "variable_lower": "nitems",
-                            "variable_name": "nitems",
-                            "variable_upper": "NITEMS"
+                            "variable_name": "nitems"
                         }
                     },
                     {
@@ -1618,9 +1600,7 @@
                             "cxx_type": "int",
                             "field_name": "ivalue",
                             "py_var": "SHPy_ivalue",
-                            "variable_lower": "ivalue",
-                            "variable_name": "ivalue",
-                            "variable_upper": "IVALUE"
+                            "variable_name": "ivalue"
                         }
                     },
                     {
@@ -1670,9 +1650,7 @@
                             "cxx_type": "double",
                             "field_name": "dvalue",
                             "py_var": "SHPy_dvalue",
-                            "variable_lower": "dvalue",
-                            "variable_name": "dvalue",
-                            "variable_upper": "DVALUE"
+                            "variable_name": "dvalue"
                         }
                     }
                 ],
@@ -1951,9 +1929,7 @@
                             "cxx_type": "char",
                             "field_name": "name",
                             "py_var": "SHPy_name",
-                            "variable_lower": "name",
-                            "variable_name": "name",
-                            "variable_upper": "NAME"
+                            "variable_name": "name"
                         }
                     },
                     {
@@ -1991,9 +1967,7 @@
                             "cxx_type": "int",
                             "field_name": "count",
                             "py_var": "SHPy_count",
-                            "variable_lower": "count",
-                            "variable_name": "count",
-                            "variable_upper": "COUNT"
+                            "variable_name": "count"
                         }
                     }
                 ],
@@ -2061,9 +2035,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "x1",
-                            "variable_lower": "x1",
-                            "variable_name": "x1",
-                            "variable_upper": "X1"
+                            "variable_name": "x1"
                         }
                     },
                     {
@@ -2088,9 +2060,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "y1",
-                            "variable_lower": "y1",
-                            "variable_name": "y1",
-                            "variable_upper": "Y1"
+                            "variable_name": "y1"
                         }
                     }
                 ],
@@ -2150,9 +2120,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "x1",
-                            "variable_lower": "x1",
-                            "variable_name": "x1",
-                            "variable_upper": "X1"
+                            "variable_name": "x1"
                         }
                     },
                     {
@@ -2177,9 +2145,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "y1",
-                            "variable_lower": "y1",
-                            "variable_name": "y1",
-                            "variable_upper": "Y1"
+                            "variable_name": "y1"
                         }
                     },
                     {
@@ -2204,9 +2170,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "z1",
-                            "variable_lower": "z1",
-                            "variable_name": "z1",
-                            "variable_upper": "Z1"
+                            "variable_name": "z1"
                         }
                     }
                 ],
@@ -2263,9 +2227,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "sublevels",
-                            "variable_lower": "sublevels",
-                            "variable_name": "sublevels",
-                            "variable_upper": "SUBLEVELS"
+                            "variable_name": "sublevels"
                         }
                     }
                 ],

--- a/regression/reference/struct-cxx/struct.json
+++ b/regression/reference/struct-cxx/struct.json
@@ -44,13 +44,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_INT",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "integer(C_INT)",
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)",
-                                    "sh_type": "SH_TYPE_INT"
+                                    "i_type": "integer(C_INT)"
                                 }
                             },
                             "share": {}
@@ -85,13 +81,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_DOUBLE",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "real(C_DOUBLE)",
                                     "i_kind": "C_DOUBLE",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "real(C_DOUBLE)",
-                                    "sh_type": "SH_TYPE_DOUBLE"
+                                    "i_type": "real(C_DOUBLE)"
                                 }
                             },
                             "share": {}
@@ -163,11 +155,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_type": "character(len=*)",
-                                    "i_kind": "C_CHAR",
+                                    "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "character(kind=C_CHAR)",
-                                    "sh_type": "SH_TYPE_OTHER"
+                                    "i_type": "type(C_PTR)"
                                 }
                             },
                             "share": {}
@@ -208,13 +198,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_DOUBLE",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "real(C_DOUBLE)",
-                                    "i_kind": "C_DOUBLE",
+                                    "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "real(C_DOUBLE)",
-                                    "sh_type": "SH_TYPE_DOUBLE"
+                                    "i_type": "type(C_PTR)"
                                 }
                             },
                             "share": {}
@@ -283,13 +269,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_INT",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "integer(C_INT)",
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)",
-                                    "sh_type": "SH_TYPE_INT"
+                                    "i_type": "integer(C_INT)"
                                 }
                             },
                             "share": {}
@@ -332,13 +314,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_INT",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "integer(C_INT)",
-                                    "i_kind": "C_INT",
+                                    "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)",
-                                    "sh_type": "SH_TYPE_INT"
+                                    "i_type": "type(C_PTR)"
                                 }
                             },
                             "share": {
@@ -396,13 +374,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_DOUBLE",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "real(C_DOUBLE)",
-                                    "i_kind": "C_DOUBLE",
+                                    "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "real(C_DOUBLE)",
-                                    "sh_type": "SH_TYPE_DOUBLE"
+                                    "i_type": "type(C_PTR)"
                                 }
                             },
                             "share": {
@@ -463,11 +437,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_type": "character(len=*)",
-                                    "i_kind": "C_CHAR",
+                                    "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "character(kind=C_CHAR)",
-                                    "sh_type": "SH_TYPE_OTHER"
+                                    "i_type": "type(C_PTR)"
                                 }
                             },
                             "share": {
@@ -546,13 +518,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_INT",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "integer(C_INT)",
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)",
-                                    "sh_type": "SH_TYPE_INT"
+                                    "i_type": "integer(C_INT)"
                                 }
                             },
                             "share": {}
@@ -595,13 +563,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_INT",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "integer(C_INT)",
-                                    "i_kind": "C_INT",
+                                    "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)",
-                                    "sh_type": "SH_TYPE_INT"
+                                    "i_type": "type(C_PTR)"
                                 }
                             },
                             "share": {
@@ -653,13 +617,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_DOUBLE",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "real(C_DOUBLE)",
-                                    "i_kind": "C_DOUBLE",
+                                    "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "real(C_DOUBLE)",
-                                    "sh_type": "SH_TYPE_DOUBLE"
+                                    "i_type": "type(C_PTR)"
                                 }
                             },
                             "share": {
@@ -742,11 +702,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_type": "character(len=*)",
                                     "i_kind": "C_CHAR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "character(kind=C_CHAR)",
-                                    "sh_type": "SH_TYPE_OTHER"
+                                    "i_type": "character(kind=C_CHAR)"
                                 }
                             },
                             "share": {}
@@ -786,13 +744,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_INT",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "integer(C_INT)",
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)",
-                                    "sh_type": "SH_TYPE_INT"
+                                    "i_type": "integer(C_INT)"
                                 }
                             },
                             "share": {}
@@ -2317,13 +2271,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_INT",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "integer(C_INT)",
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)",
-                                    "sh_type": "SH_TYPE_INT"
+                                    "i_type": "integer(C_INT)"
                                 }
                             },
                             "share": {}

--- a/regression/reference/struct-cxx/struct.json
+++ b/regression/reference/struct-cxx/struct.json
@@ -43,7 +43,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_INT",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "integer(C_INT)",
+                                    "i_kind": "C_INT",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "integer(C_INT)",
+                                    "sh_type": "SH_TYPE_INT"
+                                }
                             },
                             "share": {}
                         },
@@ -76,7 +84,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_DOUBLE",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "real(C_DOUBLE)",
+                                    "i_kind": "C_DOUBLE",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "real(C_DOUBLE)",
+                                    "sh_type": "SH_TYPE_DOUBLE"
+                                }
                             },
                             "share": {}
                         },
@@ -146,7 +162,13 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_type": "character(len=*)",
+                                    "i_kind": "C_CHAR",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "character(kind=C_CHAR)",
+                                    "sh_type": "SH_TYPE_OTHER"
+                                }
                             },
                             "share": {}
                         },
@@ -185,7 +207,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_DOUBLE",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "real(C_DOUBLE)",
+                                    "i_kind": "C_DOUBLE",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "real(C_DOUBLE)",
+                                    "sh_type": "SH_TYPE_DOUBLE"
+                                }
                             },
                             "share": {}
                         },
@@ -252,7 +282,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_INT",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "integer(C_INT)",
+                                    "i_kind": "C_INT",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "integer(C_INT)",
+                                    "sh_type": "SH_TYPE_INT"
+                                }
                             },
                             "share": {}
                         },
@@ -293,7 +331,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_INT",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "integer(C_INT)",
+                                    "i_kind": "C_INT",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "integer(C_INT)",
+                                    "sh_type": "SH_TYPE_INT"
+                                }
                             },
                             "share": {
                                 "meta": {
@@ -349,7 +395,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_DOUBLE",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "real(C_DOUBLE)",
+                                    "i_kind": "C_DOUBLE",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "real(C_DOUBLE)",
+                                    "sh_type": "SH_TYPE_DOUBLE"
+                                }
                             },
                             "share": {
                                 "meta": {
@@ -408,7 +462,13 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_type": "character(len=*)",
+                                    "i_kind": "C_CHAR",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "character(kind=C_CHAR)",
+                                    "sh_type": "SH_TYPE_OTHER"
+                                }
                             },
                             "share": {
                                 "meta": {
@@ -485,7 +545,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_INT",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "integer(C_INT)",
+                                    "i_kind": "C_INT",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "integer(C_INT)",
+                                    "sh_type": "SH_TYPE_INT"
+                                }
                             },
                             "share": {}
                         },
@@ -526,7 +594,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_INT",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "integer(C_INT)",
+                                    "i_kind": "C_INT",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "integer(C_INT)",
+                                    "sh_type": "SH_TYPE_INT"
+                                }
                             },
                             "share": {
                                 "meta": {
@@ -576,7 +652,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_DOUBLE",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "real(C_DOUBLE)",
+                                    "i_kind": "C_DOUBLE",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "real(C_DOUBLE)",
+                                    "sh_type": "SH_TYPE_DOUBLE"
+                                }
                             },
                             "share": {
                                 "meta": {
@@ -657,7 +741,13 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_type": "character(len=*)",
+                                    "i_kind": "C_CHAR",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "character(kind=C_CHAR)",
+                                    "sh_type": "SH_TYPE_OTHER"
+                                }
                             },
                             "share": {}
                         },
@@ -695,7 +785,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_INT",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "integer(C_INT)",
+                                    "i_kind": "C_INT",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "integer(C_INT)",
+                                    "sh_type": "SH_TYPE_INT"
+                                }
                             },
                             "share": {}
                         },
@@ -2218,7 +2316,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_INT",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "integer(C_INT)",
+                                    "i_kind": "C_INT",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "integer(C_INT)",
+                                    "sh_type": "SH_TYPE_INT"
+                                }
                             },
                             "share": {}
                         },

--- a/regression/reference/struct-cxx/struct.json
+++ b/regression/reference/struct-cxx/struct.json
@@ -702,6 +702,7 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
+                                    "i_dimension": "(20)",
                                     "i_kind": "C_CHAR",
                                     "i_module_name": "iso_c_binding",
                                     "i_type": "character(kind=C_CHAR)"
@@ -744,6 +745,7 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
+                                    "i_dimension": "(10)",
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
                                     "i_type": "integer(C_INT)"

--- a/regression/reference/struct-cxx/struct.json
+++ b/regression/reference/struct-cxx/struct.json
@@ -42,6 +42,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {}
                         },
                         "zz_fmtdict": {
@@ -72,6 +75,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {}
                         },
                         "zz_fmtdict": {
@@ -139,6 +145,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {}
                         },
                         "zz_fmtdict": {
@@ -175,6 +184,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {}
                         },
                         "zz_fmtdict": {
@@ -239,6 +251,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {}
                         },
                         "zz_fmtdict": {
@@ -277,6 +292,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {
                                 "meta": {
                                     "dim_ast": [
@@ -330,6 +348,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {
                                 "meta": {
                                     "dim_ast": [
@@ -386,6 +407,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {
                                 "meta": {
                                     "dim_ast": [
@@ -460,6 +484,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {}
                         },
                         "zz_fmtdict": {
@@ -498,6 +525,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {
                                 "meta": {
                                     "dim_ast": [
@@ -545,6 +575,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {
                                 "meta": {
                                     "dim_ast": [
@@ -623,6 +656,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {}
                         },
                         "zz_fmtdict": {
@@ -658,6 +694,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {}
                         },
                         "zz_fmtdict": {
@@ -2178,6 +2217,9 @@
                             "fortran": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {}
                         },
                         "zz_fmtdict": {

--- a/regression/reference/struct-cxx/struct.json
+++ b/regression/reference/struct-cxx/struct.json
@@ -46,7 +46,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)"
+                                    "i_type": "integer(C_INT)",
+                                    "i_var": "ifield"
                                 }
                             },
                             "share": {}
@@ -83,7 +84,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_DOUBLE",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "real(C_DOUBLE)"
+                                    "i_type": "real(C_DOUBLE)",
+                                    "i_var": "dfield"
                                 }
                             },
                             "share": {}
@@ -157,7 +159,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "type(C_PTR)"
+                                    "i_type": "type(C_PTR)",
+                                    "i_var": "cfield"
                                 }
                             },
                             "share": {}
@@ -200,7 +203,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "type(C_PTR)"
+                                    "i_type": "type(C_PTR)",
+                                    "i_var": "const_dvalue"
                                 }
                             },
                             "share": {}
@@ -271,7 +275,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)"
+                                    "i_type": "integer(C_INT)",
+                                    "i_var": "nitems"
                                 }
                             },
                             "share": {}
@@ -316,7 +321,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "type(C_PTR)"
+                                    "i_type": "type(C_PTR)",
+                                    "i_var": "ivalue"
                                 }
                             },
                             "share": {
@@ -376,7 +382,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "type(C_PTR)"
+                                    "i_type": "type(C_PTR)",
+                                    "i_var": "dvalue"
                                 }
                             },
                             "share": {
@@ -439,7 +446,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "type(C_PTR)"
+                                    "i_type": "type(C_PTR)",
+                                    "i_var": "svalue"
                                 }
                             },
                             "share": {
@@ -520,7 +528,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)"
+                                    "i_type": "integer(C_INT)",
+                                    "i_var": "nitems"
                                 }
                             },
                             "share": {}
@@ -565,7 +574,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "type(C_PTR)"
+                                    "i_type": "type(C_PTR)",
+                                    "i_var": "ivalue"
                                 }
                             },
                             "share": {
@@ -619,7 +629,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_PTR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "type(C_PTR)"
+                                    "i_type": "type(C_PTR)",
+                                    "i_var": "dvalue"
                                 }
                             },
                             "share": {
@@ -705,7 +716,8 @@
                                     "i_dimension": "(20)",
                                     "i_kind": "C_CHAR",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "character(kind=C_CHAR)"
+                                    "i_type": "character(kind=C_CHAR)",
+                                    "i_var": "name"
                                 }
                             },
                             "share": {}
@@ -748,7 +760,8 @@
                                     "i_dimension": "(10)",
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)"
+                                    "i_type": "integer(C_INT)",
+                                    "i_var": "count"
                                 }
                             },
                             "share": {}
@@ -2275,7 +2288,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)"
+                                    "i_type": "integer(C_INT)",
+                                    "i_var": "sublevels"
                                 }
                             },
                             "share": {}

--- a/regression/reference/struct-cxx/struct.json
+++ b/regression/reference/struct-cxx/struct.json
@@ -56,9 +56,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "ifield",
-                            "variable_lower": "ifield",
-                            "variable_name": "ifield",
-                            "variable_upper": "IFIELD"
+                            "variable_name": "ifield"
                         }
                     },
                     {
@@ -94,9 +92,7 @@
                             "c_type": "double",
                             "cxx_type": "double",
                             "field_name": "dfield",
-                            "variable_lower": "dfield",
-                            "variable_name": "dfield",
-                            "variable_upper": "DFIELD"
+                            "variable_name": "dfield"
                         }
                     }
                 ],
@@ -169,9 +165,7 @@
                             "c_type": "char",
                             "cxx_type": "char",
                             "field_name": "cfield",
-                            "variable_lower": "cfield",
-                            "variable_name": "cfield",
-                            "variable_upper": "CFIELD"
+                            "variable_name": "cfield"
                         }
                     },
                     {
@@ -213,9 +207,7 @@
                             "c_type": "double",
                             "cxx_type": "double",
                             "field_name": "const_dvalue",
-                            "variable_lower": "const_dvalue",
-                            "variable_name": "const_dvalue",
-                            "variable_upper": "CONST_DVALUE"
+                            "variable_name": "const_dvalue"
                         }
                     }
                 ],
@@ -285,9 +277,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "nitems",
-                            "variable_lower": "nitems",
-                            "variable_name": "nitems",
-                            "variable_upper": "NITEMS"
+                            "variable_name": "nitems"
                         }
                     },
                     {
@@ -346,9 +336,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "ivalue",
-                            "variable_lower": "ivalue",
-                            "variable_name": "ivalue",
-                            "variable_upper": "IVALUE"
+                            "variable_name": "ivalue"
                         }
                     },
                     {
@@ -407,9 +395,7 @@
                             "c_type": "double",
                             "cxx_type": "double",
                             "field_name": "dvalue",
-                            "variable_lower": "dvalue",
-                            "variable_name": "dvalue",
-                            "variable_upper": "DVALUE"
+                            "variable_name": "dvalue"
                         }
                     },
                     {
@@ -465,9 +451,7 @@
                             "c_type": "char",
                             "cxx_type": "char",
                             "field_name": "svalue",
-                            "variable_lower": "svalue",
-                            "variable_name": "svalue",
-                            "variable_upper": "SVALUE"
+                            "variable_name": "svalue"
                         }
                     }
                 ],
@@ -538,9 +522,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "nitems",
-                            "variable_lower": "nitems",
-                            "variable_name": "nitems",
-                            "variable_upper": "NITEMS"
+                            "variable_name": "nitems"
                         }
                     },
                     {
@@ -593,9 +575,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "ivalue",
-                            "variable_lower": "ivalue",
-                            "variable_name": "ivalue",
-                            "variable_upper": "IVALUE"
+                            "variable_name": "ivalue"
                         }
                     },
                     {
@@ -648,9 +628,7 @@
                             "c_type": "double",
                             "cxx_type": "double",
                             "field_name": "dvalue",
-                            "variable_lower": "dvalue",
-                            "variable_name": "dvalue",
-                            "variable_upper": "DVALUE"
+                            "variable_name": "dvalue"
                         }
                     }
                 ],
@@ -726,9 +704,7 @@
                             "c_type": "char",
                             "cxx_type": "char",
                             "field_name": "name",
-                            "variable_lower": "name",
-                            "variable_name": "name",
-                            "variable_upper": "NAME"
+                            "variable_name": "name"
                         }
                     },
                     {
@@ -770,9 +746,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "count",
-                            "variable_lower": "count",
-                            "variable_name": "count",
-                            "variable_upper": "COUNT"
+                            "variable_name": "count"
                         }
                     }
                 ],
@@ -1326,9 +1300,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "x1",
-                            "variable_lower": "x1",
-                            "variable_name": "x1",
-                            "variable_upper": "X1"
+                            "variable_name": "x1"
                         }
                     },
                     {
@@ -1356,9 +1328,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "y1",
-                            "variable_lower": "y1",
-                            "variable_name": "y1",
-                            "variable_upper": "Y1"
+                            "variable_name": "y1"
                         }
                     }
                 ],
@@ -2161,9 +2131,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "x1",
-                            "variable_lower": "x1",
-                            "variable_name": "x1",
-                            "variable_upper": "X1"
+                            "variable_name": "x1"
                         }
                     },
                     {
@@ -2191,9 +2159,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "y1",
-                            "variable_lower": "y1",
-                            "variable_name": "y1",
-                            "variable_upper": "Y1"
+                            "variable_name": "y1"
                         }
                     },
                     {
@@ -2221,9 +2187,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "z1",
-                            "variable_lower": "z1",
-                            "variable_name": "z1",
-                            "variable_upper": "Z1"
+                            "variable_name": "z1"
                         }
                     }
                 ],
@@ -2298,9 +2262,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "sublevels",
-                            "variable_lower": "sublevels",
-                            "variable_name": "sublevels",
-                            "variable_upper": "SUBLEVELS"
+                            "variable_name": "sublevels"
                         }
                     }
                 ],

--- a/regression/reference/struct-list-cxx/struct.json
+++ b/regression/reference/struct-list-cxx/struct.json
@@ -47,9 +47,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "ifield",
-                            "variable_lower": "ifield",
-                            "variable_name": "ifield",
-                            "variable_upper": "IFIELD"
+                            "variable_name": "ifield"
                         }
                     },
                     {
@@ -76,9 +74,7 @@
                             "c_type": "double",
                             "cxx_type": "double",
                             "field_name": "dfield",
-                            "variable_lower": "dfield",
-                            "variable_name": "dfield",
-                            "variable_upper": "DFIELD"
+                            "variable_name": "dfield"
                         }
                     }
                 ],
@@ -146,9 +142,7 @@
                             "c_type": "char",
                             "cxx_type": "char",
                             "field_name": "cfield",
-                            "variable_lower": "cfield",
-                            "variable_name": "cfield",
-                            "variable_upper": "CFIELD"
+                            "variable_name": "cfield"
                         }
                     },
                     {
@@ -181,9 +175,7 @@
                             "c_type": "double",
                             "cxx_type": "double",
                             "field_name": "const_dvalue",
-                            "variable_lower": "const_dvalue",
-                            "variable_name": "const_dvalue",
-                            "variable_upper": "CONST_DVALUE"
+                            "variable_name": "const_dvalue"
                         }
                     }
                 ],
@@ -248,9 +240,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "nitems",
-                            "variable_lower": "nitems",
-                            "variable_name": "nitems",
-                            "variable_upper": "NITEMS"
+                            "variable_name": "nitems"
                         }
                     },
                     {
@@ -300,9 +290,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "ivalue",
-                            "variable_lower": "ivalue",
-                            "variable_name": "ivalue",
-                            "variable_upper": "IVALUE"
+                            "variable_name": "ivalue"
                         }
                     },
                     {
@@ -352,9 +340,7 @@
                             "c_type": "double",
                             "cxx_type": "double",
                             "field_name": "dvalue",
-                            "variable_lower": "dvalue",
-                            "variable_name": "dvalue",
-                            "variable_upper": "DVALUE"
+                            "variable_name": "dvalue"
                         }
                     },
                     {
@@ -401,9 +387,7 @@
                             "c_type": "char",
                             "cxx_type": "char",
                             "field_name": "svalue",
-                            "variable_lower": "svalue",
-                            "variable_name": "svalue",
-                            "variable_upper": "SVALUE"
+                            "variable_name": "svalue"
                         }
                     }
                 ],
@@ -469,9 +453,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "nitems",
-                            "variable_lower": "nitems",
-                            "variable_name": "nitems",
-                            "variable_upper": "NITEMS"
+                            "variable_name": "nitems"
                         }
                     },
                     {
@@ -515,9 +497,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "ivalue",
-                            "variable_lower": "ivalue",
-                            "variable_name": "ivalue",
-                            "variable_upper": "IVALUE"
+                            "variable_name": "ivalue"
                         }
                     },
                     {
@@ -561,9 +541,7 @@
                             "c_type": "double",
                             "cxx_type": "double",
                             "field_name": "dvalue",
-                            "variable_lower": "dvalue",
-                            "variable_name": "dvalue",
-                            "variable_upper": "DVALUE"
+                            "variable_name": "dvalue"
                         }
                     }
                 ],
@@ -633,9 +611,7 @@
                             "c_type": "char",
                             "cxx_type": "char",
                             "field_name": "name",
-                            "variable_lower": "name",
-                            "variable_name": "name",
-                            "variable_upper": "NAME"
+                            "variable_name": "name"
                         }
                     },
                     {
@@ -667,9 +643,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "count",
-                            "variable_lower": "count",
-                            "variable_name": "count",
-                            "variable_upper": "COUNT"
+                            "variable_name": "count"
                         }
                     }
                 ],
@@ -734,9 +708,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "x1",
-                            "variable_lower": "x1",
-                            "variable_name": "x1",
-                            "variable_upper": "X1"
+                            "variable_name": "x1"
                         }
                     },
                     {
@@ -761,9 +733,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "y1",
-                            "variable_lower": "y1",
-                            "variable_name": "y1",
-                            "variable_upper": "Y1"
+                            "variable_name": "y1"
                         }
                     }
                 ],
@@ -823,9 +793,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "x1",
-                            "variable_lower": "x1",
-                            "variable_name": "x1",
-                            "variable_upper": "X1"
+                            "variable_name": "x1"
                         }
                     },
                     {
@@ -850,9 +818,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "y1",
-                            "variable_lower": "y1",
-                            "variable_name": "y1",
-                            "variable_upper": "Y1"
+                            "variable_name": "y1"
                         }
                     },
                     {
@@ -877,9 +843,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "z1",
-                            "variable_lower": "z1",
-                            "variable_name": "z1",
-                            "variable_upper": "Z1"
+                            "variable_name": "z1"
                         }
                     }
                 ],
@@ -936,9 +900,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "sublevels",
-                            "variable_lower": "sublevels",
-                            "variable_name": "sublevels",
-                            "variable_upper": "SUBLEVELS"
+                            "variable_name": "sublevels"
                         }
                     }
                 ],

--- a/regression/reference/struct-numpy-c/struct.json
+++ b/regression/reference/struct-numpy-c/struct.json
@@ -47,9 +47,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "ifield",
-                            "variable_lower": "ifield",
-                            "variable_name": "ifield",
-                            "variable_upper": "IFIELD"
+                            "variable_name": "ifield"
                         }
                     },
                     {
@@ -76,9 +74,7 @@
                             "c_type": "double",
                             "cxx_type": "double",
                             "field_name": "dfield",
-                            "variable_lower": "dfield",
-                            "variable_name": "dfield",
-                            "variable_upper": "DFIELD"
+                            "variable_name": "dfield"
                         }
                     }
                 ],
@@ -146,9 +142,7 @@
                             "c_type": "char",
                             "cxx_type": "char",
                             "field_name": "cfield",
-                            "variable_lower": "cfield",
-                            "variable_name": "cfield",
-                            "variable_upper": "CFIELD"
+                            "variable_name": "cfield"
                         }
                     },
                     {
@@ -181,9 +175,7 @@
                             "c_type": "double",
                             "cxx_type": "double",
                             "field_name": "const_dvalue",
-                            "variable_lower": "const_dvalue",
-                            "variable_name": "const_dvalue",
-                            "variable_upper": "CONST_DVALUE"
+                            "variable_name": "const_dvalue"
                         }
                     }
                 ],
@@ -248,9 +240,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "nitems",
-                            "variable_lower": "nitems",
-                            "variable_name": "nitems",
-                            "variable_upper": "NITEMS"
+                            "variable_name": "nitems"
                         }
                     },
                     {
@@ -300,9 +290,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "ivalue",
-                            "variable_lower": "ivalue",
-                            "variable_name": "ivalue",
-                            "variable_upper": "IVALUE"
+                            "variable_name": "ivalue"
                         }
                     },
                     {
@@ -352,9 +340,7 @@
                             "c_type": "double",
                             "cxx_type": "double",
                             "field_name": "dvalue",
-                            "variable_lower": "dvalue",
-                            "variable_name": "dvalue",
-                            "variable_upper": "DVALUE"
+                            "variable_name": "dvalue"
                         }
                     },
                     {
@@ -401,9 +387,7 @@
                             "c_type": "char",
                             "cxx_type": "char",
                             "field_name": "svalue",
-                            "variable_lower": "svalue",
-                            "variable_name": "svalue",
-                            "variable_upper": "SVALUE"
+                            "variable_name": "svalue"
                         }
                     }
                 ],
@@ -469,9 +453,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "nitems",
-                            "variable_lower": "nitems",
-                            "variable_name": "nitems",
-                            "variable_upper": "NITEMS"
+                            "variable_name": "nitems"
                         }
                     },
                     {
@@ -515,9 +497,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "ivalue",
-                            "variable_lower": "ivalue",
-                            "variable_name": "ivalue",
-                            "variable_upper": "IVALUE"
+                            "variable_name": "ivalue"
                         }
                     },
                     {
@@ -561,9 +541,7 @@
                             "c_type": "double",
                             "cxx_type": "double",
                             "field_name": "dvalue",
-                            "variable_lower": "dvalue",
-                            "variable_name": "dvalue",
-                            "variable_upper": "DVALUE"
+                            "variable_name": "dvalue"
                         }
                     }
                 ],
@@ -633,9 +611,7 @@
                             "c_type": "char",
                             "cxx_type": "char",
                             "field_name": "name",
-                            "variable_lower": "name",
-                            "variable_name": "name",
-                            "variable_upper": "NAME"
+                            "variable_name": "name"
                         }
                     },
                     {
@@ -667,9 +643,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "count",
-                            "variable_lower": "count",
-                            "variable_name": "count",
-                            "variable_upper": "COUNT"
+                            "variable_name": "count"
                         }
                     }
                 ],
@@ -734,9 +708,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "x1",
-                            "variable_lower": "x1",
-                            "variable_name": "x1",
-                            "variable_upper": "X1"
+                            "variable_name": "x1"
                         }
                     },
                     {
@@ -761,9 +733,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "y1",
-                            "variable_lower": "y1",
-                            "variable_name": "y1",
-                            "variable_upper": "Y1"
+                            "variable_name": "y1"
                         }
                     }
                 ],
@@ -823,9 +793,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "x1",
-                            "variable_lower": "x1",
-                            "variable_name": "x1",
-                            "variable_upper": "X1"
+                            "variable_name": "x1"
                         }
                     },
                     {
@@ -850,9 +818,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "y1",
-                            "variable_lower": "y1",
-                            "variable_name": "y1",
-                            "variable_upper": "Y1"
+                            "variable_name": "y1"
                         }
                     },
                     {
@@ -877,9 +843,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "z1",
-                            "variable_lower": "z1",
-                            "variable_name": "z1",
-                            "variable_upper": "Z1"
+                            "variable_name": "z1"
                         }
                     }
                 ],
@@ -936,9 +900,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "sublevels",
-                            "variable_lower": "sublevels",
-                            "variable_name": "sublevels",
-                            "variable_upper": "SUBLEVELS"
+                            "variable_name": "sublevels"
                         }
                     }
                 ],

--- a/regression/reference/struct-numpy-cxx/struct.json
+++ b/regression/reference/struct-numpy-cxx/struct.json
@@ -47,9 +47,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "ifield",
-                            "variable_lower": "ifield",
-                            "variable_name": "ifield",
-                            "variable_upper": "IFIELD"
+                            "variable_name": "ifield"
                         }
                     },
                     {
@@ -76,9 +74,7 @@
                             "c_type": "double",
                             "cxx_type": "double",
                             "field_name": "dfield",
-                            "variable_lower": "dfield",
-                            "variable_name": "dfield",
-                            "variable_upper": "DFIELD"
+                            "variable_name": "dfield"
                         }
                     }
                 ],
@@ -146,9 +142,7 @@
                             "c_type": "char",
                             "cxx_type": "char",
                             "field_name": "cfield",
-                            "variable_lower": "cfield",
-                            "variable_name": "cfield",
-                            "variable_upper": "CFIELD"
+                            "variable_name": "cfield"
                         }
                     },
                     {
@@ -181,9 +175,7 @@
                             "c_type": "double",
                             "cxx_type": "double",
                             "field_name": "const_dvalue",
-                            "variable_lower": "const_dvalue",
-                            "variable_name": "const_dvalue",
-                            "variable_upper": "CONST_DVALUE"
+                            "variable_name": "const_dvalue"
                         }
                     }
                 ],
@@ -248,9 +240,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "nitems",
-                            "variable_lower": "nitems",
-                            "variable_name": "nitems",
-                            "variable_upper": "NITEMS"
+                            "variable_name": "nitems"
                         }
                     },
                     {
@@ -300,9 +290,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "ivalue",
-                            "variable_lower": "ivalue",
-                            "variable_name": "ivalue",
-                            "variable_upper": "IVALUE"
+                            "variable_name": "ivalue"
                         }
                     },
                     {
@@ -352,9 +340,7 @@
                             "c_type": "double",
                             "cxx_type": "double",
                             "field_name": "dvalue",
-                            "variable_lower": "dvalue",
-                            "variable_name": "dvalue",
-                            "variable_upper": "DVALUE"
+                            "variable_name": "dvalue"
                         }
                     },
                     {
@@ -401,9 +387,7 @@
                             "c_type": "char",
                             "cxx_type": "char",
                             "field_name": "svalue",
-                            "variable_lower": "svalue",
-                            "variable_name": "svalue",
-                            "variable_upper": "SVALUE"
+                            "variable_name": "svalue"
                         }
                     }
                 ],
@@ -469,9 +453,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "nitems",
-                            "variable_lower": "nitems",
-                            "variable_name": "nitems",
-                            "variable_upper": "NITEMS"
+                            "variable_name": "nitems"
                         }
                     },
                     {
@@ -515,9 +497,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "ivalue",
-                            "variable_lower": "ivalue",
-                            "variable_name": "ivalue",
-                            "variable_upper": "IVALUE"
+                            "variable_name": "ivalue"
                         }
                     },
                     {
@@ -561,9 +541,7 @@
                             "c_type": "double",
                             "cxx_type": "double",
                             "field_name": "dvalue",
-                            "variable_lower": "dvalue",
-                            "variable_name": "dvalue",
-                            "variable_upper": "DVALUE"
+                            "variable_name": "dvalue"
                         }
                     }
                 ],
@@ -633,9 +611,7 @@
                             "c_type": "char",
                             "cxx_type": "char",
                             "field_name": "name",
-                            "variable_lower": "name",
-                            "variable_name": "name",
-                            "variable_upper": "NAME"
+                            "variable_name": "name"
                         }
                     },
                     {
@@ -667,9 +643,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "count",
-                            "variable_lower": "count",
-                            "variable_name": "count",
-                            "variable_upper": "COUNT"
+                            "variable_name": "count"
                         }
                     }
                 ],
@@ -734,9 +708,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "x1",
-                            "variable_lower": "x1",
-                            "variable_name": "x1",
-                            "variable_upper": "X1"
+                            "variable_name": "x1"
                         }
                     },
                     {
@@ -761,9 +733,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "y1",
-                            "variable_lower": "y1",
-                            "variable_name": "y1",
-                            "variable_upper": "Y1"
+                            "variable_name": "y1"
                         }
                     }
                 ],
@@ -823,9 +793,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "x1",
-                            "variable_lower": "x1",
-                            "variable_name": "x1",
-                            "variable_upper": "X1"
+                            "variable_name": "x1"
                         }
                     },
                     {
@@ -850,9 +818,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "y1",
-                            "variable_lower": "y1",
-                            "variable_name": "y1",
-                            "variable_upper": "Y1"
+                            "variable_name": "y1"
                         }
                     },
                     {
@@ -877,9 +843,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "z1",
-                            "variable_lower": "z1",
-                            "variable_name": "z1",
-                            "variable_upper": "Z1"
+                            "variable_name": "z1"
                         }
                     }
                 ],
@@ -936,9 +900,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "sublevels",
-                            "variable_lower": "sublevels",
-                            "variable_name": "sublevels",
-                            "variable_upper": "SUBLEVELS"
+                            "variable_name": "sublevels"
                         }
                     }
                 ],

--- a/regression/reference/struct-py-c/struct-py.json
+++ b/regression/reference/struct-py-c/struct-py.json
@@ -228,9 +228,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "x1",
-                            "variable_lower": "x1",
-                            "variable_name": "x1",
-                            "variable_upper": "X1"
+                            "variable_name": "x1"
                         }
                     },
                     {
@@ -260,9 +258,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "y1",
-                            "variable_lower": "y1",
-                            "variable_name": "y1",
-                            "variable_upper": "Y1"
+                            "variable_name": "y1"
                         }
                     }
                 ],
@@ -330,9 +326,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "x2",
-                            "variable_lower": "x2",
-                            "variable_name": "x2",
-                            "variable_upper": "X2"
+                            "variable_name": "x2"
                         }
                     },
                     {
@@ -359,9 +353,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "y2",
-                            "variable_lower": "y2",
-                            "variable_name": "y2",
-                            "variable_upper": "Y2"
+                            "variable_name": "y2"
                         }
                     }
                 ],

--- a/regression/reference/struct-py-cxx/struct-py.json
+++ b/regression/reference/struct-py-cxx/struct-py.json
@@ -228,9 +228,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "x1",
-                            "variable_lower": "x1",
-                            "variable_name": "x1",
-                            "variable_upper": "X1"
+                            "variable_name": "x1"
                         }
                     },
                     {
@@ -260,9 +258,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "y1",
-                            "variable_lower": "y1",
-                            "variable_name": "y1",
-                            "variable_upper": "Y1"
+                            "variable_name": "y1"
                         }
                     }
                 ],
@@ -330,9 +326,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "x2",
-                            "variable_lower": "x2",
-                            "variable_name": "x2",
-                            "variable_upper": "X2"
+                            "variable_name": "x2"
                         }
                     },
                     {
@@ -359,9 +353,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "y2",
-                            "variable_lower": "y2",
-                            "variable_name": "y2",
-                            "variable_upper": "Y2"
+                            "variable_name": "y2"
                         }
                     }
                 ],

--- a/regression/reference/structlist/structlist.json
+++ b/regression/reference/structlist/structlist.json
@@ -252,9 +252,7 @@
                             "cxx_type": "char",
                             "field_name": "name",
                             "py_var": "SHPy_name",
-                            "variable_lower": "name",
-                            "variable_name": "name",
-                            "variable_upper": "NAME"
+                            "variable_name": "name"
                         }
                     },
                     {
@@ -292,9 +290,7 @@
                             "cxx_type": "int",
                             "field_name": "count",
                             "py_var": "SHPy_count",
-                            "variable_lower": "count",
-                            "variable_name": "count",
-                            "variable_upper": "COUNT"
+                            "variable_name": "count"
                         }
                     }
                 ],

--- a/regression/reference/tutorial/tutorial.json
+++ b/regression/reference/tutorial/tutorial.json
@@ -8907,9 +8907,7 @@
                     "c_type": "int",
                     "cxx_type": "int",
                     "field_name": "global_flag",
-                    "variable_lower": "global_flag",
-                    "variable_name": "global_flag",
-                    "variable_upper": "GLOBAL_FLAG"
+                    "variable_name": "global_flag"
                 }
             },
             {
@@ -8939,9 +8937,7 @@
                     "c_type": "int",
                     "cxx_type": "int",
                     "field_name": "tutorial_flag",
-                    "variable_lower": "tutorial_flag",
-                    "variable_name": "tutorial_flag",
-                    "variable_upper": "TUTORIAL_FLAG"
+                    "variable_name": "tutorial_flag"
                 }
             }
         ],

--- a/regression/reference/typedefs-c/typedefs.json
+++ b/regression/reference/typedefs-c/typedefs.json
@@ -35,13 +35,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_INT",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "integer(C_INT)",
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)",
-                                    "sh_type": "SH_TYPE_INT"
+                                    "i_type": "integer(C_INT)"
                                 }
                             },
                             "share": {}
@@ -76,13 +72,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_DOUBLE",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "real(C_DOUBLE)",
                                     "i_kind": "C_DOUBLE",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "real(C_DOUBLE)",
-                                    "sh_type": "SH_TYPE_DOUBLE"
+                                    "i_type": "real(C_DOUBLE)"
                                 }
                             },
                             "share": {}

--- a/regression/reference/typedefs-c/typedefs.json
+++ b/regression/reference/typedefs-c/typedefs.json
@@ -34,7 +34,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_INT",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "integer(C_INT)",
+                                    "i_kind": "C_INT",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "integer(C_INT)",
+                                    "sh_type": "SH_TYPE_INT"
+                                }
                             },
                             "share": {}
                         },
@@ -67,7 +75,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_DOUBLE",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "real(C_DOUBLE)",
+                                    "i_kind": "C_DOUBLE",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "real(C_DOUBLE)",
+                                    "sh_type": "SH_TYPE_DOUBLE"
+                                }
                             },
                             "share": {}
                         },

--- a/regression/reference/typedefs-c/typedefs.json
+++ b/regression/reference/typedefs-c/typedefs.json
@@ -47,9 +47,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "i",
-                            "variable_lower": "i",
-                            "variable_name": "i",
-                            "variable_upper": "I"
+                            "variable_name": "i"
                         }
                     },
                     {
@@ -85,9 +83,7 @@
                             "c_type": "double",
                             "cxx_type": "double",
                             "field_name": "d",
-                            "variable_lower": "d",
-                            "variable_name": "d",
-                            "variable_upper": "D"
+                            "variable_name": "d"
                         }
                     }
                 ],

--- a/regression/reference/typedefs-c/typedefs.json
+++ b/regression/reference/typedefs-c/typedefs.json
@@ -33,6 +33,9 @@
                             "python": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {}
                         },
                         "zz_fmtdict": {
@@ -63,6 +66,9 @@
                             "python": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {}
                         },
                         "zz_fmtdict": {

--- a/regression/reference/typedefs-c/typedefs.json
+++ b/regression/reference/typedefs-c/typedefs.json
@@ -37,7 +37,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)"
+                                    "i_type": "integer(C_INT)",
+                                    "i_var": "i"
                                 }
                             },
                             "share": {}
@@ -74,7 +75,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_DOUBLE",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "real(C_DOUBLE)"
+                                    "i_type": "real(C_DOUBLE)",
+                                    "i_var": "d"
                                 }
                             },
                             "share": {}

--- a/regression/reference/typedefs-cxx/typedefs.json
+++ b/regression/reference/typedefs-cxx/typedefs.json
@@ -36,13 +36,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_INT",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "integer(C_INT)",
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)",
-                                    "sh_type": "SH_TYPE_INT"
+                                    "i_type": "integer(C_INT)"
                                 }
                             },
                             "share": {}
@@ -78,13 +74,9 @@
                         "zz_bind": {
                             "f": {
                                 "fmtdict": {
-                                    "f_kind": "C_DOUBLE",
-                                    "f_module_name": "iso_c_binding",
-                                    "f_type": "real(C_DOUBLE)",
                                     "i_kind": "C_DOUBLE",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "real(C_DOUBLE)",
-                                    "sh_type": "SH_TYPE_DOUBLE"
+                                    "i_type": "real(C_DOUBLE)"
                                 }
                             },
                             "share": {}

--- a/regression/reference/typedefs-cxx/typedefs.json
+++ b/regression/reference/typedefs-cxx/typedefs.json
@@ -34,6 +34,9 @@
                             "python": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {}
                         },
                         "zz_fmtdict": {
@@ -65,6 +68,9 @@
                             "python": true
                         },
                         "zz_bind": {
+                            "f": {
+                                "fmtdict": {}
+                            },
                             "share": {}
                         },
                         "zz_fmtdict": {

--- a/regression/reference/typedefs-cxx/typedefs.json
+++ b/regression/reference/typedefs-cxx/typedefs.json
@@ -48,9 +48,7 @@
                             "c_type": "int",
                             "cxx_type": "int",
                             "field_name": "i",
-                            "variable_lower": "i",
-                            "variable_name": "i",
-                            "variable_upper": "I"
+                            "variable_name": "i"
                         }
                     },
                     {
@@ -87,9 +85,7 @@
                             "c_type": "double",
                             "cxx_type": "double",
                             "field_name": "d",
-                            "variable_lower": "d",
-                            "variable_name": "d",
-                            "variable_upper": "D"
+                            "variable_name": "d"
                         }
                     }
                 ],

--- a/regression/reference/typedefs-cxx/typedefs.json
+++ b/regression/reference/typedefs-cxx/typedefs.json
@@ -38,7 +38,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_INT",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "integer(C_INT)"
+                                    "i_type": "integer(C_INT)",
+                                    "i_var": "i"
                                 }
                             },
                             "share": {}
@@ -76,7 +77,8 @@
                                 "fmtdict": {
                                     "i_kind": "C_DOUBLE",
                                     "i_module_name": "iso_c_binding",
-                                    "i_type": "real(C_DOUBLE)"
+                                    "i_type": "real(C_DOUBLE)",
+                                    "i_var": "d"
                                 }
                             },
                             "share": {}

--- a/regression/reference/typedefs-cxx/typedefs.json
+++ b/regression/reference/typedefs-cxx/typedefs.json
@@ -35,7 +35,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_INT",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "integer(C_INT)",
+                                    "i_kind": "C_INT",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "integer(C_INT)",
+                                    "sh_type": "SH_TYPE_INT"
+                                }
                             },
                             "share": {}
                         },
@@ -69,7 +77,15 @@
                         },
                         "zz_bind": {
                             "f": {
-                                "fmtdict": {}
+                                "fmtdict": {
+                                    "f_kind": "C_DOUBLE",
+                                    "f_module_name": "iso_c_binding",
+                                    "f_type": "real(C_DOUBLE)",
+                                    "i_kind": "C_DOUBLE",
+                                    "i_module_name": "iso_c_binding",
+                                    "i_type": "real(C_DOUBLE)",
+                                    "sh_type": "SH_TYPE_DOUBLE"
+                                }
                             },
                             "share": {}
                         },

--- a/shroud/ast.py
+++ b/shroud/ast.py
@@ -2088,8 +2088,6 @@ class VariableNode(AstNode):
         #        fmt_struct.class_scope = self.name + '::'
         fmt_var.field_name = ast.declarator.name
         fmt_var.variable_name = self.name
-        fmt_var.variable_lower = fmt_var.variable_name.lower()
-        fmt_var.variable_upper = fmt_var.variable_name.upper()
 
         ntypemap = ast.typemap
         fmt_var.c_type = ntypemap.c_type

--- a/shroud/fcfmt.py
+++ b/shroud/fcfmt.py
@@ -86,7 +86,6 @@ class FillFormat(object):
             bind = statements.fetch_var_bind(var, "f")
             fmt = statements.set_bind_fmtdict(bind, node.fmtdict)
             set_f_var_format(var, bind)
-#            self.set_fmt_fields_dimension(None, node, var.ast, bind)
 
     def fmt_typedefs(self, node):
         if node.wrap.fortran:
@@ -915,7 +914,6 @@ def set_share_function_format(node, fmt, bind, wlang):
     fmt.gen = FormatGen(node, node.ast, fmt, wlang)
     
 def set_f_function_format(node, bind, subprogram):
-#    subprogram = node.ast.declarator.get_subprogram()
     if subprogram == "function":
         fmt = bind.fmtdict
         fmt.f_intent = "OUT"

--- a/shroud/fcfmt.py
+++ b/shroud/fcfmt.py
@@ -63,6 +63,11 @@ class FillFormat(object):
         cursor.pop_phase("FillFormat typedef")
 
         for cls in node.classes:
+            if cls.wrap_as == "struct":
+                cursor.push_phase("FillFormat class struct")
+                self.wrap_struct(cls)
+                cursor.pop_phase("FillFormat class struct")
+                
             cursor.push_phase("FillFormat class function")
             self.fmt_functions(cls, cls.functions)
             cursor.pop_phase("FillFormat class function")
@@ -73,6 +78,13 @@ class FillFormat(object):
 
         for ns in node.namespaces:
             self.fmt_namespace(ns)
+
+    def wrap_struct(self, node):
+        if not node.wrap.fortran:
+            return
+        for var in node.variables:
+            bind = statements.fetch_var_bind(var, "f")
+            fmt = statements.set_bind_fmtdict(bind, node.fmtdict)
 
     def fmt_typedefs(self, node):
         if node.wrap.fortran:
@@ -94,6 +106,7 @@ class FillFormat(object):
                     # XXX - To be changed to i_module, i_kind
                     fmt.i_module_name = ntypemap.f_module_name
                     fmt.i_kind = ntypemap.f_kind
+
     def fmt_functions(self, cls, functions):
         for node in functions:
             if node.wrap.c:

--- a/shroud/fcfmt.py
+++ b/shroud/fcfmt.py
@@ -982,6 +982,8 @@ def set_f_var_format(var, bind):
     declarator = var.ast.declarator
     ntypemap = declarator.typemap
 
+    fmt.i_var = declarator.name
+
     if declarator.is_indirect():
         fmt.i_type = "type(C_PTR)"
         fmt.i_module_name = "iso_c_binding"

--- a/shroud/fcfmt.py
+++ b/shroud/fcfmt.py
@@ -194,7 +194,7 @@ class FillFormat(object):
                 fmt_arg.i_var = arg_name
 
                 # XXX - fill_interface_arg
-                self.set_fmt_fields_iface(node, arg, bind_arg, arg_name, arg.typemap)
+                self.set_fmt_fields_iface(arg, bind_arg, arg.typemap)
                 self.set_fmt_fields_dimension(None, node, arg, bind_arg)
 
                 
@@ -319,9 +319,7 @@ class FillFormat(object):
         if subprogram == "function":
             fmt_result.i_var = fmt_result.i_result_var
             fmt_result.f_var = fmt_result.i_result_var
-            self.set_fmt_fields_iface(node, ast, bind,
-                                      fmt_result.i_result_var, result_typemap,
-                                      "function")
+            self.set_fmt_fields_iface(ast, bind, result_typemap, "function")
             self.set_fmt_fields_dimension(cls, node, ast, bind)
 
         if result_stmt.i_result_var == "as-subroutine":
@@ -354,7 +352,7 @@ class FillFormat(object):
 
         fmt_arg.i_var = arg_name
         fmt_arg.f_var = arg_name
-        self.set_fmt_fields_iface(node, arg, bind, arg_name, arg_typemap)
+        self.set_fmt_fields_iface(arg, bind, arg_typemap)
         self.set_fmt_fields_dimension(cls, node, arg, bind)
         self.name_temp_vars(arg_name, bind, "c", "i")
         statements.apply_fmtdict_from_stmts(bind)
@@ -536,18 +534,15 @@ class FillFormat(object):
         if meta["len"]:
             fmt.c_char_len = meta["len"]
                 
-    def set_fmt_fields_iface(self, fcn, ast, bind, rootname,
-                             ntypemap, subprogram=None):
+    def set_fmt_fields_iface(self, ast, bind, ntypemap, subprogram=None):
         """Set format fields for interface.
 
         Transfer info from Typemap to fmt for use by statements.
 
         Parameters
         ----------
-        fcn : ast.FunctionNode
         ast : declast.Declaration
         bind : statements.BindArg
-        rootname : str
         ntypemap : typemap.Typemap
             The typemap has already resolved template arguments.
             For example, std::vector<int>.  ntypemap will be 'int'.
@@ -641,8 +636,7 @@ class FillFormat(object):
         if ntypemap.sgroup != "shadow" and c_ast.template_arguments:
             statements.set_template_fields(c_ast, fmt)
         if subprogram != "subroutine":
-            self.set_fmt_fields_iface(fcn, c_ast, bind, rootname,
-                                      ntypemap, subprogram)
+            self.set_fmt_fields_iface(c_ast, bind, ntypemap, subprogram)
             if "pass" in c_attrs:
                 # Used with wrap_struct_as=class for passed-object dummy argument.
                 fmt.f_type = ntypemap.f_class

--- a/shroud/fcfmt.py
+++ b/shroud/fcfmt.py
@@ -999,6 +999,18 @@ def set_f_var_format(var, bind):
             if ntypemap.f_kind:
                 fmt.i_kind = ntypemap.f_kind
 
+        if meta["len"]:
+            fmt.i_type = "character(len={})".format(meta["len"])
+
+        if declarator.array:
+            decl = ["("]
+            # Convert to column-major order.
+            for dim in reversed(declarator.array):
+                decl.append(todict.print_node(dim))
+                decl.append(",")
+            decl[-1] = ")"
+            fmt.i_dimension = "".join(decl)
+
 def compute_c_deref(arg, fmt):
     """Compute format fields to dereference C argument."""
     if arg.declarator.is_indirect(): #pointer():

--- a/shroud/fcfmt.py
+++ b/shroud/fcfmt.py
@@ -85,6 +85,8 @@ class FillFormat(object):
         for var in node.variables:
             bind = statements.fetch_var_bind(var, "f")
             fmt = statements.set_bind_fmtdict(bind, node.fmtdict)
+            self.set_fmt_fields_iface(var, bind, var.ast.typemap)
+#            self.set_fmt_fields_dimension(None, node, arg, bind_arg)
 
     def fmt_typedefs(self, node):
         if node.wrap.fortran:

--- a/shroud/statements.py
+++ b/shroud/statements.py
@@ -100,6 +100,9 @@ def fetch_typedef_bind(node, wlang):
     return bindarg
 
 def fetch_name_bind(bind, wlang, name):
+    """
+    bind - dictionary index by wlang
+    """
     bind = bind.setdefault(wlang, {})
     bindarg = bind.setdefault(name, BindArg())
     if bindarg.meta is None:

--- a/tests/test_declast.py
+++ b/tests/test_declast.py
@@ -56,8 +56,6 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(0, declarator.is_pointer())
         s = gen_decl(r)
         self.assertEqual("int var1", s)
-        s = wrapf.gen_arg_as_fortran(r, local=True)
-        self.assertEqual("integer(C_INT) :: var1", s)
 
         r = declast.check_decl("const int var1", symtab)
         declarator = r.declarator
@@ -103,7 +101,6 @@ class CheckParse(unittest.TestCase):
         self.assertEqual("int *var1 +dimension(:)", s)
         self.assertEqual("int *var1", gen_arg_as_c(r))
         self.assertEqual("int *var1", gen_arg_as_cxx(r))
-        self.assertEqual("integer(C_INT) :: var1(:)", wrapf.gen_arg_as_fortran(r))
 
         r = declast.check_decl("const int * var1", symtab)
         s = gen_decl(r)
@@ -234,9 +231,6 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(
             "int var1[20]",
             gen_arg_as_c(r))
-        self.assertEqual(
-            "integer(C_INT), value :: var1(20)",
-            wrapf.gen_arg_as_fortran(r))
         
         r = declast.check_decl("int var2[20][10]", symtab)
         self.assertEqual("int", str(r))
@@ -260,9 +254,6 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(
             "int var2[20][10]",
             gen_arg_as_c(r))
-        self.assertEqual(
-            "integer(C_INT) :: var2(10,20)",
-            wrapf.gen_arg_as_fortran(r, local=True))
         
         r = declast.check_decl("int var3[DEFINE + 3]", symtab)
         self.assertEqual("var3[DEFINE+3]", str(r.declarator))
@@ -286,9 +277,6 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(
             "int var3[DEFINE+3]",
             gen_arg_as_c(r))
-        self.assertEqual(
-            "integer(C_INT) :: var3(DEFINE+3)",
-            wrapf.gen_arg_as_fortran(r, local=True))
        
     def test_type_string(self):
         """Test string declarations
@@ -306,20 +294,14 @@ class CheckParse(unittest.TestCase):
         self.assertEqual("char *", r.as_cast())
         s = gen_decl(r)
         self.assertEqual("char *var1", s)
-        s = wrapf.gen_arg_as_fortran(r)
-        self.assertEqual("character(len=*) :: var1", s)
 
         r = declast.check_decl("char *var1 +len(30)", symtab)
         s = gen_decl(r)
         self.assertEqual("char *var1 +len(30)", s)
-        s = wrapf.gen_arg_as_fortran(r, local=True)
-        self.assertEqual("character(len=30) :: var1", s)
 
         r = declast.check_decl("char *var1 +deref(allocatable)", symtab)
         s = gen_decl(r)
         self.assertEqual("char *var1 +deref(allocatable)", s)
-        s = wrapf.gen_arg_as_fortran(r)
-        self.assertEqual("character(len=:), allocatable :: var1", s)
 
         r = declast.check_decl("char **var1", symtab)
         declarator = r.declarator
@@ -380,9 +362,6 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(
             "char var1[20]",
             gen_arg_as_c(r))
-        self.assertEqual(
-            "character(kind=C_CHAR) :: var1(20)",
-            wrapf.gen_arg_as_fortran(r))
         
         r = declast.check_decl("char var2[20][10][5]", symtab)
         declarator = r.declarator
@@ -411,9 +390,6 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(
             "char var2[20][10][5]",
             gen_arg_as_c(r))
-        self.assertEqual(
-            "character(kind=C_CHAR) :: var2(5,10,20)",
-            wrapf.gen_arg_as_fortran(r))
         
         r = declast.check_decl("char var3[DEFINE + 3]", symtab)
         declarator = r.declarator
@@ -442,9 +418,6 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(
             "char var3[DEFINE+3]",
             gen_arg_as_c(r))
-        self.assertEqual(
-            "character(kind=C_CHAR) :: var3(DEFINE+3)",
-            wrapf.gen_arg_as_fortran(r))
     
         r = declast.check_decl("char *var4[44]", symtab)
         declarator = r.declarator
@@ -471,9 +444,6 @@ class CheckParse(unittest.TestCase):
         self.assertEqual(
             "char *var4[44]",
             gen_arg_as_c(r))
-        self.assertEqual(  # XXX - fixme
-            "character(kind=C_CHAR) :: var4(44)",
-            wrapf.gen_arg_as_fortran(r))
     
     def test_type_vector(self):
         """Test vector declarations


### PR DESCRIPTION
Remove function `gen_arg_as_fortran`. Instead create a `VariableNode.bind.fmtdict` entry for Fortran and fill in format fields. Then format as ``{i_type} :: {i_var}{i_dimension}``