### PR TITLE
Add mixin groups to wrapp.py

### DIFF
--- a/regression/reference/cxxlibrary/pycxxlibrary_structnsmodule.cpp
+++ b/regression/reference/cxxlibrary/pycxxlibrary_structnsmodule.cpp
@@ -57,7 +57,7 @@ PY_passStructByReference(
 {
 // splicer begin namespace.structns.function.passStructByReference
     structns::Cstruct1 *arg;
-    PyObject * SHTPy_arg = nullptr;
+    PyObject * SHTPy_arg;
     PyArrayObject * SHPy_arg = nullptr;
     const char *SHT_kwlist[] = {
         "arg",
@@ -118,7 +118,7 @@ PY_passStructByReferenceIn(
 {
 // splicer begin namespace.structns.function.passStructByReferenceIn
     structns::Cstruct1 *arg;
-    PyObject * SHTPy_arg = nullptr;
+    PyObject * SHTPy_arg;
     PyArrayObject * SHPy_arg = nullptr;
     const char *SHT_kwlist[] = {
         "arg",
@@ -179,7 +179,7 @@ PY_passStructByReferenceInout(
 {
 // splicer begin namespace.structns.function.passStructByReferenceInout
     structns::Cstruct1 *arg;
-    PyObject * SHTPy_arg = nullptr;
+    PyObject * SHTPy_arg;
     PyArrayObject * SHPy_arg = nullptr;
     const char *SHT_kwlist[] = {
         "arg",

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -16118,6 +16118,7 @@ py_mixin_array_error:
     );"
   - goto fail;
   - -}}
+  goto_fail: true
 py_mixin_capsule:
   name: py_mixin_capsule
   intent: mixin
@@ -16149,6 +16150,7 @@ py_mixin_template_array_error:
     );"
   - goto fail;
   - -}}
+  goto_fail: true
 py_mixin_unknown:
   name: py_mixin_unknown
   intent: mixin

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -14564,6 +14564,12 @@ root
     mixin
       array
         error -- py_mixin_array_error
+      array-ContiguousFromObject -- py_mixin_array-ContiguousFromObject
+      array-FROM-OFT-in -- py_mixin_array-FROM-OFT-in
+      array-FROM-OTF -- py_mixin_array-FROM-OTF
+      array-FromAny -- py_mixin_array-FromAny
+      array-NewFromDescr -- py_mixin_array-NewFromDescr
+      array-SimpleNew -- py_mixin_array-SimpleNew
       capsule -- py_mixin_capsule
       malloc
         error -- py_mixin_malloc_error
@@ -16053,6 +16059,44 @@ py_inout_struct*_numpy:
 py_inout_struct_list:
   name: py_inout_struct_list
   intent: inout
+py_mixin_array-ContiguousFromObject:
+  name: py_mixin_array-ContiguousFromObject
+  intent: mixin
+  post_parse:
+  - "{py_var} = {cast_reinterpret}PyArrayObject *{cast1}PyArray_ContiguousFromObject(\t\
+    {pytmp_var},\t {numpy_type},\t {rank},\t {rank}){cast2};"
+py_mixin_array-FROM-OFT-in:
+  name: py_mixin_array-FROM-OFT-in
+  intent: mixin
+  post_parse:
+  - "{py_var} = {cast_reinterpret}PyArrayObject *{cast1}PyArray_FROM_OTF(\t{pytmp_var},\t\
+    \ {numpy_type},\t NPY_ARRAY_IN_ARRAY){cast2};"
+py_mixin_array-FROM-OTF:
+  name: py_mixin_array-FROM-OTF
+  intent: mixin
+  post_parse:
+  - "{py_var} = {cast_reinterpret}PyArrayObject *{cast1}PyArray_FROM_OTF(\t{pytmp_var},\t\
+    \ {numpy_type},\t NPY_ARRAY_INOUT_ARRAY){cast2};"
+py_mixin_array-FromAny:
+  name: py_mixin_array-FromAny
+  intent: mixin
+  post_parse:
+  - Py_INCREF({PYN_descr});
+  - "{py_var} = {cast_reinterpret}PyArrayObject *{cast1}PyArray_FromAny(\t{pytmp_var},\t\
+    \ {PYN_descr},\t 0,\t 1,\t NPY_ARRAY_IN_ARRAY,\t {nullptr}){cast2};"
+py_mixin_array-NewFromDescr:
+  name: py_mixin_array-NewFromDescr
+  intent: mixin
+  post_parse:
+  - Py_INCREF({PYN_descr});
+  - "{py_var} = {cast_reinterpret}PyArrayObject *{cast1}PyArray_NewFromDescr(\t&PyArray_Type,\t\
+    \ {PYN_descr},\t 0,\t {nullptr},\t {nullptr},\t {nullptr},\t 0,\t {nullptr}){cast2};"
+py_mixin_array-SimpleNew:
+  name: py_mixin_array-SimpleNew
+  intent: mixin
+  post_parse:
+  - '{npy_intp_asgn}{py_var} = {cast_reinterpret}PyArrayObject *{cast1}PyArray_SimpleNew({npy_rank},
+    {npy_dims_var}, {numpy_type}){cast2};'
 py_mixin_array_error:
   name: py_mixin_array_error
   intent: mixin

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -14571,6 +14571,7 @@ root
       array-NewFromDescr -- py_mixin_array-NewFromDescr
       array-SimpleNew -- py_mixin_array-SimpleNew
       array-get-data -- py_mixin_array-get-data
+      array-parse -- py_mixin_array-parse
       capsule -- py_mixin_capsule
       malloc
         error -- py_mixin_malloc_error
@@ -15634,7 +15635,7 @@ py_in_struct&_numpy:
   parse_args:
   - '&{pytmp_var}'
   declare:
-  - PyObject * {pytmp_var} = {nullptr};
+  - PyObject * {pytmp_var};
   - PyArrayObject * {py_var} = {nullptr};
   post_parse:
   - Py_INCREF({PYN_descr});
@@ -15680,7 +15681,7 @@ py_in_struct*_numpy:
   parse_args:
   - '&{pytmp_var}'
   declare:
-  - PyObject * {pytmp_var} = {nullptr};
+  - PyObject * {pytmp_var};
   - PyArrayObject * {py_var} = {nullptr};
   post_parse:
   - Py_INCREF({PYN_descr});
@@ -15728,7 +15729,7 @@ py_in_struct_numpy:
   parse_args:
   - '&{pytmp_var}'
   declare:
-  - PyObject * {pytmp_var} = {nullptr};
+  - PyObject * {pytmp_var};
   - PyArrayObject * {py_var} = {nullptr};
   post_parse:
   - Py_INCREF({PYN_descr});
@@ -15989,7 +15990,7 @@ py_inout_struct&_numpy:
   parse_args:
   - '&{pytmp_var}'
   declare:
-  - PyObject * {pytmp_var} = {nullptr};
+  - PyObject * {pytmp_var};
   - PyArrayObject * {py_var} = {nullptr};
   post_parse:
   - Py_INCREF({PYN_descr});
@@ -16035,7 +16036,7 @@ py_inout_struct*_numpy:
   parse_args:
   - '&{pytmp_var}'
   declare:
-  - PyObject * {pytmp_var} = {nullptr};
+  - PyObject * {pytmp_var};
   - PyArrayObject * {py_var} = {nullptr};
   post_parse:
   - Py_INCREF({PYN_descr});
@@ -16109,6 +16110,18 @@ py_mixin_array-get-data:
   lang_cxx:
     pre_call:
     - "{cxx_var} = static_cast<{cxx_type} *>\t(PyArray_DATA({py_var}));"
+py_mixin_array-parse:
+  name: py_mixin_array-parse
+  intent: mixin
+  need_numpy: true
+  parse_format: O
+  parse_args:
+  - '&{pytmp_var}'
+  declare:
+  - PyObject * {pytmp_var};
+  - PyArrayObject * {py_var} = {nullptr};
+  fail:
+  - Py_XDECREF({py_var});
 py_mixin_array_error:
   name: py_mixin_array_error
   intent: mixin

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -14562,6 +14562,14 @@ root
         list -- py_inout_struct*_list
         numpy -- py_inout_struct*_numpy
     mixin
+      array
+        error -- py_mixin_array_error
+      capsule -- py_mixin_capsule
+      malloc
+        error -- py_mixin_malloc_error
+      template
+        array
+          error -- py_mixin_template_array_error
       unknown -- py_mixin_unknown
     out
       bool -- py_out_bool
@@ -16045,6 +16053,46 @@ py_inout_struct*_numpy:
 py_inout_struct_list:
   name: py_inout_struct_list
   intent: inout
+py_mixin_array_error:
+  name: py_mixin_array_error
+  intent: mixin
+  post_parse:
+  - if ({py_var} == {nullptr}) {{+
+  - "PyErr_SetString(PyExc_ValueError,\t \"{c_var} must be a {rank}-D array of {c_type}\"\
+    );"
+  - goto fail;
+  - -}}
+py_mixin_capsule:
+  name: py_mixin_capsule
+  intent: mixin
+  declare_capsule:
+  - PyObject *{py_capsule} = {nullptr};
+  post_call_capsule:
+  - "{py_capsule} = PyCapsule_New({cxx_var}, \"{PY_numpy_array_capsule_name}\", \t\
+    {PY_capsule_destructor_function});"
+  - if ({py_capsule} == {nullptr}) goto fail;
+  - "PyCapsule_SetContext({py_capsule},\t {PY_fetch_context_function}({capsule_order}));"
+  - "if (PyArray_SetBaseObject(\t{cast_reinterpret}PyArrayObject *{cast1}{py_var}{cast2},\t\
+    \ {py_capsule}) < 0)\t goto fail;"
+  fail_capsule:
+  - Py_XDECREF({py_capsule});
+py_mixin_malloc_error:
+  name: py_mixin_malloc_error
+  intent: mixin
+  pre_call:
+  - if ({cxx_var} == {nullptr}) {{+
+  - PyErr_NoMemory();
+  - goto fail;
+  - -}}
+py_mixin_template_array_error:
+  name: py_mixin_template_array_error
+  intent: mixin
+  post_parse:
+  - if ({py_var} == {nullptr}) {{+
+  - "PyErr_SetString(PyExc_ValueError,\t \"{c_var} must be a 1-D array of {cxx_T}\"\
+    );"
+  - goto fail;
+  - -}}
 py_mixin_unknown:
   name: py_mixin_unknown
   intent: mixin

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -14570,6 +14570,7 @@ root
       array-FromAny -- py_mixin_array-FromAny
       array-NewFromDescr -- py_mixin_array-NewFromDescr
       array-SimpleNew -- py_mixin_array-SimpleNew
+      array-get-data -- py_mixin_array-get-data
       capsule -- py_mixin_capsule
       malloc
         error -- py_mixin_malloc_error
@@ -16097,6 +16098,17 @@ py_mixin_array-SimpleNew:
   post_parse:
   - '{npy_intp_asgn}{py_var} = {cast_reinterpret}PyArrayObject *{cast1}PyArray_SimpleNew({npy_rank},
     {npy_dims_var}, {numpy_type}){cast2};'
+py_mixin_array-get-data:
+  name: py_mixin_array-get-data
+  intent: mixin
+  pre_call:
+  - "{cxx_var} = static_cast<{cxx_type} *>\t(PyArray_DATA({py_var}));"
+  lang_c:
+    pre_call:
+    - '{c_var} = PyArray_DATA({py_var});'
+  lang_cxx:
+    pre_call:
+    - "{cxx_var} = static_cast<{cxx_type} *>\t(PyArray_DATA({py_var}));"
 py_mixin_array_error:
   name: py_mixin_array_error
   intent: mixin

--- a/regression/reference/none/statements
+++ b/regression/reference/none/statements
@@ -14573,7 +14573,7 @@ root
       array-get-data -- py_mixin_array-get-data
       array-parse -- py_mixin_array-parse
       capsule -- py_mixin_capsule
-      malloc
+      malloc -- py_mixin_malloc
         error -- py_mixin_malloc_error
       template
         array
@@ -16146,6 +16146,31 @@ py_mixin_capsule:
     \ {py_capsule}) < 0)\t goto fail;"
   fail_capsule:
   - Py_XDECREF({py_capsule});
+py_mixin_malloc:
+  name: py_mixin_malloc
+  intent: mixin
+  pre_call:
+  - "{cxx_var} = static_cast<{cxx_type} *>\t(std::malloc(\tsizeof({cxx_type}) * ({array_size})));"
+  - if ({cxx_var} == {nullptr}) {{+
+  - PyErr_NoMemory();
+  - goto fail;
+  - -}}
+  goto_fail: true
+  lang_c:
+    pre_call:
+    - "{c_var} = malloc(\tsizeof({c_type}) * ({array_size}));"
+    - if ({c_var} == {nullptr}) {{+
+    - PyErr_NoMemory();
+    - goto fail;
+    - -}}
+  lang_cxx:
+    pre_call:
+    - "{cxx_var} = static_cast<{cxx_type} *>\t(std::malloc(\tsizeof({cxx_type}) *\
+      \ ({array_size})));"
+    - if ({cxx_var} == {nullptr}) {{+
+    - PyErr_NoMemory();
+    - goto fail;
+    - -}}
 py_mixin_malloc_error:
   name: py_mixin_malloc_error
   intent: mixin
@@ -16351,7 +16376,7 @@ py_out_native*_list:
   lang_c:
     pre_call:
     - "{c_var} = malloc(\tsizeof({c_type}) * ({array_size}));"
-    - if ({cxx_var} == {nullptr}) {{+
+    - if ({c_var} == {nullptr}) {{+
     - PyErr_NoMemory();
     - goto fail;
     - -}}

--- a/regression/reference/struct-numpy-c/pystructmodule.c
+++ b/regression/reference/struct-numpy-c/pystructmodule.c
@@ -58,7 +58,7 @@ PY_passStructByValue(
 {
 // splicer begin function.passStructByValue
     Cstruct1 *arg;
-    PyObject * SHTPy_arg = NULL;
+    PyObject * SHTPy_arg;
     PyArrayObject * SHPy_arg = NULL;
     char *SHT_kwlist[] = {
         "arg",
@@ -117,7 +117,7 @@ PY_passStruct1(
 {
 // splicer begin function.passStruct1
     Cstruct1 *arg;
-    PyObject * SHTPy_arg = NULL;
+    PyObject * SHTPy_arg;
     PyArrayObject * SHPy_arg = NULL;
     char *SHT_kwlist[] = {
         "arg",
@@ -182,7 +182,7 @@ PY_passStruct2(
 {
 // splicer begin function.passStruct2
     Cstruct1 *s1;
-    PyObject * SHTPy_s1 = NULL;
+    PyObject * SHTPy_s1;
     PyArrayObject * SHPy_s1 = NULL;
     char outbuf[LENOUTBUF];  // intent(out)
     char *SHT_kwlist[] = {
@@ -242,7 +242,7 @@ PY_acceptStructInPtr(
 {
 // splicer begin function.acceptStructInPtr
     Cstruct1 *arg;
-    PyObject * SHTPy_arg = NULL;
+    PyObject * SHTPy_arg;
     PyArrayObject * SHPy_arg = NULL;
     char *SHT_kwlist[] = {
         "arg",
@@ -362,7 +362,7 @@ PY_acceptStructInOutPtr(
 {
 // splicer begin function.acceptStructInOutPtr
     Cstruct1 *arg;
-    PyObject * SHTPy_arg = NULL;
+    PyObject * SHTPy_arg;
     PyArrayObject * SHPy_arg = NULL;
     char *SHT_kwlist[] = {
         "arg",

--- a/regression/reference/struct-numpy-cxx/pystructmodule.cpp
+++ b/regression/reference/struct-numpy-cxx/pystructmodule.cpp
@@ -58,7 +58,7 @@ PY_passStructByValue(
 {
 // splicer begin function.passStructByValue
     Cstruct1 *arg;
-    PyObject * SHTPy_arg = nullptr;
+    PyObject * SHTPy_arg;
     PyArrayObject * SHPy_arg = nullptr;
     const char *SHT_kwlist[] = {
         "arg",
@@ -118,7 +118,7 @@ PY_passStruct1(
 {
 // splicer begin function.passStruct1
     Cstruct1 *arg;
-    PyObject * SHTPy_arg = nullptr;
+    PyObject * SHTPy_arg;
     PyArrayObject * SHPy_arg = nullptr;
     const char *SHT_kwlist[] = {
         "arg",
@@ -184,7 +184,7 @@ PY_passStruct2(
 {
 // splicer begin function.passStruct2
     Cstruct1 *s1;
-    PyObject * SHTPy_s1 = nullptr;
+    PyObject * SHTPy_s1;
     PyArrayObject * SHPy_s1 = nullptr;
     char outbuf[LENOUTBUF];  // intent(out)
     const char *SHT_kwlist[] = {
@@ -245,7 +245,7 @@ PY_acceptStructInPtr(
 {
 // splicer begin function.acceptStructInPtr
     Cstruct1 *arg;
-    PyObject * SHTPy_arg = nullptr;
+    PyObject * SHTPy_arg;
     PyArrayObject * SHPy_arg = nullptr;
     const char *SHT_kwlist[] = {
         "arg",
@@ -368,7 +368,7 @@ PY_acceptStructInOutPtr(
 {
 // splicer begin function.acceptStructInOutPtr
     Cstruct1 *arg;
-    PyObject * SHTPy_arg = nullptr;
+    PyObject * SHTPy_arg;
     PyArrayObject * SHPy_arg = nullptr;
     const char *SHT_kwlist[] = {
         "arg",

--- a/regression/reference/struct-py-c/pystructmodule.c
+++ b/regression/reference/struct-py-c/pystructmodule.c
@@ -58,7 +58,7 @@ PY_acceptBothStructs(
 // splicer begin function.acceptBothStructs
     PY_Cstruct_as_class * SHPy_s1;
     Cstruct_as_numpy *s2;
-    PyObject * SHTPy_s2 = NULL;
+    PyObject * SHTPy_s2;
     PyArrayObject * SHPy_s2 = NULL;
     char *SHT_kwlist[] = {
         "s1",

--- a/regression/reference/struct-py-cxx/pystructmodule.cpp
+++ b/regression/reference/struct-py-cxx/pystructmodule.cpp
@@ -58,7 +58,7 @@ PY_acceptBothStructs(
 // splicer begin function.acceptBothStructs
     PY_Cstruct_as_class * SHPy_s1;
     Cstruct_as_numpy *s2;
-    PyObject * SHTPy_s2 = nullptr;
+    PyObject * SHTPy_s2;
     PyArrayObject * SHPy_s2 = nullptr;
     const char *SHT_kwlist[] = {
         "s1",

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -3696,25 +3696,6 @@ malloc_error = [
     "-}}",
 ]
 
-declare_capsule=[
-    "PyObject *{py_capsule} = {nullptr};",
-]
-post_call_capsule=[
-    "{py_capsule} = "
-    'PyCapsule_New({cxx_var}, "{PY_numpy_array_capsule_name}", '
-    "\t{PY_capsule_destructor_function});",
-    "if ({py_capsule} == {nullptr}) goto fail;",
-    "PyCapsule_SetContext({py_capsule},"
-    "\t {PY_fetch_context_function}({capsule_order}));",
-    "if (PyArray_SetBaseObject(\t"
-    "{cast_reinterpret}PyArrayObject *{cast1}{py_var}{cast2},"
-    "\t {py_capsule}) < 0)\t goto fail;",
-]
-fail_capsule=[
-    "Py_XDECREF({py_capsule});",
-]
-
-
 # language   "py"
 # intent     "in", "out", "inout", "function", "subroutine", "descr", "ctor", "dtor"
 # sgroup     "native", "string", "char"
@@ -4077,6 +4058,9 @@ py_statements = [
             "py_function_native*_numpy",
             "py_function_native&_numpy",
         ],
+        mixin=[
+            "py_mixin_capsule",
+        ],
         need_numpy=True,
         declare=[
             "{npy_intp_decl}"
@@ -4094,9 +4078,6 @@ py_statements = [
             "Py_XDECREF({py_var});",
         ],
         goto_fail=True,
-        declare_capsule=declare_capsule,
-        post_call_capsule=post_call_capsule,
-        fail_capsule=fail_capsule,
     ),
 
     dict(
@@ -4585,6 +4566,9 @@ py_statements = [
             "py_function_struct_numpy",
             "py_function_struct*_numpy",
         ],
+        mixin=[
+            "py_mixin_capsule",
+        ],
         # XXX - expand to array of struct
         need_numpy=True,
         allocate_local_var=True,
@@ -4605,9 +4589,6 @@ py_statements = [
             "Py_XDECREF({py_var});",
         ],
         goto_fail=True,
-        declare_capsule=declare_capsule,
-        post_call_capsule=post_call_capsule,
-        fail_capsule=fail_capsule,
     ),
 
     dict(
@@ -4931,6 +4912,9 @@ py_statements = [
         name="py_out_vector<native>&_numpy",
         # Create a pointer a std::vector and pass to C++ function.
         # Create a NumPy array with the std::vector as the capsule object.
+        mixin=[
+            "py_mixin_capsule",
+        ],
         need_numpy=True,
         cxx_local_var="pointer",
         allocate_local_var=True,
@@ -4953,14 +4937,14 @@ py_statements = [
             "Py_XDECREF({py_var});",
         ],
         goto_fail=True,
-        declare_capsule=declare_capsule,
-        post_call_capsule=post_call_capsule,
-        fail_capsule=fail_capsule,
     ),
     dict(
         alias=[
             "py_function_vector_numpy",
             "py_function_vector<native>_numpy",
+        ],
+        mixin=[
+            "py_mixin_capsule",
         ],
         need_numpy=True,
         allocate_local_var=True,
@@ -4981,9 +4965,6 @@ py_statements = [
             "Py_XDECREF({py_var});",
         ],
         goto_fail=True,
-        declare_capsule=declare_capsule,
-        post_call_capsule=post_call_capsule,
-        fail_capsule=fail_capsule,
     ),
 
 

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -3782,6 +3782,7 @@ py_statements = [
             "goto fail;",
             "-}}",
         ],
+        goto_fail=True,
     ),
     dict(
         name="py_mixin_template_array_error",
@@ -3795,6 +3796,7 @@ py_statements = [
             "goto fail;",
             "-}}",
         ],
+        goto_fail=True,
     ),
     dict(
         name="py_mixin_array-get-data",
@@ -4027,7 +4029,6 @@ py_statements = [
         fail=[
             "Py_XDECREF({py_var});",
         ],
-        goto_fail=True,
     ),
 
     dict(
@@ -4049,7 +4050,6 @@ py_statements = [
         fail=[
             "Py_XDECREF({py_var});",
         ],
-        goto_fail=True,
     ),
 
     dict(
@@ -4069,7 +4069,6 @@ py_statements = [
         fail=[
             "Py_XDECREF({py_var});",
         ],
-        goto_fail=True,
     ),
 
     dict(
@@ -4510,7 +4509,6 @@ py_statements = [
         fail=[
             "Py_XDECREF({py_var});",
         ],
-        goto_fail=True,
     ),
     dict(
         name="py_inout_struct*_numpy",
@@ -4534,7 +4532,6 @@ py_statements = [
         fail=[
             "Py_XDECREF({py_var});",
         ],
-        goto_fail=True,
     ),
     dict(
         name="py_out_struct*_numpy",
@@ -4557,7 +4554,6 @@ py_statements = [
         fail=[
             "Py_XDECREF({py_var});",
         ],
-        goto_fail=True,
     ),
     dict(
         alias=[
@@ -4904,7 +4900,6 @@ py_statements = [
         fail=[
             "Py_XDECREF({py_var});",
         ],
-        goto_fail=True,
     ),
     dict(
         name="py_out_vector<native>&_numpy",

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -3705,6 +3705,23 @@ py_statements = [
             "Default returned by lookup_fc_stmts when group is not found.",
         ],
     ),
+
+    dict(name="py_mixin_array-parse",
+         comments=[
+             "Parse a Python Object to be used as PyArrayObject.",
+         ],
+         need_numpy=True,
+         declare=[
+             "PyObject * {pytmp_var};",    # Object set by ParseTupleAndKeywords.
+             "PyArrayObject * {py_var} = {nullptr};",
+         ],
+         parse_format="O",
+         parse_args=["&{pytmp_var}"],
+         fail=[
+             "Py_XDECREF({py_var});",
+         ],
+    ),
+        
     dict(
         name="py_mixin_array-ContiguousFromObject",
         notes=[
@@ -4011,45 +4028,27 @@ py_statements = [
     dict(
         name="py_in_native*_numpy",
         mixin=[
+            "py_mixin_array-parse",
             "py_mixin_array-ContiguousFromObject",
             "py_mixin_array_error",
             "py_mixin_array-get-data",
         ],
-        need_numpy=True,
-        declare=[
-            "PyObject * {pytmp_var};",
-            "PyArrayObject * {py_var} = {nullptr};",
-        ],
-        parse_format="O",
-        parse_args=["&{pytmp_var}"],
         arg_call=["{c_var}"],
         cleanup=[
             "{PY_cleanup_decref}({py_var});",
-        ],
-        fail=[
-            "Py_XDECREF({py_var});",
         ],
     ),
 
     dict(
         name="py_inout_native*_numpy",
         mixin=[
+            "py_mixin_array-parse",
             "py_mixin_array-FROM-OTF",
             "py_mixin_array_error",
             "py_mixin_array-get-data",
         ],
-        need_numpy=True,
-        parse_format="O",
-        parse_args=["&{pytmp_var}"],
-        declare=[
-            "PyObject * {pytmp_var};",
-            "PyArrayObject * {py_var} = {nullptr};",
-        ],
         arg_call=["{c_var}"],
         object_created=True,
-        fail=[
-            "Py_XDECREF({py_var});",
-        ],
     ),
 
     dict(
@@ -4487,51 +4486,31 @@ py_statements = [
     dict(
         name="py_in_struct*_numpy",
         mixin=[
+            "py_mixin_array-parse",
             "py_mixin_array-FromAny",
             "py_mixin_array_error",
             "py_mixin_array-get-data",
         ],
-        need_numpy=True,
-        parse_format="O",
-        parse_args=["&{pytmp_var}"],
         cxx_local_var="pointer",
         arg_declare=[ # Must be a pointer of cxx_type.
             "{cxx_type} *{cxx_var};",
         ],
-        declare=[
-            "PyObject * {pytmp_var} = {nullptr};",
-            "PyArrayObject * {py_var} = {nullptr};",
-#            "PyArray_Descr * {pydescr_var} = {PYN_descr};",
-        ],
         cleanup=[
             "{PY_cleanup_decref}({py_var});",
-        ],
-        fail=[
-            "Py_XDECREF({py_var});",
         ],
     ),
     dict(
         name="py_inout_struct*_numpy",
         mixin=[
+            "py_mixin_array-parse",
             "py_mixin_array-FromAny",
             "py_mixin_array_error",
             "py_mixin_array-get-data",
         ],
-        need_numpy=True,
-        parse_format="O",
-        parse_args=["&{pytmp_var}"],
         arg_declare=[ # Must be a pointer.
             "{cxx_type} *{cxx_var};",
         ],
-        declare=[
-            "PyObject * {pytmp_var} = {nullptr};",
-            "PyArrayObject * {py_var} = {nullptr};",
-#            "PyArray_Descr * {pydescr_var} = {PYN_descr};",
-        ],
         object_created=True,
-        fail=[
-            "Py_XDECREF({py_var});",
-        ],
     ),
     dict(
         name="py_out_struct*_numpy",
@@ -4877,18 +4856,12 @@ py_statements = [
         # create a local std::vector which will copy the values.
         # Pass to C++ function.
         mixin=[
+            "py_mixin_array-parse",
             "py_mixin_array-FROM-OFT-in",
             "py_mixin_template_array_error",
         ],
-        need_numpy=True,
-        parse_format="O",
-        parse_args=["&{pytmp_var}"],
         cxx_local_var="scalar",
         arg_declare=[],
-        declare=[
-            "PyObject * {pytmp_var};",  # Object set by ParseTupleAndKeywords.
-            "PyArrayObject * {py_var} = {nullptr};",
-        ],
         post_declare=[
             "std::vector<{cxx_T}> {cxx_var};",
             "{cxx_T} * {data_var};",
@@ -4896,9 +4869,6 @@ py_statements = [
         pre_call=[
             "{data_var} = static_cast<{cxx_T} *>(PyArray_DATA({py_var}));",
             "{cxx_var}.assign(\t{data_var},\t {data_var}+PyArray_SIZE({py_var}));",
-        ],
-        fail=[
-            "Py_XDECREF({py_var});",
         ],
     ),
     dict(

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -3797,6 +3797,20 @@ py_statements = [
         ],
     ),
     dict(
+        name="py_mixin_array-get-data",
+        lang_c=dict(
+            pre_call=[
+                "{c_var} = PyArray_DATA({py_var});",
+            ],
+        ),
+        lang_cxx=dict(
+            pre_call=[
+                "{cxx_var} = static_cast<{cxx_type} *>\t(PyArray_DATA({py_var}));",
+            ],
+        ),
+    ),
+    
+    dict(
         name="py_mixin_malloc_error",
         pre_call=[
             "if ({cxx_var} == {nullptr}) {{+",
@@ -3997,6 +4011,7 @@ py_statements = [
         mixin=[
             "py_mixin_array-ContiguousFromObject",
             "py_mixin_array_error",
+            "py_mixin_array-get-data",
         ],
         need_numpy=True,
         declare=[
@@ -4005,16 +4020,6 @@ py_statements = [
         ],
         parse_format="O",
         parse_args=["&{pytmp_var}"],
-        lang_c=dict(
-            pre_call=[
-                "{c_var} = PyArray_DATA({py_var});",
-            ],
-        ),
-        lang_cxx=dict(
-            pre_call=[
-                "{cxx_var} = static_cast<{cxx_type} *>\t(PyArray_DATA({py_var}));",
-            ],
-        ),
         arg_call=["{c_var}"],
         cleanup=[
             "{PY_cleanup_decref}({py_var});",
@@ -4030,6 +4035,7 @@ py_statements = [
         mixin=[
             "py_mixin_array-FROM-OTF",
             "py_mixin_array_error",
+            "py_mixin_array-get-data",
         ],
         need_numpy=True,
         parse_format="O",
@@ -4038,16 +4044,6 @@ py_statements = [
             "PyObject * {pytmp_var};",
             "PyArrayObject * {py_var} = {nullptr};",
         ],
-        lang_c=dict(
-            pre_call=[
-                "{c_var} = PyArray_DATA({py_var});",
-            ],
-        ),
-        lang_cxx=dict(
-            pre_call=[
-                "{cxx_var} = static_cast<{cxx_type} *>\t(PyArray_DATA({py_var}));",
-            ],
-        ),
         arg_call=["{c_var}"],
         object_created=True,
         fail=[
@@ -4061,22 +4057,13 @@ py_statements = [
         mixin=[
             "py_mixin_array-SimpleNew",
             "py_mixin_array_error",
+            "py_mixin_array-get-data",
         ],
         need_numpy=True,
         declare=[
             "{npy_intp_decl}"  # Must contain a newline if non-blank.
             "PyArrayObject * {py_var} = {nullptr};",
         ],
-        lang_c=dict(
-            pre_call=[
-                "{c_var} = PyArray_DATA({py_var});",
-            ],
-        ),
-        lang_cxx=dict(
-            pre_call=[
-                "{cxx_var} = static_cast<{cxx_type} *>\t(PyArray_DATA({py_var}));",
-            ],
-        ),
         arg_call=["{c_var}"],
         object_created=True,
         fail=[
@@ -4503,6 +4490,7 @@ py_statements = [
         mixin=[
             "py_mixin_array-FromAny",
             "py_mixin_array_error",
+            "py_mixin_array-get-data",
         ],
         need_numpy=True,
         parse_format="O",
@@ -4516,16 +4504,6 @@ py_statements = [
             "PyArrayObject * {py_var} = {nullptr};",
 #            "PyArray_Descr * {pydescr_var} = {PYN_descr};",
         ],
-        lang_c=dict(
-            pre_call=[
-                "{c_var} = PyArray_DATA({py_var});",
-            ],
-        ),
-        lang_cxx=dict(
-            pre_call=[
-                "{cxx_var} = static_cast<{cxx_type} *>\t(PyArray_DATA({py_var}));",
-            ],
-        ),
         cleanup=[
             "{PY_cleanup_decref}({py_var});",
         ],
@@ -4539,6 +4517,7 @@ py_statements = [
         mixin=[
             "py_mixin_array-FromAny",
             "py_mixin_array_error",
+            "py_mixin_array-get-data",
         ],
         need_numpy=True,
         parse_format="O",
@@ -4551,16 +4530,6 @@ py_statements = [
             "PyArrayObject * {py_var} = {nullptr};",
 #            "PyArray_Descr * {pydescr_var} = {PYN_descr};",
         ],
-        lang_c=dict(
-            pre_call=[
-                "{c_var} = PyArray_DATA({py_var});",
-            ],
-        ),
-        lang_cxx=dict(
-            pre_call=[
-                "{cxx_var} = static_cast<{cxx_type} *>\t(PyArray_DATA({py_var}));",
-            ],
-        ),
         object_created=True,
         fail=[
             "Py_XDECREF({py_var});",
@@ -4572,6 +4541,7 @@ py_statements = [
         mixin=[
             "py_mixin_array-NewFromDescr",
             "py_mixin_array_error",
+            "py_mixin_array-get-data",
         ],
         # XXX - expand to array of struct
         need_numpy=True,
@@ -4583,16 +4553,6 @@ py_statements = [
 #            "{npy_intp_decl}"
             "PyArrayObject * {py_var} = {nullptr};",
         ],
-        lang_c=dict(
-            pre_call=[
-                "{c_var} = PyArray_DATA({py_var});",
-            ],
-        ),
-        lang_cxx=dict(
-            pre_call=[
-                "{cxx_var} = static_cast<{cxx_type} *>\t(PyArray_DATA({py_var}));",
-            ],
-        ),
         object_created=True,
         fail=[
             "Py_XDECREF({py_var});",

--- a/shroud/wrapp.py
+++ b/shroud/wrapp.py
@@ -3742,6 +3742,55 @@ py_statements = [
         ],
     ),
     dict(
+        name="py_mixin_array_error",
+        post_parse=[
+            "if ({py_var} == {nullptr}) {{+",
+            "PyErr_SetString(PyExc_ValueError,"
+            '\t "{c_var} must be a {rank}-D array of {c_type}");',
+            "goto fail;",
+            "-}}",
+        ],
+    ),
+    dict(
+        name="py_mixin_template_array_error",
+        post_parse=[
+            "if ({py_var} == {nullptr}) {{+",
+            "PyErr_SetString(PyExc_ValueError,"
+            '\t "{c_var} must be a 1-D array of {cxx_T}");',
+            "goto fail;",
+            "-}}",
+        ],
+    ),
+    dict(
+        name="py_mixin_malloc_error",
+        pre_call=[
+            "if ({cxx_var} == {nullptr}) {{+",
+            "PyErr_NoMemory();",
+            "goto fail;",
+            "-}}",
+        ],
+    ),
+    dict(
+        name="py_mixin_capsule",
+        declare_capsule=[
+            "PyObject *{py_capsule} = {nullptr};",
+        ],
+        post_call_capsule=[
+            "{py_capsule} = "
+            'PyCapsule_New({cxx_var}, "{PY_numpy_array_capsule_name}", '
+            "\t{PY_capsule_destructor_function});",
+            "if ({py_capsule} == {nullptr}) goto fail;",
+            "PyCapsule_SetContext({py_capsule},"
+            "\t {PY_fetch_context_function}({capsule_order}));",
+            "if (PyArray_SetBaseObject(\t"
+            "{cast_reinterpret}PyArrayObject *{cast1}{py_var}{cast2},"
+            "\t {py_capsule}) < 0)\t goto fail;",
+        ],
+        fail_capsule=[
+            "Py_XDECREF({py_capsule});",
+        ],
+    ),
+    dict(
         alias=[
             "py_function_native",
             "py_in_native",


### PR DESCRIPTION
Before, some shared code was added by assigning variables in `py_statements`

Old:

    post_parse=[
    ] + array_error

New:

    mixin=[
      "py_mixin_array-FromAny",
      "py_mixin_array_error",
    ]

This will make it possible to convert py-statements into JSON.