### PR TITLE
Refactor fc-statements

### DIFF
--- a/docs/cstatements.rst
+++ b/docs/cstatements.rst
@@ -389,5 +389,5 @@ Shroud provides several mixins that provide some common functionality.
 
 .. literalinclude:: ../shroud/fc-statements.json
    :language: json
-   :start-after: "sphinx-start-after": "c_mixin_argument"
-   :end-before: "sphinx-end-before": "c_mixin_argument"
+   :start-after: "sphinx-start-after": "c_mixin_declare-arg"
+   :end-before: "sphinx-end-before": "c_mixin_declare-arg"

--- a/docs/fstatements.rst
+++ b/docs/fstatements.rst
@@ -215,8 +215,12 @@ f_module
 ``USE`` statements to add to Fortran wrapper.
 A dictionary of list of ``ONLY`` names.
 The names will be expanded before being uses for format values can be used.
-If the name is `-f_module_name-`, the values will not be added.
-This is used by types such as ``CHARACTER`` which does not use a kind in the declaration.
+
+If ``typemap.f_module_name` is None, then the default
+``format.f_module_name`` value will be used. No module will be used in
+the wrapper in this case.  For example, ``CHARACTER`` which does not
+use a kind in the declaration since it uses the Fortran native
+character kind.
 
 .. code-block:: yaml
 

--- a/regression/input/sgroup.yaml
+++ b/regression/input/sgroup.yaml
@@ -39,7 +39,7 @@ statements:
     extend:
     - name: f_in_twostruct<native,native>
       mixin:
-      - f_mixin_declare-fortran-arg
+      - c_mixin_declare-arg
       - f_mixin_declare-interface-arg
-      - c_mixin_argument2
+      - f_mixin_declare-fortran-arg
     # Add meaningful fields here

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -9443,7 +9443,7 @@ f_in_native:
   f_arg_name:
   - '{f_var}'
   f_arg_decl:
-  - '{f_type}{f_value_attr}{f_intent_attr}{f_optional_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_module:
     '{f_module_name}':
     - '{f_kind}'
@@ -9487,7 +9487,7 @@ f_in_native*:
   f_arg_name:
   - '{f_var}'
   f_arg_decl:
-  - '{f_type}{f_value_attr}{f_intent_attr}{f_optional_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_module:
     '{f_module_name}':
     - '{f_kind}'
@@ -9512,7 +9512,7 @@ f_in_native**:
   f_arg_name:
   - '{f_var}'
   f_arg_decl:
-  - '{f_type}{f_value_attr}{f_intent_attr}{f_optional_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_module:
     '{f_module_name}':
     - '{f_kind}'
@@ -10517,7 +10517,7 @@ f_in_void:
   f_arg_name:
   - '{f_var}'
   f_arg_decl:
-  - '{f_type}{f_value_attr}{f_intent_attr}{f_optional_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_module:
     '{f_module_name}':
     - '{f_kind}'
@@ -10885,7 +10885,7 @@ f_inout_native*:
   f_arg_name:
   - '{f_var}'
   f_arg_decl:
-  - '{f_type}{f_value_attr}{f_intent_attr}{f_optional_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_module:
     '{f_module_name}':
     - '{f_kind}'
@@ -12524,7 +12524,7 @@ f_none_native:
   f_arg_name:
   - '{f_var}'
   f_arg_decl:
-  - '{f_type}{f_value_attr}{f_intent_attr}{f_optional_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_module:
     '{f_module_name}':
     - '{f_kind}'
@@ -12546,7 +12546,7 @@ f_none_native*:
   f_arg_name:
   - '{f_var}'
   f_arg_decl:
-  - '{f_type}{f_value_attr}{f_intent_attr}{f_optional_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_module:
     '{f_module_name}':
     - '{f_kind}'
@@ -12806,7 +12806,7 @@ f_out_native*:
   f_arg_name:
   - '{f_var}'
   f_arg_decl:
-  - '{f_type}{f_value_attr}{f_intent_attr}{f_optional_attr} :: {f_var}{f_dimension}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_module:
     '{f_module_name}':
     - '{f_kind}'

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -1791,7 +1791,7 @@ c_in_native:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - '{f_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
     '{i_module_name}':
     - '{i_kind}'
@@ -1821,7 +1821,7 @@ c_in_native*:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - '{f_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
     '{i_module_name}':
     - '{i_kind}'
@@ -1839,7 +1839,7 @@ c_in_native**:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - 'type(C_PTR), intent(IN), value :: {i_var}'
+  - 'type(C_PTR){f_intent_attr}, value :: {i_var}'
   i_module:
     iso_c_binding:
     - C_PTR
@@ -2503,7 +2503,7 @@ c_in_void:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - '{f_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
     '{i_module_name}':
     - '{i_kind}'
@@ -2687,7 +2687,7 @@ c_inout_native*:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - '{f_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
     '{i_module_name}':
     - '{i_kind}'
@@ -3244,13 +3244,6 @@ c_mixin_arg_native_cfi:
 c_mixin_argument:
   name: c_mixin_argument
   intent: mixin
-  i_arg_names:
-  - '{i_var}'
-  i_arg_decl:
-  - '{f_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
-  i_module:
-    '{i_module_name}':
-    - '{i_kind}'
   c_arg_decl:
   - '{gen.cdecl.c_var}'
   c_arg_call:
@@ -3733,7 +3726,7 @@ c_out_native*:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - '{f_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
     '{i_module_name}':
     - '{i_kind}'
@@ -3765,7 +3758,7 @@ c_out_native**:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - 'type(C_PTR){f_intent_attr} :: {f_var}'
+  - 'type(C_PTR){f_intent_attr} :: {i_var}'
   i_module:
     iso_c_binding:
     - C_PTR
@@ -3780,7 +3773,7 @@ c_out_native***:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - 'type(C_PTR){f_intent_attr} :: {f_var}'
+  - 'type(C_PTR){f_intent_attr} :: {i_var}'
   i_module:
     iso_c_binding:
     - C_PTR
@@ -3797,7 +3790,7 @@ c_out_native**_raw:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - 'type(C_PTR){f_intent_attr} :: {f_var}'
+  - 'type(C_PTR){f_intent_attr} :: {i_var}'
   i_module:
     iso_c_binding:
     - C_PTR
@@ -9457,7 +9450,7 @@ f_in_native:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - '{f_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
     '{i_module_name}':
     - '{i_kind}'
@@ -9501,7 +9494,7 @@ f_in_native*:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - '{f_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
     '{i_module_name}':
     - '{i_kind}'
@@ -9526,7 +9519,7 @@ f_in_native**:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - 'type(C_PTR), intent(IN), value :: {i_var}'
+  - 'type(C_PTR){f_intent_attr}, value :: {i_var}'
   i_module:
     iso_c_binding:
     - C_PTR
@@ -10531,7 +10524,7 @@ f_in_void:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - '{f_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
     '{i_module_name}':
     - '{i_kind}'
@@ -10899,7 +10892,7 @@ f_inout_native*:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - '{f_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
     '{i_module_name}':
     - '{i_kind}'
@@ -12538,7 +12531,7 @@ f_none_native:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - '{f_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
     '{i_module_name}':
     - '{i_kind}'
@@ -12560,7 +12553,7 @@ f_none_native*:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - '{f_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
     '{i_module_name}':
     - '{i_kind}'
@@ -12820,7 +12813,7 @@ f_out_native*:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - '{f_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
     '{i_module_name}':
     - '{i_kind}'
@@ -12942,7 +12935,7 @@ f_out_native***:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - 'type(C_PTR){f_intent_attr} :: {f_var}'
+  - 'type(C_PTR){f_intent_attr} :: {i_var}'
   i_module:
     iso_c_binding:
     - C_PTR
@@ -13189,7 +13182,7 @@ f_out_native**_raw:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - 'type(C_PTR){f_intent_attr} :: {f_var}'
+  - 'type(C_PTR){f_intent_attr} :: {i_var}'
   i_module:
     iso_c_binding:
     - C_PTR

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -146,9 +146,8 @@ root
           cfi -- c_mixin_arg_character_cfi
         native
           cfi -- c_mixin_arg_native_cfi
-      argument -- c_mixin_argument
-      argument2 -- c_mixin_argument2
       character -- c_mixin_character
+      declare-arg -- c_mixin_declare-arg
       declare-fortran-result -- c_mixin_declare-fortran-result
       destructor
         new-string -- c_mixin_destructor_new-string
@@ -3241,22 +3240,6 @@ c_mixin_arg_native_cfi:
   iface_header:
   - ISO_Fortran_binding.h
   owner: library
-c_mixin_argument:
-  name: c_mixin_argument
-  intent: mixin
-  c_arg_decl:
-  - '{gen.cdecl.c_var}'
-  c_arg_call:
-  - '{cxx_var}'
-  owner: library
-c_mixin_argument2:
-  name: c_mixin_argument2
-  intent: mixin
-  c_arg_decl:
-  - '{gen.cdecl.c_var}'
-  c_arg_call:
-  - '{cxx_var}'
-  owner: library
 c_mixin_character:
   name: c_mixin_character
   intent: mixin
@@ -3269,6 +3252,14 @@ c_mixin_character:
     - C_CHAR
   c_arg_decl:
   - '{gen.cdecl.c_var}'
+  owner: library
+c_mixin_declare-arg:
+  name: c_mixin_declare-arg
+  intent: mixin
+  c_arg_decl:
+  - '{gen.cdecl.c_var}'
+  c_arg_call:
+  - '{cxx_var}'
   owner: library
 c_mixin_declare-fortran-result:
   name: c_mixin_declare-fortran-result

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -497,8 +497,6 @@ root
     mixin
       arg
         capsule -- f_mixin_arg_capsule
-      argument-as-cptr -- f_mixin_argument-as-cptr
-      argument-as-cptr-value -- f_mixin_argument-as-cptr-value
       capsule
         dtor -- f_mixin_capsule_dtor
       char
@@ -539,6 +537,8 @@ root
       inout
         array
           cdesc -- f_mixin_inout_array_cdesc
+      interface-as-cptr -- f_mixin_interface-as-cptr
+      interface-as-cptr-value -- f_mixin_interface-as-cptr-value
       local-logical-var -- f_mixin_local-logical-var
       native
         cdesc
@@ -11687,28 +11687,6 @@ f_mixin_arg_capsule:
   fmtdict:
     f_var_capsule: Crv
   owner: library
-f_mixin_argument-as-cptr:
-  name: f_mixin_argument-as-cptr
-  intent: mixin
-  i_arg_names:
-  - '{i_var}'
-  i_arg_decl:
-  - 'type(C_PTR){f_intent_attr} :: {i_var}'
-  i_module:
-    iso_c_binding:
-    - C_PTR
-  owner: library
-f_mixin_argument-as-cptr-value:
-  name: f_mixin_argument-as-cptr-value
-  intent: mixin
-  i_arg_names:
-  - '{i_var}'
-  i_arg_decl:
-  - 'type(C_PTR){f_intent_attr}, value :: {i_var}'
-  i_module:
-    iso_c_binding:
-    - C_PTR
-  owner: library
 f_mixin_capsule_dtor:
   name: f_mixin_capsule_dtor
   comments:
@@ -12088,6 +12066,28 @@ f_mixin_inout_array_cdesc:
   - cdesc
   f_helper:
   - array_context
+  owner: library
+f_mixin_interface-as-cptr:
+  name: f_mixin_interface-as-cptr
+  intent: mixin
+  i_arg_names:
+  - '{i_var}'
+  i_arg_decl:
+  - 'type(C_PTR){f_intent_attr} :: {i_var}'
+  i_module:
+    iso_c_binding:
+    - C_PTR
+  owner: library
+f_mixin_interface-as-cptr-value:
+  name: f_mixin_interface-as-cptr-value
+  intent: mixin
+  i_arg_names:
+  - '{i_var}'
+  i_arg_decl:
+  - 'type(C_PTR){f_intent_attr}, value :: {i_var}'
+  i_module:
+    iso_c_binding:
+    - C_PTR
   owner: library
 f_mixin_local-logical-var:
   name: f_mixin_local-logical-var

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -503,6 +503,7 @@ root
         cdesc
           allocate -- f_mixin_char_cdesc_allocate
           pointer -- f_mixin_char_cdesc_pointer
+      declare-as-cptr -- f_mixin_declare-as-cptr
       declare-fortran-arg -- f_mixin_declare-fortran-arg
       declare-fortran-result -- f_mixin_declare-fortran-result
       declare-interface-arg -- f_mixin_declare-interface-arg
@@ -1523,10 +1524,10 @@ c_function_struct:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - '{f_type}, intent(OUT) :: {i_var}'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
-    '{f_module_name}':
-    - '{f_kind}'
+    '{i_module_name}':
+    - '{i_kind}'
   c_arg_decl:
   - '{c_type} *{c_var}'
   c_call:
@@ -8661,10 +8662,10 @@ f_function_struct:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - '{f_type}, intent(OUT) :: {i_var}'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
-    '{f_module_name}':
-    - '{f_kind}'
+    '{i_module_name}':
+    - '{i_kind}'
   c_arg_decl:
   - '{c_type} *{c_var}'
   c_call:
@@ -11728,6 +11729,17 @@ f_mixin_char_cdesc_pointer:
   f_helper:
   - pointer_string
   owner: library
+f_mixin_declare-as-cptr:
+  name: f_mixin_declare-as-cptr
+  intent: mixin
+  f_arg_name:
+  - '{f_var}'
+  f_arg_decl:
+  - 'type(C_PTR){f_intent_attr} :: {f_var}'
+  f_module:
+    iso_c_binding:
+    - C_PTR
+  owner: library
 f_mixin_declare-fortran-arg:
   name: f_mixin_declare-fortran-arg
   intent: mixin
@@ -14346,7 +14358,10 @@ f_setter_struct*:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - '{f_type}, intent(IN) :: {i_var}{i_dimension}'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
+  i_module:
+    '{i_module_name}':
+    - '{i_kind}'
   c_arg_decl:
   - '{gen.cdecl.c_var}'
   c_arg_call:
@@ -14391,7 +14406,10 @@ f_setter_struct*_pointer:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - '{f_type}, intent(IN) :: {i_var}{i_dimension}'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
+  i_module:
+    '{i_module_name}':
+    - '{i_kind}'
   c_arg_decl:
   - '{gen.cdecl.c_var}'
   c_arg_call:

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -546,7 +546,6 @@ root
           allocate -- f_mixin_native_cdesc_allocate
           pointer -- f_mixin_native_cdesc_pointer
           raw -- f_mixin_native_cdesc_raw
-        default -- f_mixin_native_default
       out
         array
           cdesc
@@ -1770,7 +1769,7 @@ c_in_enum:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - '{f_type}, value{f_intent_attr} :: {i_var}'
+  - '{i_type}, value{f_intent_attr} :: {i_var}'
   i_module:
     '{i_module_name}':
     - '{i_kind}'
@@ -5719,7 +5718,7 @@ f_function_native*_cfi_allocatable:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - '{f_type}{f_intent_attr}, allocatable :: {i_var}{f_assumed_shape}'
+  - '{i_type}{f_intent_attr}, allocatable :: {i_var}{f_assumed_shape}'
   i_module:
     iso_c_binding:
     - '{f_kind}'
@@ -5768,7 +5767,7 @@ f_function_native*_cfi_pointer:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - '{f_type}{f_intent_attr}, pointer :: {i_var}{f_assumed_shape}'
+  - '{i_type}{f_intent_attr}, pointer :: {i_var}{f_assumed_shape}'
   i_module:
     iso_c_binding:
     - '{f_kind}'
@@ -9435,7 +9434,7 @@ f_in_enum:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - '{f_type}, value{f_intent_attr} :: {i_var}'
+  - '{i_type}, value{f_intent_attr} :: {i_var}'
   i_module:
     '{i_module_name}':
     - '{i_kind}'
@@ -12184,16 +12183,6 @@ f_mixin_native_cdesc_raw:
     - C_PTR
     - c_f_pointer
   owner: library
-f_mixin_native_default:
-  name: f_mixin_native_default
-  intent: mixin
-  f_arg_name:
-  - '{f_var}'
-  f_arg_decl:
-  - '{f_type}{f_intent_attr} :: {f_var}'
-  f_arg_call:
-  - '{f_var}'
-  owner: library
 f_mixin_out_array_cdesc_allocatable:
   name: f_mixin_out_array_cdesc_allocatable
   comments:
@@ -13120,7 +13109,7 @@ f_out_native**_cfi_allocatable:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - '{f_type}{f_intent_attr}, allocatable :: {i_var}{f_assumed_shape}'
+  - '{i_type}{f_intent_attr}, allocatable :: {i_var}{f_assumed_shape}'
   i_module:
     iso_c_binding:
     - '{f_kind}'
@@ -13162,7 +13151,7 @@ f_out_native**_cfi_pointer:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - '{f_type}{f_intent_attr}, pointer :: {i_var}{f_assumed_shape}'
+  - '{i_type}{f_intent_attr}, pointer :: {i_var}{f_assumed_shape}'
   i_module:
     iso_c_binding:
     - '{f_kind}'

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -6393,7 +6393,7 @@ f_function_string&_buf:
   - Pass CHARACTER and LEN to C wrapper.
   intent: function
   f_arg_decl:
-  - '{f_type} :: {f_var}'
+  - '{f_type}{f_deref_attr} :: {f_var}{f_dimension}'
   f_declare:
   - integer(C_INT) {f_var_len}
   f_pre_call:
@@ -6404,6 +6404,8 @@ f_function_string&_buf:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_module:
+    '{f_module_name}':
+    - '{f_kind}'
     iso_c_binding:
     - C_INT
   f_temps:
@@ -6457,6 +6459,8 @@ f_function_string&_buf_arg:
   - call {f_call_function}({F_arg_c_call})
   f_result_var: as-subroutine
   f_module:
+    '{f_module_name}':
+    - '{f_kind}'
     iso_c_binding:
     - C_INT
   f_temps:
@@ -6503,7 +6507,7 @@ f_function_string&_buf_copy:
   - Pass CHARACTER and LEN to C wrapper.
   intent: function
   f_arg_decl:
-  - '{f_type} :: {f_var}'
+  - '{f_type}{f_deref_attr} :: {f_var}{f_dimension}'
   f_declare:
   - integer(C_INT) {f_var_len}
   f_pre_call:
@@ -6514,6 +6518,8 @@ f_function_string&_buf_copy:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_module:
+    '{f_module_name}':
+    - '{f_kind}'
     iso_c_binding:
     - C_INT
   f_temps:
@@ -7216,7 +7222,7 @@ f_function_string*_buf:
   - Pass CHARACTER and LEN to C wrapper.
   intent: function
   f_arg_decl:
-  - '{f_type} :: {f_var}'
+  - '{f_type}{f_deref_attr} :: {f_var}{f_dimension}'
   f_declare:
   - integer(C_INT) {f_var_len}
   f_pre_call:
@@ -7227,6 +7233,8 @@ f_function_string*_buf:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_module:
+    '{f_module_name}':
+    - '{f_kind}'
     iso_c_binding:
     - C_INT
   f_temps:
@@ -7266,7 +7274,7 @@ f_function_string*_buf_copy:
   - Pass CHARACTER and LEN to C wrapper.
   intent: function
   f_arg_decl:
-  - '{f_type} :: {f_var}'
+  - '{f_type}{f_deref_attr} :: {f_var}{f_dimension}'
   f_declare:
   - integer(C_INT) {f_var_len}
   f_pre_call:
@@ -7277,6 +7285,8 @@ f_function_string*_buf_copy:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_module:
+    '{f_module_name}':
+    - '{f_kind}'
     iso_c_binding:
     - C_INT
   f_temps:
@@ -7928,7 +7938,7 @@ f_function_string_buf:
   - Pass CHARACTER and LEN to C wrapper.
   intent: function
   f_arg_decl:
-  - '{f_type} :: {f_var}'
+  - '{f_type}{f_deref_attr} :: {f_var}{f_dimension}'
   f_declare:
   - integer(C_INT) {f_var_len}
   f_pre_call:
@@ -7939,6 +7949,8 @@ f_function_string_buf:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_module:
+    '{f_module_name}':
+    - '{f_kind}'
     iso_c_binding:
     - C_INT
   f_temps:
@@ -7992,6 +8004,8 @@ f_function_string_buf_arg:
   - call {f_call_function}({F_arg_c_call})
   f_result_var: as-subroutine
   f_module:
+    '{f_module_name}':
+    - '{f_kind}'
     iso_c_binding:
     - C_INT
   f_temps:
@@ -8038,7 +8052,7 @@ f_function_string_buf_copy:
   - Pass CHARACTER and LEN to C wrapper.
   intent: function
   f_arg_decl:
-  - '{f_type} :: {f_var}'
+  - '{f_type}{f_deref_attr} :: {f_var}{f_dimension}'
   f_declare:
   - integer(C_INT) {f_var_len}
   f_pre_call:
@@ -8049,6 +8063,8 @@ f_function_string_buf_copy:
   f_call:
   - call {f_call_function}({F_arg_c_call})
   f_module:
+    '{f_module_name}':
+    - '{f_kind}'
     iso_c_binding:
     - C_INT
   f_temps:

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -1665,10 +1665,10 @@ c_in_char*:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - 'character(kind=C_CHAR){f_intent_attr} :: {i_var}(*)'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
-    iso_c_binding:
-    - C_CHAR
+    '{i_module_name}':
+    - '{i_kind}'
   c_arg_decl:
   - '{gen.cdecl.c_var}'
   c_arg_call:
@@ -2011,10 +2011,10 @@ c_in_string&:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - 'character(kind=C_CHAR){f_intent_attr} :: {i_var}(*)'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
-    iso_c_binding:
-    - C_CHAR
+    '{i_module_name}':
+    - '{i_kind}'
   c_arg_decl:
   - '{gen.cdecl.c_var}'
   c_arg_call:
@@ -2056,14 +2056,16 @@ c_in_string&_buf:
   owner: library
 c_in_string*:
   name: c_in_string*
+  comments:
+  - Create local std::string from the argument.
   intent: in
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - 'character(kind=C_CHAR){f_intent_attr} :: {i_var}(*)'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
-    iso_c_binding:
-    - C_CHAR
+    '{i_module_name}':
+    - '{i_kind}'
   c_arg_decl:
   - '{gen.cdecl.c_var}'
   c_arg_call:
@@ -2592,10 +2594,10 @@ c_inout_char*:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - 'character(kind=C_CHAR){f_intent_attr} :: {i_var}(*)'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
-    iso_c_binding:
-    - C_CHAR
+    '{i_module_name}':
+    - '{i_kind}'
   c_arg_decl:
   - '{gen.cdecl.c_var}'
   c_arg_call:
@@ -3629,10 +3631,10 @@ c_out_char*:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - 'character(kind=C_CHAR){f_intent_attr} :: {i_var}(*)'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
-    iso_c_binding:
-    - C_CHAR
+    '{i_module_name}':
+    - '{i_kind}'
   c_arg_decl:
   - '{gen.cdecl.c_var}'
   c_arg_call:
@@ -3836,10 +3838,10 @@ c_out_string&:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - 'character(kind=C_CHAR){f_intent_attr} :: {i_var}(*)'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
-    iso_c_binding:
-    - C_CHAR
+    '{i_module_name}':
+    - '{i_kind}'
   c_arg_decl:
   - '{gen.cdecl.c_var}'
   c_arg_call:
@@ -3893,10 +3895,10 @@ c_out_string*:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - 'character(kind=C_CHAR){f_intent_attr} :: {i_var}(*)'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
-    iso_c_binding:
-    - C_CHAR
+    '{i_module_name}':
+    - '{i_kind}'
   c_arg_decl:
   - '{gen.cdecl.c_var}'
   c_arg_call:
@@ -9173,10 +9175,10 @@ f_in_char*:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - 'character(kind=C_CHAR){f_intent_attr} :: {i_var}(*)'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
-    iso_c_binding:
-    - C_CHAR
+    '{i_module_name}':
+    - '{i_kind}'
   c_arg_decl:
   - '{gen.cdecl.c_var}'
   c_arg_call:
@@ -9351,10 +9353,10 @@ f_in_char*_capi:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - 'character(kind=C_CHAR){f_intent_attr} :: {i_var}(*)'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
-    iso_c_binding:
-    - C_CHAR
+    '{i_module_name}':
+    - '{i_kind}'
   c_arg_decl:
   - '{gen.cdecl.c_var}'
   c_arg_call:
@@ -9767,10 +9769,10 @@ f_in_string&:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - 'character(kind=C_CHAR){f_intent_attr} :: {i_var}(*)'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
-    iso_c_binding:
-    - C_CHAR
+    '{i_module_name}':
+    - '{i_kind}'
   c_arg_decl:
   - '{gen.cdecl.c_var}'
   c_arg_call:
@@ -9863,14 +9865,16 @@ f_in_string&_cfi:
   owner: library
 f_in_string*:
   name: f_in_string*
+  comments:
+  - Create local std::string from the argument.
   intent: in
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - 'character(kind=C_CHAR){f_intent_attr} :: {i_var}(*)'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
-    iso_c_binding:
-    - C_CHAR
+    '{i_module_name}':
+    - '{i_kind}'
   c_arg_decl:
   - '{gen.cdecl.c_var}'
   c_arg_call:
@@ -10688,10 +10692,10 @@ f_inout_char*:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - 'character(kind=C_CHAR){f_intent_attr} :: {i_var}(*)'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
-    iso_c_binding:
-    - C_CHAR
+    '{i_module_name}':
+    - '{i_kind}'
   c_arg_decl:
   - '{gen.cdecl.c_var}'
   c_arg_call:
@@ -10762,10 +10766,10 @@ f_inout_char*_capi:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - 'character(kind=C_CHAR){f_intent_attr} :: {i_var}(*)'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
-    iso_c_binding:
-    - C_CHAR
+    '{i_module_name}':
+    - '{i_kind}'
   c_arg_decl:
   - '{gen.cdecl.c_var}'
   c_arg_call:
@@ -12498,10 +12502,10 @@ f_none_char*:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - 'character(kind=C_CHAR){f_intent_attr} :: {i_var}(*)'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
-    iso_c_binding:
-    - C_CHAR
+    '{i_module_name}':
+    - '{i_kind}'
   c_arg_decl:
   - '{gen.cdecl.c_var}'
   c_arg_call:
@@ -12620,10 +12624,10 @@ f_out_char*:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - 'character(kind=C_CHAR){f_intent_attr} :: {i_var}(*)'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
-    iso_c_binding:
-    - C_CHAR
+    '{i_module_name}':
+    - '{i_kind}'
   c_arg_decl:
   - '{gen.cdecl.c_var}'
   c_arg_call:
@@ -12688,10 +12692,10 @@ f_out_char*_capi:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - 'character(kind=C_CHAR){f_intent_attr} :: {i_var}(*)'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
-    iso_c_binding:
-    - C_CHAR
+    '{i_module_name}':
+    - '{i_kind}'
   c_arg_decl:
   - '{gen.cdecl.c_var}'
   c_arg_call:

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -2841,6 +2841,9 @@ c_inout_string*:
   name: c_inout_string*
   comments:
   - Pass CHARACTER and LEN to C wrapper.
+  notes:
+  - XXX - the fortran wrapper is incorrect since it is passing buf
+  - '  but only accepting one argument. Confused with f_inout_string*_buf'
   intent: inout
   i_arg_names:
   - '{i_var}'
@@ -11180,6 +11183,9 @@ f_inout_string*:
   name: f_inout_string*
   comments:
   - Pass CHARACTER and LEN to C wrapper.
+  notes:
+  - XXX - the fortran wrapper is incorrect since it is passing buf
+  - '  but only accepting one argument. Confused with f_inout_string*_buf'
   intent: inout
   f_declare:
   - integer(C_INT) {f_var_len}

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -13175,8 +13175,6 @@ f_out_native**_raw:
   f_arg_decl:
   - 'type(C_PTR){f_intent_attr} :: {f_var}'
   f_module:
-    '{f_module_name}':
-    - '{f_kind}'
     iso_c_binding:
     - C_PTR
   i_arg_names:

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -2520,7 +2520,7 @@ c_in_void*:
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - '{f_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
     iso_c_binding:
     - C_PTR
@@ -8853,10 +8853,10 @@ f_function_void*:
   - XXX - f entries are the same as the i entries, share?
   intent: function
   f_arg_decl:
-  - 'type(C_PTR) :: {f_var}'
+  - '{f_type}{f_deref_attr} :: {f_var}{f_dimension}'
   f_module:
-    iso_c_binding:
-    - C_PTR
+    '{f_module_name}':
+    - '{f_kind}'
   i_result_decl:
   - 'type(C_PTR) :: {f_var}'
   i_module:
@@ -9993,7 +9993,7 @@ f_in_string_buf:
   f_arg_name:
   - '{f_var}'
   f_arg_decl:
-  - 'character(len=*){f_intent_attr} :: {f_var}'
+  - '{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}'
   f_declare:
   - integer(C_INT) {f_var_len}
   f_pre_call:
@@ -10002,6 +10002,8 @@ f_in_string_buf:
   - '{f_var}'
   - '{f_var_len}'
   f_module:
+    '{f_module_name}':
+    - '{f_kind}'
     iso_c_binding:
     - C_INT
   f_temps:
@@ -10556,12 +10558,12 @@ f_in_void*:
   f_arg_decl:
   - '{f_type}{f_intent_attr} :: {f_var}'
   f_module:
-    iso_c_binding:
-    - C_PTR
+    '{f_module_name}':
+    - '{f_kind}'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - '{f_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
     iso_c_binding:
     - C_PTR
@@ -12599,12 +12601,12 @@ f_none_void*:
   f_arg_decl:
   - '{f_type}{f_intent_attr} :: {f_var}'
   f_module:
-    iso_c_binding:
-    - C_PTR
+    '{f_module_name}':
+    - '{f_kind}'
   i_arg_names:
   - '{i_var}'
   i_arg_decl:
-  - '{f_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
+  - '{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}'
   i_module:
     iso_c_binding:
     - C_PTR

--- a/regression/reference/pointers-c-f/wrapfpointers.f
+++ b/regression/reference/pointers-c-f/wrapfpointers.f
@@ -1513,7 +1513,7 @@ contains
     !<
     ! start get_raw_ptr_to_scalar
     subroutine get_raw_ptr_to_scalar(nitems)
-        use iso_c_binding, only : C_INT, C_PTR
+        use iso_c_binding, only : C_PTR
         type(C_PTR), intent(OUT) :: nitems
         ! splicer begin function.get_raw_ptr_to_scalar
         call c_get_raw_ptr_to_scalar(nitems)
@@ -1533,7 +1533,7 @@ contains
     !<
     ! start get_raw_ptr_to_scalar_force
     subroutine get_raw_ptr_to_scalar_force(nitems)
-        use iso_c_binding, only : C_INT, C_PTR
+        use iso_c_binding, only : C_PTR
         type(C_PTR), intent(OUT) :: nitems
         ! splicer begin function.get_raw_ptr_to_scalar_force
         call c_get_raw_ptr_to_scalar_force(nitems)
@@ -1556,7 +1556,7 @@ contains
     !<
     ! start get_raw_ptr_to_fixed_array
     subroutine get_raw_ptr_to_fixed_array(count)
-        use iso_c_binding, only : C_INT, C_PTR
+        use iso_c_binding, only : C_PTR
         type(C_PTR), intent(OUT) :: count
         ! splicer begin function.get_raw_ptr_to_fixed_array
         call c_get_raw_ptr_to_fixed_array(count)
@@ -1577,7 +1577,7 @@ contains
     !<
     ! start get_raw_ptr_to_fixed_array_force
     subroutine get_raw_ptr_to_fixed_array_force(count)
-        use iso_c_binding, only : C_INT, C_PTR
+        use iso_c_binding, only : C_PTR
         type(C_PTR), intent(OUT) :: count
         ! splicer begin function.get_raw_ptr_to_fixed_array_force
         call c_get_raw_ptr_to_fixed_array_force(count)

--- a/regression/reference/pointers-c/wrapfpointers.f
+++ b/regression/reference/pointers-c/wrapfpointers.f
@@ -1513,7 +1513,7 @@ contains
     !<
     ! start get_raw_ptr_to_scalar
     subroutine get_raw_ptr_to_scalar(nitems)
-        use iso_c_binding, only : C_INT, C_PTR
+        use iso_c_binding, only : C_PTR
         type(C_PTR), intent(OUT) :: nitems
         ! splicer begin function.get_raw_ptr_to_scalar
         call c_get_raw_ptr_to_scalar(nitems)
@@ -1533,7 +1533,7 @@ contains
     !<
     ! start get_raw_ptr_to_scalar_force
     subroutine get_raw_ptr_to_scalar_force(nitems)
-        use iso_c_binding, only : C_INT, C_PTR
+        use iso_c_binding, only : C_PTR
         type(C_PTR), intent(OUT) :: nitems
         ! splicer begin function.get_raw_ptr_to_scalar_force
         call c_get_raw_ptr_to_scalar_force(nitems)
@@ -1556,7 +1556,7 @@ contains
     !<
     ! start get_raw_ptr_to_fixed_array
     subroutine get_raw_ptr_to_fixed_array(count)
-        use iso_c_binding, only : C_INT, C_PTR
+        use iso_c_binding, only : C_PTR
         type(C_PTR), intent(OUT) :: count
         ! splicer begin function.get_raw_ptr_to_fixed_array
         call c_get_raw_ptr_to_fixed_array(count)
@@ -1577,7 +1577,7 @@ contains
     !<
     ! start get_raw_ptr_to_fixed_array_force
     subroutine get_raw_ptr_to_fixed_array_force(count)
-        use iso_c_binding, only : C_INT, C_PTR
+        use iso_c_binding, only : C_PTR
         type(C_PTR), intent(OUT) :: count
         ! splicer begin function.get_raw_ptr_to_fixed_array_force
         call c_get_raw_ptr_to_fixed_array_force(count)

--- a/regression/reference/pointers-cfi/wrapfpointers.f
+++ b/regression/reference/pointers-cfi/wrapfpointers.f
@@ -1833,7 +1833,7 @@ contains
     !<
     ! start get_raw_ptr_to_scalar
     subroutine get_raw_ptr_to_scalar(nitems)
-        use iso_c_binding, only : C_INT, C_PTR
+        use iso_c_binding, only : C_PTR
         type(C_PTR), intent(OUT) :: nitems
         ! splicer begin function.get_raw_ptr_to_scalar
         call c_get_raw_ptr_to_scalar(nitems)
@@ -1853,7 +1853,7 @@ contains
     !<
     ! start get_raw_ptr_to_scalar_force
     subroutine get_raw_ptr_to_scalar_force(nitems)
-        use iso_c_binding, only : C_INT, C_PTR
+        use iso_c_binding, only : C_PTR
         type(C_PTR), intent(OUT) :: nitems
         ! splicer begin function.get_raw_ptr_to_scalar_force
         call c_get_raw_ptr_to_scalar_force(nitems)
@@ -1876,7 +1876,7 @@ contains
     !<
     ! start get_raw_ptr_to_fixed_array
     subroutine get_raw_ptr_to_fixed_array(count)
-        use iso_c_binding, only : C_INT, C_PTR
+        use iso_c_binding, only : C_PTR
         type(C_PTR), intent(OUT) :: count
         ! splicer begin function.get_raw_ptr_to_fixed_array
         call c_get_raw_ptr_to_fixed_array(count)
@@ -1897,7 +1897,7 @@ contains
     !<
     ! start get_raw_ptr_to_fixed_array_force
     subroutine get_raw_ptr_to_fixed_array_force(count)
-        use iso_c_binding, only : C_INT, C_PTR
+        use iso_c_binding, only : C_PTR
         type(C_PTR), intent(OUT) :: count
         ! splicer begin function.get_raw_ptr_to_fixed_array_force
         call c_get_raw_ptr_to_fixed_array_force(count)

--- a/regression/reference/pointers-cxx-f/wrapfpointers.f
+++ b/regression/reference/pointers-cxx-f/wrapfpointers.f
@@ -1513,7 +1513,7 @@ contains
     !<
     ! start get_raw_ptr_to_scalar
     subroutine get_raw_ptr_to_scalar(nitems)
-        use iso_c_binding, only : C_INT, C_PTR
+        use iso_c_binding, only : C_PTR
         type(C_PTR), intent(OUT) :: nitems
         ! splicer begin function.get_raw_ptr_to_scalar
         call c_get_raw_ptr_to_scalar_bufferify(nitems)
@@ -1533,7 +1533,7 @@ contains
     !<
     ! start get_raw_ptr_to_scalar_force
     subroutine get_raw_ptr_to_scalar_force(nitems)
-        use iso_c_binding, only : C_INT, C_PTR
+        use iso_c_binding, only : C_PTR
         type(C_PTR), intent(OUT) :: nitems
         ! splicer begin function.get_raw_ptr_to_scalar_force
         call c_get_raw_ptr_to_scalar_force_bufferify(nitems)
@@ -1556,7 +1556,7 @@ contains
     !<
     ! start get_raw_ptr_to_fixed_array
     subroutine get_raw_ptr_to_fixed_array(count)
-        use iso_c_binding, only : C_INT, C_PTR
+        use iso_c_binding, only : C_PTR
         type(C_PTR), intent(OUT) :: count
         ! splicer begin function.get_raw_ptr_to_fixed_array
         call c_get_raw_ptr_to_fixed_array_bufferify(count)
@@ -1577,7 +1577,7 @@ contains
     !<
     ! start get_raw_ptr_to_fixed_array_force
     subroutine get_raw_ptr_to_fixed_array_force(count)
-        use iso_c_binding, only : C_INT, C_PTR
+        use iso_c_binding, only : C_PTR
         type(C_PTR), intent(OUT) :: count
         ! splicer begin function.get_raw_ptr_to_fixed_array_force
         call c_get_raw_ptr_to_fixed_array_force_bufferify(count)

--- a/regression/reference/pointers-cxx/wrapfpointers.f
+++ b/regression/reference/pointers-cxx/wrapfpointers.f
@@ -1766,7 +1766,7 @@ contains
     !<
     ! start get_raw_ptr_to_scalar
     subroutine get_raw_ptr_to_scalar(nitems)
-        use iso_c_binding, only : C_INT, C_PTR
+        use iso_c_binding, only : C_PTR
         type(C_PTR), intent(OUT) :: nitems
         ! splicer begin function.get_raw_ptr_to_scalar
         call c_get_raw_ptr_to_scalar(nitems)
@@ -1786,7 +1786,7 @@ contains
     !<
     ! start get_raw_ptr_to_scalar_force
     subroutine get_raw_ptr_to_scalar_force(nitems)
-        use iso_c_binding, only : C_INT, C_PTR
+        use iso_c_binding, only : C_PTR
         type(C_PTR), intent(OUT) :: nitems
         ! splicer begin function.get_raw_ptr_to_scalar_force
         call c_get_raw_ptr_to_scalar_force(nitems)
@@ -1809,7 +1809,7 @@ contains
     !<
     ! start get_raw_ptr_to_fixed_array
     subroutine get_raw_ptr_to_fixed_array(count)
-        use iso_c_binding, only : C_INT, C_PTR
+        use iso_c_binding, only : C_PTR
         type(C_PTR), intent(OUT) :: count
         ! splicer begin function.get_raw_ptr_to_fixed_array
         call c_get_raw_ptr_to_fixed_array(count)
@@ -1830,7 +1830,7 @@ contains
     !<
     ! start get_raw_ptr_to_fixed_array_force
     subroutine get_raw_ptr_to_fixed_array_force(count)
-        use iso_c_binding, only : C_INT, C_PTR
+        use iso_c_binding, only : C_PTR
         type(C_PTR), intent(OUT) :: count
         ! splicer begin function.get_raw_ptr_to_fixed_array_force
         call c_get_raw_ptr_to_fixed_array_force(count)

--- a/shroud/fc-statements.json
+++ b/shroud/fc-statements.json
@@ -62,6 +62,24 @@
         "sphinx-end-before": "f_mixin_declare-fortran-arg"
     },
     {
+        "name": "f_mixin_interface-as-cptr",
+        "notes": [
+            "Pass the address of the argument directly to C.",
+            "Used when there is no direct mapping to Fortran"
+        ],
+        "i_arg_names": [
+            "{i_var}"
+        ],
+        "i_arg_decl": [
+            "type(C_PTR){f_intent_attr} :: {i_var}"
+        ],
+        "i_module": {
+            "iso_c_binding": [
+                "C_PTR"
+            ]
+        }
+    },
+    {
         "name": "f_mixin_interface-as-cptr-value",
         "notes": [
             "Pass the address of the argument directly to C.",
@@ -80,7 +98,7 @@
         }
     },
     {
-        "name": "f_mixin_interface-as-cptr",
+        "name": "#f_mixin_interface-as-cptr-dimension",
         "notes": [
             "Pass the address of the argument directly to C.",
             "Used when there is no direct mapping to Fortran"
@@ -89,7 +107,7 @@
             "{i_var}"
         ],
         "i_arg_decl": [
-            "type(C_PTR){f_intent_attr} :: {i_var}"
+            "type(C_PTR){f_intent_attr} :: {i_var}{i_dimension}"
         ],
         "i_module": {
             "iso_c_binding": [
@@ -1545,29 +1563,15 @@
             "f_none_void*"
         ],
         "mixin": [
-            "c_mixin_declare-arg"
-        ],
-        "f_module": {
-            "iso_c_binding": [
-                "C_PTR"
-            ]
-        },
-        "f_arg_name": [
-            "{f_var}"
+            "c_mixin_declare-arg",
+            "f_mixin_interface-as-cptr",
+            "f_mixin_declare-fortran-arg"
         ],
         "f_arg_decl": [
             "{f_type}{f_intent_attr} :: {f_var}"
         ],
-        "i_module": {
-            "iso_c_binding": [
-                "C_PTR"
-            ]
-        },
-        "i_arg_names": [
-            "{i_var}"
-        ],
         "i_arg_decl": [
-            "{f_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}"
+            "{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}"
         ]
     },
     {
@@ -1579,15 +1583,8 @@
             "XXX - f entries are the same as the i entries, share?"
         ],
         "mixin": [
+            "f_mixin_declare-fortran-result",
             "c_mixin_function"
-        ],
-        "f_module": {
-            "iso_c_binding": [
-                "C_PTR"
-            ]
-        },
-        "f_arg_decl": [
-            "type(C_PTR) :: {f_var}"
         ],
         "i_module": {
             "iso_c_binding": [
@@ -1748,6 +1745,26 @@
         "name":"##### char #################################################"
     },
     {
+        "name": "c_mixin_character",
+        "notes": [
+            "Create a character argument"
+        ],
+        "i_arg_names": [
+            "{i_var}"
+        ],
+        "i_arg_decl": [
+            "character(kind=C_CHAR){f_intent_attr} :: {i_var}(*)"
+        ],
+        "i_module": {
+            "iso_c_binding": [
+                "C_CHAR"
+            ]
+        },
+        "c_arg_decl": [
+            "{gen.cdecl.c_var}"
+        ]
+    },
+    {
         "alias": [
             "f_in_char",
             "c_in_char",
@@ -1832,26 +1849,6 @@
                 "C_PTR"
             ]
         }
-    },
-    {
-        "name": "c_mixin_character",
-        "notes": [
-            "Create a character argument"
-        ],
-        "i_arg_names": [
-            "{i_var}"
-        ],
-        "i_arg_decl": [
-            "character(kind=C_CHAR){f_intent_attr} :: {i_var}(*)"
-        ],
-        "i_module": {
-            "iso_c_binding": [
-                "C_CHAR"
-            ]
-        },
-        "c_arg_decl": [
-            "{gen.cdecl.c_var}"
-        ]
     },
     {
         "alias": [
@@ -2527,14 +2524,9 @@
             "c_in_string_buf"
         ],
         "mixin": [
+            "f_mixin_declare-fortran-arg",
             "f_mixin_pass_character_buf",
             "c_mixin_in_character_buf"
-        ],
-        "f_arg_name": [
-            "{f_var}"
-        ],
-        "f_arg_decl": [
-            "character(len=*){f_intent_attr} :: {f_var}"
         ],
         "c_helper": [
             "char_len_trim"

--- a/shroud/fc-statements.json
+++ b/shroud/fc-statements.json
@@ -1859,19 +1859,9 @@
         ],
         "mixin": [
             "c_mixin_declare-arg",
+            "f_mixin_declare-interface-arg",
             "f_mixin_declare-fortran-arg"
-        ],
-        "i_arg_names": [
-            "{i_var}"
-        ],
-        "i_arg_decl": [
-            "character(kind=C_CHAR){f_intent_attr} :: {i_var}(*)"
-        ],
-        "i_module": {
-            "iso_c_binding": [
-                "C_CHAR"
-            ]
-        }
+        ]
     },
     {
         "alias": [

--- a/shroud/fc-statements.json
+++ b/shroud/fc-statements.json
@@ -2584,11 +2584,9 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
+            "f_mixin_declare-fortran-result",
             "f_mixin_pass_character_buf",
             "c_mixin_in_character_buf"
-        ],
-        "f_arg_decl": [
-            "{f_type} :: {f_var}"
         ],
         "c_helper": [
             "char_copy"

--- a/shroud/fc-statements.json
+++ b/shroud/fc-statements.json
@@ -31,17 +31,6 @@
         "notes": [
             "Use typemap.cxx_to_c to create an argument"
         ],
-        "f_arg_name": [
-            "{f_var}"
-        ],
-        "f_arg_decl": [
-            "{f_type}{f_value_attr}{f_intent_attr}{f_optional_attr} :: {f_var}{f_dimension}"
-        ],
-        "f_module": {
-            "{f_module_name}": [
-                "{f_kind}"
-            ]
-        },
         "c_arg_decl": [
             "{gen.cdecl.c_var}"
         ],
@@ -1118,7 +1107,8 @@
         ],
         "mixin": [
             "c_mixin_argument",
-            "f_mixin_declare-interface-arg"
+            "f_mixin_declare-interface-arg",
+            "f_mixin_declare-fortran-arg"
         ]
     },
     {
@@ -1132,7 +1122,8 @@
         ],
         "mixin": [
             "c_mixin_argument",
-            "f_mixin_declare-interface-arg"
+            "f_mixin_declare-interface-arg",
+            "f_mixin_declare-fortran-arg"
         ]
     },
     {
@@ -1164,7 +1155,8 @@
         ],
         "mixin": [
             "c_mixin_argument",
-            "f_mixin_argument-as-cptr-value"
+            "f_mixin_argument-as-cptr-value",
+            "f_mixin_declare-fortran-arg"
         ]
     },
     {
@@ -1178,7 +1170,8 @@
         ],
         "mixin": [
             "c_mixin_argument",
-            "f_mixin_argument-as-cptr"
+            "f_mixin_argument-as-cptr",
+            "f_mixin_declare-fortran-arg"
         ],
         "f_arg_decl": [
             "type(C_PTR){f_intent_attr} :: {f_var}"
@@ -1214,7 +1207,8 @@
         ],
         "mixin": [
             "c_mixin_argument",
-            "f_mixin_argument-as-cptr"
+            "f_mixin_argument-as-cptr",
+            "f_mixin_declare-fortran-arg"
         ],
         "f_arg_decl": [
             "type(C_PTR){f_intent_attr} :: {f_var}"

--- a/shroud/fc-statements.json
+++ b/shroud/fc-statements.json
@@ -2125,8 +2125,12 @@
             "f_in_string*",
             "c_in_string*"
         ],
+        "comments": [
+            "Create local std::string from the argument."
+        ],
         "mixin": [
-            "c_mixin_character"
+            "c_mixin_declare-arg",
+            "f_mixin_declare-interface-arg"
         ],
         "c_local": [
             "cxx"
@@ -2147,7 +2151,8 @@
             "Similar to f_in_string*, but c_arg_call is pass by value"
         ],
         "mixin": [
-            "c_mixin_character"
+            "c_mixin_declare-arg",
+            "f_mixin_declare-interface-arg"
         ],
         "c_local": [
             "cxx"
@@ -2164,7 +2169,8 @@
             "c_out_string*"
         ],
         "mixin": [
-            "c_mixin_character"
+            "c_mixin_declare-arg",
+            "f_mixin_declare-interface-arg"
         ],
         "lang_cxx": {
             "impl_header": [
@@ -2192,7 +2198,8 @@
             "Similar to f_out_string*"
         ],
         "mixin": [
-            "c_mixin_character"
+            "c_mixin_declare-arg",
+            "f_mixin_declare-interface-arg"
         ],
         "lang_cxx": {
             "impl_header": [

--- a/shroud/fc-statements.json
+++ b/shroud/fc-statements.json
@@ -13,30 +13,15 @@
         "c_arg_call": []
     },
     {
-        "sphinx-start-after": "c_mixin_argument",
-        "name": "c_mixin_argument2",
-        "notes": [
-            "XXX - work in progress"
-        ],
+        "sphinx-start-after": "c_mixin_declare-arg",
+        "name": "c_mixin_declare-arg",
         "c_arg_decl": [
             "{gen.cdecl.c_var}"
         ],
         "c_arg_call": [
             "{cxx_var}"
         ],
-        "sphinx-end-before": "c_mixin_argument"
-    },
-    {
-        "name": "c_mixin_argument",
-        "notes": [
-            "Use typemap.cxx_to_c to create an argument"
-        ],
-        "c_arg_decl": [
-            "{gen.cdecl.c_var}"
-        ],
-        "c_arg_call": [
-            "{cxx_var}"
-        ]
+        "sphinx-end-before": "c_mixin_declare-arg"
     },
     {
         "sphinx-start-after": "f_mixin_declare-fortran-arg",
@@ -1106,7 +1091,7 @@
             "f_none_native*"
         ],
         "mixin": [
-            "c_mixin_argument",
+            "c_mixin_declare-arg",
             "f_mixin_declare-interface-arg",
             "f_mixin_declare-fortran-arg"
         ]
@@ -1121,7 +1106,7 @@
             "An intent of 'none' is used with function pointers"
         ],
         "mixin": [
-            "c_mixin_argument",
+            "c_mixin_declare-arg",
             "f_mixin_declare-interface-arg",
             "f_mixin_declare-fortran-arg"
         ]
@@ -1136,9 +1121,9 @@
             "c_inout_native&"
         ],
         "mixin": [
-            "f_mixin_declare-fortran-arg",
+            "c_mixin_declare-arg",
             "f_mixin_declare-interface-arg",
-            "c_mixin_argument2"
+            "f_mixin_declare-fortran-arg"
         ],
         "c_arg_call": [
             "*{cxx_var}"
@@ -1154,7 +1139,7 @@
             "All Fortran can do is treat as a type(C_PTR)."
         ],
         "mixin": [
-            "c_mixin_argument",
+            "c_mixin_declare-arg",
             "f_mixin_argument-as-cptr-value",
             "f_mixin_declare-fortran-arg"
         ]
@@ -1169,7 +1154,7 @@
             "Make argument type(C_PTR) from 'int ** +intent(out)+deref(raw)'"
         ],
         "mixin": [
-            "c_mixin_argument",
+            "c_mixin_declare-arg",
             "f_mixin_argument-as-cptr",
             "f_mixin_declare-fortran-arg"
         ],
@@ -1189,9 +1174,9 @@
             "c_out_native*&"
         ],
         "mixin": [
+            "c_mixin_declare-arg",
             "f_mixin_declare-fortran-arg",
-            "f_mixin_argument-as-cptr",
-            "c_mixin_argument2"
+            "f_mixin_argument-as-cptr"
         ],
         "c_arg_call": [
             "*{cxx_var}"
@@ -1203,7 +1188,7 @@
             "c_out_native***"
         ],
         "mixin": [
-            "c_mixin_argument",
+            "c_mixin_declare-arg",
             "f_mixin_argument-as-cptr",
             "f_mixin_declare-fortran-arg"
         ],
@@ -1454,9 +1439,9 @@
             "Used with MPI types"
         ],
         "mixin": [
+            "c_mixin_declare-arg",
             "f_mixin_declare-fortran-arg",
-            "f_mixin_declare-interface-arg",
-            "c_mixin_argument2"
+            "f_mixin_declare-interface-arg"
         ]
     },
     {
@@ -1486,7 +1471,7 @@
             "f_none_bool"
         ],
         "mixin": [
-            "c_mixin_argument2",
+            "c_mixin_declare-arg",
             "f_mixin_declare-fortran-arg",
             "f_mixin_declare-interface-arg",
             "f_mixin_local-logical-var"
@@ -1502,10 +1487,10 @@
             "f_none_bool*"
         ],
         "mixin": [
+            "c_mixin_declare-arg",
             "f_mixin_declare-fortran-arg",
             "f_mixin_declare-interface-arg",
-            "f_mixin_local-logical-var",
-            "c_mixin_argument2"
+            "f_mixin_local-logical-var"
         ],
         "f_post_call": [
             "{f_var} = {f_var_cxx}  ! coerce to logical"
@@ -1517,10 +1502,10 @@
             "c_inout_bool_*"
         ],
         "mixin": [
+            "c_mixin_declare-arg",
             "f_mixin_declare-fortran-arg",
             "f_mixin_declare-interface-arg",
-            "f_mixin_local-logical-var",
-            "c_mixin_argument2"
+            "f_mixin_local-logical-var"
         ],
         "f_pre_call": [
             "{f_var_cxx} = {f_var}  ! coerce to C_BOOL"
@@ -1551,7 +1536,7 @@
             "f_none_void*"
         ],
         "mixin": [
-            "c_mixin_argument2"
+            "c_mixin_declare-arg"
         ],
         "f_module": {
             "iso_c_binding": [
@@ -1873,8 +1858,8 @@
             "f_none_char*"
         ],
         "mixin": [
-            "f_mixin_declare-fortran-arg",
-            "c_mixin_argument2"
+            "c_mixin_declare-arg",
+            "f_mixin_declare-fortran-arg"
         ],
         "i_arg_names": [
             "{i_var}"
@@ -2703,7 +2688,7 @@
             "mapping for the C interface.  Fortran calls the +api(cdesc) variant."
         ],
         "mixin": [
-            "c_mixin_argument2",
+            "c_mixin_declare-arg",
             "f_mixin_argument-as-cptr-value"
         ],
         "notimplemented": true
@@ -3224,7 +3209,7 @@
         ],
         "notimplemented": true,
         "mixin": [
-            "c_mixin_argument2"
+            "c_mixin_declare-arg"
         ],
         "i_arg_names": [
             "{i_var}"
@@ -3778,9 +3763,9 @@
             "C pointer -> void pointer -> C++ pointer"
         ],
         "mixin": [
-            "f_mixin_declare-fortran-arg",
+            "c_mixin_declare-arg",
             "f_mixin_declare-interface-arg",
-            "c_mixin_argument2"
+            "f_mixin_declare-fortran-arg"
         ]
     },
     {
@@ -3793,9 +3778,9 @@
             "c_inout_struct&"
         ],
         "mixin": [
-            "f_mixin_declare-fortran-arg",
+            "c_mixin_declare-arg",
             "f_mixin_declare-interface-arg",
-            "c_mixin_argument2"
+            "f_mixin_declare-fortran-arg"
         ],
         "c_arg_call": [
             "*{cxx_var}"
@@ -3874,8 +3859,8 @@
             "f_setter_struct*"
         ],
         "mixin": [
-            "f_mixin_declare-fortran-arg",
-            "c_mixin_argument2"
+            "c_mixin_declare-arg",
+            "f_mixin_declare-fortran-arg"
         ],
         "i_arg_names": [
             "{i_var}"
@@ -3890,8 +3875,8 @@
     {
         "name": "f_setter_struct**",
         "mixin": [
-            "f_mixin_declare-fortran-arg",
-            "c_mixin_argument2"
+            "c_mixin_declare-arg",
+            "f_mixin_declare-fortran-arg"
         ],
         "i_arg_names": [
             "{i_var}"
@@ -3926,10 +3911,10 @@
     {
         "name": "f_setter_bool",
         "mixin": [
+            "c_mixin_declare-arg",
             "f_mixin_declare-fortran-arg",
             "f_mixin_declare-interface-arg",
-            "f_mixin_local-logical-var",
-            "c_mixin_argument2"
+            "f_mixin_local-logical-var"
         ],
         "f_pre_call": [
             "{f_var_cxx} = {f_var}  ! coerce to C_BOOL"
@@ -3982,9 +3967,9 @@
             "c_setter_native*"
         ],
         "mixin": [
-            "f_mixin_declare-fortran-arg",
+            "c_mixin_declare-arg",
             "f_mixin_declare-interface-arg",
-            "c_mixin_argument2"
+            "f_mixin_declare-fortran-arg"
         ],
         "f_arg_call": [
             "{fc_var}"
@@ -4895,7 +4880,7 @@
             "c_in_procedure"
         ],
         "mixin": [
-            "c_mixin_argument2"
+            "c_mixin_declare-arg"
         ],
         "f_arg_name": [
             "{f_var}"
@@ -4936,7 +4921,7 @@
             "c_in_procedure_funptr"
         ],
         "mixin": [
-            "c_mixin_argument2"
+            "c_mixin_declare-arg"
         ],
         "f_arg_name": [
             "{f_var}"

--- a/shroud/fc-statements.json
+++ b/shroud/fc-statements.json
@@ -1177,9 +1177,6 @@
             "type(C_PTR){f_intent_attr} :: {f_var}"
         ],
         "f_module": {
-            "{f_module_name}": [
-                "{f_kind}"
-            ],
             "iso_c_binding": [
                 "C_PTR"
             ]

--- a/shroud/fc-statements.json
+++ b/shroud/fc-statements.json
@@ -62,7 +62,7 @@
         "sphinx-end-before": "f_mixin_declare-fortran-arg"
     },
     {
-        "name": "f_mixin_argument-as-cptr-value",
+        "name": "f_mixin_interface-as-cptr-value",
         "notes": [
             "Pass the address of the argument directly to C.",
             "Used when there is no direct mapping to Fortran"
@@ -80,7 +80,7 @@
         }
     },
     {
-        "name": "f_mixin_argument-as-cptr",
+        "name": "f_mixin_interface-as-cptr",
         "notes": [
             "Pass the address of the argument directly to C.",
             "Used when there is no direct mapping to Fortran"
@@ -1140,7 +1140,7 @@
         ],
         "mixin": [
             "c_mixin_declare-arg",
-            "f_mixin_argument-as-cptr-value",
+            "f_mixin_interface-as-cptr-value",
             "f_mixin_declare-fortran-arg"
         ]
     },
@@ -1155,7 +1155,7 @@
         ],
         "mixin": [
             "c_mixin_declare-arg",
-            "f_mixin_argument-as-cptr"
+            "f_mixin_interface-as-cptr"
         ],
         "f_arg_name": [
             "{f_var}"
@@ -1177,8 +1177,8 @@
         ],
         "mixin": [
             "c_mixin_declare-arg",
-            "f_mixin_declare-fortran-arg",
-            "f_mixin_argument-as-cptr"
+            "f_mixin_interface-as-cptr",
+            "f_mixin_declare-fortran-arg"
         ],
         "c_arg_call": [
             "*{cxx_var}"
@@ -1191,7 +1191,7 @@
         ],
         "mixin": [
             "c_mixin_declare-arg",
-            "f_mixin_argument-as-cptr",
+            "f_mixin_interface-as-cptr",
             "f_mixin_declare-fortran-arg"
         ],
         "f_arg_decl": [
@@ -2692,7 +2692,7 @@
         ],
         "mixin": [
             "c_mixin_declare-arg",
-            "f_mixin_argument-as-cptr-value"
+            "f_mixin_interface-as-cptr-value"
         ],
         "notimplemented": true
     },

--- a/shroud/fc-statements.json
+++ b/shroud/fc-statements.json
@@ -388,21 +388,6 @@
         }
     },
     {
-        "name": "f_mixin_native_default",
-        "notes": [
-            "Accept an argument of native type."
-        ],
-        "f_arg_name": [
-            "{f_var}"
-        ],
-        "f_arg_decl": [
-            "{f_type}{f_intent_attr} :: {f_var}"
-        ],
-        "f_arg_call": [
-            "{f_var}"
-        ]
-    },
-    {
         "name": "f_mixin_native_cdesc_allocate",
         "comments": [
             "Allocate Fortran native array, then fill from cdesc",
@@ -1653,7 +1638,7 @@
             "f_mixin_declare-fortran-arg"
         ],
         "i_arg_decl": [
-            "{f_type}, value{f_intent_attr} :: {i_var}"
+            "{i_type}, value{f_intent_attr} :: {i_var}"
         ],
         "i_arg_names": [
             "{i_var}"
@@ -4764,7 +4749,7 @@
             "c_mixin_native_cfi_allocatable"
         ],
         "i_arg_decl": [
-            "{f_type}{f_intent_attr}, allocatable :: {i_var}{f_assumed_shape}"
+            "{i_type}{f_intent_attr}, allocatable :: {i_var}{f_assumed_shape}"
         ],
         "c_pre_call": [
             "{c_const}{c_type} * {c_local_cxx};"
@@ -4784,7 +4769,7 @@
             "c_mixin_native_cfi_pointer"
         ],
         "i_arg_decl": [
-            "{f_type}{f_intent_attr}, pointer :: {i_var}{f_assumed_shape}"
+            "{i_type}{f_intent_attr}, pointer :: {i_var}{f_assumed_shape}"
         ],
         "c_pre_call": [
             "{c_const}{c_type} * {c_local_cxx};"
@@ -4817,7 +4802,7 @@
             "{f_var}"
         ],
         "i_arg_decl": [
-            "{f_type}{f_intent_attr}, allocatable :: {i_var}{f_assumed_shape}"
+            "{i_type}{f_intent_attr}, allocatable :: {i_var}{f_assumed_shape}"
         ],
         "c_call": [
             "{c_const}{cxx_type} *{c_local_cxx} = {C_call_function};"
@@ -4850,7 +4835,7 @@
             "{f_var}"
         ],
         "i_arg_decl": [
-            "{f_type}{f_intent_attr}, pointer :: {i_var}{f_assumed_shape}"
+            "{i_type}{f_intent_attr}, pointer :: {i_var}{f_assumed_shape}"
         ],
         "c_call": [
             "{c_const}{cxx_type} *{c_local_cxx} = {C_call_function};"

--- a/shroud/fc-statements.json
+++ b/shroud/fc-statements.json
@@ -24,25 +24,6 @@
         "sphinx-end-before": "c_mixin_declare-arg"
     },
     {
-        "sphinx-start-after": "f_mixin_declare-fortran-arg",
-        "name": "f_mixin_declare-fortran-arg",
-        "notes": [
-            "Fortran wrapper argument"
-        ],
-        "f_arg_name": [
-            "{f_var}"
-        ],
-        "f_module": {
-            "{f_module_name}": [
-                "{f_kind}"
-            ]
-        },
-        "f_arg_decl": [
-            "{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}"
-        ],
-        "sphinx-end-before": "f_mixin_declare-fortran-arg"
-    },
-    {
         "sphinx-start-after": "f_mixin_declare-interface-arg",
         "name": "f_mixin_declare-interface-arg",
         "notes": [
@@ -60,6 +41,25 @@
             "{i_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}"
         ],
         "sphinx-end-before": "f_mixin_declare-interface-arg"
+    },
+    {
+        "sphinx-start-after": "f_mixin_declare-fortran-arg",
+        "name": "f_mixin_declare-fortran-arg",
+        "notes": [
+            "Fortran wrapper argument"
+        ],
+        "f_arg_name": [
+            "{f_var}"
+        ],
+        "f_module": {
+            "{f_module_name}": [
+                "{f_kind}"
+            ]
+        },
+        "f_arg_decl": [
+            "{f_type}{f_value_attr}{f_intent_attr}{f_deref_attr}{f_optional_attr} :: {f_var}{f_dimension}"
+        ],
+        "sphinx-end-before": "f_mixin_declare-fortran-arg"
     },
     {
         "name": "f_mixin_argument-as-cptr-value",
@@ -1155,17 +1155,19 @@
         ],
         "mixin": [
             "c_mixin_declare-arg",
-            "f_mixin_argument-as-cptr",
-            "f_mixin_declare-fortran-arg"
+            "f_mixin_argument-as-cptr"
         ],
-        "f_arg_decl": [
-            "type(C_PTR){f_intent_attr} :: {f_var}"
+        "f_arg_name": [
+            "{f_var}"
         ],
         "f_module": {
             "iso_c_binding": [
                 "C_PTR"
             ]
-        }
+        },
+        "f_arg_decl": [
+            "type(C_PTR){f_intent_attr} :: {f_var}"
+        ]
     },
     {
         "alias": [

--- a/shroud/fc-statements.json
+++ b/shroud/fc-statements.json
@@ -42,17 +42,6 @@
                 "{f_kind}"
             ]
         },
-        "i_arg_names": [
-            "{i_var}"
-        ],
-        "i_arg_decl": [
-            "{f_type}{f_value_attr}{f_intent_attr} :: {i_var}{i_dimension}"
-        ],
-        "i_module": {
-            "{i_module_name}": [
-                "{i_kind}"
-            ]
-        },
         "c_arg_decl": [
             "{gen.cdecl.c_var}"
         ],
@@ -1128,7 +1117,8 @@
             "f_none_native*"
         ],
         "mixin": [
-            "c_mixin_argument"
+            "c_mixin_argument",
+            "f_mixin_declare-interface-arg"
         ]
     },
     {
@@ -1141,7 +1131,8 @@
             "An intent of 'none' is used with function pointers"
         ],
         "mixin": [
-            "c_mixin_argument"
+            "c_mixin_argument",
+            "f_mixin_declare-interface-arg"
         ]
     },
     {
@@ -1172,16 +1163,9 @@
             "All Fortran can do is treat as a type(C_PTR)."
         ],
         "mixin": [
-            "c_mixin_argument"
-        ],
-        "i_arg_decl": [
-            "type(C_PTR), intent(IN), value :: {i_var}"
-        ],
-        "i_module": {
-            "iso_c_binding": [
-                "C_PTR"
-            ]
-        }
+            "c_mixin_argument",
+            "f_mixin_argument-as-cptr-value"
+        ]
     },
     {
         "alias": [
@@ -1193,7 +1177,8 @@
             "Make argument type(C_PTR) from 'int ** +intent(out)+deref(raw)'"
         ],
         "mixin": [
-            "c_mixin_argument"
+            "c_mixin_argument",
+            "f_mixin_argument-as-cptr"
         ],
         "f_arg_decl": [
             "type(C_PTR){f_intent_attr} :: {f_var}"
@@ -1202,14 +1187,6 @@
             "{f_module_name}": [
                 "{f_kind}"
             ],
-            "iso_c_binding": [
-                "C_PTR"
-            ]
-        },
-        "i_arg_decl": [
-            "type(C_PTR){f_intent_attr} :: {f_var}"
-        ],
-        "i_module": {
             "iso_c_binding": [
                 "C_PTR"
             ]
@@ -1236,20 +1213,13 @@
             "c_out_native***"
         ],
         "mixin": [
-            "c_mixin_argument"
+            "c_mixin_argument",
+            "f_mixin_argument-as-cptr"
         ],
         "f_arg_decl": [
             "type(C_PTR){f_intent_attr} :: {f_var}"
         ],
         "f_module": {
-            "iso_c_binding": [
-                "C_PTR"
-            ]
-        },
-        "i_arg_decl": [
-            "type(C_PTR){f_intent_attr} :: {f_var}"
-        ],
-        "i_module": {
             "iso_c_binding": [
                 "C_PTR"
             ]

--- a/shroud/fc-statements.json
+++ b/shroud/fc-statements.json
@@ -2224,6 +2224,10 @@
             "f_inout_string*",
             "c_inout_string*"
         ],
+        "notes": [
+            "XXX - the fortran wrapper is incorrect since it is passing buf",
+            "  but only accepting one argument. Confused with f_inout_string*_buf"
+        ],
         "mixin": [
             "f_mixin_pass_character_buf",
             "c_mixin_character"

--- a/shroud/fc-statements.json
+++ b/shroud/fc-statements.json
@@ -98,6 +98,23 @@
         }
     },
     {
+        "name": "f_mixin_declare-as-cptr",
+        "notes": [
+            "Used when there is no direct mapping to Fortran"
+        ],
+        "f_arg_name": [
+            "{f_var}"
+        ],
+        "f_arg_decl": [
+            "type(C_PTR){f_intent_attr} :: {f_var}"
+        ],
+        "f_module": {
+            "iso_c_binding": [
+                "C_PTR"
+            ]
+        }
+    },
+    {
         "alias": [
             "f_subroutine",
             "c_subroutine"
@@ -1155,18 +1172,8 @@
         ],
         "mixin": [
             "c_mixin_declare-arg",
-            "f_mixin_interface-as-cptr"
-        ],
-        "f_arg_name": [
-            "{f_var}"
-        ],
-        "f_module": {
-            "iso_c_binding": [
-                "C_PTR"
-            ]
-        },
-        "f_arg_decl": [
-            "type(C_PTR){f_intent_attr} :: {f_var}"
+            "f_mixin_interface-as-cptr",
+            "f_mixin_declare-as-cptr"
         ]
     },
     {
@@ -3797,6 +3804,7 @@
         ],
         "mixin": [
             "f_mixin_function-to-subroutine",
+            "f_mixin_declare-interface-arg",
             "f_mixin_declare-fortran-result"
         ],
         "f_arg_call": [
@@ -3805,17 +3813,6 @@
         "c_arg_decl": [
             "{c_type} *{c_var}"
         ],
-        "i_arg_decl": [
-            "{f_type}, intent(OUT) :: {i_var}"
-        ],
-        "i_arg_names": [
-            "{i_var}"
-        ],
-        "i_module": {
-            "{f_module_name}": [
-                "{f_kind}"
-            ]
-        },
         "c_call": [
             "*{c_var} = {C_call_function};"
         ],
@@ -3863,13 +3860,8 @@
         ],
         "mixin": [
             "c_mixin_declare-arg",
+            "f_mixin_declare-interface-arg",
             "f_mixin_declare-fortran-arg"
-        ],
-        "i_arg_names": [
-            "{i_var}"
-        ],
-        "i_arg_decl": [
-            "{f_type}, intent(IN) :: {i_var}{i_dimension}"
         ],
         "c_post_call": [
             "{CXX_this}->{field_name} = val;"


### PR DESCRIPTION
Use more mixin in ``fc-statements.json``

Factor out common functionality by using mixin groups.The format dictionary is now more complete so the same mixin can be used in more cases. native and char and void.

It should be easier to reason about what a group is doing and only the exception behavior is listed explicitly in the non-mixin groups. A lot more can be done in this direction.